### PR TITLE
Stabilizing GetTranslationStatusesFilterByStatusTest by ensuring cancellation is propagated

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
@@ -228,12 +228,16 @@ namespace Azure.AI.Translation.Document
 
                 try
                 {
+                    var statusList = options?.Statuses?.Count > 0 ? options.Statuses.Select(status => status.ToString()) : null;
+                    var idList = options?.Ids?.Count > 0 ? options?.Ids?.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")) : null;
+                    var orderByList = options?.OrderBy?.Count > 0 ? options?.OrderBy?.Select(order => order.ToGenerated()) : null;
+
                     var response = _serviceRestClient.GetTranslationsStatus(
-                        ids: options?.Ids?.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")),
-                        statuses: options?.Statuses?.Select(status => status.ToString()),
+                        ids: idList,
+                        statuses: statusList,
                         createdDateTimeUtcStart: options?.CreatedAfter,
                         createdDateTimeUtcEnd: options?.CreatedBefore,
-                        orderBy: options?.OrderBy?.Select(order => order.ToGenerated()),
+                        orderBy: orderByList,
                         cancellationToken: cancellationToken);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
@@ -278,13 +282,18 @@ namespace Azure.AI.Translation.Document
 
                 try
                 {
+                    var statusList = options?.Statuses?.Count > 0 ? options.Statuses.Select(status => status.ToString()) : null;
+                    var idList = options?.Ids?.Count > 0 ? options?.Ids?.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")) : null;
+                    var orderByList = options?.OrderBy?.Count > 0 ? options?.OrderBy?.Select(order => order.ToGenerated()) : null;
+
                     var response = await _serviceRestClient.GetTranslationsStatusAsync(
-                        ids: options?.Ids?.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")),
-                        statuses: options?.Statuses?.Select(status => status.ToString()),
+                        ids: idList,
+                        statuses: statusList,
                         createdDateTimeUtcStart: options?.CreatedAfter,
                         createdDateTimeUtcEnd: options?.CreatedBefore,
-                        orderBy: options?.OrderBy?.Select(order => order.ToGenerated()),
+                        orderBy: orderByList,
                         cancellationToken: cancellationToken).ConfigureAwait(false);
+
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationClient.cs
@@ -228,9 +228,9 @@ namespace Azure.AI.Translation.Document
 
                 try
                 {
-                    var statusList = options?.Statuses?.Count > 0 ? options.Statuses.Select(status => status.ToString()) : null;
-                    var idList = options?.Ids?.Count > 0 ? options?.Ids?.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")) : null;
-                    var orderByList = options?.OrderBy?.Count > 0 ? options?.OrderBy?.Select(order => order.ToGenerated()) : null;
+                    var statusList = options?.Statuses.Count > 0 ? options.Statuses.Select(status => status.ToString()) : null;
+                    var idList = options?.Ids.Count > 0 ? options.Ids.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")) : null;
+                    var orderByList = options?.OrderBy.Count > 0 ? options.OrderBy.Select(order => order.ToGenerated()) : null;
 
                     var response = _serviceRestClient.GetTranslationsStatus(
                         ids: idList,
@@ -282,9 +282,9 @@ namespace Azure.AI.Translation.Document
 
                 try
                 {
-                    var statusList = options?.Statuses?.Count > 0 ? options.Statuses.Select(status => status.ToString()) : null;
-                    var idList = options?.Ids?.Count > 0 ? options?.Ids?.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")) : null;
-                    var orderByList = options?.OrderBy?.Count > 0 ? options?.OrderBy?.Select(order => order.ToGenerated()) : null;
+                    var statusList = options?.Statuses.Count > 0 ? options.Statuses.Select(status => status.ToString()) : null;
+                    var idList = options?.Ids.Count > 0 ? options.Ids.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")) : null;
+                    var orderByList = options?.OrderBy.Count > 0 ? options.OrderBy.Select(order => order.ToGenerated()) : null;
 
                     var response = await _serviceRestClient.GetTranslationsStatusAsync(
                         ids: idList,

--- a/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/src/DocumentTranslationOperation.cs
@@ -373,13 +373,17 @@ namespace Azure.AI.Translation.Document
 
                 try
                 {
+                    var idList = options?.Ids.Count > 0 ? options.Ids.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")) : null;
+                    var statusList = options?.Statuses.Count > 0 ? options.Statuses.Select(status => status.ToString()) : null;
+                    var orderByList = options?.OrderBy.Count > 0 ? options.OrderBy.Select(order => order.ToGenerated()) : null;
+
                     var response = _serviceClient.GetDocumentsStatus(
                         new Guid(Id),
-                        ids: options?.Ids?.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")),
-                        statuses: options?.Statuses?.Select(status => status.ToString()),
+                        ids: idList,
+                        statuses: statusList,
                         createdDateTimeUtcStart: options?.CreatedAfter,
                         createdDateTimeUtcEnd: options?.CreatedBefore,
-                        orderBy: options?.OrderBy?.Select(order => order.ToGenerated()),
+                        orderBy: orderByList,
                         cancellationToken: cancellationToken);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
@@ -424,13 +428,17 @@ namespace Azure.AI.Translation.Document
 
                 try
                 {
+                    var idList = options?.Ids.Count > 0 ? options.Ids.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")) : null;
+                    var statusList = options?.Statuses.Count > 0 ? options.Statuses.Select(status => status.ToString()) : null;
+                    var orderByList = options?.OrderBy.Count > 0 ? options.OrderBy.Select(order => order.ToGenerated()) : null;
+
                     var response = await _serviceClient.GetDocumentsStatusAsync(
                         new Guid(Id),
-                        ids: options?.Ids?.Select(id => ClientCommon.ValidateModelId(id, "Id Filter")),
-                        statuses: options?.Statuses?.Select(status => status.ToString()),
+                        ids: idList,
+                        statuses: statusList,
                         createdDateTimeUtcStart: options?.CreatedAfter,
                         createdDateTimeUtcEnd: options?.CreatedBefore,
-                        orderBy: options?.OrderBy?.Select(order => order.ToGenerated()),
+                        orderBy: orderByList,
                         cancellationToken: cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
@@ -81,9 +81,14 @@ namespace Azure.AI.Translation.Document.Tests
                     DocumentTranslationStatus.Canceled,
                     DocumentTranslationStatus.Canceling
             };
+
+            // getting only translations from the last few hours
+            var recentTimestamp = Recording.UtcNow.AddHours(-6);
+
             var options = new GetTranslationStatusesOptions
             {
-                Statuses = { canceledStatusList[0], canceledStatusList[1] }
+                Statuses = { canceledStatusList[0], canceledStatusList[1] },
+                CreatedAfter = recentTimestamp
             };
 
             var filteredTranslations = await client.GetTranslationStatusesAsync(options: options).ToEnumerableAsync();
@@ -149,10 +154,14 @@ namespace Azure.AI.Translation.Document.Tests
             var timestamp = Recording.UtcNow;
             await CreateTranslationJobsAsync(client, jobsCount: 1, docsPerJob: 1, jobTerminalStatus: DocumentTranslationStatus.Succeeded);
 
+            // getting only translations from the last hour
+            var recentTimestamp = Recording.UtcNow.AddHours(-1);
+
             // list translations with filter
             var options = new GetTranslationStatusesOptions
             {
-                CreatedBefore = timestamp
+                CreatedBefore = timestamp,
+                CreatedAfter = recentTimestamp
             };
 
             var filteredTranslations = await client.GetTranslationStatusesAsync(options: options).ToEnumerableAsync();
@@ -171,10 +180,14 @@ namespace Azure.AI.Translation.Document.Tests
             // create test jobs
             await CreateTranslationJobsAsync(client, jobsCount: 3, docsPerJob: 1, jobTerminalStatus: DocumentTranslationStatus.Succeeded);
 
+            // getting only translations from the last few hours
+            var recentTimestamp = Recording.UtcNow.AddHours(-6);
+
             // list translations with filter
             var options = new GetTranslationStatusesOptions
             {
-                OrderBy = { new TranslationFilterOrder(property: TranslationFilterProperty.CreatedOn, asc: false) }
+                OrderBy = { new TranslationFilterOrder(property: TranslationFilterProperty.CreatedOn, asc: false) },
+                CreatedAfter = recentTimestamp
             };
 
             var filteredTranslations = await client.GetTranslationStatusesAsync(options: options).ToEnumerableAsync();

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByIdsTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByIdsTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1526944569?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1805082759?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-07a993cd0ae22644bb598c75b5aa0537-bf3ce6d9e1fa0b43-00",
+        "traceparent": "00-5ff980cb8217bc46b65a4c3a1f22e6a3-ebaac142dade914a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "920d371c75cc18adc66a42198fee55ee",
-        "x-ms-date": "Wed, 18 Aug 2021 18:07:01 GMT",
+        "x-ms-client-request-id": "13b2a2183ce387678585b367b29a32cf",
+        "x-ms-date": "Thu, 26 Aug 2021 14:33:32 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:07:00 GMT",
-        "ETag": "\u00220x8D96272F9A2EE3D\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:07:00 GMT",
+        "Date": "Thu, 26 Aug 2021 14:33:32 GMT",
+        "ETag": "\u00220x8D9689E7B38DDAB\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:33:33 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "920d371c75cc18adc66a42198fee55ee",
-        "x-ms-request-id": "0b1a8b3b-601e-0056-2e5b-94cd70000000",
+        "x-ms-client-request-id": "13b2a2183ce387678585b367b29a32cf",
+        "x-ms-request-id": "b9a66240-901e-006d-7287-9a88d4000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1526944569/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1805082759/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-e9bc0ea073522949b059d59a08ba88c5-579c45c861556445-00",
+        "traceparent": "00-abc6e4ef665f404bbc0cfad54e4f9f27-c00dac8b660a7041-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "6528bd96e0f8ba056b597f1d30e6cb3a",
-        "x-ms-date": "Wed, 18 Aug 2021 18:07:02 GMT",
+        "x-ms-client-request-id": "15f977d007a82850b2f175fe55b6de1b",
+        "x-ms-date": "Thu, 26 Aug 2021 14:33:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,30 +47,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:07:00 GMT",
-        "ETag": "\u00220x8D96272F9D7D95F\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:07:00 GMT",
+        "Date": "Thu, 26 Aug 2021 14:33:32 GMT",
+        "ETag": "\u00220x8D9689E7B7C0621\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:33:33 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "6528bd96e0f8ba056b597f1d30e6cb3a",
+        "x-ms-client-request-id": "15f977d007a82850b2f175fe55b6de1b",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0b1a8bb3-601e-0056-1c5b-94cd70000000",
+        "x-ms-request-id": "b9a6633b-901e-006d-5c87-9a88d4000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1526944569/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1805082759/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-fad36d8486e1fe45895f7853d920fbea-ebf335019386ac4f-00",
+        "traceparent": "00-3203d54741f1ba4a9c8398cf68c40903-37fc7f30acede74e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "c1fd91c6e8770ed5d621499d32efe159",
-        "x-ms-date": "Wed, 18 Aug 2021 18:07:02 GMT",
+        "x-ms-client-request-id": "463dfa9c637cef2457ec72c254198aa7",
+        "x-ms-date": "Thu, 26 Aug 2021 14:33:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -79,28 +79,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:07:00 GMT",
-        "ETag": "\u00220x8D96272FA02E8C3\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:07:00 GMT",
+        "Date": "Thu, 26 Aug 2021 14:33:33 GMT",
+        "ETag": "\u00220x8D9689E7BAABFD5\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:33:33 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "c1fd91c6e8770ed5d621499d32efe159",
+        "x-ms-client-request-id": "463dfa9c637cef2457ec72c254198aa7",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0b1a8ca5-601e-0056-7c5b-94cd70000000",
+        "x-ms-request-id": "b9a6646c-901e-006d-0187-9a88d4000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1402114609?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1385302454?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f5629a33f6c7764e93e5b0f8227ecf81-547e4e5dfb9c7d4a-00",
+        "traceparent": "00-8d79a4c691bea646b28b18017e3eb71e-3d6621837cec7743-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "09f2662f4011313b532672f58fe7e09f",
-        "x-ms-date": "Wed, 18 Aug 2021 18:07:03 GMT",
+        "x-ms-client-request-id": "41452653df0a52118a61f1c76831cfa6",
+        "x-ms-date": "Thu, 26 Aug 2021 14:33:33 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -108,12 +108,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:07:01 GMT",
-        "ETag": "\u00220x8D96272FA194534\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:07:01 GMT",
+        "Date": "Thu, 26 Aug 2021 14:33:33 GMT",
+        "ETag": "\u00220x8D9689E7BC9ED86\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:33:34 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "09f2662f4011313b532672f58fe7e09f",
-        "x-ms-request-id": "0b1a8d72-601e-0056-345b-94cd70000000",
+        "x-ms-client-request-id": "41452653df0a52118a61f1c76831cfa6",
+        "x-ms-request-id": "b9a6653b-901e-006d-4587-9a88d4000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -126,9 +126,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7afc63d0c63d6644b4d782c443a07326-1cf16c3bec192646-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f1fe52087693e8ad198fd79767877c77",
+        "traceparent": "00-b283ae6ceca52849b680ef53501a69eb-f30b449da0aeb84d-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5cb7ca9752eb526c0abdbc948dd39866",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -148,57 +148,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "7a31f444-ef17-4f67-b837-bd5366382e55",
+        "apim-request-id": "1bf30dbb-d875-49df-b092-2f23cf6a990f",
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:07:02 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+        "Date": "Thu, 26 Aug 2021 14:33:35 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7a31f444-ef17-4f67-b837-bd5366382e55"
+        "X-RequestId": "1bf30dbb-d875-49df-b092-2f23cf6a990f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7f00eb2631d950b4c19024c162184639",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "900248ceda991b912cf4f1023228efba",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "070d3c03-3ead-4d91-bf66-db42dcaec07e",
+        "apim-request-id": "5026b1bf-5555-448f-a3df-87c9e3691dd3",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:02 GMT",
-        "ETag": "\u0022B955B936F8F15E36E7DB6C115A61A687EDC7BDE85F2AF732D60719433F89EE54\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:35 GMT",
+        "ETag": "\u00221B8CBD10D97EFF9E5D8C5EF2B565030CFCA150A1D5C89EF8161BAB21DD8D5876\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "070d3c03-3ead-4d91-bf66-db42dcaec07e"
+        "X-RequestId": "5026b1bf-5555-448f-a3df-87c9e3691dd3"
       },
       "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:02.6572683Z",
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:35.6677933Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -212,26 +212,122 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9c29fe6868e3b99db809ef8269a4cacb",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4ebc1ba34ad200cab9f2374d227cc4b7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "be131b27-93d3-450a-9874-07e4b691a0ba",
+        "apim-request-id": "fd9877ac-9369-47ae-9739-ffe2bb2cbb2e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:03 GMT",
-        "ETag": "\u00228C523C7C7549A1BEA8F5B342DE23216EA87741A87289789FA6D1E25B7D67ABAD\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:37 GMT",
+        "ETag": "\u00222D3B0C0D1E06FF81F617010189760C458B456FB28E48F66ACDF806AF74C4326C\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "fd9877ac-9369-47ae-9739-ffe2bb2cbb2e"
+      },
+      "ResponseBody": {
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:36.9034641Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 2,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "20f98bc83e2fbd0d399c30f7616920e1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2bbfc574-c981-4dd8-befd-5bc441b305d9",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:33:38 GMT",
+        "ETag": "\u00222D3B0C0D1E06FF81F617010189760C458B456FB28E48F66ACDF806AF74C4326C\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2bbfc574-c981-4dd8-befd-5bc441b305d9"
+      },
+      "ResponseBody": {
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:36.9034641Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 2,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "72f102ce491683937d01d6a6a344f9af",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3d447dab-8e6e-4622-b204-84bc087219fa",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:33:39 GMT",
+        "ETag": "\u00222D3B0C0D1E06FF81F617010189760C458B456FB28E48F66ACDF806AF74C4326C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -241,12 +337,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "be131b27-93d3-450a-9874-07e4b691a0ba"
+        "X-RequestId": "3d447dab-8e6e-4622-b204-84bc087219fa"
       },
       "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:03.8159114Z",
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:36.9034641Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -260,41 +356,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a4cffbaa60e6d7c59dae300352ec8600",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a7393a30ce2f658b0efe15361ad39f50",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f127fcc1-0cbe-47bd-9761-ba25de4286e5",
+        "apim-request-id": "dcbd21f5-f7aa-47fb-9103-acf4da80634b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:04 GMT",
-        "ETag": "\u00228C523C7C7549A1BEA8F5B342DE23216EA87741A87289789FA6D1E25B7D67ABAD\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:40 GMT",
+        "ETag": "\u00222D3B0C0D1E06FF81F617010189760C458B456FB28E48F66ACDF806AF74C4326C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f127fcc1-0cbe-47bd-9761-ba25de4286e5"
+        "X-RequestId": "dcbd21f5-f7aa-47fb-9103-acf4da80634b"
       },
       "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:03.8159114Z",
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:36.9034641Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -308,122 +404,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "682e9d48df5ebd944d47c6cf4132e61c",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "207e55d2528b7fa0f775a32d67661af4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "68389edf-b4ba-42e2-a325-afae678a2d4e",
+        "apim-request-id": "f36c1231-fbca-4b31-849d-d3b95c9e7c63",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:06 GMT",
-        "ETag": "\u00228C523C7C7549A1BEA8F5B342DE23216EA87741A87289789FA6D1E25B7D67ABAD\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "68389edf-b4ba-42e2-a325-afae678a2d4e"
-      },
-      "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:03.8159114Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 2,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 2,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "661758c5a24907523852fe35379967cc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6fa68f38-1e08-4c14-b15b-0edc81b046ac",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:08 GMT",
-        "ETag": "\u00228C523C7C7549A1BEA8F5B342DE23216EA87741A87289789FA6D1E25B7D67ABAD\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6fa68f38-1e08-4c14-b15b-0edc81b046ac"
-      },
-      "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:03.8159114Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 2,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 2,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cc39ee836176ca6d6711569f99f6956a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ab2d6a82-1e27-41d1-b220-af223ce9194d",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:09 GMT",
-        "ETag": "\u00228C523C7C7549A1BEA8F5B342DE23216EA87741A87289789FA6D1E25B7D67ABAD\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:42 GMT",
+        "ETag": "\u00222D3B0C0D1E06FF81F617010189760C458B456FB28E48F66ACDF806AF74C4326C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -433,12 +433,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ab2d6a82-1e27-41d1-b220-af223ce9194d"
+        "X-RequestId": "f36c1231-fbca-4b31-849d-d3b95c9e7c63"
       },
       "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:03.8159114Z",
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:36.9034641Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -452,41 +452,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f93e13c71fd4a6b74a26300be05e86b3",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "26c780a2782fffb2768b6417335c69a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "83289946-5eaa-49ec-af64-c0fd477d32d4",
+        "apim-request-id": "5212d4c8-433e-4f96-b00f-6e9d844c574f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:10 GMT",
-        "ETag": "\u002273AD533118D25717427A079F753C03631BD09C9364296CF553EE59548DAD6E96\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:43 GMT",
+        "ETag": "\u0022203C9B9D127A3F9BCECD75F1916120DE6526A8DCBF87774FF29DFE55B5B9F5E5\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "83289946-5eaa-49ec-af64-c0fd477d32d4"
+        "X-RequestId": "5212d4c8-433e-4f96-b00f-6e9d844c574f"
       },
       "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:10.120139Z",
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:42.6318326Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -500,26 +500,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "524bfae01af964a6eb4cff374bb36d42",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4dd48662d8c5dd249abaafb92b5dfda7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "69beeda4-0e9d-410a-b742-00dbde24de66",
+        "apim-request-id": "e6573039-88a8-43fa-9034-b09955f50244",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:11 GMT",
-        "ETag": "\u0022868920A0B9F77533A88AD46E7647E0C799AA6C21AF4C6B3899F00010006003D5\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:44 GMT",
+        "ETag": "\u002204A3502C2BC53878968F2965CDFBDC6FDB26AD9EDB1F1749D062607D81F8B90F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -529,12 +529,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "69beeda4-0e9d-410a-b742-00dbde24de66"
+        "X-RequestId": "e6573039-88a8-43fa-9034-b09955f50244"
       },
       "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:10.7494727Z",
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:44.137412Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -548,41 +548,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "246d93bc6d5b64f83792814f3162e908",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "999421e4780c5920a37fa9ffee884b9a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c94554ce-9574-4c7a-9aed-4485fe372fa9",
+        "apim-request-id": "b03f8e5e-d891-4796-9d9c-17966c4ca9f5",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:13 GMT",
-        "ETag": "\u0022868920A0B9F77533A88AD46E7647E0C799AA6C21AF4C6B3899F00010006003D5\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:45 GMT",
+        "ETag": "\u002204A3502C2BC53878968F2965CDFBDC6FDB26AD9EDB1F1749D062607D81F8B90F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c94554ce-9574-4c7a-9aed-4485fe372fa9"
+        "X-RequestId": "b03f8e5e-d891-4796-9d9c-17966c4ca9f5"
       },
       "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:10.7494727Z",
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:44.137412Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -596,26 +596,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9fbea28b43abad716dd90e8720805b97",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e1cbf90bcc92ca2e5be98c75c8f8d318",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4908735-9416-400a-9b20-ea64bb8e18e2",
+        "apim-request-id": "fac1234c-bbaa-4e79-9c32-27eba961e8d3",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:14 GMT",
-        "ETag": "\u0022EC478F58D06B3C6C6CB6C6E352309D1EEB2F05612E66C89CF5F86DF4D1F718C4\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:46 GMT",
+        "ETag": "\u002204A3502C2BC53878968F2965CDFBDC6FDB26AD9EDB1F1749D062607D81F8B90F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -625,12 +625,60 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e4908735-9416-400a-9b20-ea64bb8e18e2"
+        "X-RequestId": "fac1234c-bbaa-4e79-9c32-27eba961e8d3"
       },
       "ResponseBody": {
-        "id": "e4ff34b7-9316-49ae-8a0d-f1f424d0e701",
-        "createdDateTimeUtc": "2021-08-18T18:07:02.6572679Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:10.7494727Z",
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:44.137412Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1133bd8ecfc8e99c667aaa462e25ef12",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ddbd275e-d28e-4efc-9924-7adb362d119d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:33:48 GMT",
+        "ETag": "\u00227E18FF0E2ADD8F787A567145B9B9FD885423A3A530C1A75D6008E5A7256E6207\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ddbd275e-d28e-4efc-9924-7adb362d119d"
+      },
+      "ResponseBody": {
+        "id": "7fe0383c-d81e-4b02-8446-ea17b1f352e0",
+        "createdDateTimeUtc": "2021-08-26T14:33:35.667793Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:48.7102819Z",
         "status": "Succeeded",
         "summary": {
           "total": 2,
@@ -644,85 +692,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4c4eeeb961f1725702e61b6698563389",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "32ad146e1c921814f3c93e23ecaa90aa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "68459965-ad28-452c-b0f1-01e64b576026",
+        "apim-request-id": "b68df339-8998-4855-8531-eb3df9d53f3e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:14 GMT",
-        "ETag": "\u00222B6BD2D43A6FEB55630743446753B5EA0806DDDE7EE2BC6900C53FFA48F91CC5\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "68459965-ad28-452c-b0f1-01e64b576026"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1402114609/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1526944569/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:10.1354597Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:13.4730033Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000ae8eb-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          },
-          {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1402114609/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1526944569/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:10.1294254Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:13.4246116Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000ae8ea-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701/documents",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a8abf663cef4799622bfb6815f7044b7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ae7e10cf-af77-4c48-af70-5e23f321d002",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:14 GMT",
-        "ETag": "\u00222B6BD2D43A6FEB55630743446753B5EA0806DDDE7EE2BC6900C53FFA48F91CC5\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:48 GMT",
+        "ETag": "\u00224FD1A801C4A0CB00AFFA124D06C8F32ABC9A05F4F75C2D4D8F4053F16C238825\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -732,78 +721,137 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ae7e10cf-af77-4c48-af70-5e23f321d002"
+        "X-RequestId": "b68df339-8998-4855-8531-eb3df9d53f3e"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1402114609/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1526944569/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:10.1354597Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:13.4730033Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1385302454/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1805082759/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:42.6540825Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:33:48.7102761Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8eb-0000-0000-0000-000000000000",
+            "id": "000b5477-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1402114609/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1526944569/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:10.1294254Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:13.4246116Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1385302454/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1805082759/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:42.6417226Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:33:48.6497917Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8ea-0000-0000-0000-000000000000",
+            "id": "000b5476-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e4ff34b7-9316-49ae-8a0d-f1f424d0e701/documents?ids=000ae8eb-0000-0000-0000-000000000000\u0026statuses=\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4396ea379d1329164a4c9dc4280b1417",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "317090ac3a543cd25ce27b1722e89b36",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1c6bd118-339e-49b7-9307-50c31afbd929",
+        "apim-request-id": "3c37dd18-d0e6-4a13-9b90-035df4cc92ae",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:15 GMT",
-        "ETag": "\u0022BB25C33374F2EA132E59B0A32D0A1F7B170E15396ADDDD23059F55E78D01266C\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:48 GMT",
+        "ETag": "\u00224FD1A801C4A0CB00AFFA124D06C8F32ABC9A05F4F75C2D4D8F4053F16C238825\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1c6bd118-339e-49b7-9307-50c31afbd929"
+        "X-RequestId": "3c37dd18-d0e6-4a13-9b90-035df4cc92ae"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1402114609/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1526944569/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:10.1354597Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:13.4730033Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1385302454/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1805082759/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:42.6540825Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:33:48.7102761Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8eb-0000-0000-0000-000000000000",
+            "id": "000b5477-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1385302454/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1805082759/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:42.6417226Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:33:48.6497917Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b5476-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7fe0383c-d81e-4b02-8446-ea17b1f352e0/documents?ids=000b5477-0000-0000-0000-000000000000",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b30779faa14a7286a81b1efe9179fcbb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "19103116-b912-4233-a4fa-9f6defce9476",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:33:48 GMT",
+        "ETag": "\u0022196389A1BB2C2F5532402EDAFAD8F9B959988688EBFF917C75DC6B1AA1302D1F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "19103116-b912-4233-a4fa-9f6defce9476"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1385302454/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1805082759/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:42.6540825Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:33:48.7102761Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b5477-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
@@ -814,6 +862,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "1883670085"
+    "RandomSeed": "655457310"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByIdsTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByIdsTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1678466464?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1407288336?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-ee7fbe506719ac4fb3b6585f564ecc43-068cfa03911e3f44-00",
+        "traceparent": "00-6e0e359efb6ead48b03af37e38c7f27f-5648256b2831fb40-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "b7afa3dcb1ace7fdfcfadb53272810f9",
-        "x-ms-date": "Wed, 18 Aug 2021 18:07:20 GMT",
+        "x-ms-client-request-id": "64cc3b70cc74ac53d83139fee81eb7b4",
+        "x-ms-date": "Thu, 26 Aug 2021 14:33:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:07:18 GMT",
-        "ETag": "\u00220x8D962730482E4CC\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:07:18 GMT",
+        "Date": "Thu, 26 Aug 2021 14:33:49 GMT",
+        "ETag": "\u00220x8D9689E855D7936\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:33:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b7afa3dcb1ace7fdfcfadb53272810f9",
-        "x-ms-request-id": "0b1abfac-601e-0056-295b-94cd70000000",
+        "x-ms-client-request-id": "64cc3b70cc74ac53d83139fee81eb7b4",
+        "x-ms-request-id": "b9a6a006-901e-006d-1287-9a88d4000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1678466464/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1407288336/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c5530b845b13ae4a95be6390e10c8992-3cedb5c522f11143-00",
+        "traceparent": "00-5ee9ae7a010b574b8541dd18dd3d24a1-0b8c300de2908844-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "2db609606510edce86558733efd59613",
-        "x-ms-date": "Wed, 18 Aug 2021 18:07:20 GMT",
+        "x-ms-client-request-id": "aa1228dddec1027c65e0a86719d61416",
+        "x-ms-date": "Thu, 26 Aug 2021 14:33:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,30 +47,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:07:18 GMT",
-        "ETag": "\u00220x8D9627304B076A3\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:07:18 GMT",
+        "Date": "Thu, 26 Aug 2021 14:33:49 GMT",
+        "ETag": "\u00220x8D9689E85909E1E\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:33:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "2db609606510edce86558733efd59613",
+        "x-ms-client-request-id": "aa1228dddec1027c65e0a86719d61416",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0b1ac015-601e-0056-0a5b-94cd70000000",
+        "x-ms-request-id": "b9a6a0be-901e-006d-3587-9a88d4000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1678466464/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1407288336/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-abcb5b136e913a4ab08969b7c0ba0515-108caaa085c7b04a-00",
+        "traceparent": "00-be1119312274f84e89c8c92e87ca6477-21b8d08a49281a4d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "c277e517f4c01d0c033f6d0c00d34bfd",
-        "x-ms-date": "Wed, 18 Aug 2021 18:07:21 GMT",
+        "x-ms-client-request-id": "ae506105bd4888ec625d913d523cb4d2",
+        "x-ms-date": "Thu, 26 Aug 2021 14:33:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -79,28 +79,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:07:19 GMT",
-        "ETag": "\u00220x8D9627304DB5EEC\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:07:19 GMT",
+        "Date": "Thu, 26 Aug 2021 14:33:50 GMT",
+        "ETag": "\u00220x8D9689E85BCE67F\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:33:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "c277e517f4c01d0c033f6d0c00d34bfd",
+        "x-ms-client-request-id": "ae506105bd4888ec625d913d523cb4d2",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0b1ac0c6-601e-0056-2e5b-94cd70000000",
+        "x-ms-request-id": "b9a6a1e1-901e-006d-4c87-9a88d4000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1590394382?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target280220715?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-cc189734b7c8624c870272f871113706-0e60065b14d7ad46-00",
+        "traceparent": "00-d9e5d10b7f96504e87f8aa1e48b947a0-4bea8b6b0fd5c548-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "7354231d9050d476c131562ac9f72764",
-        "x-ms-date": "Wed, 18 Aug 2021 18:07:21 GMT",
+        "x-ms-client-request-id": "2c17a0644fedbe92c9fe9324ec92011d",
+        "x-ms-date": "Thu, 26 Aug 2021 14:33:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -108,12 +108,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:07:19 GMT",
-        "ETag": "\u00220x8D9627304F17230\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:07:19 GMT",
+        "Date": "Thu, 26 Aug 2021 14:33:50 GMT",
+        "ETag": "\u00220x8D9689E85D3A91D\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:33:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "7354231d9050d476c131562ac9f72764",
-        "x-ms-request-id": "0b1ac1a8-601e-0056-7b5b-94cd70000000",
+        "x-ms-client-request-id": "2c17a0644fedbe92c9fe9324ec92011d",
+        "x-ms-request-id": "b9a6a2c8-901e-006d-2987-9a88d4000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -126,9 +126,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6ae6c83bd621d3429445cb77ebf6fde3-626a9762d9899e40-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b0423bc8384dfc6c992ad0f8c1ecb209",
+        "traceparent": "00-e2007adf152b7f44a4ef6d32f047cdc5-00ee1d9470f29840-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "cd87f9236b093b1f8a47644d3eaf292b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -148,57 +148,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "7568baf3-aec4-4968-88d4-a85c4b6805a0",
+        "apim-request-id": "cecbf3a9-fa3b-4465-9c76-063f2fbde3c2",
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:07:19 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
+        "Date": "Thu, 26 Aug 2021 14:33:50 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7568baf3-aec4-4968-88d4-a85c4b6805a0"
+        "X-RequestId": "cecbf3a9-fa3b-4465-9c76-063f2fbde3c2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b2d22589a04255c701edfec2b6f23948",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "36b43cd5eafc1117beef7ebe586375ca",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e671e4b8-cbd4-48de-aaa8-8abb5b8e2608",
+        "apim-request-id": "734fbd98-808d-46e5-a3f1-dc361af20490",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:19 GMT",
-        "ETag": "\u00227FFBE2E1C11944E3606330E8CBFA4018E1E6E6E3A20C320E04F01C6C6B2E8031\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:50 GMT",
+        "ETag": "\u002209D0BF731FC3054BD224E3063CC5CF3D2027ACDB918C3E71AD77CCBC9CFCC177\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e671e4b8-cbd4-48de-aaa8-8abb5b8e2608"
+        "X-RequestId": "734fbd98-808d-46e5-a3f1-dc361af20490"
       },
       "ResponseBody": {
-        "id": "2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-        "createdDateTimeUtc": "2021-08-18T18:07:19.602765Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:19.6027654Z",
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:51.1955621Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -212,26 +212,74 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9738a7464c09e4c1b757da25bf7d13d5",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "432f2090052df92180dca2a5eb447f19",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0214b9aa-c6b4-4d01-bb18-380403934c9b",
+        "apim-request-id": "b7dbee22-98e6-4ffd-8d43-587237334a53",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:20 GMT",
-        "ETag": "\u00223F3EF953947AB0302E6F3B0D827D95D9BBF2B6DCB7ED7CFE3FB16AF9A1EDD58A\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:52 GMT",
+        "ETag": "\u002236A499D6C7C1852B602313F50D89E37BD611B03CBC8D3A6D01ECB2FA4802E976\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "b7dbee22-98e6-4ffd-8d43-587237334a53"
+      },
+      "ResponseBody": {
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:51.9464953Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 2,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b04f68d5cadd3921e1750e19ed60e226",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "da19e501-8c34-4833-98b1-02e2166b2f86",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:33:53 GMT",
+        "ETag": "\u002236A499D6C7C1852B602313F50D89E37BD611B03CBC8D3A6D01ECB2FA4802E976\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -241,60 +289,60 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0214b9aa-c6b4-4d01-bb18-380403934c9b"
+        "X-RequestId": "da19e501-8c34-4833-98b1-02e2166b2f86"
       },
       "ResponseBody": {
-        "id": "2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-        "createdDateTimeUtc": "2021-08-18T18:07:19.602765Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:21.0493551Z",
-        "status": "Running",
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:51.9464953Z",
+        "status": "NotStarted",
         "summary": {
           "total": 2,
           "failed": 0,
           "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 2,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a4a04c7e7424272274ecae5f3aa946a6",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1ebd99d2e680cffd1abbb61f48722679",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "768777d7-4c44-4bab-80ec-f46dd01fe398",
+        "apim-request-id": "9d829ae4-7141-41fa-912c-c6a5da674a2c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:22 GMT",
-        "ETag": "\u002267BDE66A427BC3E883ABF0AB40398CD76EC6A085F7601852451D375F26997243\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:54 GMT",
+        "ETag": "\u0022F221C82B50619F2E623C7783C0BB0291E8BDBA820732E4F64ABB95344802E7A8\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "768777d7-4c44-4bab-80ec-f46dd01fe398"
+        "X-RequestId": "9d829ae4-7141-41fa-912c-c6a5da674a2c"
       },
       "ResponseBody": {
-        "id": "2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-        "createdDateTimeUtc": "2021-08-18T18:07:19.602765Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:21.5950584Z",
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:54.9346146Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -308,122 +356,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "19b188f11bb43d0063edfaeac6a19583",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f0e9646fc413c5edfff561b8f6080b1f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "969d621d-42f9-4deb-b98f-1d2724cc9b93",
+        "apim-request-id": "d950d9d0-7b07-4f1b-9108-85380926c652",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:23 GMT",
-        "ETag": "\u002267BDE66A427BC3E883ABF0AB40398CD76EC6A085F7601852451D375F26997243\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "969d621d-42f9-4deb-b98f-1d2724cc9b93"
-      },
-      "ResponseBody": {
-        "id": "2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-        "createdDateTimeUtc": "2021-08-18T18:07:19.602765Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:21.5950584Z",
-        "status": "Running",
-        "summary": {
-          "total": 2,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "694429da9551d1238510231c9e61aa0d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "df2bd816-a0cd-4ede-af94-90d417f4dbe4",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:25 GMT",
-        "ETag": "\u002267BDE66A427BC3E883ABF0AB40398CD76EC6A085F7601852451D375F26997243\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "df2bd816-a0cd-4ede-af94-90d417f4dbe4"
-      },
-      "ResponseBody": {
-        "id": "2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-        "createdDateTimeUtc": "2021-08-18T18:07:19.602765Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:21.5950584Z",
-        "status": "Running",
-        "summary": {
-          "total": 2,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "36343310f9cb63204c634037793861d2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "813cbe2a-ca2f-4e76-92c8-bbec12e40919",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:26 GMT",
-        "ETag": "\u002267BDE66A427BC3E883ABF0AB40398CD76EC6A085F7601852451D375F26997243\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:55 GMT",
+        "ETag": "\u0022994B6443F1E9F6107772F17F2D5E27FAA7BFB7F738FA9281A78FFD6391C43EEB\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -433,12 +385,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "813cbe2a-ca2f-4e76-92c8-bbec12e40919"
+        "X-RequestId": "d950d9d0-7b07-4f1b-9108-85380926c652"
       },
       "ResponseBody": {
-        "id": "2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-        "createdDateTimeUtc": "2021-08-18T18:07:19.602765Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:21.5950584Z",
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:55.6013416Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -452,41 +404,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "10852a57dc655b5565e094a3f8e39e02",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "52d27bf96187ee996a8096211401f16e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "59430341-3b17-4420-94f1-163be19257ff",
+        "apim-request-id": "88223d36-b4fe-47eb-b4d3-d9d9a3054c6a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:27 GMT",
-        "ETag": "\u002267BDE66A427BC3E883ABF0AB40398CD76EC6A085F7601852451D375F26997243\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:57 GMT",
+        "ETag": "\u0022994B6443F1E9F6107772F17F2D5E27FAA7BFB7F738FA9281A78FFD6391C43EEB\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "59430341-3b17-4420-94f1-163be19257ff"
+        "X-RequestId": "88223d36-b4fe-47eb-b4d3-d9d9a3054c6a"
       },
       "ResponseBody": {
-        "id": "2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-        "createdDateTimeUtc": "2021-08-18T18:07:19.602765Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:21.5950584Z",
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:55.6013416Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -500,26 +452,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "92d9ed435f6de1b708e01ded55ec574d",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "88a9954ef2760d12abf71e8a8445d811",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7f3de068-7ae5-41bb-964d-ad56baa6c79f",
+        "apim-request-id": "ca11cddd-24e4-424d-8718-95ab6040bc8b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:28 GMT",
-        "ETag": "\u00221F316F940FD7ACD5631C7EF850933CC601B84F9A258D2143F947D130ABD91F6D\u0022",
+        "Date": "Thu, 26 Aug 2021 14:33:58 GMT",
+        "ETag": "\u0022994B6443F1E9F6107772F17F2D5E27FAA7BFB7F738FA9281A78FFD6391C43EEB\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -529,12 +481,300 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7f3de068-7ae5-41bb-964d-ad56baa6c79f"
+        "X-RequestId": "ca11cddd-24e4-424d-8718-95ab6040bc8b"
       },
       "ResponseBody": {
-        "id": "2ad3f19d-5f1a-4e22-9b30-6b62ba413a59",
-        "createdDateTimeUtc": "2021-08-18T18:07:19.602765Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:07:21.5950584Z",
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:55.6013416Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "cc2696afd49f0ef1cbfb85932dcbb1fe",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "992fbe52-54c7-4225-aa75-5f8b7af2f2e9",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:33:59 GMT",
+        "ETag": "\u0022994B6443F1E9F6107772F17F2D5E27FAA7BFB7F738FA9281A78FFD6391C43EEB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "992fbe52-54c7-4225-aa75-5f8b7af2f2e9"
+      },
+      "ResponseBody": {
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:55.6013416Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "616af204835f07a968c4a690420e6925",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bdf7e03a-c25c-405e-b096-0dc36f11a066",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:34:00 GMT",
+        "ETag": "\u0022994B6443F1E9F6107772F17F2D5E27FAA7BFB7F738FA9281A78FFD6391C43EEB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "bdf7e03a-c25c-405e-b096-0dc36f11a066"
+      },
+      "ResponseBody": {
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:55.6013416Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7d7185a724da7acfa39bbc7b6d7edfe0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bbbc36b5-88a6-428f-ad25-57602fb1a847",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:34:02 GMT",
+        "ETag": "\u0022994B6443F1E9F6107772F17F2D5E27FAA7BFB7F738FA9281A78FFD6391C43EEB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "bbbc36b5-88a6-428f-ad25-57602fb1a847"
+      },
+      "ResponseBody": {
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:55.6013416Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9285204677da2cb2ed1f63da2d61cbbd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7d87f1de-7fe6-468c-9302-f8d31a70cbad",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:34:04 GMT",
+        "ETag": "\u0022994B6443F1E9F6107772F17F2D5E27FAA7BFB7F738FA9281A78FFD6391C43EEB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7d87f1de-7fe6-468c-9302-f8d31a70cbad"
+      },
+      "ResponseBody": {
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:55.6013416Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a8ec5f913359df2323f0bec3c62d99e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "02d6c27e-0326-4db7-94af-d17d8d2f3cc5",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:34:05 GMT",
+        "ETag": "\u0022994B6443F1E9F6107772F17F2D5E27FAA7BFB7F738FA9281A78FFD6391C43EEB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "02d6c27e-0326-4db7-94af-d17d8d2f3cc5"
+      },
+      "ResponseBody": {
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:33:55.6013416Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "224ac6e5d788304ad24590bbc1f44c41",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "50fd805b-9e9d-4adb-a07c-3c27be2009e0",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:34:06 GMT",
+        "ETag": "\u0022255B90D418CB0F4649A655DAC19D52DFA30DEC44E31345FE708F250FD4F33DB7\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "50fd805b-9e9d-4adb-a07c-3c27be2009e0"
+      },
+      "ResponseBody": {
+        "id": "bcaef985-cefc-42a2-97b2-da71a31e4514",
+        "createdDateTimeUtc": "2021-08-26T14:33:51.1955617Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:05.8994639Z",
         "status": "Succeeded",
         "summary": {
           "total": 2,
@@ -548,85 +788,85 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "73c551ae99dc34a7ded8d1eb647d6b68",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0eeaffcf37921286fda66eeab8ee65c0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ed3b4bc0-544f-4435-9389-54ffe953f627",
+        "apim-request-id": "fe07a402-cd72-4cb1-9302-646c4a956296",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:29 GMT",
-        "ETag": "\u0022E397133F8568CF8A85BC07A1CB1251ED9CF3E8AC192582A90AF303B5280FD2B3\u0022",
+        "Date": "Thu, 26 Aug 2021 14:34:06 GMT",
+        "ETag": "\u002234943EA85AD8534BCB41891CA52154D7F67934E94BB9AE2C370473D36E9BEBFA\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ed3b4bc0-544f-4435-9389-54ffe953f627"
+        "X-RequestId": "fe07a402-cd72-4cb1-9302-646c4a956296"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1590394382/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1678466464/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:21.061511Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:28.3891604Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target280220715/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1407288336/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:54.9730095Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:34:05.8994449Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8ed-0000-0000-0000-000000000000",
+            "id": "000b5479-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1590394382/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1678466464/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:21.0575428Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:28.4008336Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target280220715/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1407288336/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:54.94716Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:34:05.903831Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8ec-0000-0000-0000-000000000000",
+            "id": "000b5478-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8cf33dc4cf5ef76472a30884be670678",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "67f57985a916b93414bcd613a3671e2e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d28dfc4b-f894-4a5a-8fc7-6ed44e57d33a",
+        "apim-request-id": "f8ec78a8-9b2a-42a4-8061-51523c31618a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:29 GMT",
-        "ETag": "\u0022E397133F8568CF8A85BC07A1CB1251ED9CF3E8AC192582A90AF303B5280FD2B3\u0022",
+        "Date": "Thu, 26 Aug 2021 14:34:07 GMT",
+        "ETag": "\u002234943EA85AD8534BCB41891CA52154D7F67934E94BB9AE2C370473D36E9BEBFA\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -636,78 +876,78 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d28dfc4b-f894-4a5a-8fc7-6ed44e57d33a"
+        "X-RequestId": "f8ec78a8-9b2a-42a4-8061-51523c31618a"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1590394382/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1678466464/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:21.061511Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:28.3891604Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target280220715/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1407288336/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:54.9730095Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:34:05.8994449Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8ed-0000-0000-0000-000000000000",
+            "id": "000b5479-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1590394382/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1678466464/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:21.0575428Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:28.4008336Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target280220715/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1407288336/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:54.94716Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:34:05.903831Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8ec-0000-0000-0000-000000000000",
+            "id": "000b5478-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/2ad3f19d-5f1a-4e22-9b30-6b62ba413a59/documents?ids=000ae8ed-0000-0000-0000-000000000000\u0026statuses=\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/bcaef985-cefc-42a2-97b2-da71a31e4514/documents?ids=000b5479-0000-0000-0000-000000000000",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a7f447882b1da92545a5b4958dcc7c8b",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c7f47ca38b42ae573f3724e2686077e4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5a642618-4ccc-4bee-b000-96f7395cf959",
+        "apim-request-id": "fe3ab2fc-ea96-4165-837f-b872f0fedc75",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:07:29 GMT",
-        "ETag": "\u00227AA1E9AAA02BF1DF82D7745BBF84DD5B1BC1A8E5FDED1BFCB63CD5FC8725E257\u0022",
+        "Date": "Thu, 26 Aug 2021 14:34:07 GMT",
+        "ETag": "\u0022270E4CCB8077165FAD5A6F2CDC72BA7A569814D0A2F14C13B4339FCACADD46C2\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "5a642618-4ccc-4bee-b000-96f7395cf959"
+        "X-RequestId": "fe3ab2fc-ea96-4165-837f-b872f0fedc75"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1590394382/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1678466464/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:07:21.061511Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:07:28.3891604Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target280220715/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1407288336/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:33:54.9730095Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:34:05.8994449Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8ed-0000-0000-0000-000000000000",
+            "id": "000b5479-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
@@ -718,6 +958,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "779659536"
+    "RandomSeed": "1098575954"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByStatusTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByStatusTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1438750987?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source761402163?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e85f346f8e48c044928438ba57e5725b-c9a3d2bca5734748-00",
+        "traceparent": "00-307a2688165a9948985bac2f3db04df9-4ee9c845a0234c4f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "ebcd7ba69176420f88e6f5d2d034e456",
-        "x-ms-date": "Wed, 18 Aug 2021 18:06:11 GMT",
+        "x-ms-client-request-id": "b641621649a989743b12a21d6bcc2e22",
+        "x-ms-date": "Thu, 26 Aug 2021 14:30:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:06:09 GMT",
-        "ETag": "\u00220x8D96272DBD4DC0D\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:06:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:30:18 GMT",
+        "ETag": "\u00220x8D9689E0753A228\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:30:18 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ebcd7ba69176420f88e6f5d2d034e456",
-        "x-ms-request-id": "db8d2552-a01e-0082-805b-947d21000000",
+        "x-ms-client-request-id": "b641621649a989743b12a21d6bcc2e22",
+        "x-ms-request-id": "61ce62c1-e01e-0015-1986-9a2b2c000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1438750987/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source761402163/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c20b9a46af20b04d8748dfb94c27e24d-765a338f8d73d347-00",
+        "traceparent": "00-66f28bf58e5b71498c3290bf036b64e4-a0cd6b3338e9be43-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "90a143851ac3eed7545b3c6431b5fc97",
-        "x-ms-date": "Wed, 18 Aug 2021 18:06:12 GMT",
+        "x-ms-client-request-id": "6ecd2297beca4e5c022bb2237a7c99e0",
+        "x-ms-date": "Thu, 26 Aug 2021 14:30:18 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,30 +47,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:06:10 GMT",
-        "ETag": "\u00220x8D96272DC0B5625\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:06:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:30:18 GMT",
+        "ETag": "\u00220x8D9689E0794635D\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:30:19 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "90a143851ac3eed7545b3c6431b5fc97",
+        "x-ms-client-request-id": "6ecd2297beca4e5c022bb2237a7c99e0",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "db8d25c3-a01e-0082-675b-947d21000000",
+        "x-ms-request-id": "61ce636b-e01e-0015-3786-9a2b2c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1438750987/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source761402163/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-e4a33c46662d0e4a90e2d0ebde063092-6225affdfa911047-00",
+        "traceparent": "00-fa9769710a8e494da748878b9deafd2a-e23787759d994846-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d7d028cfd2e705a9383dfbc6c2a54ac7",
-        "x-ms-date": "Wed, 18 Aug 2021 18:06:12 GMT",
+        "x-ms-client-request-id": "7c1eb63cbe258848e97100297bd73389",
+        "x-ms-date": "Thu, 26 Aug 2021 14:30:19 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -79,28 +79,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:06:10 GMT",
-        "ETag": "\u00220x8D96272DC39734C\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:06:11 GMT",
+        "Date": "Thu, 26 Aug 2021 14:30:19 GMT",
+        "ETag": "\u00220x8D9689E07BFE82D\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:30:19 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d7d028cfd2e705a9383dfbc6c2a54ac7",
+        "x-ms-client-request-id": "7c1eb63cbe258848e97100297bd73389",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "db8d2677-a01e-0082-0d5b-947d21000000",
+        "x-ms-request-id": "61ce6406-e01e-0015-4686-9a2b2c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target587511852?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target2111158774?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-78ce49f40919bf4fa248a49848bec075-27afca0c9e4b544f-00",
+        "traceparent": "00-57f763fc38f1b040878287d98bd2f40c-d5c13364e5caa04b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "66ba1e9548b0a48cde961a55aa11d3e9",
-        "x-ms-date": "Wed, 18 Aug 2021 18:06:13 GMT",
+        "x-ms-client-request-id": "7293dbd668440658f3b37e97510fbe79",
+        "x-ms-date": "Thu, 26 Aug 2021 14:30:19 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -108,12 +108,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:06:10 GMT",
-        "ETag": "\u00220x8D96272DC4F799E\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:06:11 GMT",
+        "Date": "Thu, 26 Aug 2021 14:30:19 GMT",
+        "ETag": "\u00220x8D9689E07DA4FC9\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:30:19 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "66ba1e9548b0a48cde961a55aa11d3e9",
-        "x-ms-request-id": "db8d271f-a01e-0082-285b-947d21000000",
+        "x-ms-client-request-id": "7293dbd668440658f3b37e97510fbe79",
+        "x-ms-request-id": "61ce648b-e01e-0015-4386-9a2b2c000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -126,9 +126,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cdae684843e4664bb785d17686c0f692-fb6f0e457c34d147-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "64a7035d6e0d99b29b57851f102cae11",
+        "traceparent": "00-6743d85241b19a4080e4cc30d8ffe71b-9da071c5a66f5248-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "aeb5e1c1fcb2d9d9458459be33d32bf7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -148,57 +148,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "92633c15-ad5a-4509-ac0d-f6bcac1d4d29",
+        "apim-request-id": "646a995d-891f-47ba-80c5-55201fab30dc",
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:06:12 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "92633c15-ad5a-4509-ac0d-f6bcac1d4d29"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "979b38743142e01e4433093b8eb08d2c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d6598608-8e2a-4956-bafa-4cca2fb8d930",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:12 GMT",
-        "ETag": "\u0022B62310D51A04D01F22E0EB9BA7186597DF12D17D7C9294A370677AAC110F59E7\u0022",
-        "Retry-After": "1",
+        "Date": "Thu, 26 Aug 2021 14:30:21 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "646a995d-891f-47ba-80c5-55201fab30dc"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a1a32c286d054df7c575320acaf19761",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d7bc2cf3-4f9c-49cb-a6c7-24dee7944dd1",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:21 GMT",
+        "ETag": "\u00221136630CA30A6A3A2FF95A772CC348FACB3870D73A3F5A5FFC1B78BE8192BAA9\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d6598608-8e2a-4956-bafa-4cca2fb8d930"
+        "X-RequestId": "d7bc2cf3-4f9c-49cb-a6c7-24dee7944dd1"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:12.6183162Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:21.2012805Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -212,41 +212,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a264dd2763a2271e6b21ca58c36c93b2",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f6b9af41db7eda4402ba2dbf0e99d320",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1d3e75cf-e5b5-4cdc-9dc9-1ad46dd39a16",
+        "apim-request-id": "9323e716-6326-4ead-afcd-9cf1c2b1ce95",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:14 GMT",
-        "ETag": "\u0022FAFEBE9867160AB673746F651C7BE4B771ED49D79837BA34384684266D6D7B58\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:22 GMT",
+        "ETag": "\u002201C8D9B26A19E20AA7B29200E508FEBA864FD3D65041CAD0AA8D10B1E91CE8C3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1d3e75cf-e5b5-4cdc-9dc9-1ad46dd39a16"
+        "X-RequestId": "9323e716-6326-4ead-afcd-9cf1c2b1ce95"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:13.9147129Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:22.2143511Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -260,41 +260,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "72e109e83c752ca7e4c71fda64760beb",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "256e87881c6c5373e967e83cc9ce0f53",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d418ffde-ff19-4373-8d16-41e1b2effda2",
+        "apim-request-id": "44d84446-c4dd-42f5-a9a7-f00089b0675b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:15 GMT",
-        "ETag": "\u0022FAFEBE9867160AB673746F651C7BE4B771ED49D79837BA34384684266D6D7B58\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:24 GMT",
+        "ETag": "\u002201C8D9B26A19E20AA7B29200E508FEBA864FD3D65041CAD0AA8D10B1E91CE8C3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d418ffde-ff19-4373-8d16-41e1b2effda2"
+        "X-RequestId": "44d84446-c4dd-42f5-a9a7-f00089b0675b"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:13.9147129Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:22.2143511Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -308,41 +308,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "33f759ca0cc7106e19742b2166c61dd8",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "837cf8ed34194d78e7c89f4b40373e2b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a196930b-838d-4608-9372-b238249c732e",
+        "apim-request-id": "403adde4-1bed-4978-9a4f-3d9e21299c61",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:16 GMT",
-        "ETag": "\u0022FAFEBE9867160AB673746F651C7BE4B771ED49D79837BA34384684266D6D7B58\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:25 GMT",
+        "ETag": "\u002201C8D9B26A19E20AA7B29200E508FEBA864FD3D65041CAD0AA8D10B1E91CE8C3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a196930b-838d-4608-9372-b238249c732e"
+        "X-RequestId": "403adde4-1bed-4978-9a4f-3d9e21299c61"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:13.9147129Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:22.2143511Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -356,41 +356,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8453579f1bcfebb63538bdda4344c2f4",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "428212a2728325f53b660c16f3071033",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "84d5f382-0c7d-4476-b9ab-fa9e9a295649",
+        "apim-request-id": "167ff8bc-ebdc-44a8-a5c3-1ad69d0485fc",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:17 GMT",
-        "ETag": "\u0022FAFEBE9867160AB673746F651C7BE4B771ED49D79837BA34384684266D6D7B58\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:26 GMT",
+        "ETag": "\u002201C8D9B26A19E20AA7B29200E508FEBA864FD3D65041CAD0AA8D10B1E91CE8C3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "84d5f382-0c7d-4476-b9ab-fa9e9a295649"
+        "X-RequestId": "167ff8bc-ebdc-44a8-a5c3-1ad69d0485fc"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:13.9147129Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:22.2143511Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -404,41 +404,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "698edf166074dceb9bd058011086c51e",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "16d2d9aa501d53070e213da37d2813b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8a81e57e-9ef2-4126-bd75-800ee8c9478f",
+        "apim-request-id": "eb70fff1-78e8-4820-9bf9-30cab1aee234",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:19 GMT",
-        "ETag": "\u0022FAFEBE9867160AB673746F651C7BE4B771ED49D79837BA34384684266D6D7B58\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:28 GMT",
+        "ETag": "\u002201C8D9B26A19E20AA7B29200E508FEBA864FD3D65041CAD0AA8D10B1E91CE8C3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8a81e57e-9ef2-4126-bd75-800ee8c9478f"
+        "X-RequestId": "eb70fff1-78e8-4820-9bf9-30cab1aee234"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:13.9147129Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:22.2143511Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -452,26 +452,74 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0d3a47aa8623ae1ba20cfd8e4e93cdd4",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b79abc28cc4c7ad0035747b2276259df",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e783da4f-0c40-40fa-a9f0-d5ce384ca99e",
+        "apim-request-id": "61edbd75-1f65-42e3-bf1a-160faa08815e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:20 GMT",
-        "ETag": "\u0022800E7F911330C77A33E9451CE9ABADB927606EB8A95D25D0B04D4FBE5A5CD3B4\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:29 GMT",
+        "ETag": "\u002201C8D9B26A19E20AA7B29200E508FEBA864FD3D65041CAD0AA8D10B1E91CE8C3\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "61edbd75-1f65-42e3-bf1a-160faa08815e"
+      },
+      "ResponseBody": {
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:22.2143511Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 2,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "66a06cb82865510e0b2e34623451a713",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "004713bf-11c0-4146-a8e9-19fd26e6f990",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:30 GMT",
+        "ETag": "\u0022ABF96220FB418FE734C9B1DD72645948C0FFE058A60B17A9B418829C2EBB2701\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -481,12 +529,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e783da4f-0c40-40fa-a9f0-d5ce384ca99e"
+        "X-RequestId": "004713bf-11c0-4146-a8e9-19fd26e6f990"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:19.8116495Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:30.3324628Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -500,41 +548,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "870b37b2b3373e636c77e9fec2b5dbaf",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "37ed5a53596ddee6095712c609542cac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7d37ef17-0ce0-449e-9eef-5012bab11792",
+        "apim-request-id": "2113489f-2427-4d2d-9ccc-91eda252f9c1",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:21 GMT",
-        "ETag": "\u002240D06D4ED900964A0D8A0A82F6A523E70B35AC68275AEE14AA39DCB8A64B7643\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:31 GMT",
+        "ETag": "\u00220EE415C7DB52CBBB970ACA6CAEDA70810A4A51D7FD739B37ADA8F326EC276E15\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7d37ef17-0ce0-449e-9eef-5012bab11792"
+        "X-RequestId": "2113489f-2427-4d2d-9ccc-91eda252f9c1"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:20.6702458Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:31.1964772Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -548,122 +596,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fb309e73b4098fd0c3dfc768635c8d07",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "11eb5dc7ac88004cad49ac1e986e46b1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "776352eb-a987-4016-a1a2-72c8dfe3d312",
+        "apim-request-id": "a7747017-0520-4673-8606-e0df8c274216",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:22 GMT",
-        "ETag": "\u002240D06D4ED900964A0D8A0A82F6A523E70B35AC68275AEE14AA39DCB8A64B7643\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "776352eb-a987-4016-a1a2-72c8dfe3d312"
-      },
-      "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:20.6702458Z",
-        "status": "Running",
-        "summary": {
-          "total": 2,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d94f84033e7bf7e7e3fba1ac9c1deced",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "00a44696-c9a2-4781-bdfc-726b82ed7400",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:23 GMT",
-        "ETag": "\u002240D06D4ED900964A0D8A0A82F6A523E70B35AC68275AEE14AA39DCB8A64B7643\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "00a44696-c9a2-4781-bdfc-726b82ed7400"
-      },
-      "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:20.6702458Z",
-        "status": "Running",
-        "summary": {
-          "total": 2,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b01b4d30d163fdca667bc357ebfbdb0f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4be01ea1-0417-4e8b-a59e-125549940743",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:25 GMT",
-        "ETag": "\u002240D06D4ED900964A0D8A0A82F6A523E70B35AC68275AEE14AA39DCB8A64B7643\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:33 GMT",
+        "ETag": "\u00220EE415C7DB52CBBB970ACA6CAEDA70810A4A51D7FD739B37ADA8F326EC276E15\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -673,12 +625,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4be01ea1-0417-4e8b-a59e-125549940743"
+        "X-RequestId": "a7747017-0520-4673-8606-e0df8c274216"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:20.6702458Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:31.1964772Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -692,41 +644,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3efbe2e902663434b739170d1224f2a6",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "cc5f34af21745f7285c25d0d154748b6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "671d7d74-1fa2-42d8-b03c-e449ca2fc15f",
+        "apim-request-id": "29606f3d-dae6-40b5-8884-0368b24af4e3",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:26 GMT",
-        "ETag": "\u002240D06D4ED900964A0D8A0A82F6A523E70B35AC68275AEE14AA39DCB8A64B7643\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:34 GMT",
+        "ETag": "\u00220EE415C7DB52CBBB970ACA6CAEDA70810A4A51D7FD739B37ADA8F326EC276E15\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "671d7d74-1fa2-42d8-b03c-e449ca2fc15f"
+        "X-RequestId": "29606f3d-dae6-40b5-8884-0368b24af4e3"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:20.6702458Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:31.1964772Z",
         "status": "Running",
         "summary": {
           "total": 2,
@@ -740,26 +692,74 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1537daf3dc4131a3b95172ff7a8f0be8",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d69a87019666a68a0ded8924acc7459a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e99e0f37-85ce-408f-9b21-4ac3b2fc3d09",
+        "apim-request-id": "162cbdd3-b84b-423e-87d5-c6bd34d539b4",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:27 GMT",
-        "ETag": "\u002203B8C731D1438EE398A24FC9C4FA64B522C2D628CD3771A5B0A01C468744D2F5\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:35 GMT",
+        "ETag": "\u00220EE415C7DB52CBBB970ACA6CAEDA70810A4A51D7FD739B37ADA8F326EC276E15\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "162cbdd3-b84b-423e-87d5-c6bd34d539b4"
+      },
+      "ResponseBody": {
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:31.1964772Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d51761115ff4a637eb8c8bc54e3fea65",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3027315b-0c8a-423c-8e5f-ac9355b436b2",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:36 GMT",
+        "ETag": "\u00220EE415C7DB52CBBB970ACA6CAEDA70810A4A51D7FD739B37ADA8F326EC276E15\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -769,12 +769,108 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e99e0f37-85ce-408f-9b21-4ac3b2fc3d09"
+        "X-RequestId": "3027315b-0c8a-423c-8e5f-ac9355b436b2"
       },
       "ResponseBody": {
-        "id": "df645b08-2cf1-4f59-aab1-368cccc6d76c",
-        "createdDateTimeUtc": "2021-08-18T18:06:12.6183158Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:20.6702458Z",
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:31.1964772Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "111cf5006fd3184ba9b8be86974eb2be",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "74ceebf6-88d5-4ce8-9a1a-a20444b4b625",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:38 GMT",
+        "ETag": "\u00220EE415C7DB52CBBB970ACA6CAEDA70810A4A51D7FD739B37ADA8F326EC276E15\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "74ceebf6-88d5-4ce8-9a1a-a20444b4b625"
+      },
+      "ResponseBody": {
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:31.1964772Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b4fcc27c7330a2c24ff4ebda0bc558ce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9509aed5-cc1e-4cbd-9fbf-90e7b34dfee9",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:39 GMT",
+        "ETag": "\u00221550A55157A86B82CEA213E315D53E1E38BD1CE9A248371A7790109173A4D311\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9509aed5-cc1e-4cbd-9fbf-90e7b34dfee9"
+      },
+      "ResponseBody": {
+        "id": "ffe69a46-1b2a-414b-a270-7febbaacbc72",
+        "createdDateTimeUtc": "2021-08-26T14:30:21.2012802Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:39.4726094Z",
         "status": "Succeeded",
         "summary": {
           "total": 2,
@@ -788,85 +884,85 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bac29220ae212e8618e6f92ab9bceb42",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b623240234aba2c716fe2b3ba0b10e9c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "edf3b6b4-ba95-46e7-9bf2-761eabae2d46",
+        "apim-request-id": "615843cd-319c-45de-89b7-bab3b0284709",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:27 GMT",
-        "ETag": "\u00226A182D56ABB5F8C88AF4F21F02EC0955BA09406953A0AF5E86DD2F51F8FBFD19\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:39 GMT",
+        "ETag": "\u0022DA700F03CCB9D2DB522E8F32BDDD385D06496AAC8C28BAB5524803C762EEAC18\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "edf3b6b4-ba95-46e7-9bf2-761eabae2d46"
+        "X-RequestId": "615843cd-319c-45de-89b7-bab3b0284709"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target587511852/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1438750987/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:06:19.8192213Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:06:27.4537912Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2111158774/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source761402163/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:30:30.340147Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:30:39.4726051Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e6-0000-0000-0000-000000000000",
+            "id": "000b5473-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target587511852/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1438750987/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:06:19.7963184Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:06:27.4994697Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2111158774/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source761402163/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:30:30.2524115Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:30:39.4632272Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e7-0000-0000-0000-000000000000",
+            "id": "000b5472-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/df645b08-2cf1-4f59-aab1-368cccc6d76c/documents?ids=\u0026statuses=Succeeded\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffe69a46-1b2a-414b-a270-7febbaacbc72/documents?statuses=Succeeded",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "11641c88c6c40ccd3ec984158f35ba27",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8b48cdd936428d34337ac1df83700de3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "38ada8d1-9a8e-437a-93ac-8db5adb22133",
+        "apim-request-id": "09f6ed4e-5901-43cd-ba5f-630ef09e0cfa",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:28 GMT",
-        "ETag": "\u00226A182D56ABB5F8C88AF4F21F02EC0955BA09406953A0AF5E86DD2F51F8FBFD19\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:39 GMT",
+        "ETag": "\u0022DA700F03CCB9D2DB522E8F32BDDD385D06496AAC8C28BAB5524803C762EEAC18\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -876,30 +972,30 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "38ada8d1-9a8e-437a-93ac-8db5adb22133"
+        "X-RequestId": "09f6ed4e-5901-43cd-ba5f-630ef09e0cfa"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target587511852/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1438750987/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:06:19.8192213Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:06:27.4537912Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2111158774/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source761402163/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:30:30.340147Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:30:39.4726051Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e6-0000-0000-0000-000000000000",
+            "id": "000b5473-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target587511852/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1438750987/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:06:19.7963184Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:06:27.4994697Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2111158774/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source761402163/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:30:30.2524115Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:30:39.4632272Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e7-0000-0000-0000-000000000000",
+            "id": "000b5472-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
@@ -910,6 +1006,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "1844511925"
+    "RandomSeed": "1129513166"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByStatusTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByStatusTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1195358713?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source60504317?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-aefde35ec74d0c46acc830ce1d1cd028-bc0603b6fd56c04d-00",
+        "traceparent": "00-9c969d4ab953144fa6906331a4a6dc05-560c2ff3e2f64f45-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "7f0035c370ca37c47459ae7b2426afa3",
-        "x-ms-date": "Wed, 18 Aug 2021 18:06:33 GMT",
+        "x-ms-client-request-id": "9df2a3ea7fbff7266f24e184b281c2c5",
+        "x-ms-date": "Thu, 26 Aug 2021 14:30:40 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:06:31 GMT",
-        "ETag": "\u00220x8D96272E88B23EC\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:06:31 GMT",
+        "Date": "Thu, 26 Aug 2021 14:30:40 GMT",
+        "ETag": "\u00220x8D9689E14649B20\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:30:40 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "7f0035c370ca37c47459ae7b2426afa3",
-        "x-ms-request-id": "db8d507e-a01e-0082-2f5b-947d21000000",
+        "x-ms-client-request-id": "9df2a3ea7fbff7266f24e184b281c2c5",
+        "x-ms-request-id": "61ce879d-e01e-0015-4086-9a2b2c000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1195358713/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source60504317/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-344ee43b860e6e4dba53712b599d3abf-5487ab80dee19e4a-00",
+        "traceparent": "00-02322b592ff7984f8298d22f35ffed38-f2ff2200f8d3f84e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "745fca2643b75cb16d54f7226f792b94",
-        "x-ms-date": "Wed, 18 Aug 2021 18:06:33 GMT",
+        "x-ms-client-request-id": "6a14026fb40edac1f1248fe83df68997",
+        "x-ms-date": "Thu, 26 Aug 2021 14:30:40 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,30 +47,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:06:31 GMT",
-        "ETag": "\u00220x8D96272E8B70BBB\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:06:31 GMT",
+        "Date": "Thu, 26 Aug 2021 14:30:40 GMT",
+        "ETag": "\u00220x8D9689E14916228\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:30:40 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "745fca2643b75cb16d54f7226f792b94",
+        "x-ms-client-request-id": "6a14026fb40edac1f1248fe83df68997",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "db8d50bd-a01e-0082-675b-947d21000000",
+        "x-ms-request-id": "61ce87d2-e01e-0015-6b86-9a2b2c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1195358713/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source60504317/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-1f13e23591e06c448a4976e5adc577f1-3aed21d57198d449-00",
+        "traceparent": "00-04aff1bc416a5b469635fb57b97b2298-bf21582dea41ff4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "76a31f0969fd807fc392cdfb1a581317",
-        "x-ms-date": "Wed, 18 Aug 2021 18:06:34 GMT",
+        "x-ms-client-request-id": "bdc4e346d7a32c8a4bf7ddda75d6dea3",
+        "x-ms-date": "Thu, 26 Aug 2021 14:30:40 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -79,28 +79,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:06:31 GMT",
-        "ETag": "\u00220x8D96272E8E1A5DB\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:06:32 GMT",
+        "Date": "Thu, 26 Aug 2021 14:30:41 GMT",
+        "ETag": "\u00220x8D9689E14BC71CB\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:30:41 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "76a31f0969fd807fc392cdfb1a581317",
+        "x-ms-client-request-id": "bdc4e346d7a32c8a4bf7ddda75d6dea3",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "db8d513b-a01e-0082-5a5b-947d21000000",
+        "x-ms-request-id": "61ce8824-e01e-0015-3986-9a2b2c000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1595019017?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target37326002?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7d630915d9e5d0468943ec46f0de7775-757794b964b5044f-00",
+        "traceparent": "00-916daec02432754c84e90c98c3d60c9d-5a3eb1938b3d894d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "a47f3ae241f88480a3127678a1c8fa2d",
-        "x-ms-date": "Wed, 18 Aug 2021 18:06:34 GMT",
+        "x-ms-client-request-id": "a972d513ee9fe13617ac9bf03db9799a",
+        "x-ms-date": "Thu, 26 Aug 2021 14:30:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -108,12 +108,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:06:31 GMT",
-        "ETag": "\u00220x8D96272E8F7B52C\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:06:32 GMT",
+        "Date": "Thu, 26 Aug 2021 14:30:41 GMT",
+        "ETag": "\u00220x8D9689E14D30168\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:30:41 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "a47f3ae241f88480a3127678a1c8fa2d",
-        "x-ms-request-id": "db8d51a6-a01e-0082-425b-947d21000000",
+        "x-ms-client-request-id": "a972d513ee9fe13617ac9bf03db9799a",
+        "x-ms-request-id": "61ce8885-e01e-0015-0e86-9a2b2c000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -126,9 +126,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d20c703f4ac7c84998552e7be718dc17-a07e796b4d04b34b-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8304721aa5384abcdeb12576b5411540",
+        "traceparent": "00-dd150954e775ef4aa2c4011085c372f5-00a6b9c25dcab840-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bdce3d4a22047898e71e16d7e7641a45",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -148,42 +148,42 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "19f40af0-55be-4533-9b60-39f01882fc0f",
+        "apim-request-id": "88a8dab6-135c-4454-9175-2deb8a21fa50",
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:06:32 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b",
+        "Date": "Thu, 26 Aug 2021 14:30:41 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "19f40af0-55be-4533-9b60-39f01882fc0f"
+        "X-RequestId": "88a8dab6-135c-4454-9175-2deb8a21fa50"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3e8c19dff0acde1023f25a57080821ca",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "202a36ebee17f5a68ddb8b2bee3c0d3d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "00ba09c1-aba0-4896-9916-78dbe44f7c54",
+        "apim-request-id": "bd387743-baef-47a3-9933-21594b8aa7ff",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:32 GMT",
-        "ETag": "\u0022004DFAA734F885B1B648D6EE9B0753B6FA7A7DCEB5C5B63A0258382885C3E9AD\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:41 GMT",
+        "ETag": "\u00227535D552458F71A5D23836CC78C4C7611C503F4C1CDDCBBCC435302ECBF401E3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -193,12 +193,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "00ba09c1-aba0-4896-9916-78dbe44f7c54"
+        "X-RequestId": "bd387743-baef-47a3-9933-21594b8aa7ff"
       },
       "ResponseBody": {
-        "id": "366618b6-462c-4b6b-8174-a6c05764430b",
-        "createdDateTimeUtc": "2021-08-18T18:06:32.6647521Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:32.6647525Z",
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:41.6174043Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -212,41 +212,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e500cdd2940e3dd17e34c5471c09ce61",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "982b3f63e610f1ad3df9c281d85ffab2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e6a8f391-6c41-4360-89bd-e69d763ee59e",
+        "apim-request-id": "918be85f-a107-42c3-9b63-d75fdbb4b940",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:33 GMT",
-        "ETag": "\u00224A1F8BBA3FC9D2C87E2A4D4D4B885E28E6E6666EDAF38A6F491A9BECF3B315A8\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:42 GMT",
+        "ETag": "\u00220B58B75C135D644457C4442C9ED2E15A6973DAD24920412904BF52385419962C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e6a8f391-6c41-4360-89bd-e69d763ee59e"
+        "X-RequestId": "918be85f-a107-42c3-9b63-d75fdbb4b940"
       },
       "ResponseBody": {
-        "id": "366618b6-462c-4b6b-8174-a6c05764430b",
-        "createdDateTimeUtc": "2021-08-18T18:06:32.6647521Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:33.6115428Z",
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:42.5795996Z",
         "status": "NotStarted",
         "summary": {
           "total": 2,
@@ -260,26 +260,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "889835fdbc3b2a8161265f464a6541d6",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "06045691588f5b8396d92f28966d8aab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cace9f80-ae80-4b29-857d-a5564125ccc6",
+        "apim-request-id": "5b39ac15-0434-4502-94e6-0fbb680aed23",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:34 GMT",
-        "ETag": "\u0022089AF0AD41A776B4BB1E605982B4743F8E2BA5B8ED67E0E6407AAA70A20003F7\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:44 GMT",
+        "ETag": "\u00220B58B75C135D644457C4442C9ED2E15A6973DAD24920412904BF52385419962C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -289,93 +289,45 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cace9f80-ae80-4b29-857d-a5564125ccc6"
+        "X-RequestId": "5b39ac15-0434-4502-94e6-0fbb680aed23"
       },
       "ResponseBody": {
-        "id": "366618b6-462c-4b6b-8174-a6c05764430b",
-        "createdDateTimeUtc": "2021-08-18T18:06:32.6647521Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:34.9053369Z",
-        "status": "Running",
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:42.5795996Z",
+        "status": "NotStarted",
         "summary": {
           "total": 2,
           "failed": 0,
           "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 2,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e8a35b8f2f414b32484ec0772ac8c11a",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a773d810823905348938e31d2b251c2e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4309d5bd-1536-4843-96b5-53369e1de486",
+        "apim-request-id": "601e7d40-a878-416d-bafe-0558664e2e87",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:36 GMT",
-        "ETag": "\u00229C42E18D076FFAB72F12A4C3F0E5C0C053BDA416E70F127D44DD797199DDABD0\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4309d5bd-1536-4843-96b5-53369e1de486"
-      },
-      "ResponseBody": {
-        "id": "366618b6-462c-4b6b-8174-a6c05764430b",
-        "createdDateTimeUtc": "2021-08-18T18:06:32.6647521Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:35.9090477Z",
-        "status": "Running",
-        "summary": {
-          "total": 2,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d35af823986f168e4bd684e7358af218",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "39e27761-4c0a-4ac0-b2e2-7c2df5e10892",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:37 GMT",
-        "ETag": "\u00229C42E18D076FFAB72F12A4C3F0E5C0C053BDA416E70F127D44DD797199DDABD0\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:45 GMT",
+        "ETag": "\u00220B58B75C135D644457C4442C9ED2E15A6973DAD24920412904BF52385419962C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -385,93 +337,93 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "39e27761-4c0a-4ac0-b2e2-7c2df5e10892"
+        "X-RequestId": "601e7d40-a878-416d-bafe-0558664e2e87"
       },
       "ResponseBody": {
-        "id": "366618b6-462c-4b6b-8174-a6c05764430b",
-        "createdDateTimeUtc": "2021-08-18T18:06:32.6647521Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:35.9090477Z",
-        "status": "Running",
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:42.5795996Z",
+        "status": "NotStarted",
         "summary": {
           "total": 2,
           "failed": 0,
           "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 2,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c0b8eef2e665ce20034d40ecfb0aff99",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9899d9e106370baebbcf0137b6845bd0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d37aed63-21c4-4cfa-b6bd-3fe3d85a7c22",
+        "apim-request-id": "e8635881-6e07-41b7-9edd-1cc066c18fb1",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:38 GMT",
-        "ETag": "\u00229C42E18D076FFAB72F12A4C3F0E5C0C053BDA416E70F127D44DD797199DDABD0\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:46 GMT",
+        "ETag": "\u00220B58B75C135D644457C4442C9ED2E15A6973DAD24920412904BF52385419962C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d37aed63-21c4-4cfa-b6bd-3fe3d85a7c22"
+        "X-RequestId": "e8635881-6e07-41b7-9edd-1cc066c18fb1"
       },
       "ResponseBody": {
-        "id": "366618b6-462c-4b6b-8174-a6c05764430b",
-        "createdDateTimeUtc": "2021-08-18T18:06:32.6647521Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:35.9090477Z",
-        "status": "Running",
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:42.5795996Z",
+        "status": "NotStarted",
         "summary": {
           "total": 2,
           "failed": 0,
           "success": 0,
-          "inProgress": 2,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 2,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "522245656e0bf667cd8d9c6aab4a16bd",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ff70176f53ec0f7921ff7d5674663071",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fe6906a3-d883-40e0-9062-3c17d1f51011",
+        "apim-request-id": "295a39c7-b792-4a0d-8d62-7ab89c0cd705",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:39 GMT",
-        "ETag": "\u002299AB08CF84E88FB5DC75E684DB20C6DE4DD446B47C7E264D1A49582A91A4FB00\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:47 GMT",
+        "ETag": "\u00228AE8D7E284E774016FB1C9E967250BFBF068B4D78BB8258C83D2DB947AB614DC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -481,12 +433,156 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "fe6906a3-d883-40e0-9062-3c17d1f51011"
+        "X-RequestId": "295a39c7-b792-4a0d-8d62-7ab89c0cd705"
       },
       "ResponseBody": {
-        "id": "366618b6-462c-4b6b-8174-a6c05764430b",
-        "createdDateTimeUtc": "2021-08-18T18:06:32.6647521Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:06:35.9090477Z",
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:47.7162518Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bd4701bcf1d309732a67ec6980fd4e04",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ad0a7a83-12d1-415c-a43a-250b0d5eb1b8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:49 GMT",
+        "ETag": "\u0022D1C8BA1B49329F28A49F6072145B7DF03ABEA2D21AF019A91D6DBF98C34006DC\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ad0a7a83-12d1-415c-a43a-250b0d5eb1b8"
+      },
+      "ResponseBody": {
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:48.3365684Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "14ad13dd1cb58d425f89773889579654",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4ded5d9c-ea51-4200-94c2-db58ed08974b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:50 GMT",
+        "ETag": "\u0022D1C8BA1B49329F28A49F6072145B7DF03ABEA2D21AF019A91D6DBF98C34006DC\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "4ded5d9c-ea51-4200-94c2-db58ed08974b"
+      },
+      "ResponseBody": {
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:48.3365684Z",
+        "status": "Running",
+        "summary": {
+          "total": 2,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b57a909f9d3d7dfca366d584670f8f23",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "642f76a8-0fad-416d-882a-098ab00c39db",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:51 GMT",
+        "ETag": "\u002287511D26A0655665BFA5E935D1396A100BE7DD5F1556AF2CEBEE403D5E6CCC60\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "642f76a8-0fad-416d-882a-098ab00c39db"
+      },
+      "ResponseBody": {
+        "id": "d5e6b9fb-a90d-43f6-996c-9a28332c146e",
+        "createdDateTimeUtc": "2021-08-26T14:30:41.6174038Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:30:51.2757111Z",
         "status": "Succeeded",
         "summary": {
           "total": 2,
@@ -500,85 +596,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3c84a75c00103cb4d88bcf2158a11a41",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "617978b01bb9a0bcbeb95d497a3a80d2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2f96ae0f-1c4d-4674-859f-40f8c63f8d98",
+        "apim-request-id": "5fdd0c9b-712d-4ca9-ba3a-6d3fe0b8189e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:39 GMT",
-        "ETag": "\u0022ADCF2A9A4AD80054339208897AAEFA548D08CD0C48902250B3A7A3AFB2D515DE\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2f96ae0f-1c4d-4674-859f-40f8c63f8d98"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1595019017/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1195358713/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:06:34.9196096Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:06:39.4418485Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000ae8e8-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          },
-          {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1595019017/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1195358713/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:06:34.8775148Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:06:39.3279053Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000ae8e9-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/366618b6-462c-4b6b-8174-a6c05764430b/documents?ids=\u0026statuses=Succeeded\u0026$orderBy=",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ef82ebd7a068830d87c1f3d84ab523b9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "2a8e0e11-743a-44bf-b937-76fc18d6f4f0",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:06:40 GMT",
-        "ETag": "\u0022ADCF2A9A4AD80054339208897AAEFA548D08CD0C48902250B3A7A3AFB2D515DE\u0022",
+        "Date": "Thu, 26 Aug 2021 14:30:51 GMT",
+        "ETag": "\u002284F653AB2B8AEA19CC7E12CD711712D976131A613E9170FEA93E94BAB7DD5ABC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -588,30 +625,89 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2a8e0e11-743a-44bf-b937-76fc18d6f4f0"
+        "X-RequestId": "5fdd0c9b-712d-4ca9-ba3a-6d3fe0b8189e"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1595019017/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1195358713/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:06:34.9196096Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:06:39.4418485Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target37326002/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source60504317/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:30:47.7442085Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:30:51.1609827Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e8-0000-0000-0000-000000000000",
+            "id": "000b5475-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1595019017/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1195358713/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:06:34.8775148Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:06:39.3279053Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target37326002/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source60504317/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:30:47.7014599Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:30:51.2757053Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e9-0000-0000-0000-000000000000",
+            "id": "000b5474-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d5e6b9fb-a90d-43f6-996c-9a28332c146e/documents?statuses=Succeeded",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "efca97d099833fc7162f704e46bd2650",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "42657dc3-0418-4f36-82f4-777d04a189a5",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:30:52 GMT",
+        "ETag": "\u002284F653AB2B8AEA19CC7E12CD711712D976131A613E9170FEA93E94BAB7DD5ABC\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "42657dc3-0418-4f36-82f4-777d04a189a5"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target37326002/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source60504317/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:30:47.7442085Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:30:51.1609827Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b5475-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target37326002/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source60504317/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:30:47.7014599Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:30:51.2757053Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b5474-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
@@ -622,6 +718,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "1052208461"
+    "RandomSeed": "1544772417"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesOrderByCreatedOn.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesOrderByCreatedOn.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1997293480?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1793933458?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b1b2ce22ee619b4abab04d6991c1d450-7102362c9044e649-00",
+        "traceparent": "00-12c1673ead068f4bab473aeb2c7690f7-e881336ce4882743-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "5f3fbaeaff83c919fc983dfa25fe9161",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:11 GMT",
+        "x-ms-client-request-id": "98d44864f14c2ffafe2cb2bbf0031c41",
+        "x-ms-date": "Thu, 26 Aug 2021 14:34:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:02:10 GMT",
-        "ETag": "\u00220x8D962724CAB20C2\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:34:51 GMT",
+        "ETag": "\u00220x8D9689EA9E107AB\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:34:51 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "5f3fbaeaff83c919fc983dfa25fe9161",
-        "x-ms-request-id": "cd83b88e-701e-0081-545b-949c45000000",
+        "x-ms-client-request-id": "98d44864f14c2ffafe2cb2bbf0031c41",
+        "x-ms-request-id": "9e02e4fa-a01e-0082-2d87-9a7d21000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-ff94ae2b218283459aa5f2063e8a52c9-7fd5fb03d55bad40-00",
+        "traceparent": "00-535354c70f35e646b5f7af5c8b134334-521b8d695ab78640-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "eda5f2e575d480b549e12a137300354d",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:12 GMT",
+        "x-ms-client-request-id": "9c89039c2a5f58a99b6db720e7b9a175",
+        "x-ms-date": "Thu, 26 Aug 2021 14:34:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,30 +47,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:02:10 GMT",
-        "ETag": "\u00220x8D962724CE8DA79\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:34:51 GMT",
+        "ETag": "\u00220x8D9689EAA23977B\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:34:51 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "eda5f2e575d480b549e12a137300354d",
+        "x-ms-client-request-id": "9c89039c2a5f58a99b6db720e7b9a175",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "cd83b925-701e-0081-5c5b-949c45000000",
+        "x-ms-request-id": "9e02e58e-a01e-0082-3587-9a7d21000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-f2aef9c7f316f446ae2d7f9cacfc8ae7-8d42039d4ddcbb43-00",
+        "traceparent": "00-9747afa60eee194a90c83f492c05b139-bd84ae75d997064a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "2d0e1ca231673eaf705937c8dc2cebc5",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:12 GMT",
+        "x-ms-client-request-id": "2c8d84ccc4361bd1abf068a3fbe78d7f",
+        "x-ms-date": "Thu, 26 Aug 2021 14:34:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -79,30 +79,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:02:10 GMT",
-        "ETag": "\u00220x8D962724D14AD51\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:34:51 GMT",
+        "ETag": "\u00220x8D9689EAA51B4DC\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:34:52 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "2d0e1ca231673eaf705937c8dc2cebc5",
+        "x-ms-client-request-id": "2c8d84ccc4361bd1abf068a3fbe78d7f",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "cd83b9f6-701e-0081-225b-949c45000000",
+        "x-ms-request-id": "9e02e642-a01e-0082-6087-9a7d21000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_2.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_2.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c70231a22f885e4fb41fac0a6039ea97-04a3fd4960007b4a-00",
+        "traceparent": "00-9dcb85c7d85ae24e89aa58797fc6c0c1-5a1964330258114c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "cdbc767731be74d405bf15a2d50656fb",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:13 GMT",
+        "x-ms-client-request-id": "983d65f64d3c39339f7cfddf3ad94745",
+        "x-ms-date": "Thu, 26 Aug 2021 14:34:52 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -111,28 +111,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:02:10 GMT",
-        "ETag": "\u00220x8D962724D42CA7D\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:11 GMT",
+        "Date": "Thu, 26 Aug 2021 14:34:52 GMT",
+        "ETag": "\u00220x8D9689EAA7D87D5\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:34:52 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "cdbc767731be74d405bf15a2d50656fb",
+        "x-ms-client-request-id": "983d65f64d3c39339f7cfddf3ad94745",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "cd83babb-701e-0081-5d5b-949c45000000",
+        "x-ms-request-id": "9e02e6ff-a01e-0082-0587-9a7d21000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target352523875?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1721391754?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-194c17411c8f7f479f9911bea66ae868-7925706907d6be4b-00",
+        "traceparent": "00-d6787c362a3ecd4cb7a534358a2540ad-eab0534ce9c2d243-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "ef0957f0fa6442b4677d7b3eeca31cf5",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:13 GMT",
+        "x-ms-client-request-id": "756bee3c0bef31d76df16ec2055cb3df",
+        "x-ms-date": "Thu, 26 Aug 2021 14:34:52 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -140,12 +140,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:02:11 GMT",
-        "ETag": "\u00220x8D962724D59D0A5\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:11 GMT",
+        "Date": "Thu, 26 Aug 2021 14:34:52 GMT",
+        "ETag": "\u00220x8D9689EAA97CEC4\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:34:52 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ef0957f0fa6442b4677d7b3eeca31cf5",
-        "x-ms-request-id": "cd83bbd1-701e-0081-6a5b-949c45000000",
+        "x-ms-client-request-id": "756bee3c0bef31d76df16ec2055cb3df",
+        "x-ms-request-id": "9e02e7ba-a01e-0082-2d87-9a7d21000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -158,9 +158,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-78950c07ad4e5f4eb855ce9bbc87f6bd-31646d4004236149-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "43fc9c658e6847719927a71b0d686902",
+        "traceparent": "00-049de23a0534314c90d3df11311fdeb5-a87e94ae391f2444-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7b822a373908517f548dbac7f2e1d1a8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -180,10 +180,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0e796bec-b921-47d1-a456-b4585a2c99c6",
+        "apim-request-id": "f459f1e0-ae55-4e18-8bd0-d285fcddf569",
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:02:12 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
+        "Date": "Thu, 26 Aug 2021 14:34:53 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -191,46 +191,46 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0e796bec-b921-47d1-a456-b4585a2c99c6"
+        "X-RequestId": "f459f1e0-ae55-4e18-8bd0-d285fcddf569"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d5ec653bd5e17c12088a57b45836191b",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f8be18230a215a066667ce5cc476991f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff92a70b-40d3-40a8-8966-ffca5710980a",
+        "apim-request-id": "549f2af1-81eb-4527-a809-7af8032688be",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:13 GMT",
-        "ETag": "\u00226FEBACD760E4F0C1D7E8AE39140A7D9EBBB3A36B87796E33D3C7614F5F6F4FFC\u0022",
+        "Date": "Thu, 26 Aug 2021 14:34:54 GMT",
+        "ETag": "\u0022A8AE95F213EB863FB2F52CF390EC8629F252C96C933DD32A91909CA279155992\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ff92a70b-40d3-40a8-8966-ffca5710980a"
+        "X-RequestId": "549f2af1-81eb-4527-a809-7af8032688be"
       },
       "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:12.9108382Z",
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:54.1307211Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -244,26 +244,74 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6a6facf9b85961fae6c1563d529835fe",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "af02ff49c9c503826f1a2162500f3e8c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "431ae0ca-a211-4769-b272-82fa94e58512",
+        "apim-request-id": "1b040848-532b-4bb1-9780-5ce025bdf896",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:14 GMT",
-        "ETag": "\u00226FEBACD760E4F0C1D7E8AE39140A7D9EBBB3A36B87796E33D3C7614F5F6F4FFC\u0022",
+        "Date": "Thu, 26 Aug 2021 14:34:55 GMT",
+        "ETag": "\u00223D2FBE0699FB167F80183EED457696E85709E0D63BEC10928D5EC58823F09BF8\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "1b040848-532b-4bb1-9780-5ce025bdf896"
+      },
+      "ResponseBody": {
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:55.8358264Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 2,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ed9fc51fbb9d2dbe232815a16a238cdd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "da813aac-c6c3-4444-a2a7-6bc71c8f761f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:34:56 GMT",
+        "ETag": "\u00228AE3D485D76B14BAB3EDB942AACB052EB48D731BB5BB9DE676A9597CD92BAB87\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -273,252 +321,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "431ae0ca-a211-4769-b272-82fa94e58512"
+        "X-RequestId": "da813aac-c6c3-4444-a2a7-6bc71c8f761f"
       },
       "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:12.9108382Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 0,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8703791347b79014897f3bde37bdef62",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1837d747-4113-43fe-a859-41c8536fe6f2",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Length": "292",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:15 GMT",
-        "ETag": "\u00222D8955D5CC82C407C23FF4AC1717376184B1FC4F4DE7B4235B96A58D16E14412\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1837d747-4113-43fe-a859-41c8536fe6f2"
-      },
-      "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:14.6341646Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 3,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 3,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "60218c0efff983a86b8aef1f7fd52a6f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ae8d739e-51c6-45e5-b9fc-259cb9885ab1",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:17 GMT",
-        "ETag": "\u00222D8955D5CC82C407C23FF4AC1717376184B1FC4F4DE7B4235B96A58D16E14412\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ae8d739e-51c6-45e5-b9fc-259cb9885ab1"
-      },
-      "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:14.6341646Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 3,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 3,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dfa058559233b26398dfe0da7c1c2a29",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7c72e981-f747-4eab-b1cb-ea7e0a853615",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:18 GMT",
-        "ETag": "\u00222D8955D5CC82C407C23FF4AC1717376184B1FC4F4DE7B4235B96A58D16E14412\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7c72e981-f747-4eab-b1cb-ea7e0a853615"
-      },
-      "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:14.6341646Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 3,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 3,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c52ef3d2d4761305d07f1c2d57f410b4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9246e62b-e8c9-4ad9-ba52-cf1e1440f852",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:19 GMT",
-        "ETag": "\u00222D8955D5CC82C407C23FF4AC1717376184B1FC4F4DE7B4235B96A58D16E14412\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9246e62b-e8c9-4ad9-ba52-cf1e1440f852"
-      },
-      "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:14.6341646Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 3,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 3,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "de88cb550f1c7c2f286fc8191fce064e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "eb15b336-b830-4a19-be12-1a71a0d36a4e",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:20 GMT",
-        "ETag": "\u002288FDBB25CD57614E2E5EEC4ACC20C1EB76090E7286D189DEEAE672D7047A1C86\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "eb15b336-b830-4a19-be12-1a71a0d36a4e"
-      },
-      "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:20.4283731Z",
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:56.8584231Z",
         "status": "Running",
         "summary": {
           "total": 3,
@@ -532,26 +340,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8b4dc56064a680f8538d0fb376365aa3",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f37d9bf322de59e296bb8907e8a40956",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "df0594e7-99e9-495b-b17b-b58e20512309",
+        "apim-request-id": "65ccb086-c992-46f5-96af-9e8536685411",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:22 GMT",
-        "ETag": "\u00226A5D69DD47AA3A6F7ABEA42F1216F0868FFB01E2067221CB868B1F272D54E6AF\u0022",
+        "Date": "Thu, 26 Aug 2021 14:34:58 GMT",
+        "ETag": "\u00228AE3D485D76B14BAB3EDB942AACB052EB48D731BB5BB9DE676A9597CD92BAB87\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -561,12 +369,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "df0594e7-99e9-495b-b17b-b58e20512309"
+        "X-RequestId": "65ccb086-c992-46f5-96af-9e8536685411"
       },
       "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:21.3038834Z",
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:56.8584231Z",
         "status": "Running",
         "summary": {
           "total": 3,
@@ -580,41 +388,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b1842cce4b93c20dc4b29d070cebf401",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fe3c4229acd78e8141d48b9db3e0984c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7a97af2e-93f2-4a05-b69e-072845c7e95c",
+        "apim-request-id": "cade3913-3332-4ac7-8212-7e2134e30026",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:23 GMT",
-        "ETag": "\u00226A5D69DD47AA3A6F7ABEA42F1216F0868FFB01E2067221CB868B1F272D54E6AF\u0022",
+        "Date": "Thu, 26 Aug 2021 14:34:59 GMT",
+        "ETag": "\u00228AE3D485D76B14BAB3EDB942AACB052EB48D731BB5BB9DE676A9597CD92BAB87\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7a97af2e-93f2-4a05-b69e-072845c7e95c"
+        "X-RequestId": "cade3913-3332-4ac7-8212-7e2134e30026"
       },
       "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:21.3038834Z",
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:56.8584231Z",
         "status": "Running",
         "summary": {
           "total": 3,
@@ -628,122 +436,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "91cccd7985a7f10dd2088a8f007b05f1",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b56f448e4a92fcade34556e232b7447e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9fb29443-2d8f-4e52-bb5f-c24edce7087a",
+        "apim-request-id": "d1aab527-35af-44d4-8465-c3ab24a09aa6",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:24 GMT",
-        "ETag": "\u00226A5D69DD47AA3A6F7ABEA42F1216F0868FFB01E2067221CB868B1F272D54E6AF\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9fb29443-2d8f-4e52-bb5f-c24edce7087a"
-      },
-      "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:21.3038834Z",
-        "status": "Running",
-        "summary": {
-          "total": 3,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 3,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f24a2415544914bbb88ac7f4c6f17368",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "97ef0a85-d062-43b4-a427-b74ba1c7df8c",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:25 GMT",
-        "ETag": "\u00226A5D69DD47AA3A6F7ABEA42F1216F0868FFB01E2067221CB868B1F272D54E6AF\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "97ef0a85-d062-43b4-a427-b74ba1c7df8c"
-      },
-      "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:21.3038834Z",
-        "status": "Running",
-        "summary": {
-          "total": 3,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 3,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a83a0d98c86949fb1e93de8bc07dc149",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c548a6b2-783b-477e-87f9-8d5eee699a36",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:26 GMT",
-        "ETag": "\u00226A5D69DD47AA3A6F7ABEA42F1216F0868FFB01E2067221CB868B1F272D54E6AF\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:00 GMT",
+        "ETag": "\u00228AE3D485D76B14BAB3EDB942AACB052EB48D731BB5BB9DE676A9597CD92BAB87\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -753,12 +465,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c548a6b2-783b-477e-87f9-8d5eee699a36"
+        "X-RequestId": "d1aab527-35af-44d4-8465-c3ab24a09aa6"
       },
       "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:21.3038834Z",
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:56.8584231Z",
         "status": "Running",
         "summary": {
           "total": 3,
@@ -772,41 +484,233 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e7f2abac01a024b812b8d91cbd192ae1",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2777bf1e8de6460519efb2099745a5b5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04c4d8fb-e8b3-465a-8c33-bcb3de329c12",
+        "apim-request-id": "67e1cb24-709f-4712-b90c-0ca373812b6b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:27 GMT",
-        "ETag": "\u0022F77BEC2BB5E3010E7F1190597B9A4524C43429D984F6632A6A62F06A6BA288EF\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:02 GMT",
+        "ETag": "\u00228AE3D485D76B14BAB3EDB942AACB052EB48D731BB5BB9DE676A9597CD92BAB87\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "04c4d8fb-e8b3-465a-8c33-bcb3de329c12"
+        "X-RequestId": "67e1cb24-709f-4712-b90c-0ca373812b6b"
       },
       "ResponseBody": {
-        "id": "9c2e1fbd-d648-4411-9b94-6cd1c582aa64",
-        "createdDateTimeUtc": "2021-08-18T18:02:12.9108379Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:21.3038834Z",
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:56.8584231Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a4783c225335dec394401b92569f5c89",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "78f55d21-1deb-4e06-9a28-bef32c385b1a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:35:03 GMT",
+        "ETag": "\u00228AE3D485D76B14BAB3EDB942AACB052EB48D731BB5BB9DE676A9597CD92BAB87\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "78f55d21-1deb-4e06-9a28-bef32c385b1a"
+      },
+      "ResponseBody": {
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:56.8584231Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f47e0d90716900653e289ca298a3659d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4d631a2e-8e28-4b16-9731-40d420f9b0a4",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:35:05 GMT",
+        "ETag": "\u00228AE3D485D76B14BAB3EDB942AACB052EB48D731BB5BB9DE676A9597CD92BAB87\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "4d631a2e-8e28-4b16-9731-40d420f9b0a4"
+      },
+      "ResponseBody": {
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:56.8584231Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f5bfa09fa03eca49fb9992a57173f079",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ecea7ee5-c4e2-4541-bd86-6f56dfebab97",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:35:06 GMT",
+        "ETag": "\u00228AE3D485D76B14BAB3EDB942AACB052EB48D731BB5BB9DE676A9597CD92BAB87\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ecea7ee5-c4e2-4541-bd86-6f56dfebab97"
+      },
+      "ResponseBody": {
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:34:56.8584231Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "89792893b1c6b14cd778660cb72145f1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "57861650-6296-41d4-979d-dc9da22d62a1",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:35:07 GMT",
+        "ETag": "\u002253B78781197619576957C0377C3E2F4B2DC2F10A8E89CE97DCE734EB826281F1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "57861650-6296-41d4-979d-dc9da22d62a1"
+      },
+      "ResponseBody": {
+        "id": "995d5e3a-b2b6-4816-95ad-ba0364d6c4a7",
+        "createdDateTimeUtc": "2021-08-26T14:34:54.1307208Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:07.3779751Z",
         "status": "Succeeded",
         "summary": {
           "total": 3,
@@ -820,140 +724,140 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f3f622945d404c872901d4b67630533a",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b5f27edb67e0f04bc3b3f8d0debf8ecb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "27cd55da-e439-495a-bfe9-67899f0f4131",
+        "apim-request-id": "110fd83f-c3c1-4d5a-817c-1327eea3c90b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
+        "Content-Length": "1220",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:28 GMT",
-        "ETag": "\u002282C7C31CB9D088AF76BAE9DB66EF8ADE6D3003A06894CDDE5E7B5584B79E8CF6\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:07 GMT",
+        "ETag": "\u002219A7B62F956A1FCB26502D0D1A0D0CC580BF1C342D90BF70ADA0962D7F210DEB\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "27cd55da-e439-495a-bfe9-67899f0f4131"
+        "X-RequestId": "110fd83f-c3c1-4d5a-817c-1327eea3c90b"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target352523875/File_2.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_2.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:20.4403807Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:27.488475Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1721391754/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_2.txt",
+            "createdDateTimeUtc": "2021-08-26T14:34:56.3692997Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:07.1289565Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e1-0000-0000-0000-000000000000",
+            "id": "000b547c-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target352523875/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:20.3650863Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:27.4766919Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1721391754/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:34:55.8749585Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:07.3779693Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e0-0000-0000-0000-000000000000",
+            "id": "000b547b-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target352523875/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:20.3572619Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:27.4848989Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1721391754/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:34:55.8521159Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:07.0852423Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8df-0000-0000-0000-000000000000",
+            "id": "000b547a-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/9c2e1fbd-d648-4411-9b94-6cd1c582aa64/documents?ids=\u0026statuses=\u0026$orderBy=createdDateTimeUtc%20Desc",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/995d5e3a-b2b6-4816-95ad-ba0364d6c4a7/documents?$orderBy=createdDateTimeUtc%20Desc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1b477ec98cfe96c7551596b1efdf8b05",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "700f2238db29eed7540d1dc63a3c13da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "384f6256-178f-4c27-bee4-5bbfc29cc738",
+        "apim-request-id": "569ee92f-09c0-46c5-9cc5-6edaa71f0ea9",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:28 GMT",
-        "ETag": "\u002282C7C31CB9D088AF76BAE9DB66EF8ADE6D3003A06894CDDE5E7B5584B79E8CF6\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:07 GMT",
+        "ETag": "\u002219A7B62F956A1FCB26502D0D1A0D0CC580BF1C342D90BF70ADA0962D7F210DEB\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "384f6256-178f-4c27-bee4-5bbfc29cc738"
+        "X-RequestId": "569ee92f-09c0-46c5-9cc5-6edaa71f0ea9"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target352523875/File_2.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_2.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:20.4403807Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:27.488475Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1721391754/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_2.txt",
+            "createdDateTimeUtc": "2021-08-26T14:34:56.3692997Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:07.1289565Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e1-0000-0000-0000-000000000000",
+            "id": "000b547c-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target352523875/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:20.3650863Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:27.4766919Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1721391754/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:34:55.8749585Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:07.3779693Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e0-0000-0000-0000-000000000000",
+            "id": "000b547b-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target352523875/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1997293480/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:20.3572619Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:27.4848989Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1721391754/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1793933458/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:34:55.8521159Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:07.0852423Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8df-0000-0000-0000-000000000000",
+            "id": "000b547a-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
@@ -961,10 +865,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-18T20:02:30.9367128\u002B02:00",
+    "DateTimeOffsetNow": "2021-08-26T16:35:08.2096384\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "1378018361"
+    "RandomSeed": "1023116774"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesOrderByCreatedOnAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesOrderByCreatedOnAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source63100077?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1944135827?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7fb1090ffa0b49428916d3531d572cf4-9d97941969ca8d4e-00",
+        "traceparent": "00-67a37cb6c3fd4f4894fd3ac67bfe89dd-af4a5658ecfc5a4d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "03902d5aee14b5864913c1b2a6214643",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:34 GMT",
+        "x-ms-client-request-id": "c2ad27c73fb5db7468e8c78289fc4a33",
+        "x-ms-date": "Thu, 26 Aug 2021 14:35:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:02:32 GMT",
-        "ETag": "\u00220x8D9627259DDB881\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:32 GMT",
+        "Date": "Thu, 26 Aug 2021 14:35:08 GMT",
+        "ETag": "\u00220x8D9689EB44BE246\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:35:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "03902d5aee14b5864913c1b2a6214643",
-        "x-ms-request-id": "cd83efad-701e-0081-695b-949c45000000",
+        "x-ms-client-request-id": "c2ad27c73fb5db7468e8c78289fc4a33",
+        "x-ms-request-id": "9e0310ff-a01e-0082-5f87-9a7d21000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-e95f880360b41e448b7a96d0609e6c0f-f1d7ed918b117045-00",
+        "traceparent": "00-49aeeb68171284429e73b58497793ff1-86dcdf74a1224745-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "e89f94af808e56ed205f6441d9f0381e",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:34 GMT",
+        "x-ms-client-request-id": "6fee88f0250024e54d44607490e9f16b",
+        "x-ms-date": "Thu, 26 Aug 2021 14:35:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,30 +47,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:02:32 GMT",
-        "ETag": "\u00220x8D962725A0B5C2F\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:32 GMT",
+        "Date": "Thu, 26 Aug 2021 14:35:09 GMT",
+        "ETag": "\u00220x8D9689EB48105CD\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:35:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "e89f94af808e56ed205f6441d9f0381e",
+        "x-ms-client-request-id": "6fee88f0250024e54d44607490e9f16b",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "cd83f020-701e-0081-545b-949c45000000",
+        "x-ms-request-id": "9e03117a-a01e-0082-5187-9a7d21000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-e3a9272cd55ec24488d02049391df552-8673d963ff68004a-00",
+        "traceparent": "00-863dac3a4798d545af2218ad3cdc33c8-c40840d54b6c1844-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "ebc3dfc1dcfff1aeebd833a4ccdf9c39",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:34 GMT",
+        "x-ms-client-request-id": "ee5e354982bf1abfc865c89fb23bb544",
+        "x-ms-date": "Thu, 26 Aug 2021 14:35:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -79,30 +79,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:02:32 GMT",
-        "ETag": "\u00220x8D962725A377D2C\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:32 GMT",
+        "Date": "Thu, 26 Aug 2021 14:35:09 GMT",
+        "ETag": "\u00220x8D9689EB4AD26FE\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:35:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ebc3dfc1dcfff1aeebd833a4ccdf9c39",
+        "x-ms-client-request-id": "ee5e354982bf1abfc865c89fb23bb544",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "cd83f0e2-701e-0081-075b-949c45000000",
+        "x-ms-request-id": "9e031280-a01e-0082-3687-9a7d21000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_2.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_2.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-f925a23bba62064382ed9b8b2aedc80f-c4bec7b951454e40-00",
+        "traceparent": "00-ea2244863c3e164cba2889f434061e5f-709828880dd8bd42-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "be9a97222b5dda1e3f3ae3b58a44db58",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:35 GMT",
+        "x-ms-client-request-id": "905086c80991a19342897570df004a7e",
+        "x-ms-date": "Thu, 26 Aug 2021 14:35:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -111,28 +111,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 18 Aug 2021 18:02:33 GMT",
-        "ETag": "\u00220x8D962725A643A8B\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:33 GMT",
+        "Date": "Thu, 26 Aug 2021 14:35:09 GMT",
+        "ETag": "\u00220x8D9689EB4D8F9F8\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:35:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "be9a97222b5dda1e3f3ae3b58a44db58",
+        "x-ms-client-request-id": "905086c80991a19342897570df004a7e",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "cd83f1ba-701e-0081-555b-949c45000000",
+        "x-ms-request-id": "9e031364-a01e-0082-0587-9a7d21000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target558287066?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1321429751?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d08b75f65607aa4ba45a545743919c6a-0eee077463ce9a4d-00",
+        "traceparent": "00-19717afef5d27e4483964121b7d78a87-84caa1893bdb984a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "5ec6f0a2435be5d2aefdb54c488a41c2",
-        "x-ms-date": "Wed, 18 Aug 2021 18:02:35 GMT",
+        "x-ms-client-request-id": "9d53385c735bc86ed3a69b5d4572128f",
+        "x-ms-date": "Thu, 26 Aug 2021 14:35:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -140,12 +140,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:02:33 GMT",
-        "ETag": "\u00220x8D962725A7A8A78\u0022",
-        "Last-Modified": "Wed, 18 Aug 2021 18:02:33 GMT",
+        "Date": "Thu, 26 Aug 2021 14:35:09 GMT",
+        "ETag": "\u00220x8D9689EB4EF44C8\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:35:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "5ec6f0a2435be5d2aefdb54c488a41c2",
-        "x-ms-request-id": "cd83f296-701e-0081-225b-949c45000000",
+        "x-ms-client-request-id": "9d53385c735bc86ed3a69b5d4572128f",
+        "x-ms-request-id": "9e03143d-a01e-0082-4f87-9a7d21000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -158,9 +158,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-41e55f1413ea0f4ea7307ddbb608859d-588fc41e984f6f4f-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "56411f2bc17ac095e9abc5f9f967a6fc",
+        "traceparent": "00-c546241d7db1364da3cb18c31087ee4a-e8328fe60585ec43-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "980aac1bd960a240bdac350c4e3ac81b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -180,10 +180,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8684f2cd-f7f1-46ef-aab8-afbd8d73ab8b",
+        "apim-request-id": "d797d70b-5871-46e0-98c8-c63e90ddd0a5",
         "Content-Length": "0",
-        "Date": "Wed, 18 Aug 2021 18:02:33 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
+        "Date": "Thu, 26 Aug 2021 14:35:09 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -191,46 +191,46 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8684f2cd-f7f1-46ef-aab8-afbd8d73ab8b"
+        "X-RequestId": "d797d70b-5871-46e0-98c8-c63e90ddd0a5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ee29cadbdbd553c6c7d8af2e688df6af",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0255a749a761136ce1c7bd62f744fc17",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0d493121-3217-43c9-8323-f1067cb443f7",
+        "apim-request-id": "90c234ce-5a65-459b-ad96-c748f2821ccb",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:33 GMT",
-        "ETag": "\u00225E87343DC8C390C53FF1BB4B063A9EBFE2AD6AF956189510E87C2879F24A187F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:09 GMT",
+        "ETag": "\u0022F4207818679D9171BDC6CE8FA0BBC2AE3974A8E5E99C5EB56D6E947A529B7EFA\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0d493121-3217-43c9-8323-f1067cb443f7"
+        "X-RequestId": "90c234ce-5a65-459b-ad96-c748f2821ccb"
       },
       "ResponseBody": {
-        "id": "5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-        "createdDateTimeUtc": "2021-08-18T18:02:33.6010367Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:33.6010371Z",
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:10.2329748Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -244,26 +244,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "255ef2a10299e05f5a0574b07ed9eb46",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "53c4e163e5408296f8b1e0ae3e627999",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5de2a162-022d-41db-a759-78146a47d0f6",
+        "apim-request-id": "dc49dd19-6478-43cb-818a-5322fd4eedde",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:35 GMT",
-        "ETag": "\u0022C669CF4B39CC197EBAF9ECC5BC4178987743885BBB92B21BDD31294A726A1816\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:11 GMT",
+        "ETag": "\u0022D53209AD0618287421F80A9A3ADEDCAE5FCA789CB81AAA68E77089DBE024487B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -273,12 +273,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "5de2a162-022d-41db-a759-78146a47d0f6"
+        "X-RequestId": "dc49dd19-6478-43cb-818a-5322fd4eedde"
       },
       "ResponseBody": {
-        "id": "5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-        "createdDateTimeUtc": "2021-08-18T18:02:33.6010367Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:34.9740437Z",
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:11.2508089Z",
         "status": "NotStarted",
         "summary": {
           "total": 3,
@@ -292,41 +292,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7e71b956536050ed58ee8ea21267575c",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9e137fde0f1c742d3ff6b6991cdeaa78",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4c3f8a2f-5f8b-49ce-9ddf-cf15f3d48669",
+        "apim-request-id": "f28614c9-ffc9-4d7f-8452-d9bd5275913b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:36 GMT",
-        "ETag": "\u00229CD5AA8FC706FB7A6AA0CBB8B8A4B26A436B1EBC0AA2D4B7B2F490FF3C9DFA9A\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:12 GMT",
+        "ETag": "\u00226F76DBBD39856638BCB602DC35BF559414AE933436944BA002DFD8D7AE6D346C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4c3f8a2f-5f8b-49ce-9ddf-cf15f3d48669"
+        "X-RequestId": "f28614c9-ffc9-4d7f-8452-d9bd5275913b"
       },
       "ResponseBody": {
-        "id": "5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-        "createdDateTimeUtc": "2021-08-18T18:02:33.6010367Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:35.8975774Z",
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:12.6331757Z",
         "status": "Running",
         "summary": {
           "total": 3,
@@ -340,26 +340,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "075715b48008d8636b4893cf6616d5ee",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6da81eb0757663db10d309b0c6bdd57f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bea39cfb-2ccf-49a7-b449-56ef8287225d",
+        "apim-request-id": "2adaff1b-832f-4f32-aa72-d638848520de",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:37 GMT",
-        "ETag": "\u00229CD5AA8FC706FB7A6AA0CBB8B8A4B26A436B1EBC0AA2D4B7B2F490FF3C9DFA9A\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:13 GMT",
+        "ETag": "\u00220B08257028503D9D50871A0978D5B7DAB2B8D7E4C7E9BF7BD4173AD523F8DA5A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -369,12 +369,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "bea39cfb-2ccf-49a7-b449-56ef8287225d"
+        "X-RequestId": "2adaff1b-832f-4f32-aa72-d638848520de"
       },
       "ResponseBody": {
-        "id": "5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-        "createdDateTimeUtc": "2021-08-18T18:02:33.6010367Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:35.8975774Z",
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:13.1199527Z",
         "status": "Running",
         "summary": {
           "total": 3,
@@ -388,41 +388,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "afd768ec781b4e4f040dcdab73bccef3",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7883234e5e3053fab34f13492efd651a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5828eb47-2e5e-421b-8d8a-eec95ee5ee66",
+        "apim-request-id": "c90464cf-c582-4ee4-bc43-54d10c9a0854",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:38 GMT",
-        "ETag": "\u00229CD5AA8FC706FB7A6AA0CBB8B8A4B26A436B1EBC0AA2D4B7B2F490FF3C9DFA9A\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:14 GMT",
+        "ETag": "\u00220B08257028503D9D50871A0978D5B7DAB2B8D7E4C7E9BF7BD4173AD523F8DA5A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "5828eb47-2e5e-421b-8d8a-eec95ee5ee66"
+        "X-RequestId": "c90464cf-c582-4ee4-bc43-54d10c9a0854"
       },
       "ResponseBody": {
-        "id": "5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-        "createdDateTimeUtc": "2021-08-18T18:02:33.6010367Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:35.8975774Z",
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:13.1199527Z",
         "status": "Running",
         "summary": {
           "total": 3,
@@ -436,122 +436,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "68fb18aee482d63e55981217bf1dea42",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1ffe67060cb96923a4b08d49067dad82",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2758ff0b-2648-47c7-9207-022e16dafc45",
+        "apim-request-id": "512fa5e3-8608-4617-ae70-9af1f4c0b1ae",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:39 GMT",
-        "ETag": "\u00229CD5AA8FC706FB7A6AA0CBB8B8A4B26A436B1EBC0AA2D4B7B2F490FF3C9DFA9A\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2758ff0b-2648-47c7-9207-022e16dafc45"
-      },
-      "ResponseBody": {
-        "id": "5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-        "createdDateTimeUtc": "2021-08-18T18:02:33.6010367Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:35.8975774Z",
-        "status": "Running",
-        "summary": {
-          "total": 3,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 3,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "aab6a018a7903b40c60802fab2b764ae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9536f2e8-afc9-490a-a5aa-d13d406b68b4",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:41 GMT",
-        "ETag": "\u00229CD5AA8FC706FB7A6AA0CBB8B8A4B26A436B1EBC0AA2D4B7B2F490FF3C9DFA9A\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9536f2e8-afc9-490a-a5aa-d13d406b68b4"
-      },
-      "ResponseBody": {
-        "id": "5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-        "createdDateTimeUtc": "2021-08-18T18:02:33.6010367Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:35.8975774Z",
-        "status": "Running",
-        "summary": {
-          "total": 3,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 3,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4d21a07a6c1a086b2a005a8265378ee7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "de12943d-f281-4740-9aa6-3b7fa0ae34c1",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:42 GMT",
-        "ETag": "\u00224B5EA49C89EB977A01AD67B8BA352DF18A49CE271E016F95A6ED99AA5119BAD6\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:16 GMT",
+        "ETag": "\u00220B08257028503D9D50871A0978D5B7DAB2B8D7E4C7E9BF7BD4173AD523F8DA5A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -561,12 +465,204 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "de12943d-f281-4740-9aa6-3b7fa0ae34c1"
+        "X-RequestId": "512fa5e3-8608-4617-ae70-9af1f4c0b1ae"
       },
       "ResponseBody": {
-        "id": "5ccbe2b9-e1ac-4234-a3bb-575659e84a36",
-        "createdDateTimeUtc": "2021-08-18T18:02:33.6010367Z",
-        "lastActionDateTimeUtc": "2021-08-18T18:02:35.8975774Z",
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:13.1199527Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f84a3721325a52482455b92661923413",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "63a9ca9d-1afd-4d00-9c27-e4154bac297b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:35:17 GMT",
+        "ETag": "\u00220B08257028503D9D50871A0978D5B7DAB2B8D7E4C7E9BF7BD4173AD523F8DA5A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "63a9ca9d-1afd-4d00-9c27-e4154bac297b"
+      },
+      "ResponseBody": {
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:13.1199527Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5fa9ee6db5bf42c6001ad380d1b14d35",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7b7dd12b-f095-4595-956b-bb2115c43417",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:35:18 GMT",
+        "ETag": "\u00220B08257028503D9D50871A0978D5B7DAB2B8D7E4C7E9BF7BD4173AD523F8DA5A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7b7dd12b-f095-4595-956b-bb2115c43417"
+      },
+      "ResponseBody": {
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:13.1199527Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f72791a26db2d3c01facfb6352fd0712",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ae67ab7d-0600-4b44-ae39-b941e1374cca",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:35:19 GMT",
+        "ETag": "\u00220B08257028503D9D50871A0978D5B7DAB2B8D7E4C7E9BF7BD4173AD523F8DA5A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ae67ab7d-0600-4b44-ae39-b941e1374cca"
+      },
+      "ResponseBody": {
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:13.1199527Z",
+        "status": "Running",
+        "summary": {
+          "total": 3,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 3,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "17db797b4ed36cc27008f83f5fc78072",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e96c4f9e-ac68-4424-b799-568639fd9526",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:35:22 GMT",
+        "ETag": "\u0022B652A6DBAEAC967A9E20D7EAD946F1C585CA41D24209403914DFB9BC69CE3668\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e96c4f9e-ac68-4424-b799-568639fd9526"
+      },
+      "ResponseBody": {
+        "id": "ecb09d46-fabf-4ad2-bea8-ce23f77ed40f",
+        "createdDateTimeUtc": "2021-08-26T14:35:10.2329745Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:35:21.0092717Z",
         "status": "Succeeded",
         "summary": {
           "total": 3,
@@ -580,96 +676,96 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d3938b2323060663d8c0a279e143239d",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d08383083d6a00602ed63f13ba62ef03",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aaab6c8f-1566-4026-a1d2-d5169bc8dc66",
+        "apim-request-id": "7394c182-ecb0-4184-b3ce-bc5a22719927",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:42 GMT",
-        "ETag": "\u002290656047927C9FB0F8FCDA91911ADE722D627418DE15763C09087C046DBB9B40\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:22 GMT",
+        "ETag": "\u0022A04597DBDD7724EB6A9C15EA8E3DBD82BDA697194FE43624C939678EC5D66CBF\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "aaab6c8f-1566-4026-a1d2-d5169bc8dc66"
+        "X-RequestId": "7394c182-ecb0-4184-b3ce-bc5a22719927"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target558287066/File_2.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_2.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:35.424389Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:41.9401995Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1321429751/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_2.txt",
+            "createdDateTimeUtc": "2021-08-26T14:35:12.6494794Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:20.7318357Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e4-0000-0000-0000-000000000000",
+            "id": "000b547f-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target558287066/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:35.4144232Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:41.941168Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1321429751/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:35:11.8727805Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:20.7491452Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e3-0000-0000-0000-000000000000",
+            "id": "000b547e-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target558287066/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:35.4115099Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:41.9556969Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1321429751/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:35:11.8314155Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:21.0092655Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e2-0000-0000-0000-000000000000",
+            "id": "000b547d-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5ccbe2b9-e1ac-4234-a3bb-575659e84a36/documents?ids=\u0026statuses=\u0026$orderBy=createdDateTimeUtc%20Desc",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ecb09d46-fabf-4ad2-bea8-ce23f77ed40f/documents?$orderBy=createdDateTimeUtc%20Desc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210818.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1f9d64349dfbab2734ae808f4dbed58e",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5704c01235d55462cebb86aa74807457",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d1673039-009e-4b53-ae09-c67fcbadc454",
+        "apim-request-id": "bb7e0f6b-7fef-4604-a00c-b86e6686e8ca",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 18 Aug 2021 18:02:42 GMT",
-        "ETag": "\u002290656047927C9FB0F8FCDA91911ADE722D627418DE15763C09087C046DBB9B40\u0022",
+        "Date": "Thu, 26 Aug 2021 14:35:22 GMT",
+        "ETag": "\u0022A04597DBDD7724EB6A9C15EA8E3DBD82BDA697194FE43624C939678EC5D66CBF\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -679,41 +775,41 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d1673039-009e-4b53-ae09-c67fcbadc454"
+        "X-RequestId": "bb7e0f6b-7fef-4604-a00c-b86e6686e8ca"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target558287066/File_2.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_2.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:35.424389Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:41.9401995Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1321429751/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_2.txt",
+            "createdDateTimeUtc": "2021-08-26T14:35:12.6494794Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:20.7318357Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e4-0000-0000-0000-000000000000",
+            "id": "000b547f-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target558287066/File_1.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_1.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:35.4144232Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:41.941168Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1321429751/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_1.txt",
+            "createdDateTimeUtc": "2021-08-26T14:35:11.8727805Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:20.7491452Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e3-0000-0000-0000-000000000000",
+            "id": "000b547e-0000-0000-0000-000000000000",
             "characterCharged": 16
           },
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target558287066/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source63100077/File_0.txt",
-            "createdDateTimeUtc": "2021-08-18T18:02:35.4115099Z",
-            "lastActionDateTimeUtc": "2021-08-18T18:02:41.9556969Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1321429751/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1944135827/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:35:11.8314155Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:35:21.0092655Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000ae8e2-0000-0000-0000-000000000000",
+            "id": "000b547d-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
@@ -721,10 +817,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-18T20:02:45.1974063\u002B02:00",
+    "DateTimeOffsetNow": "2021-08-26T16:35:22.3133152\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "677548068"
+    "RandomSeed": "1084600977"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedAfterTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedAfterTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source254142079?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source254142079?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0d5b0dde3e831945a9b4883af5c2c509-d2247a67b337c744-00",
+        "traceparent": "00-47bc4efdeac36446a29bce66dc834a25-023ccfaf9321994f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "d7f5bfa300736d1d64c949e05430b741",
-        "x-ms-date": "Wed, 04 Aug 2021 20:28:49 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:20 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:28:51 GMT",
-        "ETag": "\u00220x8D9578679193228\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:28:51 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:21 GMT",
+        "ETag": "\u00220x8D96889803465D2\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:22 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "d7f5bfa300736d1d64c949e05430b741",
-        "x-ms-request-id": "0526fee6-a01e-003b-2a6f-896135000000",
+        "x-ms-request-id": "36b84425-701e-0091-7672-9a592d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source254142079/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source254142079/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-d9c1b1205563f84da02683a4c7e10c72-3cbfaf36367cbd49-00",
+        "traceparent": "00-e224cd3ef4f1a1469f3ba1eba815c8f3-1d336e6c60f5724b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "f783c5f6fb36a56064b80229a78c9da5",
-        "x-ms-date": "Wed, 04 Aug 2021 20:28:51 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:28:51 GMT",
-        "ETag": "\u00220x8D957867979C51C\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:28:52 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:21 GMT",
+        "ETag": "\u00220x8D9688980697E2C\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:22 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "f783c5f6fb36a56064b80229a78c9da5",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0526ff80-a01e-003b-2a6f-896135000000",
+        "x-ms-request-id": "36b844bf-701e-0091-7772-9a592d000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1626648402?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1626648402?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f8af4a88b019ee41a812f03d3c673e41-d954dcafcdbb3643-00",
+        "traceparent": "00-f505ba4f9f53cc45834d4fc05721228e-6ca23031cf01f648-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "4edfb63c36ec03a38bbf2311a9127365",
-        "x-ms-date": "Wed, 04 Aug 2021 20:28:52 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:28:52 GMT",
-        "ETag": "\u00220x8D9578679A585F7\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:28:52 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:21 GMT",
+        "ETag": "\u00220x8D96889808022B5\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:22 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "4edfb63c36ec03a38bbf2311a9127365",
-        "x-ms-request-id": "05270032-a01e-003b-496f-896135000000",
+        "x-ms-request-id": "36b84556-701e-0091-7f72-9a592d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c15287ffc35efe41ae429a3a212b9231-430a3607e23f1c4d-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-62c5d09d51ea5f4d84e177598fc2bd7c-0daa63a49deb2a46-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "aa7b619448b95ea84f72bafef3c6d72b",
         "x-ms-return-client-request-id": "true"
       },
@@ -116,57 +116,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3a8edfc3-ea2a-4045-b08f-bb5458427e60",
+        "apim-request-id": "ffbf53be-3876-4aff-af3f-3e56e9355c5d",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:28:54 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffecb1d4-4f3c-4b37-896e-4de9fd083855",
+        "Date": "Thu, 26 Aug 2021 12:03:22 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3a8edfc3-ea2a-4045-b08f-bb5458427e60"
+        "X-RequestId": "ffbf53be-3876-4aff-af3f-3e56e9355c5d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffecb1d4-4f3c-4b37-896e-4de9fd083855",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "7a178da4f2d78e0ae0f3ab3c3c94bba6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca106e62-cd5e-4536-b0cd-54ce5b55c73b",
+        "apim-request-id": "c878e71f-9ada-408b-9c55-5d60066a1331",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:28:54 GMT",
-        "ETag": "\u0022B1E8BACA1B4D92BED33BA47D202A5EA678E5B1EDF687E0D16A5F6E2C122967E1\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:23 GMT",
+        "ETag": "\u0022F633E0A25B8204586D07B7644283EB69EFA6525993DF1C8B0CB43FB517DB2111\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ca106e62-cd5e-4536-b0cd-54ce5b55c73b"
+        "X-RequestId": "c878e71f-9ada-408b-9c55-5d60066a1331"
       },
       "ResponseBody": {
-        "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-        "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:28:54.7241781Z",
+        "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+        "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:23.2692463Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,89 +180,89 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffecb1d4-4f3c-4b37-896e-4de9fd083855",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "2b13c48ffa22f4980d80fe797ca510c5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bbd02ab9-b6c8-4980-911c-4baa15998510",
+        "apim-request-id": "7d5d6330-f875-4bf8-866b-be55bf969449",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:28:56 GMT",
-        "ETag": "\u0022C27446DF2EBEF41C101B97D443D207230FD32455295774441546EC25CE2801F6\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:24 GMT",
+        "ETag": "\u0022889280F10F268234C94CD3E8210D412DF494F17DA2E70B75EB20B586B737AE9A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "bbd02ab9-b6c8-4980-911c-4baa15998510"
+        "X-RequestId": "7d5d6330-f875-4bf8-866b-be55bf969449"
       },
       "ResponseBody": {
-        "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-        "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:28:55.14358Z",
-        "status": "NotStarted",
+        "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+        "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:24.1811716Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffecb1d4-4f3c-4b37-896e-4de9fd083855",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "1c6cf7e7f9faa18d57edcac69c6b22bb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aa9481ee-d020-4b97-a85d-8210eb6bf995",
+        "apim-request-id": "b2424d1d-9f8d-487c-bd21-254e09c978f2",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:28:57 GMT",
-        "ETag": "\u0022882A311DB81238B70E1C7B1A8170A2BBE0940B44678F31F7176B79FA691C2C69\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:25 GMT",
+        "ETag": "\u0022BEA29097608D9D260A0BD524A9EC0863CA0F4B538B44F99DF81348EDFF54B5B7\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "aa9481ee-d020-4b97-a85d-8210eb6bf995"
+        "X-RequestId": "b2424d1d-9f8d-487c-bd21-254e09c978f2"
       },
       "ResponseBody": {
-        "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-        "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:28:57.0357411Z",
+        "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+        "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:25.1122563Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -276,137 +276,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffecb1d4-4f3c-4b37-896e-4de9fd083855",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "2e6f14b7acb3a909f4236c57f490123a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "18d858c6-67a4-404b-8ace-48d2767aef43",
+        "apim-request-id": "4e3948ba-c9cd-44d0-afc9-9ebc07a55a5a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:28:58 GMT",
-        "ETag": "\u0022882A311DB81238B70E1C7B1A8170A2BBE0940B44678F31F7176B79FA691C2C69\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:30 GMT",
+        "ETag": "\u00222F4DA885608E11EF92D40FE821AD806D4E9DAB93A4E0B0D0F1682371EB16F08B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "18d858c6-67a4-404b-8ace-48d2767aef43"
+        "X-RequestId": "4e3948ba-c9cd-44d0-afc9-9ebc07a55a5a"
       },
       "ResponseBody": {
-        "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-        "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:28:57.0357411Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4554e6e39e2795ab3771d43530d257a1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "edb4555c-62eb-4e0b-a483-0c8d288e18cb",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:28:59 GMT",
-        "ETag": "\u0022882A311DB81238B70E1C7B1A8170A2BBE0940B44678F31F7176B79FA691C2C69\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "edb4555c-62eb-4e0b-a483-0c8d288e18cb"
-      },
-      "ResponseBody": {
-        "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-        "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:28:57.0357411Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "67c1425ee1363b12eec327d78d36acc6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "bb3b701a-4115-4f7f-9623-b2f68086ba0f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:01 GMT",
-        "ETag": "\u0022F8EF492532544A91098C0CC322982B27912C7B2350195A6CC364828EDD004505\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "bb3b701a-4115-4f7f-9623-b2f68086ba0f"
-      },
-      "ResponseBody": {
-        "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-        "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:28:57.0357411Z",
+        "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+        "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:30.7517838Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -420,63 +324,63 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ffecb1d4-4f3c-4b37-896e-4de9fd083855/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b6e28fdadc17189468d9f741d8d47821",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4554e6e39e2795ab3771d43530d257a1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e8892b3-c0a9-4487-aff1-3a60fc57b088",
+        "apim-request-id": "b3ac3e9d-f177-4362-b028-13ccf4152cf1",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:01 GMT",
-        "ETag": "\u00225DCE53DB7082FCBBFD0BD8A264D6ECCA3614623A813A70C4550FF034BDCAA5DD\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:31 GMT",
+        "ETag": "\u0022B54B4E3A1442C5D5E716C0505DD029268E22B18B4F4D742856D2A6E012911B99\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2e8892b3-c0a9-4487-aff1-3a60fc57b088"
+        "X-RequestId": "b3ac3e9d-f177-4362-b028-13ccf4152cf1"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target1626648402/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source254142079/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:28:56.5746234Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:00.8940397Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1626648402/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source254142079/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:03:24.19349Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:03:30.7517671Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53ca-0000-0000-0000-000000000000",
+            "id": "000b467c-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1681617611?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1088529502?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a8a9993523e78446b662db1950031f1b-70dc67f0d6a8754a-00",
+        "traceparent": "00-72669318e9ff3446a6ae4a9ab30e76c2-f6a1d15cf9b1374f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "cfb1f8ca04aad40119576477d40701c4",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:01 GMT",
+        "x-ms-client-request-id": "3667c14212e1ee3bc327d78d36acc6da",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -484,28 +388,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:01 GMT",
-        "ETag": "\u00220x8D957867F3568BD\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:02 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:31 GMT",
+        "ETag": "\u00220x8D968898615FDE4\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:31 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "cfb1f8ca04aad40119576477d40701c4",
-        "x-ms-request-id": "05270ef6-a01e-003b-5b6f-896135000000",
+        "x-ms-client-request-id": "3667c14212e1ee3bc327d78d36acc6da",
+        "x-ms-request-id": "36b85c84-701e-0091-2b72-9a592d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1681617611/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1088529502/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-a3da72d2b7a8a849b2e3a0d4b135107a-f169f40fc8c9e641-00",
+        "traceparent": "00-45e62926c9a3f647a5df6826467fb22b-52b6392558bba243-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "f0a15a0d8aa0ae81a8ff5cead062194a",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:01 GMT",
+        "x-ms-client-request-id": "17b6e28f94dc6818d9f741d8d47821cb",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -514,28 +418,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:01 GMT",
-        "ETag": "\u00220x8D957867F7DB4B3\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:02 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:31 GMT",
+        "ETag": "\u00220x8D9688986439C94\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:32 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "f0a15a0d8aa0ae81a8ff5cead062194a",
+        "x-ms-client-request-id": "17b6e28f94dc6818d9f741d8d47821cb",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05270f50-a01e-003b-226f-896135000000",
+        "x-ms-request-id": "36b85ce5-701e-0091-8072-9a592d000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target516166918?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target632004810?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-36c5a021f839b047ac3edc2fe3d4d93b-eae5af3268914248-00",
+        "traceparent": "00-68ed1fdeb3c8c341ad571a7668926fd9-21678f88d3a2a54f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "fb3dc30b2ff7e08ae2fd8530a194d1f6",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:02 GMT",
+        "x-ms-client-request-id": "aacfb1f8010419d4576477d40701c40d",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:32 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -543,27 +447,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:02 GMT",
-        "ETag": "\u00220x8D957867FA35995\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:02 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:31 GMT",
+        "ETag": "\u00220x8D96889865ADBBA\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:32 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "fb3dc30b2ff7e08ae2fd8530a194d1f6",
-        "x-ms-request-id": "05271030-a01e-003b-5d6f-896135000000",
+        "x-ms-client-request-id": "aacfb1f8010419d4576477d40701c40d",
+        "x-ms-request-id": "36b85db3-701e-0091-3972-9a592d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4c909ae1a7d9f14cac06cbc6432bdcc6-29b429ae528e0343-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d779ca7c2b31773f0326aba81703b63d",
+        "traceparent": "00-7e83afb79e15d749866f252a7b515269-5dbeec4c06b7df47-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a0f0a15a818aa8aeff5cead062194a06",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -583,57 +487,153 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cc11f09f-783b-4464-84e7-c799a931e6ad",
+        "apim-request-id": "12be429c-b673-4aff-b52b-6ec76903781b",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:02 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+        "Date": "Thu, 26 Aug 2021 12:03:32 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "12be429c-b673-4aff-b52b-6ec76903781b"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fb3dc30b2ff7e08ae2fd8530a194d1f6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c4874b47-74d0-45e1-87a2-96e27e98f319",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:03:32 GMT",
+        "ETag": "\u00223BCFD9C1483B7015EC341DBAB948F36A42A8367178DD300B43FCBBE6C50FF368\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cc11f09f-783b-4464-84e7-c799a931e6ad"
+        "X-RequestId": "c4874b47-74d0-45e1-87a2-96e27e98f319"
       },
-      "ResponseBody": []
+      "ResponseBody": {
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:32.6291728Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d779ca7c2b31773f0326aba81703b63d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3d5f5996-5a68-4bca-a464-465e7d210623",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:03:33 GMT",
+        "ETag": "\u002249715EFEE16E9CF46E4A903717503C565142FC38D5B93D1ABA6653F2262FD458\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "3d5f5996-5a68-4bca-a464-465e7d210623"
+      },
+      "ResponseBody": {
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:33.1273959Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "44c87019c9c42a15160fbe8dfc7d076a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0bbd49cb-bf4f-45b7-9179-ffdb32369796",
+        "apim-request-id": "ee7c26fa-6d8c-4f9a-9a03-9ef03fec745e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:03 GMT",
-        "ETag": "\u0022124E637CF0FCF1C6FF754A82D9597CC19EAC5110D2387965706D5A9AB958056B\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:34 GMT",
+        "ETag": "\u002249715EFEE16E9CF46E4A903717503C565142FC38D5B93D1ABA6653F2262FD458\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0bbd49cb-bf4f-45b7-9179-ffdb32369796"
+        "X-RequestId": "ee7c26fa-6d8c-4f9a-9a03-9ef03fec745e"
       },
       "ResponseBody": {
-        "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-        "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:03.5611671Z",
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:33.1273959Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -647,233 +647,233 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "9854f48a729fe0d483c6f7d184e2c9df",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "36dc2636-c1af-4ded-8068-359e87ef053b",
+        "apim-request-id": "cb871e39-fd6f-4750-b51e-5315770ef58d",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:04 GMT",
-        "ETag": "\u0022124E637CF0FCF1C6FF754A82D9597CC19EAC5110D2387965706D5A9AB958056B\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:35 GMT",
+        "ETag": "\u00226C2C3BBAD5C9403EA44BB41405D4E83D34FAA1BABA1352FFC4FAEF65B6CB794B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "36dc2636-c1af-4ded-8068-359e87ef053b"
+        "X-RequestId": "cb871e39-fd6f-4750-b51e-5315770ef58d"
       },
       "ResponseBody": {
-        "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-        "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:03.5611671Z",
-        "status": "NotStarted",
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:35.7246687Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "301647468cccb231b44fc0226cb27a85",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "61a5b189-011e-4115-8a94-cc01f109f4f7",
+        "apim-request-id": "03e6310f-1e96-40da-8cd2-23eaba3aa18a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:05 GMT",
-        "ETag": "\u0022124E637CF0FCF1C6FF754A82D9597CC19EAC5110D2387965706D5A9AB958056B\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:37 GMT",
+        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "61a5b189-011e-4115-8a94-cc01f109f4f7"
+        "X-RequestId": "03e6310f-1e96-40da-8cd2-23eaba3aa18a"
       },
       "ResponseBody": {
-        "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-        "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:03.5611671Z",
-        "status": "NotStarted",
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "231d411e1eaea69d9ce7c1fdd144a634",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6ce15309-41fa-4cb2-a999-fb9bf8ba2135",
+        "apim-request-id": "9e7ed7fc-28f0-42b8-9972-5c3e84294b9f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:06 GMT",
-        "ETag": "\u0022124E637CF0FCF1C6FF754A82D9597CC19EAC5110D2387965706D5A9AB958056B\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:38 GMT",
+        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6ce15309-41fa-4cb2-a999-fb9bf8ba2135"
+        "X-RequestId": "9e7ed7fc-28f0-42b8-9972-5c3e84294b9f"
       },
       "ResponseBody": {
-        "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-        "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:03.5611671Z",
-        "status": "NotStarted",
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "b446de45d667fd9ec2a1e350b2b273d1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9e27c523-26ec-44d7-8c8b-525abdbc33f4",
+        "apim-request-id": "5e2b4c18-0f43-4dba-8156-0343ef432bc2",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:07 GMT",
-        "ETag": "\u0022124E637CF0FCF1C6FF754A82D9597CC19EAC5110D2387965706D5A9AB958056B\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:40 GMT",
+        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9e27c523-26ec-44d7-8c8b-525abdbc33f4"
+        "X-RequestId": "5e2b4c18-0f43-4dba-8156-0343ef432bc2"
       },
       "ResponseBody": {
-        "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-        "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:03.5611671Z",
-        "status": "NotStarted",
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "43b2724ba6c52730aa6f94e4cb34e170",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4024084b-3366-4077-a911-42b56c105bc7",
+        "apim-request-id": "346d0f7a-55b8-4d01-baa1-6203254d8a61",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:09 GMT",
-        "ETag": "\u0022C09332AEE01F5D053B0AB4F38E977FBE706461640DA99ED097B1119EA7CA210B\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:41 GMT",
+        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4024084b-3366-4077-a911-42b56c105bc7"
+        "X-RequestId": "346d0f7a-55b8-4d01-baa1-6203254d8a61"
       },
       "ResponseBody": {
-        "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-        "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:09.8583078Z",
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -887,41 +887,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "8edc8ca8c66b481ea21f600c3b4cf4e9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80e13da5-a634-4f10-ae2b-ada7d7935a14",
+        "apim-request-id": "195a0280-0967-4340-a9ea-6da7e8d5a4a6",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:10 GMT",
-        "ETag": "\u0022C09332AEE01F5D053B0AB4F38E977FBE706461640DA99ED097B1119EA7CA210B\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:42 GMT",
+        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "80e13da5-a634-4f10-ae2b-ada7d7935a14"
+        "X-RequestId": "195a0280-0967-4340-a9ea-6da7e8d5a4a6"
       },
       "ResponseBody": {
-        "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-        "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:09.8583078Z",
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -935,41 +935,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "5fb2ef7463929f6fad1f0af741b9328e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3004ed3f-35c7-447f-9e74-71b1a2d947ad",
+        "apim-request-id": "21a5cfaf-2940-48c4-83e5-3f929c43193b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:11 GMT",
-        "ETag": "\u00221818DBF4793F289B6CAE198EB49DA9AA3EF31F7C8476499D3A9AC9AB538693D3\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:43 GMT",
+        "ETag": "\u002213B2015A36198CB1B9B29DA639D9B37C320F1364094A19C05DBA512D164924D6\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3004ed3f-35c7-447f-9e74-71b1a2d947ad"
+        "X-RequestId": "21a5cfaf-2940-48c4-83e5-3f929c43193b"
       },
       "ResponseBody": {
-        "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-        "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:09.8583078Z",
+        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:43.710026Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -983,75 +983,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3998c574-c735-49bf-b118-d33fee05dd0d/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "25a872c0e5d685665369a0a54524eb5d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "26146f99-54b2-4e9f-b4af-76236f08fa52",
+        "apim-request-id": "a1b589d0-bd6e-49c4-a349-678c7c804458",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:11 GMT",
-        "ETag": "\u0022548515F1847FB1BA75CE59F4074F49EBF244646F583E21B9D0066D8ECB8D2583\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "26146f99-54b2-4e9f-b4af-76236f08fa52"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target516166918/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1681617611/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:29:09.4386591Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:11.9759433Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000a53cb-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=\u0026createdDateTimeUtcStart=2021-08-04T20%3A29%3A01.4902512Z\u0026$orderBy=",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d059165e5253394291a1d8699ee5f7a6-d98516d04892d541-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "db70ab7b818145de1d3ce04bbc2706e9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8a2986cf-d60e-4635-959e-14050864b01f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:12 GMT",
-        "ETag": "\u0022540ABF35FD8C4EC829B6A334A0F9B6CACD68DE00BE6CFD94D76CBE63FF1D61BE\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:44 GMT",
+        "ETag": "\u0022687D20DCE6993F556593A13FDF3DB6ADFE18CEFEA4D4DE599BF0EC9088502455\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1061,14 +1012,63 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8a2986cf-d60e-4635-959e-14050864b01f"
+        "X-RequestId": "a1b589d0-bd6e-49c4-a349-678c7c804458"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-            "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:09.8583078Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target632004810/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1088529502/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:03:35.7373407Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:03:43.7100188Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b467d-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2021-08-26T12%3A03%3A31.8241066Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-83a8070ec9c1824fa804607227811df0-87b5c0246e733b49-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "db70ab7b818145de1d3ce04bbc2706e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f70d6fe8-d3d6-452e-b500-0cc340818622",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:03:44 GMT",
+        "ETag": "\u00224F13B76AA379E4D8A60C7AA9DC08581E9EF0A1F1C2AD4695FD2FF3E63792BE07\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f70d6fe8-d3d6-452e-b500-0cc340818622"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+            "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:03:43.710026Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -1085,10 +1085,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-04T22:29:01.4902512\u002B02:00",
+    "DateTimeOffsetNow": "2021-08-26T14:03:31.8241066\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
     "RandomSeed": "221592565"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedAfterTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedAfterTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1157461599?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1157461599?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-370c1c13690ff9458fb4cf6abf654565-bfb90d1a70ef864a-00",
+        "traceparent": "00-f005521bd8747547b35362a5f65b68d5-5259b920d5f8714e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "e7af71a06d407893aafb6254ae09eac9",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:46 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:46 GMT",
-        "ETag": "\u00220x8D95786BDED0AC0\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:47 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:53 GMT",
+        "ETag": "\u00220x8D9688993516D72\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:54 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "e7af71a06d407893aafb6254ae09eac9",
-        "x-ms-request-id": "0527cc17-a01e-003b-626f-896135000000",
+        "x-ms-request-id": "36b89291-701e-0091-3f72-9a592d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1157461599/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1157461599/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-f649cbd97b9a464791cbc4e4c48f269a-d45435e5df677f4d-00",
+        "traceparent": "00-be3d910f34789443ac286d0c23fb873c-ea49ecef9e677245-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b8403d1719c573e912fed8ea5c745df2",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:46 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:46 GMT",
-        "ETag": "\u00220x8D95786BE372F7E\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:47 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:53 GMT",
+        "ETag": "\u00220x8D96889937DAF9A\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:54 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "b8403d1719c573e912fed8ea5c745df2",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0527cc83-a01e-003b-3d6f-896135000000",
+        "x-ms-request-id": "36b8932a-701e-0091-2272-9a592d000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target617672365?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target617672365?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4af89156a5143f41bdd556505e99e078-ca4a4bda43d0f34a-00",
+        "traceparent": "00-afe929962c02e444b667ff8fdfa9f708-656adfa0eab0aa4c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "56347764a0c30ee5263d5be12d6efaea",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:47 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:03:54 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:47 GMT",
-        "ETag": "\u00220x8D95786BE5CA99C\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:48 GMT",
+        "Date": "Thu, 26 Aug 2021 12:03:53 GMT",
+        "ETag": "\u00220x8D968899393D9D5\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:03:54 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "56347764a0c30ee5263d5be12d6efaea",
-        "x-ms-request-id": "0527cd28-a01e-003b-4b6f-896135000000",
+        "x-ms-request-id": "36b89446-701e-0091-5472-9a592d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-52915f6d10179749a10cbf87ee52327c-b6300e30f296c340-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-c415c83494043c4b96911bf9b3a6171f-5c6c7a1b1673d14a-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "9e0c24cf9a8087873cd54295a81c369e",
         "x-ms-return-client-request-id": "true"
       },
@@ -116,105 +116,105 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4547e1da-09c1-48c0-aa7e-563936392cae",
+        "apim-request-id": "cff867c2-8def-484a-8d8a-89601a0f42c7",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:47 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
+        "Date": "Thu, 26 Aug 2021 12:03:54 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4547e1da-09c1-48c0-aa7e-563936392cae"
+        "X-RequestId": "cff867c2-8def-484a-8d8a-89601a0f42c7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "9249a77072b59c545baa9fdb8e92e48f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cfc6b927-4e3d-4f0f-b1ba-a633ddc70ebf",
+        "apim-request-id": "4cf06274-96bb-4cf3-a282-d01eb1ce8854",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:48 GMT",
-        "ETag": "\u00227942387FAE7187161DB47B64BBDAEA4F3EB0A58DDD7F35EA69522981CDC5DC8A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:54 GMT",
+        "ETag": "\u0022DF8F730D81A1BD3F67F9E5AFC7C54D58AF09BC8AD600FD988237EDE61ECBFFB6\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cfc6b927-4e3d-4f0f-b1ba-a633ddc70ebf"
+        "X-RequestId": "4cf06274-96bb-4cf3-a282-d01eb1ce8854"
       },
       "ResponseBody": {
-        "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-        "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:48.8158465Z",
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:54.8079008Z",
         "status": "NotStarted",
         "summary": {
-          "total": 1,
+          "total": 0,
           "failed": 0,
           "success": 0,
           "inProgress": 0,
-          "notYetStarted": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "4f8d00dd5350ca2cefad1aed5e4f6509",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f815555-7727-49af-bc08-e637f1230bd1",
+        "apim-request-id": "98e93d6f-5713-4bcd-8e4e-e27b7be92732",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:49 GMT",
-        "ETag": "\u00227942387FAE7187161DB47B64BBDAEA4F3EB0A58DDD7F35EA69522981CDC5DC8A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:55 GMT",
+        "ETag": "\u0022565F2C83BAB1DBF74D56E3F6D7CE35915FA9ACB85628CC0C71687A28CA37AF8F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6f815555-7727-49af-bc08-e637f1230bd1"
+        "X-RequestId": "98e93d6f-5713-4bcd-8e4e-e27b7be92732"
       },
       "ResponseBody": {
-        "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-        "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:48.8158465Z",
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:55.6131342Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -228,41 +228,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "8670bc0768245c34cf7042d6faabf8a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9c8aff71-29c5-4d14-8bf5-3444050f0058",
+        "apim-request-id": "3a13feaa-f7a4-49ae-9ad7-b292b5ea4b11",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:50 GMT",
-        "ETag": "\u00227942387FAE7187161DB47B64BBDAEA4F3EB0A58DDD7F35EA69522981CDC5DC8A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:57 GMT",
+        "ETag": "\u0022565F2C83BAB1DBF74D56E3F6D7CE35915FA9ACB85628CC0C71687A28CA37AF8F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9c8aff71-29c5-4d14-8bf5-3444050f0058"
+        "X-RequestId": "3a13feaa-f7a4-49ae-9ad7-b292b5ea4b11"
       },
       "ResponseBody": {
-        "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-        "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:48.8158465Z",
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:55.6131342Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -276,89 +276,89 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "a8b7b3f0e68f1c4d7a7fa20857663e0b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8d6e2869-e542-4fb3-90a0-c04d8b10724e",
+        "apim-request-id": "66ecb7cd-4f7e-4e61-9d4a-806c928cddd8",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:51 GMT",
-        "ETag": "\u0022119394B04A44A52EFCF8D6AB64579A575CAFBC2CC454795EF3BD7A0DD1DB4422\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:58 GMT",
+        "ETag": "\u0022565F2C83BAB1DBF74D56E3F6D7CE35915FA9ACB85628CC0C71687A28CA37AF8F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8d6e2869-e542-4fb3-90a0-c04d8b10724e"
+        "X-RequestId": "66ecb7cd-4f7e-4e61-9d4a-806c928cddd8"
       },
       "ResponseBody": {
-        "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-        "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:52.0223948Z",
-        "status": "Running",
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:55.6131342Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "d1d495455e22756acc307fe01156d044",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2ac86d6a-e024-4cb6-86f0-fff286cb46a8",
+        "apim-request-id": "46e7f3e0-1914-43fd-9aa0-efc48b1f8481",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:53 GMT",
-        "ETag": "\u0022119394B04A44A52EFCF8D6AB64579A575CAFBC2CC454795EF3BD7A0DD1DB4422\u0022",
+        "Date": "Thu, 26 Aug 2021 12:03:59 GMT",
+        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2ac86d6a-e024-4cb6-86f0-fff286cb46a8"
+        "X-RequestId": "46e7f3e0-1914-43fd-9aa0-efc48b1f8481"
       },
       "ResponseBody": {
-        "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-        "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:52.0223948Z",
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -372,41 +372,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "abfc71b4bd97207a6f530ba5c52b0568",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dce238fc-2d10-4f74-970b-22bb8c05cb54",
+        "apim-request-id": "167d443f-d4ee-4ea0-a459-9fd926e769a7",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:54 GMT",
-        "ETag": "\u0022119394B04A44A52EFCF8D6AB64579A575CAFBC2CC454795EF3BD7A0DD1DB4422\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:00 GMT",
+        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "dce238fc-2d10-4f74-970b-22bb8c05cb54"
+        "X-RequestId": "167d443f-d4ee-4ea0-a459-9fd926e769a7"
       },
       "ResponseBody": {
-        "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-        "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:52.0223948Z",
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -420,26 +420,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "6491363226d692874842dc5e676d0b24",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a197c355-8dc3-46a8-8620-02e61bd43df1",
+        "apim-request-id": "c5729ffa-06a1-4ea4-a76f-0337609b02ed",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:55 GMT",
-        "ETag": "\u0022001330BE85C4D9F0B34AAE30A216483EAB99376B474A608737E0CFEF5CDBCF2B\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:02 GMT",
+        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c5729ffa-06a1-4ea4-a76f-0337609b02ed"
+      },
+      "ResponseBody": {
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e6545eae936a87731bb462ce53c4b0a0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8cb233a2-e10e-40eb-a4ff-8d0146be4ff8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:04:03 GMT",
+        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -449,12 +497,108 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a197c355-8dc3-46a8-8620-02e61bd43df1"
+        "X-RequestId": "8cb233a2-e10e-40eb-a4ff-8d0146be4ff8"
       },
       "ResponseBody": {
-        "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-        "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:52.0223948Z",
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "daad162b6bc58d6de96a6255e01bb901",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "82a93a3b-01f4-4631-a13b-b8dec294ec5f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:04:04 GMT",
+        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "82a93a3b-01f4-4631-a13b-b8dec294ec5f"
+      },
+      "ResponseBody": {
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "67f6e6481ed69ffec2094922c3b83e83",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8f8f2300-2f0c-4ac6-a87c-f19d78bfa69a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:04:05 GMT",
+        "ETag": "\u00221D665891DB5B9BA6D9A06F2B3DC4DA4D707F381F327BEE5DB57C50B98EDAAF2E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "8f8f2300-2f0c-4ac6-a87c-f19d78bfa69a"
+      },
+      "ResponseBody": {
+        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:05.8188604Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -468,63 +612,63 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/10f5f9f9-2d5c-463c-815b-4fc7e3f50be2/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e6545eae936a87731bb462ce53c4b0a0",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "50333b9130bf435ff1c7fcff301da700",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "35eae33b-bcc3-4242-aa79-4500c0899aca",
+        "apim-request-id": "9ac01725-0824-47b9-bb00-9e5f3752db6b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:55 GMT",
-        "ETag": "\u00222182EAA3F9B4DE239164E2CCB68D5A09E3C1DEDBE43E7854DBF25B6A48C1B902\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:05 GMT",
+        "ETag": "\u0022ABFB935FC6AD81977E8462317AB908F21BB36BC7E1F96229BFC78DFE78941C7A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "35eae33b-bcc3-4242-aa79-4500c0899aca"
+        "X-RequestId": "9ac01725-0824-47b9-bb00-9e5f3752db6b"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target617672365/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1157461599/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:30:51.746191Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:55.3738132Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target617672365/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1157461599/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:03:59.3333368Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:04:05.8188531Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53e8-0000-0000-0000-000000000000",
+            "id": "000b467e-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source308696619?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source637022715?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-848ced921afa184e904a9093c06caf8e-95da0b1440fce54f-00",
+        "traceparent": "00-647fa9b0b87c75498f4cf9f47ef9c66c-1841b012c4086746-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "c5daad166d6be98d6a6255e01bb90148",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:56 GMT",
+        "x-ms-client-request-id": "cd6c8661c949170c0e17bc224ac9302b",
+        "x-ms-date": "Thu, 26 Aug 2021 12:04:06 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -532,28 +676,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:56 GMT",
-        "ETag": "\u00220x8D95786C3BFA7E4\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:57 GMT",
+        "Date": "Thu, 26 Aug 2021 12:04:06 GMT",
+        "ETag": "\u00220x8D968899AE9DFBB\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:04:06 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "c5daad166d6be98d6a6255e01bb90148",
-        "x-ms-request-id": "0527dbad-a01e-003b-046f-896135000000",
+        "x-ms-client-request-id": "cd6c8661c949170c0e17bc224ac9302b",
+        "x-ms-request-id": "36b8c095-701e-0091-1e72-9a592d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source308696619/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source637022715/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-4a93da9341da894a99efbe33e80e2760-1563f297a4083244-00",
+        "traceparent": "00-ec48988df0061e49914ede667a67a143-d4de03e1d9df6f4a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d667f6e6fe1ec29f094922c3b83e8391",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:56 GMT",
+        "x-ms-client-request-id": "e7a4c4df41688717b3760f22ff6ea461",
+        "x-ms-date": "Thu, 26 Aug 2021 12:04:06 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -562,28 +706,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:56 GMT",
-        "ETag": "\u00220x8D95786C4081EFE\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:57 GMT",
+        "Date": "Thu, 26 Aug 2021 12:04:06 GMT",
+        "ETag": "\u00220x8D968899B193195\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:04:07 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d667f6e6fe1ec29f094922c3b83e8391",
+        "x-ms-client-request-id": "e7a4c4df41688717b3760f22ff6ea461",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0527dc1f-a01e-003b-596f-896135000000",
+        "x-ms-request-id": "36b8c0e8-701e-0091-6a72-9a592d000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1668979259?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1978624584?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-f6893cd3b789714382484f9f503f53fc-9211d07cbf38cd47-00",
+        "traceparent": "00-b8d655dede25f9418a36000192bd9216-db2e3dd11b27d54f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "30bf5033435fc7f1fcff301da700fb61",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:57 GMT",
+        "x-ms-client-request-id": "d232622748b5277138b018a220a6fdcb",
+        "x-ms-date": "Thu, 26 Aug 2021 12:04:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -591,27 +735,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:56 GMT",
-        "ETag": "\u00220x8D95786C42D98C4\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:57 GMT",
+        "Date": "Thu, 26 Aug 2021 12:04:06 GMT",
+        "ETag": "\u00220x8D968899B3240A4\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:04:07 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "30bf5033435fc7f1fcff301da700fb61",
-        "x-ms-request-id": "0527dcd5-a01e-003b-726f-896135000000",
+        "x-ms-client-request-id": "d232622748b5277138b018a220a6fdcb",
+        "x-ms-request-id": "36b8c1c2-701e-0091-2b72-9a592d000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-04d06eb127f5fe4fbb8cf169130e5010-82818e095614c34b-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "49cd6c860cc90e1717bc224ac9302bdf",
+        "traceparent": "00-2001f221b19f6943b41489c1a7a132d0-a9c30f7d14ae1b47-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "025951d392186e1fe41ad3baea18a072",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -631,10 +775,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d892024d-19b2-4084-94ad-da92529613b7",
+        "apim-request-id": "b41f78f5-141d-4de3-b305-24843c5b214b",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:57 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f7fe9d68-111f-4a6b-a389-0119d4df3805",
+        "Date": "Thu, 26 Aug 2021 12:04:07 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -642,46 +786,46 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d892024d-19b2-4084-94ad-da92529613b7"
+        "X-RequestId": "b41f78f5-141d-4de3-b305-24843c5b214b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f7fe9d68-111f-4a6b-a389-0119d4df3805",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "68e7a4c41741b387760f22ff6ea46148",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6723d95a59fe7b2932c03090fee593cf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa377781-e82c-40d0-b559-ff04b8a7315b",
+        "apim-request-id": "0a7e476b-b004-44a2-a3b5-9edfbd10c5c8",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:57 GMT",
-        "ETag": "\u0022AC1A3DE9715F3CA408D365B6964FD3DFFD08EF5B0DFB2207E0FA20F84B4E812A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:07 GMT",
+        "ETag": "\u002244FB88E8ABCA6D00027559017BF3052DCEEC71580358190C41EC56501A70F7F1\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "fa377781-e82c-40d0-b559-ff04b8a7315b"
+        "X-RequestId": "0a7e476b-b004-44a2-a3b5-9edfbd10c5c8"
       },
       "ResponseBody": {
-        "id": "f7fe9d68-111f-4a6b-a389-0119d4df3805",
-        "createdDateTimeUtc": "2021-08-04T20:30:58.2974422Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:58.2974427Z",
+        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:07.6583599Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -695,26 +839,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f7fe9d68-111f-4a6b-a389-0119d4df3805",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d232622748b5277138b018a220a6fdcb",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1d2b56125f4b943042c4ed9b75b73d1f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f3a9a747-8bae-4b5a-b70d-bd8f2123bc80",
+        "apim-request-id": "8d12627e-5576-46f9-81a2-93619a36de76",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:00 GMT",
-        "ETag": "\u002234EA199C8496F770B3716A4B88B214E0D6DEF46A53E14E17ACEF804EC1712AD2\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:08 GMT",
+        "ETag": "\u0022D42C7FCED043400E8195294EF7A3CC8308B9616887D5CC5483728A45F64E1E7E\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -724,12 +868,204 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f3a9a747-8bae-4b5a-b70d-bd8f2123bc80"
+        "X-RequestId": "8d12627e-5576-46f9-81a2-93619a36de76"
       },
       "ResponseBody": {
-        "id": "f7fe9d68-111f-4a6b-a389-0119d4df3805",
-        "createdDateTimeUtc": "2021-08-04T20:30:58.2974422Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:59.07834Z",
+        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:08.1551698Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4648a610968279cd27decf57628f6fff",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a295b88a-66b3-42eb-a91a-e02eefcbaba2",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:04:09 GMT",
+        "ETag": "\u0022D42C7FCED043400E8195294EF7A3CC8308B9616887D5CC5483728A45F64E1E7E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "a295b88a-66b3-42eb-a91a-e02eefcbaba2"
+      },
+      "ResponseBody": {
+        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:08.1551698Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "93a7038682ecfb27a98f243a6c8e067a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2f6fea1a-f691-4b14-8b40-cd6f23dacccb",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:04:10 GMT",
+        "ETag": "\u0022D42C7FCED043400E8195294EF7A3CC8308B9616887D5CC5483728A45F64E1E7E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2f6fea1a-f691-4b14-8b40-cd6f23dacccb"
+      },
+      "ResponseBody": {
+        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:08.1551698Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "587f10834c9c7b4d88b1f56d8fd832b3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2c94a30e-3a68-449d-95ab-d3f450224955",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:04:12 GMT",
+        "ETag": "\u0022D42C7FCED043400E8195294EF7A3CC8308B9616887D5CC5483728A45F64E1E7E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2c94a30e-3a68-449d-95ab-d3f450224955"
+      },
+      "ResponseBody": {
+        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:08.1551698Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7214ed54a9108e327e4d9df271930d99",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "206b1c6c-d75f-43ba-8951-2dd20923e9f8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:04:13 GMT",
+        "ETag": "\u00225F5491CA29EF2EB5FC7B887D638FAA011D69F22B04B57A57A9123AC95DE4C722\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "206b1c6c-d75f-43ba-8951-2dd20923e9f8"
+      },
+      "ResponseBody": {
+        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:13.8184144Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -743,41 +1079,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f7fe9d68-111f-4a6b-a389-0119d4df3805",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "025951d392186e1fe41ad3baea18a072",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "51d454d7170f3a63b52b0b3b8cba6bd0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ba694044-782a-43fd-a942-147d8eee471b",
+        "apim-request-id": "8dd7b0fd-b927-4a02-b06a-e5c7d04e50a6",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:01 GMT",
-        "ETag": "\u002234EA199C8496F770B3716A4B88B214E0D6DEF46A53E14E17ACEF804EC1712AD2\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:14 GMT",
+        "ETag": "\u002266EC335D8DEB3A7F91F56459122E5DF3BE4F58E12F62B715DC483BF992E3982F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ba694044-782a-43fd-a942-147d8eee471b"
+        "X-RequestId": "8dd7b0fd-b927-4a02-b06a-e5c7d04e50a6"
       },
       "ResponseBody": {
-        "id": "f7fe9d68-111f-4a6b-a389-0119d4df3805",
-        "createdDateTimeUtc": "2021-08-04T20:30:58.2974422Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:59.07834Z",
+        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:14.3445642Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -791,26 +1127,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f7fe9d68-111f-4a6b-a389-0119d4df3805",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6723d95a59fe7b2932c03090fee593cf",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7fe6715d9479da6addf1da4fae5a0af5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9ea7b658-0f28-4943-9792-7e875c9ef088",
+        "apim-request-id": "4b51f2fd-61f7-44d7-8eb7-5ca434b1074b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:02 GMT",
-        "ETag": "\u00222130A063600B1A6669E7EE27508B0218429F26816111CC9FA2E1F1F6E816ED75\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:15 GMT",
+        "ETag": "\u0022623A46C41A3D44EC3E9CA9984EA28E5B42DDD5D8B09FD5245A069D7C513E0814\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -820,12 +1156,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9ea7b658-0f28-4943-9792-7e875c9ef088"
+        "X-RequestId": "4b51f2fd-61f7-44d7-8eb7-5ca434b1074b"
       },
       "ResponseBody": {
-        "id": "f7fe9d68-111f-4a6b-a389-0119d4df3805",
-        "createdDateTimeUtc": "2021-08-04T20:30:58.2974422Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:59.07834Z",
+        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:04:16.1141626Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -839,75 +1175,75 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f7fe9d68-111f-4a6b-a389-0119d4df3805/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1d2b56125f4b943042c4ed9b75b73d1f",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3b955ca4e0043ca48ad9bce49df701c3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5d6a9482-ff7f-42f5-9ffb-bb0a867d0839",
+        "apim-request-id": "0e13a343-64db-4207-ab1a-a14f8ed1eea0",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:02 GMT",
-        "ETag": "\u00227E28DD3429DEEE5FF0A3264639D770F8C8AAAB54511B732DF54E603E45FD6FC7\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:17 GMT",
+        "ETag": "\u0022987B10CCD9023DBB31F552E2E31294A56FAF7DCBE80FF26DB548D81435E9B4E4\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "5d6a9482-ff7f-42f5-9ffb-bb0a867d0839"
+        "X-RequestId": "0e13a343-64db-4207-ab1a-a14f8ed1eea0"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target1668979259/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source308696619/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:30:58.7387832Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:02.4521785Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1978624584/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source637022715/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:04:13.8272033Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:04:16.1141571Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53e9-0000-0000-0000-000000000000",
+            "id": "000b467f-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=\u0026createdDateTimeUtcStart=2021-08-04T20%3A30%3A56.4836986Z\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2021-08-26T12%3A04%3A06.7589709Z",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21b9575b4f972246a3a0129606ce1436-ddce2c170d57f74a-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4648a610968279cd27decf57628f6fff",
+        "traceparent": "00-510f9c22dda3004b8d46addf2307b774-bbde3b03a94b3548-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0095cde18ead4320e9fa741d3d138c5a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "19ce91da-c4b9-4bbd-a5e2-afabef6b0b10",
+        "apim-request-id": "4de74637-db5c-4b72-9e14-c4a0c282d642",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:03 GMT",
-        "ETag": "\u00227344E546DBC25DB86A11DAD2C2CF5D4B5ADE07990E651AFB944EC0944AE8D1B5\u0022",
+        "Date": "Thu, 26 Aug 2021 12:04:17 GMT",
+        "ETag": "\u00220D4A4845FEECE96A6D04EEA2DF27306D67F9E35A5425C91E9F74205CF9BAC81A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -917,14 +1253,14 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "19ce91da-c4b9-4bbd-a5e2-afabef6b0b10"
+        "X-RequestId": "4de74637-db5c-4b72-9e14-c4a0c282d642"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "f7fe9d68-111f-4a6b-a389-0119d4df3805",
-            "createdDateTimeUtc": "2021-08-04T20:30:58.2974422Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:59.07834Z",
+            "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+            "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:04:16.1141626Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -941,10 +1277,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-04T22:30:56.4836986\u002B02:00",
+    "DateTimeOffsetNow": "2021-08-26T14:04:06.7589709\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
     "RandomSeed": "1670188230"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedBeforeTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedBeforeTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source680448150?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1647739607?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-ef24511c9cca464f8f19654ebd686cee-3de6ea8b9a66e747-00",
+        "traceparent": "00-e36d827dc2f3f0429da35d457d244072-77b0dfcdf178064a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "825017374621e1754255bfa5e0e55bda",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:12 GMT",
+        "x-ms-client-request-id": "1df559d209aec46df8800d6583d51bb8",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:12 GMT",
-        "ETag": "\u00220x8D9578686099ED1\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:13 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:07 GMT",
+        "ETag": "\u00220x8D9689D72578D95\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "825017374621e1754255bfa5e0e55bda",
-        "x-ms-request-id": "052722ee-a01e-003b-1d6f-896135000000",
+        "x-ms-client-request-id": "1df559d209aec46df8800d6583d51bb8",
+        "x-ms-request-id": "9acda33d-801e-0061-1086-9a1fdc000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source680448150/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1647739607/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-0b414c4f96b525438473ff9c0a1ed54b-2d6e58421cb7d149-00",
+        "traceparent": "00-3152bcc1e37c484e825ee099c5196369-153fa09aa626d747-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b8490d94c6e3efec980d483c7c8adc23",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:13 GMT",
+        "x-ms-client-request-id": "38aae55d4f87214514afabb2d6251941",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:13 GMT",
-        "ETag": "\u00220x8D95786865658D1\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:14 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:08 GMT",
+        "ETag": "\u00220x8D9689D729D0C10\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b8490d94c6e3efec980d483c7c8adc23",
+        "x-ms-client-request-id": "38aae55d4f87214514afabb2d6251941",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0527233e-a01e-003b-636f-896135000000",
+        "x-ms-request-id": "9acda392-801e-0061-5f86-9a1fdc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target148032307?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target2060907711?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-3b2b6785f3f1a840ab52db9f1de6c024-dafa6f54268b2140-00",
+        "traceparent": "00-d2c8a474d9c69d43a71bf1ebe077c96b-660af4ec41758848-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "09bc3f930bc385465f65af2c06d1ee81",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:13 GMT",
+        "x-ms-client-request-id": "981db4a145af5717265e041c295fb3f4",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,27 +76,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:13 GMT",
-        "ETag": "\u00220x8D95786867B8805\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:14 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:08 GMT",
+        "ETag": "\u00220x8D9689D72B7C0BC\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "09bc3f930bc385465f65af2c06d1ee81",
-        "x-ms-request-id": "0527244f-a01e-003b-4d6f-896135000000",
+        "x-ms-client-request-id": "981db4a145af5717265e041c295fb3f4",
+        "x-ms-request-id": "9acda438-801e-0061-6f86-9a1fdc000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bf453845f892e24b81112827253c7d9d-935ab328c16cfb4c-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "50ca106fb3b42a7060ea14fe3865b779",
+        "traceparent": "00-270496f211bf3f4d91883c2196e74f9e-974dde8bdf26cb45-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e8d825c44f1c1383d409fe5dbaedd267",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -116,57 +116,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d4baa4c0-12a3-4ec1-a792-37e321627bb7",
+        "apim-request-id": "2f600696-f348-49f3-91dc-756f56b3e0b6",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:13 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d4baa4c0-12a3-4ec1-a792-37e321627bb7"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a64d729bd09e02d1033283613cc3923c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e52ac24f-aa33-43dc-a3b5-7c1049a4e9d3",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:14 GMT",
-        "ETag": "\u0022421EF7C5432B8208C98FE82BAC3BD6C834D2B811406B3823EFA974C8DF7BF950\u0022",
-        "Retry-After": "1",
+        "Date": "Thu, 26 Aug 2021 14:26:10 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2f600696-f348-49f3-91dc-756f56b3e0b6"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "21e2a5cc1ffea0ad93e161f04104eb50",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0acf5193-901d-4483-b8b9-6e83ce5a885d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:10 GMT",
+        "ETag": "\u00229B82C4DB9589D1233BC6D3A89426C067DD7107A1528A9C59BF3BC2A0C73B1C4E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e52ac24f-aa33-43dc-a3b5-7c1049a4e9d3"
+        "X-RequestId": "0acf5193-901d-4483-b8b9-6e83ce5a885d"
       },
       "ResponseBody": {
-        "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-        "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:14.8411487Z",
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:10.7838791Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,41 +180,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "790cbb59d212e07ece91a9d8f7474dfa",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0012bef8584051a33009c4a646b99c39",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b013c6a7-09db-4e50-bc94-8bf553a19611",
+        "apim-request-id": "7ec31440-f84c-41a2-b6e9-778d592fc0e6",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:16 GMT",
-        "ETag": "\u0022B3FDEA6D79A6908D0DF355C304F661D27552571379F49FD724C1812E531AAB9F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:11 GMT",
+        "ETag": "\u0022FFBB68CF61BA4861952EA26EA5F9D70864420637904C932A0D69493815AEAAC6\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b013c6a7-09db-4e50-bc94-8bf553a19611"
+        "X-RequestId": "7ec31440-f84c-41a2-b6e9-778d592fc0e6"
       },
       "ResponseBody": {
-        "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-        "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:15.2347299Z",
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:11.9595834Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -228,26 +228,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "939036ae48849fe23fc84d812f0fee9d",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "83509c8b917ca4f57738543aee93d2cf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aa388438-3794-4094-b24b-4482b22022d5",
+        "apim-request-id": "54fbeba7-0ba6-4879-9bcd-24c2c00b3ea2",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:17 GMT",
-        "ETag": "\u0022CEAD58511244131204E565DDCA415E7ABA60C398B9580FACA3D6524F658EDCDE\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:12 GMT",
+        "ETag": "\u0022FFBB68CF61BA4861952EA26EA5F9D70864420637904C932A0D69493815AEAAC6\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "54fbeba7-0ba6-4879-9bcd-24c2c00b3ea2"
+      },
+      "ResponseBody": {
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:11.9595834Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fc65ae1dd2da73270190f1f45b0659da",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f8d97644-92a8-483b-9adb-8cfc71ed9c0b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:14 GMT",
+        "ETag": "\u0022FFBB68CF61BA4861952EA26EA5F9D70864420637904C932A0D69493815AEAAC6\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -257,12 +305,60 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "aa388438-3794-4094-b24b-4482b22022d5"
+        "X-RequestId": "f8d97644-92a8-483b-9adb-8cfc71ed9c0b"
       },
       "ResponseBody": {
-        "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-        "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:16.7676912Z",
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:11.9595834Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a464274567b466d3c86e88070368629c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4006cbe1-450c-4575-b2ac-2a03527b2988",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:15 GMT",
+        "ETag": "\u00228C2EEEE1EBE32BC92F82AFD1DFBC0CA7643F99C4404EE09425FEBB0474B8A258\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "4006cbe1-450c-4575-b2ac-2a03527b2988"
+      },
+      "ResponseBody": {
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:16.2771676Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -276,41 +372,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7da5d8583d58c866f36cd80d27f90abb",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9888f4369f53b95f75dc81eba0004870",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "87b13975-4577-407c-9dbd-32929842b61e",
+        "apim-request-id": "4133ceb5-cb06-4e62-8cfa-6651864fbec7",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:18 GMT",
-        "ETag": "\u0022CEAD58511244131204E565DDCA415E7ABA60C398B9580FACA3D6524F658EDCDE\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:16 GMT",
+        "ETag": "\u00228C2EEEE1EBE32BC92F82AFD1DFBC0CA7643F99C4404EE09425FEBB0474B8A258\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "87b13975-4577-407c-9dbd-32929842b61e"
+        "X-RequestId": "4133ceb5-cb06-4e62-8cfa-6651864fbec7"
       },
       "ResponseBody": {
-        "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-        "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:16.7676912Z",
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:16.2771676Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -324,26 +420,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "06b288e5fe3211b8d86d3a4a85fdb0be",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c7f57adf2e2eb61bdaff336b491f7099",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "66413772-820d-435c-b9be-893422dab911",
+        "apim-request-id": "f88569cc-1356-4dcc-9043-51d3e0b23076",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:20 GMT",
-        "ETag": "\u0022CECC7D51F1D82658AABBA268F46F4E0ACC9DC16D5FDBBA1D4A3C1143CDDFE490\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:17 GMT",
+        "ETag": "\u00228C2EEEE1EBE32BC92F82AFD1DFBC0CA7643F99C4404EE09425FEBB0474B8A258\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f88569cc-1356-4dcc-9043-51d3e0b23076"
+      },
+      "ResponseBody": {
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:16.2771676Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "66bd542ec07da587c8ab2ed8e5e7c6c7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f750e202-7622-4e3c-bc57-d8e3ddaa79c4",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:20 GMT",
+        "ETag": "\u00228C2EEEE1EBE32BC92F82AFD1DFBC0CA7643F99C4404EE09425FEBB0474B8A258\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -353,12 +497,156 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "66413772-820d-435c-b9be-893422dab911"
+        "X-RequestId": "f750e202-7622-4e3c-bc57-d8e3ddaa79c4"
       },
       "ResponseBody": {
-        "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-        "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:16.7676912Z",
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:16.2771676Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "892818259b72086ed9d2bd546cf37056",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "22a315b5-afa7-4e94-a340-a27d950f389d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:21 GMT",
+        "ETag": "\u00228C2EEEE1EBE32BC92F82AFD1DFBC0CA7643F99C4404EE09425FEBB0474B8A258\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "22a315b5-afa7-4e94-a340-a27d950f389d"
+      },
+      "ResponseBody": {
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:16.2771676Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4bbde86ce2431ef2f350fe83ff42d0f3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "92969a2f-7634-4169-9379-2c3333d1109f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:22 GMT",
+        "ETag": "\u00228C2EEEE1EBE32BC92F82AFD1DFBC0CA7643F99C4404EE09425FEBB0474B8A258\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "92969a2f-7634-4169-9379-2c3333d1109f"
+      },
+      "ResponseBody": {
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:16.2771676Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "31456c38e7f79226e6b48cab033238d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "15f4f242-baff-47f6-9319-d09f0796cb4c",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:24 GMT",
+        "ETag": "\u002219FBC7BB00D26896CEB45E717C15F3AA3584884BE885978BA340F7B83D25A7A5\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "15f4f242-baff-47f6-9319-d09f0796cb4c"
+      },
+      "ResponseBody": {
+        "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+        "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:22.750038Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -372,63 +660,63 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b52c3e52-8d38-4c7a-b5d0-54679bcc80b5/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a11da8bf-52c5-4ded-b29e-0e2607a91a47/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1f800ba3d0a271a2cfc79f1770d57746",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fd6bd83a7a294384250996219cea0996",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "edbe7894-228f-4967-97b0-954cbf2b13a6",
+        "apim-request-id": "de63d980-b720-468c-9e70-0b4e93c51caa",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:20 GMT",
-        "ETag": "\u002295BBFFD61494E1227C9E9C8EE73F7D67E2908205402A7E56F002C5FD4597CFC7\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:24 GMT",
+        "ETag": "\u0022A60F3CD94E5FB6A3D6970579CB34F4D858DEA1833F37D3F37A9B9356FF8413D6\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "edbe7894-228f-4967-97b0-954cbf2b13a6"
+        "X-RequestId": "de63d980-b720-468c-9e70-0b4e93c51caa"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target148032307/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source680448150/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:29:16.4245308Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:19.0909889Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2060907711/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1647739607/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:26:15.3474021Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:26:22.7500282Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53cc-0000-0000-0000-000000000000",
+            "id": "000b546e-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1618384829?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source2111282433?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0b8b3e0aeb88c74b91b884e9dd79752b-3c1ddba7673fa24c-00",
+        "traceparent": "00-f73bc7dd59370f43a527ac9874ed3be3-3bc70148394e0640-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "5da79c916ae71f5993a4ea021c43f6bc",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:20 GMT",
+        "x-ms-client-request-id": "ae001bca5e3fc1842b658e55471bc017",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -436,28 +724,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:20 GMT",
-        "ETag": "\u00220x8D957868A68E12F\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:20 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:23 GMT",
+        "ETag": "\u00220x8D9689D7BDAC62C\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:24 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "5da79c916ae71f5993a4ea021c43f6bc",
-        "x-ms-request-id": "05272f8c-a01e-003b-056f-896135000000",
+        "x-ms-client-request-id": "ae001bca5e3fc1842b658e55471bc017",
+        "x-ms-request-id": "9acdbc9b-801e-0061-2786-9a1fdc000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1618384829/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source2111282433/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-71e8622897b3134da655a4b5b0000c65-12336587d3db454c-00",
+        "traceparent": "00-27977cfd43ecd14a8fbfa8ca9b927d6e-163453747f432a46-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "781b691919ebe61541366b5ea0a103f6",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:20 GMT",
+        "x-ms-client-request-id": "d727482ac9d3e7be010bed5105f5fbab",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -466,28 +754,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:20 GMT",
-        "ETag": "\u00220x8D957868AC1F9B8\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:21 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:24 GMT",
+        "ETag": "\u00220x8D9689D7C152025\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:25 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "781b691919ebe61541366b5ea0a103f6",
+        "x-ms-client-request-id": "d727482ac9d3e7be010bed5105f5fbab",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05273027-a01e-003b-156f-896135000000",
+        "x-ms-request-id": "9acdbd16-801e-0061-1586-9a1fdc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1517017844?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1979728373?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c513529ad2b3b64f85bdd79bc3e43539-f093b9eeecab954f-00",
+        "traceparent": "00-a1a85e0b30460f49ab230c377010181a-7fff94d528f5a246-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "0961f38cbb6127a0ff0f2bb76fb383a9",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:21 GMT",
+        "x-ms-client-request-id": "381738a9fb25e7793bfe14f6eeddeed5",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -495,27 +783,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:20 GMT",
-        "ETag": "\u00220x8D957868AE79DF2\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:21 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:24 GMT",
+        "ETag": "\u00220x8D9689D7C3504AB\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:25 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "0961f38cbb6127a0ff0f2bb76fb383a9",
-        "x-ms-request-id": "05273101-a01e-003b-556f-896135000000",
+        "x-ms-client-request-id": "381738a9fb25e7793bfe14f6eeddeed5",
+        "x-ms-request-id": "9acdbdf0-801e-0061-5d86-9a1fdc000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fb26ce3e19956940b15fedc345de9839-f93e6d99ff9ae240-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5b6b565bd2cd8678c01bb1fffa7ff2a1",
+        "traceparent": "00-1780267ce5d3a5418e4c08f67214e27a-58b124828b11b74f-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e2a172092ebf5d0018ac337133bc3569",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -535,57 +823,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cdc8ade5-3a96-4dcb-9ad0-4a27068a368a",
+        "apim-request-id": "29436bb2-b3ba-49a1-8fbb-6a73898c62d1",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:22 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/129932a4-ccc4-4702-ae64-ed24fa9ebe30",
+        "Date": "Thu, 26 Aug 2021 14:26:25 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cdc8ade5-3a96-4dcb-9ad0-4a27068a368a"
+        "X-RequestId": "29436bb2-b3ba-49a1-8fbb-6a73898c62d1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/129932a4-ccc4-4702-ae64-ed24fa9ebe30",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "50900df4b295aeb77b51eb0ae92ed183",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e29e5fe2dfa94d04adef98caa9f1132e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a0affefe-4ae4-4b5b-9ef3-cd2df75898ac",
+        "apim-request-id": "f08a6209-6a41-4b57-8015-6d75a2313e08",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:22 GMT",
-        "ETag": "\u0022CAF9E7E952E560237F55992A086963732763AF1FA5B68BAD98AC0ACF8844EF6C\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:25 GMT",
+        "ETag": "\u00226BBC1D903737AAB60E0DE7A7725389F4D2AF538AED5DCB8E50DF6CCE989C17F0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a0affefe-4ae4-4b5b-9ef3-cd2df75898ac"
+        "X-RequestId": "f08a6209-6a41-4b57-8015-6d75a2313e08"
       },
       "ResponseBody": {
-        "id": "129932a4-ccc4-4702-ae64-ed24fa9ebe30",
-        "createdDateTimeUtc": "2021-08-04T20:29:22.21029Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:22.2102903Z",
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:25.730972Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -599,26 +887,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/129932a4-ccc4-4702-ae64-ed24fa9ebe30",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4a45b5e79a97b9267ada48450aa12c80",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "83fb7bfec9597a3637b92079c807b37f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "630302ac-1f35-46dc-8b1a-e020694c0c82",
+        "apim-request-id": "9858cc27-8260-4664-8a6d-a912e313b51f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:23 GMT",
-        "ETag": "\u0022D611D275D214654E9FB8C90A784718B1B38731A1E37B05CF783104A3ACB262F0\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:27 GMT",
+        "ETag": "\u00228609773CEA6A1DFEF94B2997639BAEC01301C92EB0C4A846E756F59AEE1AAC99\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9858cc27-8260-4664-8a6d-a912e313b51f"
+      },
+      "ResponseBody": {
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:26.5631882Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8e13aac90b3f2a2c6d5434cf9635b327",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "132ca17d-2b9e-484b-b2b9-21803bc0ab12",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:28 GMT",
+        "ETag": "\u00228609773CEA6A1DFEF94B2997639BAEC01301C92EB0C4A846E756F59AEE1AAC99\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -628,12 +964,108 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "630302ac-1f35-46dc-8b1a-e020694c0c82"
+        "X-RequestId": "132ca17d-2b9e-484b-b2b9-21803bc0ab12"
       },
       "ResponseBody": {
-        "id": "129932a4-ccc4-4702-ae64-ed24fa9ebe30",
-        "createdDateTimeUtc": "2021-08-04T20:29:22.21029Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:23.4652864Z",
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:26.5631882Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b7720498b1c1180f2923aaefbe8b85a5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5f6ebb7d-c444-4613-8d9f-31dbd5753012",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:29 GMT",
+        "ETag": "\u00228609773CEA6A1DFEF94B2997639BAEC01301C92EB0C4A846E756F59AEE1AAC99\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "5f6ebb7d-c444-4613-8d9f-31dbd5753012"
+      },
+      "ResponseBody": {
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:26.5631882Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ff01193c84ddf3ef4fd016059566e401",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2826ba2c-dfef-4bad-99a5-595596eb7fc7",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:30 GMT",
+        "ETag": "\u0022D138D7D41A1DD9333DFE6E1E5BFCA5A4868867B646A2DD8E11CFD11F609C4B19\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2826ba2c-dfef-4bad-99a5-595596eb7fc7"
+      },
+      "ResponseBody": {
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:30.4279906Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -647,41 +1079,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/129932a4-ccc4-4702-ae64-ed24fa9ebe30",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "61c38a1c3322a8149fbde07ce76e9d91",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c3e1f906fb9518bd9afa651b603c6ce2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "035b4c71-7e4d-4012-8d3c-a7fa39dea6d1",
+        "apim-request-id": "6cf17687-46be-4d2d-9f60-6dee9eab64ae",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:24 GMT",
-        "ETag": "\u002292C4DFD519DA9A090465BCA1E5C0949174390AA24C00115011C6D57276870F40\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:32 GMT",
+        "ETag": "\u00228A57FB63E7FD9CD549194EE45E82C2C5A427F321AAFD4469F3E533E43ED2144C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "035b4c71-7e4d-4012-8d3c-a7fa39dea6d1"
+        "X-RequestId": "6cf17687-46be-4d2d-9f60-6dee9eab64ae"
       },
       "ResponseBody": {
-        "id": "129932a4-ccc4-4702-ae64-ed24fa9ebe30",
-        "createdDateTimeUtc": "2021-08-04T20:29:22.21029Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:23.790485Z",
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:31.9555243Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -695,26 +1127,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/129932a4-ccc4-4702-ae64-ed24fa9ebe30",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "45182e4aa7395909e6d6d5ba6971a4da",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7d938ecfb4341349157f68f09a0a83c3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "462f8240-cf31-48ba-a2ab-8170fe4365ba",
+        "apim-request-id": "800a749d-c7f0-41b8-9634-124658c30874",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:26 GMT",
-        "ETag": "\u00223CE16BCDAE53B9435D4E7F0EABA79CAE7015B38633769FFED4095E4B6F41265F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:33 GMT",
+        "ETag": "\u00228A57FB63E7FD9CD549194EE45E82C2C5A427F321AAFD4469F3E533E43ED2144C\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "800a749d-c7f0-41b8-9634-124658c30874"
+      },
+      "ResponseBody": {
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:31.9555243Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c5e8a93ec1aa41105be964e21fd39212",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2763c369-3477-497b-bbd1-411466233a26",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:34 GMT",
+        "ETag": "\u00228A57FB63E7FD9CD549194EE45E82C2C5A427F321AAFD4469F3E533E43ED2144C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -724,12 +1204,156 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "462f8240-cf31-48ba-a2ab-8170fe4365ba"
+        "X-RequestId": "2763c369-3477-497b-bbd1-411466233a26"
       },
       "ResponseBody": {
-        "id": "129932a4-ccc4-4702-ae64-ed24fa9ebe30",
-        "createdDateTimeUtc": "2021-08-04T20:29:22.21029Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:23.790485Z",
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:31.9555243Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0636346467d352cdafcdad1593cd7d90",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d012904f-6fee-4f7c-8a37-87ecb59460a3",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:35 GMT",
+        "ETag": "\u00228A57FB63E7FD9CD549194EE45E82C2C5A427F321AAFD4469F3E533E43ED2144C\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d012904f-6fee-4f7c-8a37-87ecb59460a3"
+      },
+      "ResponseBody": {
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:31.9555243Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b7dca277a7530d387e52214b5067f442",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "70dbeee6-185e-4a5f-a19e-b91831e16b6e",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:37 GMT",
+        "ETag": "\u00228A57FB63E7FD9CD549194EE45E82C2C5A427F321AAFD4469F3E533E43ED2144C\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "70dbeee6-185e-4a5f-a19e-b91831e16b6e"
+      },
+      "ResponseBody": {
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:31.9555243Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "668c55ed7dd4d7f0db9615dc14fbae8e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6e80b5f0-a4b7-4799-b676-8c47fc686d2d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:38 GMT",
+        "ETag": "\u0022C5F25A551C041A96345B0C136C2000180856BA83B16F4F7E9D797BC04B8FE311\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "6e80b5f0-a4b7-4799-b676-8c47fc686d2d"
+      },
+      "ResponseBody": {
+        "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+        "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:37.7800382Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -743,92 +1367,92 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/129932a4-ccc4-4702-ae64-ed24fa9ebe30/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6967a5c1-7e38-4a12-a2f8-ba46d0de1382/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5fed6b24706bb360a19daadabaaad20c",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7d6bd36bdaf7bdbefc28888045810248",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "324b230f-cfe0-4efe-8055-f35307bda308",
+        "apim-request-id": "dab92bdb-d684-4a63-b29e-9a69f828d85c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:26 GMT",
-        "ETag": "\u0022E446972351D8EE98327319C84E85CCCBEFCB967CDE7745B942DB6856710F78A0\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:38 GMT",
+        "ETag": "\u0022B2A521F1F961BB7E5E8AA78749C588B089F200E3E07B862B54F940CB0816CC8F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "324b230f-cfe0-4efe-8055-f35307bda308"
+        "X-RequestId": "dab92bdb-d684-4a63-b29e-9a69f828d85c"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target1517017844/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1618384829/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:29:23.4728611Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:25.8981127Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1979728373/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source2111282433/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:26:30.4595658Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:26:37.7800309Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53cd-0000-0000-0000-000000000000",
+            "id": "000b546f-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=\u0026createdDateTimeUtcEnd=2021-08-04T20%3A29%3A20.1766912Z\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2021-08-26T13%3A26%3A24.5965448Z\u0026createdDateTimeUtcEnd=2021-08-26T14%3A26%3A24.5965448Z",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b0e00f4e288634e9631b97b8befcb39-2944f289dcc55a46-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dcfbb63de7887547806a7a4c5d593e2e",
+        "traceparent": "00-389e64baf3d0b84595859834a66ea917-d4098f211289c448-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3d286bd81740fabcb205dbbd915bf982",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0634f662-7805-4162-8b4f-c0158e7b6172",
+        "apim-request-id": "d942682b-2ba8-4c95-af0e-320bd53a594f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:26 GMT",
-        "ETag": "\u0022CCC2ABE47E17B81A3B733718BB088B4C216E6A8322ED99475D17BFB00D11B19F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:38 GMT",
+        "ETag": "\u0022F973A9A41D10556F206113C29D0EE12B2C5CFD01E54FD5F84A1BF23947C29BA8\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0634f662-7805-4162-8b4f-c0158e7b6172"
+        "X-RequestId": "d942682b-2ba8-4c95-af0e-320bd53a594f"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-            "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:16.7676912Z",
+            "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+            "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:26:22.750038Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -841,9 +1465,9 @@
             }
           },
           {
-            "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-            "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:09.8583078Z",
+            "id": "bb45a362-13a0-449e-90dc-d69533d8d6ac",
+            "createdDateTimeUtc": "2021-08-26T14:17:29.5270404Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:17:34.9950826Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -856,9 +1480,9 @@
             }
           },
           {
-            "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-            "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:28:57.0357411Z",
+            "id": "27afbfd6-2719-4056-96a9-139c27a71cda",
+            "createdDateTimeUtc": "2021-08-26T14:17:24.3347057Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:17:28.1450972Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -871,99 +1495,9 @@
             }
           },
           {
-            "id": "de3ae1b9-065c-4a2b-9da3-a413d0e1d828",
-            "createdDateTimeUtc": "2021-08-04T20:13:20.3289712Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:21.8009118Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5e58ffb7-c561-4ada-908a-5fb618214b57",
-            "createdDateTimeUtc": "2021-08-04T20:13:14.1830952Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:16.2626995Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "7349a49c-f2e4-4c35-938e-976306fdf0ec",
-            "createdDateTimeUtc": "2021-08-04T20:13:07.7204022Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:09.4175921Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "dad50132-5081-4e87-9cdb-8305960adaad",
-            "createdDateTimeUtc": "2021-08-04T20:13:00.3134951Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:02.1869029Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5149a480-1a90-4483-b9fe-8c0ae356c975",
-            "createdDateTimeUtc": "2021-08-04T20:12:48.8123001Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:12:52.257366Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "95d1a6fa-cbcc-4eda-b8c5-7f9dea903155",
-            "createdDateTimeUtc": "2021-08-04T20:12:39.6819361Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:12:42.109702Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "ee205c17-3434-4372-9ec8-093d3fc2ab0e",
-            "createdDateTimeUtc": "2021-08-03T21:39:22.1215914Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:24.0088345Z",
+            "id": "ec3c7f81-c26e-4839-b30b-49b33f053911",
+            "createdDateTimeUtc": "2021-08-26T14:17:18.1117495Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:17:21.3046774Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -976,9 +1510,9 @@
             }
           },
           {
-            "id": "034ac505-8e05-45e9-b69d-4ae5db5c3206",
-            "createdDateTimeUtc": "2021-08-03T21:39:15.57059Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:16.9287241Z",
+            "id": "f242782c-459d-4398-b7e4-3e0e0c6e84db",
+            "createdDateTimeUtc": "2021-08-26T14:17:05.0963349Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:17:16.3535435Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -991,54 +1525,9 @@
             }
           },
           {
-            "id": "1c2e403d-4f5f-4176-ac0b-d6525df7993d",
-            "createdDateTimeUtc": "2021-08-03T21:39:08.8759005Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:09.8373116Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1f96fca2-aaec-427c-92d0-fc8d43372768",
-            "createdDateTimeUtc": "2021-08-03T21:39:02.4121988Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:05.2080796Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "52fa5dc7-49d0-4490-b402-1817331f10f9",
-            "createdDateTimeUtc": "2021-08-03T21:38:57.2193344Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:58.2127609Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "98452bfa-797a-44c2-9bb2-d7fd159fab0d",
-            "createdDateTimeUtc": "2021-08-03T21:38:51.6547083Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:54.3057302Z",
+            "id": "3c773c25-3b05-48cb-92b3-fe321b99ca9d",
+            "createdDateTimeUtc": "2021-08-26T14:07:14.0385355Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:07:21.6924944Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1051,9 +1540,24 @@
             }
           },
           {
-            "id": "32aebb1f-9dd9-4bf4-a684-514bde841fd8",
-            "createdDateTimeUtc": "2021-08-03T21:38:47.6125244Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:53.9775319Z",
+            "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+            "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:07:06.928173Z",
+            "status": "Succeeded",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 1,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 16
+            }
+          },
+          {
+            "id": "f81d5c81-f7db-41da-baa7-dff063bd88c4",
+            "createdDateTimeUtc": "2021-08-26T14:06:50.6689792Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:06:55.7249243Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1066,9 +1570,9 @@
             }
           },
           {
-            "id": "8e25b211-27f2-4793-99d0-6e47f55427a8",
-            "createdDateTimeUtc": "2021-08-03T21:38:30.9134208Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:33.1131258Z",
+            "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+            "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:06:43.2132613Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -1078,6216 +1582,6 @@
               "notYetStarted": 0,
               "cancelled": 0,
               "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "45af44ab-ab27-4533-be94-d14fdc2f1d69",
-            "createdDateTimeUtc": "2021-08-03T21:38:23.1840352Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:26.0456158Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5fe83ec6-8231-4c42-8f7e-a04b75c0fa20",
-            "createdDateTimeUtc": "2021-08-03T21:38:16.5690668Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:19.2704212Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2dcc3a07-d808-4004-8cbc-f8d7047be6ea",
-            "createdDateTimeUtc": "2021-08-03T21:38:08.8344934Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:12.1744445Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d44ccbb4-7c5e-4230-8641-699df49bc974",
-            "createdDateTimeUtc": "2021-08-03T21:38:03.662895Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:05.099967Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b911d708-f339-4c49-b387-3a93b892edca",
-            "createdDateTimeUtc": "2021-08-03T21:37:55.9487829Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:58.091697Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3e1a9fd7-eefa-4140-bb3d-0cae619045c8",
-            "createdDateTimeUtc": "2021-08-03T21:37:49.2093973Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:51.1527605Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5c031e55-d105-4fcd-bddf-341af3c07de3",
-            "createdDateTimeUtc": "2021-08-03T21:37:42.4444943Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:44.066063Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f422877d-d674-4826-855b-6b918a1f8448",
-            "createdDateTimeUtc": "2021-08-03T21:37:35.5232446Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:37.1398344Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6d647efa-7b96-4bb4-b74a-76f2cf63b647",
-            "createdDateTimeUtc": "2021-08-03T21:37:28.0253539Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:30.0244215Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9530409a-3f1c-4184-a932-62f7586ca48c",
-            "createdDateTimeUtc": "2021-08-03T21:37:21.3477618Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:23.0535345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "02188384-3e1d-4fd5-b7b2-1c436155a427",
-            "createdDateTimeUtc": "2021-08-03T21:37:14.5363644Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:15.8789238Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e462cb0b-c257-4a03-8704-bafedb9a34ec",
-            "createdDateTimeUtc": "2021-08-03T21:37:06.740111Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:08.9139737Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9c2aff22-052b-4fe3-a77a-0e3d002157cb",
-            "createdDateTimeUtc": "2021-08-03T21:37:00.1515856Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:01.782922Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cbd315d5-9d09-4805-aeaf-dbf5a09b3f7f",
-            "createdDateTimeUtc": "2021-08-03T21:36:50.9777091Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:54.8378022Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f434c3d-7dd9-4305-8231-52ea7ef8822a",
-            "createdDateTimeUtc": "2021-08-03T21:36:37.1050378Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:39.7392021Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9bb6ced9-7570-404b-ae57-f0f6239284ff",
-            "createdDateTimeUtc": "2021-08-03T21:36:17.4274204Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:24.6427413Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c55e7e92-9f89-4061-b896-c719864f6227",
-            "createdDateTimeUtc": "2021-08-03T21:36:09.0638051Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:10.9653857Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e7d6e45d-7068-410e-b993-c18ad571354f",
-            "createdDateTimeUtc": "2021-08-03T21:35:56.6699145Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:03.8654828Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce58c3d3-4f45-498d-b593-6a5e7e7bd192",
-            "createdDateTimeUtc": "2021-08-03T21:35:47.9412218Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:49.5951191Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1eb03d70-54fd-4310-a4bc-de808f681a39",
-            "createdDateTimeUtc": "2021-08-03T21:35:41.0214036Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:42.5156289Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0554a9e0-53ab-49cc-8f1b-6d102523e16e",
-            "createdDateTimeUtc": "2021-08-03T21:35:34.1373856Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:35.4992558Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2219aa8b-281e-4c42-9605-10c76cc72913",
-            "createdDateTimeUtc": "2021-08-03T21:35:26.2122116Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:28.9695764Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8ed3d7d1-4161-4da8-969f-f9ecd5080ad9",
-            "createdDateTimeUtc": "2021-08-03T21:35:20.7604613Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:21.8167479Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2a132541-29db-4298-8ba7-16244a41d852",
-            "createdDateTimeUtc": "2021-08-03T21:35:07.9761301Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:14.7038749Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "72f0b845-0052-4963-b25f-5e8af00d9b14",
-            "createdDateTimeUtc": "2021-08-03T21:34:58.9227471Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:59.6529936Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "134a4212-2732-497b-8390-42fdd37d21e4",
-            "createdDateTimeUtc": "2021-08-03T21:34:50.9445779Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:52.6686072Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0f9f6f1d-fbb2-4fc0-af0e-6f150e37af73",
-            "createdDateTimeUtc": "2021-08-03T21:34:44.4279088Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:45.6922406Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7ad52735-0cfc-4605-994b-a001b55239da",
-            "createdDateTimeUtc": "2021-08-03T21:34:36.6416807Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:40.3689165Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4a6f90f-809d-49a7-94bd-02b8ca21f03c",
-            "createdDateTimeUtc": "2021-08-03T21:34:23.5791957Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:25.3619831Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7fd3d1ca-a218-465c-8ff4-eb4048c38473",
-            "createdDateTimeUtc": "2021-08-03T21:34:16.1133883Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:18.3802341Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "196b19e9-ecbd-436d-877a-35b530e2c0fe",
-            "createdDateTimeUtc": "2021-08-03T21:34:09.5321065Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:11.3582876Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1fb76e64-f983-4edc-9d22-4f99e100acc3",
-            "createdDateTimeUtc": "2021-08-03T21:33:57.8667531Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:04.2518359Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c89dca35-2a09-4223-aead-e3e3c5d620f7",
-            "createdDateTimeUtc": "2021-08-03T21:33:46.1148308Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:50.7386282Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=353\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=353\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3d32445348990546988006d5e9646617-e6af53fac689d94d-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7b5806183d81d926cd64a39bfc2f9f3c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e491d528-3622-4d94-bfac-d98696c51ed7",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:27 GMT",
-        "ETag": "\u0022F626F34B7726F37E220189508A6B4DC66E055732ABC22082E96B4FDDE6BC62FE\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e491d528-3622-4d94-bfac-d98696c51ed7"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "6c30daea-f0dc-45d2-a5f2-c9c9ca5c454d",
-            "createdDateTimeUtc": "2021-08-03T21:33:40.0877854Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:42.98622Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "06da1349-40ca-40a9-bcbc-bd1e846f3b88",
-            "createdDateTimeUtc": "2021-08-03T21:33:35.9538097Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:38.6215767Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8afbd2b4-c1ed-4724-9e12-85961ac830ea",
-            "createdDateTimeUtc": "2021-08-03T21:33:09.7165208Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:18.2261067Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f14238b7-28ec-48ab-b76f-24d83d6dffb1",
-            "createdDateTimeUtc": "2021-08-03T21:33:01.8426407Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:03.3408766Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "dba26cd3-c01a-41a3-aa8f-8267cf500fec",
-            "createdDateTimeUtc": "2021-08-03T21:32:55.2352866Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:56.1955205Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "658543b1-f494-4515-b258-7df811c67fc4",
-            "createdDateTimeUtc": "2021-08-03T21:32:48.2354429Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:49.1386196Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "909802b6-105c-43b8-b323-1c2a8e3312bb",
-            "createdDateTimeUtc": "2021-08-03T21:32:42.6249984Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:43.7383766Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c0eb9e4b-eb06-4d7a-a1f9-d38af1250cfd",
-            "createdDateTimeUtc": "2021-08-03T21:32:34.5973391Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:36.730268Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "76ebe7f5-60a3-4ef7-a683-49370dad24a6",
-            "createdDateTimeUtc": "2021-08-03T21:32:28.4958568Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:29.6601157Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bb59e6b0-23b7-44e5-9057-2254f90fe98f",
-            "createdDateTimeUtc": "2021-08-03T21:32:20.7234242Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:22.6496271Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "28e02b6f-0895-4f5c-9a9f-2b52422c014c",
-            "createdDateTimeUtc": "2021-08-03T21:32:14.2081813Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:15.7088003Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1dbd7a32-7f17-4aef-9d3c-9dd4cdd2efa5",
-            "createdDateTimeUtc": "2021-08-03T21:32:07.5152962Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:08.641319Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9b3a8bcf-3b59-46f1-b705-7c6baf22c1a5",
-            "createdDateTimeUtc": "2021-08-03T21:32:00.4355607Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:01.5891063Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6318a8e-c90f-4781-92d1-8ce5e24597fe",
-            "createdDateTimeUtc": "2021-08-03T21:31:52.5113337Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:54.509403Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e9b2eeb6-267b-47aa-8fa9-5967c6388d6b",
-            "createdDateTimeUtc": "2021-08-03T21:31:46.0577699Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:47.5253048Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "487aa9c1-42d1-4b50-b8fc-3f85395ad6ac",
-            "createdDateTimeUtc": "2021-08-03T21:31:39.494573Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:40.4162301Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b50424f3-68b3-4e1b-8234-a23451697697",
-            "createdDateTimeUtc": "2021-08-03T21:31:30.3843702Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:34.1919695Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2541716b-10fc-4ab7-b914-f0c77cb139be",
-            "createdDateTimeUtc": "2021-08-03T21:31:14.9137729Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:19.0230031Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fdd7087b-33d3-403d-be85-1ab00fb30319",
-            "createdDateTimeUtc": "2021-08-03T21:31:01.2624907Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:05.3693236Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "203a2eb7-45bb-4bea-a0f8-0c955469a993",
-            "createdDateTimeUtc": "2021-08-03T21:30:48.6999513Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:53.8967855Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8fd4aa26-458e-4039-bb3e-98bbcced99e0",
-            "createdDateTimeUtc": "2021-08-03T21:30:37.0230807Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:38.9030608Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7b349018-5715-4420-a7f0-c43bd66289fc",
-            "createdDateTimeUtc": "2021-08-03T21:30:28.4100426Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:30.2839253Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d26b9cd2-9b7d-4237-a26f-499dc048e311",
-            "createdDateTimeUtc": "2021-08-03T21:30:20.4404126Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:23.9070865Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "052b5b6a-f84c-4230-aa1f-26a61effcde2",
-            "createdDateTimeUtc": "2021-08-03T21:30:13.8603639Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:16.8464878Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ff2b5c18-708a-440f-bf37-efc7110c99ad",
-            "createdDateTimeUtc": "2021-08-03T21:30:06.9759347Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:09.8165024Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "73fead5d-cc86-4599-a092-9cc9d0c2c342",
-            "createdDateTimeUtc": "2021-08-03T21:30:00.4839216Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:02.7580915Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9575e40d-8d1f-448d-8b42-0eab021412d1",
-            "createdDateTimeUtc": "2021-08-03T21:29:53.8576053Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:55.676247Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "acd96228-cfd4-49fb-b646-794db3c9e15e",
-            "createdDateTimeUtc": "2021-08-03T21:29:47.0106537Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:48.6365299Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e77e2fc-38e5-4f47-9cb8-b90cc449a4d8",
-            "createdDateTimeUtc": "2021-08-03T21:29:40.1528777Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:41.6088908Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e37cc03a-bf95-42b7-8e51-518f72b5e87b",
-            "createdDateTimeUtc": "2021-08-03T21:29:32.2421265Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:35.2150657Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "741e8783-65a0-4a78-b0bb-40bb90ca2ce2",
-            "createdDateTimeUtc": "2021-08-03T21:29:22.6625965Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:28.3897554Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b4c5f90d-21f4-4776-a25d-69e2c24c61a2",
-            "createdDateTimeUtc": "2021-08-03T21:26:15.0534924Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:16.4602371Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "160fbcac-6719-48b1-a381-07c96def522c",
-            "createdDateTimeUtc": "2021-08-03T21:26:08.1805962Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:09.0728405Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "21177280-61be-420c-b6a7-99dea8ba6ffa",
-            "createdDateTimeUtc": "2021-08-03T21:26:00.6291023Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:02.0416868Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "9d566e00-1591-47d1-82c0-39a2e5d7b8cc",
-            "createdDateTimeUtc": "2021-08-03T21:25:45.4916681Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:46.9737716Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "61f64340-86f6-42f1-9c8a-d5caca0214bf",
-            "createdDateTimeUtc": "2021-08-03T21:25:30.4527461Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:31.898234Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "bebd6ab4-1fc5-4cc4-8b6e-12d70b67bb67",
-            "createdDateTimeUtc": "2021-08-03T21:25:20.9001519Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:23.1142408Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "3e44fb4d-cf68-45c5-93e1-0475502d2b40",
-            "createdDateTimeUtc": "2021-08-03T21:18:36.5471645Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:37.3185218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3cb0b34a-a92b-4e3e-9800-ee9aa656eebb",
-            "createdDateTimeUtc": "2021-08-03T21:18:32.7278914Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:34.3336582Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "da1c519e-1edf-4635-859d-1978cb2f95df",
-            "createdDateTimeUtc": "2021-08-03T21:18:26.0432979Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:27.3608779Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "450f4c8a-a15d-485c-9cc1-2451642cb05b",
-            "createdDateTimeUtc": "2021-08-03T21:18:19.0642978Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:20.5598666Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fcb39bba-503d-4772-bd60-8d48be8d1ded",
-            "createdDateTimeUtc": "2021-08-03T21:18:12.3671482Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:13.3939974Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "710b0db7-e99c-4736-9798-019d82bb972c",
-            "createdDateTimeUtc": "2021-08-03T21:18:04.4662377Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:06.5663381Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bcd5dbd0-4c9a-4d31-bbb2-38b1fd7a9f17",
-            "createdDateTimeUtc": "2021-08-03T21:17:57.9246063Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:59.5267689Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ea865d15-6652-456a-bc50-a82036d4b55e",
-            "createdDateTimeUtc": "2021-08-03T21:17:49.8058405Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:52.3338079Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "75cd36ab-60aa-4efb-b8ce-89bd8f2482d0",
-            "createdDateTimeUtc": "2021-08-03T21:17:36.2201985Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:37.5230684Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "05e4db62-aed0-4bc9-849c-1d1fa00e9101",
-            "createdDateTimeUtc": "2021-08-03T21:17:23.2025629Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:30.3004066Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a98bd901-115e-485e-a9c3-d6848740d430",
-            "createdDateTimeUtc": "2021-08-03T21:17:10.996439Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:15.4071683Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c0ebf31-6ec7-49ec-ba54-92b3ec4111f6",
-            "createdDateTimeUtc": "2021-08-03T21:17:05.8588787Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:08.1711768Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "565abdcf-3502-4ad2-bdf1-104fa16a21eb",
-            "createdDateTimeUtc": "2021-08-03T21:16:57.3872761Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:01.0170435Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=303\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=303\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8e8b42eca30c3e4984d91a9cb3d13641-b685e7f8da2f9448-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b27dc903c8753c512378df01f5145647",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6e35a811-8f72-4789-92b8-d7e96f7e5de8",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:27 GMT",
-        "ETag": "\u0022E7B0B0DB2CF9761F8956C25B2005216FCB2B1BAFF0D53124148C6D3B9A09DD6E\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6e35a811-8f72-4789-92b8-d7e96f7e5de8"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "9db34ff3-784f-4ba8-bd65-f9daea73dc84",
-            "createdDateTimeUtc": "2021-08-03T21:16:49.8079754Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:54.0100467Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "be0f4975-feb8-4a4c-99df-58a2eda64759",
-            "createdDateTimeUtc": "2021-08-03T21:16:43.5676725Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:46.9951206Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ad79180b-657e-411d-8214-6e2217f5f16f",
-            "createdDateTimeUtc": "2021-08-03T21:16:37.0494791Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:39.9664948Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a6b4d2cc-dc08-4883-93d5-4e0ce1f67b2b",
-            "createdDateTimeUtc": "2021-08-03T21:16:30.4598878Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:32.9278125Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e7348e3-fa87-4468-852d-3375d2e67dea",
-            "createdDateTimeUtc": "2021-08-03T21:16:22.0289093Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:25.9157037Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e415502b-72a2-46ae-bf89-116f60f159a2",
-            "createdDateTimeUtc": "2021-08-03T21:16:15.7930067Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:18.843387Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "12ae8466-a78d-4b54-96b3-491ff6092290",
-            "createdDateTimeUtc": "2021-08-03T21:16:08.3346723Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:11.9162731Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "972d3dd5-e5ad-435f-b1c0-19994a850368",
-            "createdDateTimeUtc": "2021-08-03T21:16:00.8089969Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:04.8935886Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c03135b1-55fc-49f8-bd8e-1aa9de944109",
-            "createdDateTimeUtc": "2021-08-03T21:15:50.7914559Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:57.8420568Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d3f42fc9-c46c-4c69-8ce8-1fa7951f0feb",
-            "createdDateTimeUtc": "2021-08-03T21:15:39.2462267Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:42.8928599Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2ee8fae6-6649-4264-8a60-005c8c2e33c3",
-            "createdDateTimeUtc": "2021-08-03T21:15:31.6638047Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:35.7812306Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64cf7af2-e9cf-42dd-be76-4c92b21200e5",
-            "createdDateTimeUtc": "2021-08-03T21:15:19.0180291Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:23.7245428Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7e3b360b-3804-4cd9-8ffc-ff8c1069f9a9",
-            "createdDateTimeUtc": "2021-08-03T21:15:07.6620949Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:10.7353955Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6f7243d-95a2-42b2-9277-db3105ffeeae",
-            "createdDateTimeUtc": "2021-08-03T21:14:57.8530134Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:58.6849403Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ff9490ff-1a22-4905-b300-f832c622fcd3",
-            "createdDateTimeUtc": "2021-08-03T21:14:52.4456431Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:55.1385001Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a291a37f-00ff-462c-90f7-af30487cfee0",
-            "createdDateTimeUtc": "2021-08-03T21:14:47.8001603Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:52.8849738Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6fe9dfde-e561-40c2-bdd6-3292556c8b44",
-            "createdDateTimeUtc": "2021-08-03T21:14:35.4879327Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:38.0663837Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "281e1d88-ad9d-4517-90b3-94e74a9c24f0",
-            "createdDateTimeUtc": "2021-08-03T21:14:28.795762Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:31.0494198Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a01a857b-9018-440a-b213-00bf32fd088e",
-            "createdDateTimeUtc": "2021-08-03T21:14:13.7887949Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:17.9704114Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8a449a7e-de6e-428f-85dc-0f5057026964",
-            "createdDateTimeUtc": "2021-08-03T21:14:02.4254824Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:05.9904305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "caf6c070-88b1-4321-8677-cad70417c272",
-            "createdDateTimeUtc": "2021-08-03T21:13:49.8557451Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:52.9922839Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e8f345d1-3424-4c4a-9d47-3008e4990352",
-            "createdDateTimeUtc": "2021-08-03T21:13:41.5900414Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:45.8133665Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5dc5da5c-8efd-4cd6-815e-4b808abb4825",
-            "createdDateTimeUtc": "2021-08-03T21:13:27.7289314Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:31.0005068Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eb91834b-fb6a-4993-9678-5858c3bb1b9b",
-            "createdDateTimeUtc": "2021-08-03T21:13:16.3384857Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:23.7963549Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "806f54be-4e77-4798-a5d5-73f6bad16868",
-            "createdDateTimeUtc": "2021-08-03T21:12:59.5334323Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:00.8743421Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ae03de4-3f6f-4c29-bf1c-1ad94a5e6b7d",
-            "createdDateTimeUtc": "2021-08-03T21:12:53.1067631Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:53.7902656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fc077fb4-83ee-4897-8b1a-5aba8c1bf0a3",
-            "createdDateTimeUtc": "2021-08-03T21:12:45.5070479Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:48.6888907Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "51fc6ec4-8eac-4cc6-ae6f-6c5f36e30f23",
-            "createdDateTimeUtc": "2021-08-03T21:12:30.4582964Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:41.6843136Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "be88aa61-1e9c-4917-a2aa-5c5cdb93a5f6",
-            "createdDateTimeUtc": "2021-08-03T21:12:24.3745624Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:26.5718318Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d0e58fcb-2b27-4914-9654-3d753fa5fc6b",
-            "createdDateTimeUtc": "2021-08-03T21:12:16.9941584Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:19.5227251Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f3a6c730-1d51-404f-8b00-45607cfae421",
-            "createdDateTimeUtc": "2021-08-03T21:12:06.8062009Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:12.5283Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "37992d98-b6d5-423c-89d1-6e54e5ec8773",
-            "createdDateTimeUtc": "2021-08-03T21:11:55.6953795Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:57.438589Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a3508cfe-30da-45d2-bc88-0047a835dd5e",
-            "createdDateTimeUtc": "2021-08-03T21:11:48.3588126Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:50.4206884Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6ab6d6e-5c85-448d-84d5-4223d3a2cd1b",
-            "createdDateTimeUtc": "2021-08-03T21:11:35.4391485Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:38.7780922Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c69177b4-9de0-4961-97f9-42b1b8d3c137",
-            "createdDateTimeUtc": "2021-08-03T21:11:21.7724833Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:23.742779Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3e1ee063-8ed9-4c9d-b237-76ec3a417bac",
-            "createdDateTimeUtc": "2021-08-03T21:11:13.556122Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:15.317426Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6042d94-2cd5-46df-85ad-52c10c998b01",
-            "createdDateTimeUtc": "2021-08-03T21:11:06.2064576Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:08.6641999Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d17081c8-ff50-4d36-8b46-e88c8deb39c5",
-            "createdDateTimeUtc": "2021-08-03T21:10:58.8540771Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:01.679116Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eeb49074-527d-4cbd-95c9-6e2a33a80fe0",
-            "createdDateTimeUtc": "2021-08-03T21:10:52.75482Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:54.5968498Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c6244025-4303-4989-a816-b905e1a30d9e",
-            "createdDateTimeUtc": "2021-08-03T21:10:46.6679174Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:47.5413043Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7515a3ad-6e5e-446b-8aea-c4cc53d12feb",
-            "createdDateTimeUtc": "2021-08-03T21:10:38.7741733Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:40.5334622Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "95aff118-ace4-4193-828d-2ae77311df6f",
-            "createdDateTimeUtc": "2021-08-03T21:10:32.6760697Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:33.4547546Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "97597b48-5a0e-4dad-8d71-2591f76bf2b6",
-            "createdDateTimeUtc": "2021-08-03T21:10:25.297809Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:26.4222067Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c21ed6b-a48d-4909-92cb-73bc8274b9d2",
-            "createdDateTimeUtc": "2021-08-03T21:10:17.9312928Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:19.3974656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9fc1780-0cbf-4e09-af18-b05ab8132e1f",
-            "createdDateTimeUtc": "2021-08-03T21:10:05.2725918Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:12.5542351Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0636e96b-8ca2-44f8-a04b-a9a1c38694c4",
-            "createdDateTimeUtc": "2021-08-03T21:04:35.2211988Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:37.0514288Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce731aed-e42d-4219-a382-133b032d5f1c",
-            "createdDateTimeUtc": "2021-08-03T21:04:28.9135303Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:29.9918727Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d86704b4-8468-4fd2-a932-fd5224d0ebed",
-            "createdDateTimeUtc": "2021-08-03T21:04:14.1901594Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:19.7321506Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9f05357-c328-48b9-a611-c3732bab678d",
-            "createdDateTimeUtc": "2021-08-03T21:04:03.8683312Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:05.0527645Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0cbb6b74-7d09-4126-992c-831741492982",
-            "createdDateTimeUtc": "2021-08-03T21:03:51.6462874Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:54.7314609Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=150\u0026$top=253\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=150\u0026$top=253\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-93387d35dfe5f147bcc3f41aef12613f-e3b6027baf623a4e-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b3c17c5f5651ff8b90220e2443ab7851",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "fbd7851a-37b7-434a-a542-bd0d09dba73b",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:28 GMT",
-        "ETag": "\u00225723D9FF8DF633F22419972E57F3EA84B1B25711B8B1DEBC1449BF7512BA9E38\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "fbd7851a-37b7-434a-a542-bd0d09dba73b"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "5f03f16e-de27-42b4-b2e2-844706de4b44",
-            "createdDateTimeUtc": "2021-08-03T21:03:45.1124183Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:47.674769Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "23c77867-65e6-4ad0-be05-9bdb30d3ad5e",
-            "createdDateTimeUtc": "2021-08-03T21:03:37.8720722Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:40.5848208Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f28ba69-dc12-4f0c-a4a1-e7b60934ad43",
-            "createdDateTimeUtc": "2021-08-03T21:03:32.2879169Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:33.7858305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7d8b4c2b-bae7-45ca-b351-4e9904d6ee65",
-            "createdDateTimeUtc": "2021-08-02T16:24:41.2089693Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:43.0994742Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6eb19d5e-da21-40c2-b5ac-31638a9d5834",
-            "createdDateTimeUtc": "2021-08-02T16:24:32.9603519Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:35.3478084Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8f83e37a-9fd2-4a27-acf9-fdf90c5ca88e",
-            "createdDateTimeUtc": "2021-08-02T16:24:25.3701107Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:28.2843485Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fa2f0660-ee60-44dc-891e-1807fe027001",
-            "createdDateTimeUtc": "2021-08-02T16:24:19.0661656Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:20.9267399Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9a921d78-9a3f-4fb0-bd3e-e9e85adfb5c7",
-            "createdDateTimeUtc": "2021-08-02T16:24:14.084628Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:14.8551961Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "35491096-d4b6-4f64-a475-3a8f425bda13",
-            "createdDateTimeUtc": "2021-08-02T16:24:08.8499137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:13.2168149Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d6516cd6-00bc-4dd4-81e0-ac3531a9ef9a",
-            "createdDateTimeUtc": "2021-08-02T16:24:04.9124096Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:09.2033129Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "53f7b772-34ef-4eb8-8296-85141574c168",
-            "createdDateTimeUtc": "2021-08-02T16:23:45.9322442Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:47.766539Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ee6fbf3b-4339-4bf7-a0e4-c6c4a43e713d",
-            "createdDateTimeUtc": "2021-08-02T16:23:39.6959419Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:40.4416417Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "136046f1-61bb-4d7a-abda-5d762ed48da2",
-            "createdDateTimeUtc": "2021-08-02T16:23:32.246383Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:33.6102582Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4c808776-ef91-44b3-b985-030778694e82",
-            "createdDateTimeUtc": "2021-08-02T16:23:24.7815606Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:25.6039914Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bbcb51e9-e16a-4575-b115-000e9df2a45e",
-            "createdDateTimeUtc": "2021-08-02T16:23:14.7939144Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:18.5400236Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "420e65a3-84f2-4784-8e76-0dbc11b9767d",
-            "createdDateTimeUtc": "2021-08-02T16:23:00.0350545Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:03.9941424Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3bed775d-83fb-4252-9f8a-52dacdb26ade",
-            "createdDateTimeUtc": "2021-08-02T16:22:48.7883283Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:53.2388717Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6ef1e57a-03d3-4eee-b0c1-cabd5862da1f",
-            "createdDateTimeUtc": "2021-08-02T16:22:35.1281238Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:38.165101Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "40a5525c-6988-4e7e-a203-d01a5a19add6",
-            "createdDateTimeUtc": "2021-08-02T16:22:22.6116988Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:28.2009407Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b12700de-181b-4bfb-a9ea-ab2920d66ba8",
-            "createdDateTimeUtc": "2021-08-02T16:22:11.0963198Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:13.2382617Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "588176c1-fb41-4077-9ce2-52eaefe1e6ec",
-            "createdDateTimeUtc": "2021-08-02T16:22:00.7493371Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:02.6302967Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eeddf064-09ac-4f8d-8571-dd1bb7fa4343",
-            "createdDateTimeUtc": "2021-08-02T16:21:54.4828121Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:57.0883721Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "86f769d2-0eb0-497c-a670-4b283cfcdfdf",
-            "createdDateTimeUtc": "2021-08-02T16:21:47.7892819Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:50.5734898Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ef96694-d6c5-4f51-9c7e-250c692cb5dd",
-            "createdDateTimeUtc": "2021-08-02T16:21:41.4813356Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:42.5383836Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "adf11117-52ab-486b-985c-bfea752c8125",
-            "createdDateTimeUtc": "2021-08-02T16:21:32.7479396Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:35.3424695Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8d9ccbdb-0672-4c0a-9776-0392c918c98f",
-            "createdDateTimeUtc": "2021-08-02T16:21:15.2775709Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:19.7632985Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8791b215-1f41-41d4-bb91-98341c1dd33c",
-            "createdDateTimeUtc": "2021-08-02T16:21:05.1178323Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:07.2972934Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6aba7c68-ce53-473d-a0ec-8a507ed316c9",
-            "createdDateTimeUtc": "2021-08-02T16:20:50.7351339Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:54.4492988Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7d30db48-4d73-41d8-997d-4a617c4004c9",
-            "createdDateTimeUtc": "2021-08-02T16:20:40.6756633Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:42.4301335Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d04c84d8-3802-49e5-bfed-513a24bd9d5a",
-            "createdDateTimeUtc": "2021-08-02T16:20:24.7609666Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:29.1667159Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bc6cf0b2-7fc1-40ee-ad43-98b0b5150223",
-            "createdDateTimeUtc": "2021-08-02T16:20:12.6767136Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:16.3662875Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "478fdbe7-fffd-4d69-baa1-b359ab0bf87e",
-            "createdDateTimeUtc": "2021-08-02T16:19:59.5448266Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:03.7580865Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8ac17a7c-0ef2-44e6-815e-11ca7283f7f0",
-            "createdDateTimeUtc": "2021-08-02T16:19:47.7119701Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:52.0454421Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9299720b-5702-4fd8-9b84-07d18770d0c9",
-            "createdDateTimeUtc": "2021-08-02T16:19:33.0940413Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:36.063599Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c53f5ac-5ae0-4186-986d-59db8052bd87",
-            "createdDateTimeUtc": "2021-08-02T16:19:25.5258566Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:27.5995027Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5fabbdd0-d3df-482e-80c5-751f5c65184b",
-            "createdDateTimeUtc": "2021-08-02T16:19:17.4593598Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:19.4263901Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f116c06f-6f87-406d-b1f6-79fb90dce630",
-            "createdDateTimeUtc": "2021-08-02T16:19:10.7346Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:12.2459497Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8d24c7aa-d4f7-4c8f-8540-10499063139f",
-            "createdDateTimeUtc": "2021-08-02T16:19:02.0656904Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:03.0995071Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f9b9346c-2649-429f-a88e-3bd5fa834aea",
-            "createdDateTimeUtc": "2021-08-02T16:18:52.7109118Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:57.1201114Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4676529-3017-4ca1-b2a8-dbb9c74ca6f0",
-            "createdDateTimeUtc": "2021-08-02T16:18:36.7769716Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:41.5280761Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d59e0316-c5eb-4011-a6ea-ba35c6977966",
-            "createdDateTimeUtc": "2021-08-02T16:18:23.3012061Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:29.1989939Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "28779945-5117-434b-9137-14e9c170d450",
-            "createdDateTimeUtc": "2021-08-02T16:18:11.1236727Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:16.2904795Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b661b7e-cdbd-461e-8540-93e2e7135084",
-            "createdDateTimeUtc": "2021-08-02T16:17:57.8044821Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:02.1356502Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "826e3203-8188-4a90-92db-b65e12b7a6e6",
-            "createdDateTimeUtc": "2021-08-02T16:17:49.6808861Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:51.33726Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ec3e1c4c-3509-4f5a-86ee-3be559f978cf",
-            "createdDateTimeUtc": "2021-08-02T16:17:43.4479159Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:46.1484498Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "cd18395a-adb6-4566-a35d-4b7394ce7e7c",
-            "createdDateTimeUtc": "2021-08-02T16:17:39.2236317Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:42.3718498Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2ab88ed2-f62f-442c-a8d4-e0fe953d60f8",
-            "createdDateTimeUtc": "2021-08-02T16:17:13.5251717Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:17.8853964Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b9deb0a-7a56-440e-b9c3-51407a716f91",
-            "createdDateTimeUtc": "2021-08-02T16:17:00.3732482Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:04.8610025Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1451731d-cb81-45b9-abb6-c0ebd8d688ff",
-            "createdDateTimeUtc": "2021-08-02T16:16:46.3333522Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:51.499965Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "139c594a-e573-42bc-ac76-79592e783b4d",
-            "createdDateTimeUtc": "2021-08-02T16:16:34.5666571Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:39.7565449Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=200\u0026$top=203\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=200\u0026$top=203\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b92e33eeea066d43975c77ef90ba63e6-8b153100de128847-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "94483eca8bdb50b9b51b57085e25e3b9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "47bec5ec-c169-4f13-965b-e11aec94f696",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:28 GMT",
-        "ETag": "\u0022FB2DB01E8E112D55C0D02C740E2C0708EF724B36C9DCA3CC40D9AC82C4E434F8\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "47bec5ec-c169-4f13-965b-e11aec94f696"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "3ea6a654-e1da-4712-9ade-698b4fa08cee",
-            "createdDateTimeUtc": "2021-08-02T16:16:20.2815511Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:26.1888498Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bb4649a1-1b3a-4ffe-a85e-7c42bae169e0",
-            "createdDateTimeUtc": "2021-08-02T16:16:12.5610209Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:14.670096Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fe16f7a4-60a7-47e5-af19-ae95f1ec681e",
-            "createdDateTimeUtc": "2021-08-02T16:16:02.1273592Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:06.1364515Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4aa714c0-4bf6-4938-87a1-434a1f4a7ebb",
-            "createdDateTimeUtc": "2021-08-02T16:15:47.0562229Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:50.6173263Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "026bf666-4189-437c-83aa-64695c311c08",
-            "createdDateTimeUtc": "2021-08-02T16:15:31.2491656Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:35.1652117Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bdd91bff-b609-4b0f-a2c0-c647662d414d",
-            "createdDateTimeUtc": "2021-08-02T16:15:16.5679328Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:20.3039847Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0498cf00-abbb-40b5-adab-e7725b8570f7",
-            "createdDateTimeUtc": "2021-08-02T16:15:09.9911137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:11.9184442Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "21177c94-70c4-44e1-8cff-235b74d0b99a",
-            "createdDateTimeUtc": "2021-08-02T16:14:55.1654786Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:00.1764926Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "85670b87-e8d6-4d6d-8ea2-c25d36c5ab31",
-            "createdDateTimeUtc": "2021-08-02T16:14:43.5832687Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:46.5409074Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6120317e-0084-4d39-be37-4a22da834f5d",
-            "createdDateTimeUtc": "2021-08-02T16:14:27.9772355Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:34.8024586Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6af7eb57-f9c1-42e2-82d7-1f12e5b212fe",
-            "createdDateTimeUtc": "2021-08-02T16:14:17.0902143Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:21.24705Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cd6a2e5d-84e2-41b1-9337-a69dad3d47c1",
-            "createdDateTimeUtc": "2021-08-02T16:14:07.7724718Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:08.5411317Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c2ef1201-4b72-4500-af9d-6c46e43d9c8b",
-            "createdDateTimeUtc": "2021-08-02T16:14:00.4820687Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:02.206196Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e02cc96c-f613-4d31-b301-64b1ba8f087d",
-            "createdDateTimeUtc": "2021-08-02T16:13:52.654235Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:53.9684859Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "56985d49-4f45-4bf5-bc5a-815be0a31d77",
-            "createdDateTimeUtc": "2021-08-02T16:13:44.4222786Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:46.3632429Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f277b4e7-6107-4fce-9843-57ea37403cd0",
-            "createdDateTimeUtc": "2021-08-02T16:13:36.1118921Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:38.5818188Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cb2ae958-26f6-497c-a0d2-0f24b680a296",
-            "createdDateTimeUtc": "2021-08-02T16:13:28.2526551Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:31.4669162Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e44cb835-83cf-4568-af90-37dc0bfc591f",
-            "createdDateTimeUtc": "2021-08-02T16:13:21.6945505Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:24.3971649Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "53732eaf-861e-4cc7-ab1b-7fe8f2c59f72",
-            "createdDateTimeUtc": "2021-08-02T16:13:09.3426779Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:09.9894448Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "22467b38-820b-496e-af13-6118e55f474f",
-            "createdDateTimeUtc": "2021-08-02T16:12:54.8368437Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:02.7871782Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f2db3e76-05f6-487e-8f7a-71ff84a07c41",
-            "createdDateTimeUtc": "2021-08-02T16:12:46.1722803Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:47.8187574Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6fa6124a-382c-4cae-a8e8-bafa8771ffb4",
-            "createdDateTimeUtc": "2021-08-02T16:12:38.3102608Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:40.6814713Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "08077374-25ed-4062-8157-d2aaf376a00c",
-            "createdDateTimeUtc": "2021-08-02T16:12:26.6208936Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:33.2913497Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a94a2a28-a797-4f76-91cd-b51148e62b16",
-            "createdDateTimeUtc": "2021-08-02T16:12:13.1684199Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:18.4618218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bc4c4898-1c22-4525-a645-7ce619839b24",
-            "createdDateTimeUtc": "2021-08-02T16:11:56.0176535Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:03.7809247Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e84c225d-6eac-485e-a02c-27944ff4dbdb",
-            "createdDateTimeUtc": "2021-08-02T16:05:51.141745Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:55.0127867Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "7c879c56-18e3-404d-a749-27467f12e635",
-            "createdDateTimeUtc": "2021-08-02T16:05:45.2156446Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:46.3340871Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "a475da26-6ac8-4c57-ad1f-a95856f88516",
-            "createdDateTimeUtc": "2021-08-02T16:05:36.590968Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:39.4988016Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "54a2e7ba-61be-4704-9a1b-2e4b36baa088",
-            "createdDateTimeUtc": "2021-08-02T16:05:21.5609955Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:24.9840622Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "7afd5c7e-13d8-4691-abd0-abde4ce5474e",
-            "createdDateTimeUtc": "2021-08-02T16:05:02.9540382Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:05.7674713Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "557f2c23-bc72-40b7-a138-4561429fa9aa",
-            "createdDateTimeUtc": "2021-08-02T16:04:47.8352521Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:04:50.2573908Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "3e9a5d00-90d9-4256-9d62-f1dfa1577da0",
-            "createdDateTimeUtc": "2021-08-01T16:20:07.4673305Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:13.4203616Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "fc266ece-821c-4ad7-9448-1813652fd6ec",
-            "createdDateTimeUtc": "2021-08-01T16:20:03.3145089Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:12.698585Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "09bd712a-8979-4a10-b5cd-e9f10cd67d10",
-            "createdDateTimeUtc": "2021-08-01T16:19:46.7079557Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:49.1799156Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d7a02f06-f676-408e-b3c1-c15c6bba0b44",
-            "createdDateTimeUtc": "2021-08-01T16:19:40.2888558Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:42.0951378Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c225a85d-2f4e-4823-bed5-aafc11420317",
-            "createdDateTimeUtc": "2021-08-01T16:19:32.7591319Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:35.0214842Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8afe93e5-55f8-4b29-aad7-e52aafa852e9",
-            "createdDateTimeUtc": "2021-08-01T16:19:26.4656956Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:27.9695511Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d2d58232-7d45-4649-8eee-884989571d14",
-            "createdDateTimeUtc": "2021-08-01T16:19:20.0951281Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:20.9141679Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9d74505c-4ec7-4849-a25e-347c9ca83531",
-            "createdDateTimeUtc": "2021-08-01T16:19:14.3845766Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:19.1001524Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5263795e-4551-4f48-94da-32a53c735650",
-            "createdDateTimeUtc": "2021-08-01T16:19:10.3372901Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:18.7374885Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b51a5572-a945-4b96-a953-c59a894ef975",
-            "createdDateTimeUtc": "2021-08-01T16:18:54.1999881Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:57.9280154Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ed28552f-7298-466f-be5d-d72fc1596544",
-            "createdDateTimeUtc": "2021-08-01T16:18:47.7220195Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:50.8569952Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c0ebd77c-0245-4fa7-b3e7-83694b3734fe",
-            "createdDateTimeUtc": "2021-08-01T16:18:41.3753213Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:43.9537812Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64716ad2-d3e2-4bcf-9a75-0fc0c9a5f4c8",
-            "createdDateTimeUtc": "2021-08-01T16:18:34.7356044Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:36.8659384Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "48155210-6958-4ce0-9863-e3747a64c145",
-            "createdDateTimeUtc": "2021-08-01T16:18:20.2854234Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:30.0642323Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9453ca0c-5d2e-4071-ab7f-442df231b85f",
-            "createdDateTimeUtc": "2021-08-01T16:15:01.5996298Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:15:05.5361722Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b0f1d39d-b564-4cd9-8032-6a12e1a9d05b",
-            "createdDateTimeUtc": "2021-08-01T16:14:55.2901759Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:58.5033728Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "59da2c26-8f14-4221-ab40-ac76b9501ad1",
-            "createdDateTimeUtc": "2021-08-01T16:14:47.6768806Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:51.4645762Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "497af134-1eb1-4531-96cf-2b6426d21b25",
-            "createdDateTimeUtc": "2021-08-01T16:14:43.8701994Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:44.532919Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "49417fb3-b2f3-4a94-a5bf-adf21b10f5d6",
-            "createdDateTimeUtc": "2021-08-01T16:14:36.2995057Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:37.5066305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=250\u0026$top=153\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=250\u0026$top=153\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b7cf86bb4297fb4eb76dfb16ce1b7956-989cc457c6f51945-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "803c5c0eeb6dadea3e7e2252b92cf878",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8d02d384-89f8-4fac-b016-10d8e6272502",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:29 GMT",
-        "ETag": "\u0022D78C26BA443B096DB499B075D5D5C3CBA753CBCEB0FFE6842A8872B85A4B13F2\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8d02d384-89f8-4fac-b016-10d8e6272502"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "3a12cc5a-b95b-4934-8fd5-f338b1e8ffca",
-            "createdDateTimeUtc": "2021-08-01T16:14:29.7501476Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:30.4496382Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f30dfeae-5899-4b4a-ab89-d6d04d0efe74",
-            "createdDateTimeUtc": "2021-08-01T16:14:22.1534158Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:26.376851Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e65c1cc-310e-4cc2-b8cb-94549af2f62e",
-            "createdDateTimeUtc": "2021-08-01T16:14:15.8071242Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:19.3429665Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3bb426c3-ecc1-4316-bc03-730dc1f3653b",
-            "createdDateTimeUtc": "2021-08-01T16:14:08.2125728Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:12.4635748Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ddf0085d-dbdf-4cba-990c-3ba10a7e1a66",
-            "createdDateTimeUtc": "2021-08-01T16:14:03.1671065Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:05.4704945Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "329cec92-7703-4747-ae44-5990a8726d8f",
-            "createdDateTimeUtc": "2021-08-01T16:13:54.1407053Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:58.3447181Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b8f07233-7e1c-4c08-80cf-1a15eb328e81",
-            "createdDateTimeUtc": "2021-08-01T16:13:47.8669235Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:51.5406534Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "77cdd294-733d-41f8-819f-92003e64ceb5",
-            "createdDateTimeUtc": "2021-08-01T16:13:40.2946017Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:44.3266783Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e0991fae-123b-4f43-bff0-cab0009d9523",
-            "createdDateTimeUtc": "2021-08-01T16:13:36.5057131Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:37.2374588Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5ca898b1-422a-4871-abb7-1ce16766fe75",
-            "createdDateTimeUtc": "2021-08-01T16:13:28.8893885Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:30.2057848Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "71c20eb7-04ac-4b18-8147-170d958cf215",
-            "createdDateTimeUtc": "2021-08-01T16:13:14.9186078Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:23.1567567Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0f6623cf-56f0-49c2-8b2d-92a7d173e656",
-            "createdDateTimeUtc": "2021-08-01T16:13:07.2768816Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:08.1446081Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "51452eaa-72c0-4d09-aece-3ce74ea05c2d",
-            "createdDateTimeUtc": "2021-08-01T16:12:58.3531499Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:00.9818419Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "83122575-c3e0-40cf-a740-bb3ab9fc56be",
-            "createdDateTimeUtc": "2021-08-01T16:12:43.7935713Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:12:49.3598783Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ab3adbcc-1036-4e0b-903d-681b154f1c19",
-            "createdDateTimeUtc": "2021-08-01T16:12:34.5845034Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:12:35.9467789Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "39c76fc2-bb64-4a08-a91a-023f467170c8",
-            "createdDateTimeUtc": "2021-08-01T16:10:30.7671066Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:33.9996641Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1946e12f-48c9-479d-a14d-957a52af4819",
-            "createdDateTimeUtc": "2021-08-01T16:10:24.4268864Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:26.950039Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "061184c9-b5cc-4622-9536-a088ef98ef51",
-            "createdDateTimeUtc": "2021-08-01T16:10:16.7322617Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:20.8210184Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6dab8cd8-4b45-4244-b5a3-1df6ce3e6e9e",
-            "createdDateTimeUtc": "2021-08-01T16:10:10.3791367Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:13.7755381Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ccecf223-30d9-427f-baac-d28fabd2ba91",
-            "createdDateTimeUtc": "2021-08-01T16:09:56.0857482Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:01.8186959Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "686c032b-f1f9-461c-b591-19be033130a6",
-            "createdDateTimeUtc": "2021-08-01T16:09:47.6916292Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:48.7555826Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f1fb728-a50b-4279-b98e-8f70a89cba26",
-            "createdDateTimeUtc": "2021-08-01T16:09:35.1147989Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:41.7039641Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ac064e9c-9558-4940-81b6-6591e24b22b0",
-            "createdDateTimeUtc": "2021-08-01T16:09:23.6462928Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:26.7238672Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f7dfd6e7-2149-4ed6-9118-1f50a9badde5",
-            "createdDateTimeUtc": "2021-08-01T16:09:15.6989555Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:16.6008152Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a37bd766-988f-4d35-93b4-82b678984a0b",
-            "createdDateTimeUtc": "2021-08-01T16:09:10.2798543Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:11.6248087Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "dd3207eb-c63b-4ee9-8d71-303a17f6831a",
-            "createdDateTimeUtc": "2021-08-01T16:09:02.3812973Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:04.6501124Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c2017771-02a1-4c4d-89c6-e53ddc375b6c",
-            "createdDateTimeUtc": "2021-08-01T16:08:54.6514534Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:57.5553054Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8e675672-c991-4b00-9f3b-151fff0ba025",
-            "createdDateTimeUtc": "2021-08-01T16:08:50.6903241Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:51.5542816Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "86d50aab-06b7-4674-94f1-d78f62cfcd3c",
-            "createdDateTimeUtc": "2021-08-01T16:08:42.9294372Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:44.5249817Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64eee42e-3b77-4308-b66b-6dfd687dfcb8",
-            "createdDateTimeUtc": "2021-08-01T16:08:29.0253923Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:37.4953732Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ec95d30a-ca29-44c2-a3d3-7f1e81768232",
-            "createdDateTimeUtc": "2021-08-01T16:08:20.5267131Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:22.4653843Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "baa67a70-f2c2-4798-af85-bf4039800973",
-            "createdDateTimeUtc": "2021-08-01T16:08:14.027446Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:15.5419027Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9fd64070-3063-4a1f-b6c7-a5433ce879c1",
-            "createdDateTimeUtc": "2021-08-01T16:08:07.3241133Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:08.3919937Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eca524e6-f052-4f33-9f75-849aa58968f2",
-            "createdDateTimeUtc": "2021-08-01T16:07:59.6488045Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:02.4292358Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e4553a79-86bc-4607-93ba-acd98eef29a8",
-            "createdDateTimeUtc": "2021-08-01T16:07:51.7754119Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:07:55.6059096Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3733384b-4378-49e9-9d6c-eb777dd951e7",
-            "createdDateTimeUtc": "2021-08-01T16:03:47.7295123Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:50.0428444Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5af0415d-d065-4223-8377-8c4b476b1e51",
-            "createdDateTimeUtc": "2021-08-01T16:03:41.2997619Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:43.1057319Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "19825a18-d71e-4d71-ad50-ac9efde28439",
-            "createdDateTimeUtc": "2021-08-01T16:03:33.0672128Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:36.0643347Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2126372c-82d1-4ca5-99cd-6320189e4456",
-            "createdDateTimeUtc": "2021-08-01T16:03:21.6139816Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:29.0787165Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "351567c2-21d9-44d7-80cd-ae88bcfc86c1",
-            "createdDateTimeUtc": "2021-08-01T16:03:11.2412744Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:14.0681571Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3687fbc7-cfc7-4946-abbd-d20c2c47872b",
-            "createdDateTimeUtc": "2021-08-01T16:02:54.8769861Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:59.157192Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "75b82710-29d5-4a29-b31d-b4b276547f85",
-            "createdDateTimeUtc": "2021-08-01T16:02:42.7637598Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:44.4525561Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "45e52c50-a5d3-4185-ad9c-302fb18b86fb",
-            "createdDateTimeUtc": "2021-08-01T16:02:33.7748165Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:37.1302955Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0794e1ae-1cbb-4ce3-a359-5baea72b7f4f",
-            "createdDateTimeUtc": "2021-08-01T15:59:52.4064413Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:54.8434933Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6bf80ca-523f-424b-bb16-43b74851cd72",
-            "createdDateTimeUtc": "2021-08-01T15:59:46.146435Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:47.7975734Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f151cf31-9668-4c64-9fa3-1eab66bd54de",
-            "createdDateTimeUtc": "2021-08-01T15:59:38.6998762Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:41.734894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eab2ef7c-cccd-4b8d-9c28-43fa1246a6ec",
-            "createdDateTimeUtc": "2021-08-01T15:59:33.1867669Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:34.7568857Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fe3b6f5b-2f4f-4ba6-87b0-b49ce11a40f1",
-            "createdDateTimeUtc": "2021-08-01T15:59:23.8646186Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:27.6910914Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c688f16b-c48f-4d93-ae25-97e9419cf990",
-            "createdDateTimeUtc": "2021-08-01T15:59:20.0728064Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:20.6633025Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "65b3ecb9-b44e-45cb-9b48-4c3dc410ea83",
-            "createdDateTimeUtc": "2021-08-01T15:59:09.2524163Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:13.6285104Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=300\u0026$top=103\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=300\u0026$top=103\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aa50a27d0712594cb354541e878fd05b-84b1d7627c0d9d43-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b7368e00c1cbd36bc271fe36fe82a06b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "79e57fa1-c2cd-49b9-b7b1-0a4816e4ed3e",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:29 GMT",
-        "ETag": "\u00221031E21BE0EC4E0F27337127E1D47D1E40B2AB24CC2AE918B982EEA5913AA725\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "79e57fa1-c2cd-49b9-b7b1-0a4816e4ed3e"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "c4dc36f8-1a47-4082-9e74-55b17a656aee",
-            "createdDateTimeUtc": "2021-08-01T15:58:55.2515733Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:02.9435279Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f3021ca2-9cec-4123-8750-e48d70416733",
-            "createdDateTimeUtc": "2021-08-01T15:56:37.0490386Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:38.4486071Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6b145029-9721-429c-a6a7-09c88b0985bf",
-            "createdDateTimeUtc": "2021-08-01T15:56:30.7478816Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:31.4431875Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bd39da52-dc84-4165-bd31-8b4e3386e291",
-            "createdDateTimeUtc": "2021-08-01T15:56:23.0776782Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:27.4828878Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fa4f24ae-2898-4a3f-99c4-1cb3803f90f9",
-            "createdDateTimeUtc": "2021-08-01T15:56:16.7471751Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:20.4937894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7ab33b72-ce13-4ddb-8201-c3c334eae327",
-            "createdDateTimeUtc": "2021-08-01T15:56:03.8859689Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:05.4735936Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ab288e5d-b6b4-44e3-abf9-6faa8c4be7ec",
-            "createdDateTimeUtc": "2021-08-01T15:55:55.0121462Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:56.3540986Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f93cafa9-8dd4-4b3b-8b51-1e2171088923",
-            "createdDateTimeUtc": "2021-08-01T15:55:47.3645091Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:49.3078416Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e4b8104a-b73b-4412-9053-8e5ebec49801",
-            "createdDateTimeUtc": "2021-08-01T15:55:40.55381Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:42.2818894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5d43cd87-26c7-4c64-a7c6-b594408e7335",
-            "createdDateTimeUtc": "2021-08-01T15:55:32.9887665Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:35.2182692Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2136b292-19b7-4256-8c19-5fa788b76984",
-            "createdDateTimeUtc": "2021-08-01T15:55:25.9783249Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:28.383526Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0517cacc-3271-4281-a3d5-104ef81a6787",
-            "createdDateTimeUtc": "2021-08-01T13:52:26.3146047Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:27.02053Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "13dc0dc6-55d9-4815-925b-53831ccd5b1a",
-            "createdDateTimeUtc": "2021-08-01T13:52:20.0346113Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:20.7450313Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d63c2da4-ba89-4240-8ca3-3303a99b2321",
-            "createdDateTimeUtc": "2021-08-01T13:52:11.7638283Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:14.351392Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5c4dd9bb-d4c3-4154-b014-5b999af767fc",
-            "createdDateTimeUtc": "2021-08-01T13:51:59.0858938Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:06.7430348Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fba3ac3e-5074-4ae6-b21b-77e83ddd5728",
-            "createdDateTimeUtc": "2021-08-01T13:51:50.096311Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:51.9229238Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "919b875a-ac8a-4168-9f5d-2b002e2e990b",
-            "createdDateTimeUtc": "2021-08-01T13:51:36.2700242Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:44.8851496Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b65dd502-78d8-41eb-a5c2-e38841e8a64d",
-            "createdDateTimeUtc": "2021-08-01T13:51:29.279615Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:29.8684676Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f31e8014-63fa-40b4-99c8-0bcd7b0e55c8",
-            "createdDateTimeUtc": "2021-08-01T13:51:18.8649454Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:23.0945034Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "03ff545e-1823-45a4-b776-69f0e04acc30",
-            "createdDateTimeUtc": "2021-08-01T13:47:29.3049005Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:31.3629345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ba88a76e-c3d3-4ea6-a53c-b85651fcf2e3",
-            "createdDateTimeUtc": "2021-08-01T13:47:23.0010181Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:24.2943392Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "74a8ff69-cb7a-4499-86df-c3a2d3832f35",
-            "createdDateTimeUtc": "2021-08-01T13:47:15.4214201Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:17.6049061Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d34a947d-dbfe-4629-94ca-583ba3135c38",
-            "createdDateTimeUtc": "2021-08-01T13:47:09.0574092Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:10.5667782Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "292e0fc5-31f9-4bbe-a16d-118e79c6447d",
-            "createdDateTimeUtc": "2021-08-01T13:46:55.8006784Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:03.6165324Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "46cfff21-a830-4bfe-bcf7-7845dea12314",
-            "createdDateTimeUtc": "2021-08-01T13:46:47.3054Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:49.2160598Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "992cdea9-d5e3-4518-a34f-463b467802b8",
-            "createdDateTimeUtc": "2021-08-01T13:46:39.1556709Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:42.1830707Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1b93d4c5-0c5a-4c53-9d0b-123580370ac4",
-            "createdDateTimeUtc": "2021-08-01T13:46:34.0334308Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:35.0748515Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c10423c1-70a0-4249-9b44-c4e35fa531cf",
-            "createdDateTimeUtc": "2021-08-01T13:46:27.7441155Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:28.5230851Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "762b843d-5634-4e71-8998-3c269c5aa71a",
-            "createdDateTimeUtc": "2021-08-01T13:46:14.8806312Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:21.7377245Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8c396dd4-a4d4-4fd6-b49c-9bf293bc5b22",
-            "createdDateTimeUtc": "2021-08-01T13:39:53.2223797Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:59.6350234Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "15fa9332-a622-4903-9c2d-30ec419c019f",
-            "createdDateTimeUtc": "2021-08-01T13:39:40.8849092Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:45.8189345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "4eba9692-8936-433d-8277-37297439855f",
-            "createdDateTimeUtc": "2021-08-01T13:39:25.8159637Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:34.600318Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "d7d61b86-c02c-44a7-9d94-1b3bf73ea68c",
-            "createdDateTimeUtc": "2021-08-01T13:39:18.4391794Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:19.4610126Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "501ab4fe-6bb1-4f2f-bc60-0ed6375ff114",
-            "createdDateTimeUtc": "2021-08-01T13:39:08.0207097Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:12.3862208Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "92b4bf08-9a7b-4e86-bf5f-6287b863b2f8",
-            "createdDateTimeUtc": "2021-08-01T13:38:54.8712186Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:01.0996993Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "e89ae3bd-9e8e-4035-91c8-1110271964f5",
-            "createdDateTimeUtc": "2021-07-29T18:56:30.5852007Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:32.8561054Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "80f86e77-a61c-4fb6-a924-86ed9fd9dcdb",
-            "createdDateTimeUtc": "2021-07-29T18:56:17.7021902Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:25.2356539Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bfebe6ca-0904-4142-8deb-def8890749cc",
-            "createdDateTimeUtc": "2021-07-29T18:56:08.9244466Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:10.2588454Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c627c2f9-4605-4e98-92d7-d9814db0bfff",
-            "createdDateTimeUtc": "2021-07-29T18:55:56.0217273Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:03.7770256Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7cff621d-1a6d-432e-8fa5-df00eb8e076e",
-            "createdDateTimeUtc": "2021-07-29T18:55:47.2424877Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:48.0765309Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4338311b-280f-4aa3-844a-a7fb7236879d",
-            "createdDateTimeUtc": "2021-07-29T18:55:36.922933Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:41.5171516Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8794c5c1-f497-4a83-8293-da713258faa8",
-            "createdDateTimeUtc": "2021-07-29T18:55:23.3488567Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:30.3458735Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b86b6998-282c-4594-81a4-a6cb6d123953",
-            "createdDateTimeUtc": "2021-07-29T18:55:14.0853219Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:16.7959039Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "af92572b-d7d2-4d21-9ec7-411116a78904",
-            "createdDateTimeUtc": "2021-07-29T18:27:48.249869Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:48.9487415Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a7725a19-0c98-4ffd-947f-4d574615fd1e",
-            "createdDateTimeUtc": "2021-07-29T18:27:35.1676798Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:41.9314655Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bf5cbc3b-2921-4372-bcae-ffd87391abef",
-            "createdDateTimeUtc": "2021-07-29T18:27:27.7901646Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:28.4614677Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "69b858d0-ff26-4cfd-911e-37e3f73bb4f7",
-            "createdDateTimeUtc": "2021-07-29T18:27:19.8707951Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:21.4611112Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "14721933-e03d-4f8a-8f21-83219f03b279",
-            "createdDateTimeUtc": "2021-07-29T18:27:03.2894117Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:10.3609678Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8375af4f-848a-46ff-891e-a8b844ca0856",
-            "createdDateTimeUtc": "2021-07-29T18:26:52.907266Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:56.3528141Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "23dfbdb4-cf55-45bb-ab9c-02e3167a29e1",
-            "createdDateTimeUtc": "2021-07-29T18:26:45.3554314Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:46.2619525Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=350\u0026$top=53\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=350\u0026$top=53\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b4ee05ea732ef3469430887003e97602-d677be3731819147-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e716553ef76fdfe3539b565d68669788",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "88862091-207c-46d5-989a-db48d6720a57",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:30 GMT",
-        "ETag": "\u002245FDDB3D7E92A0C0C8A41448B2FDCF5E42A726F8A7F419E3379B7995E2EEF6D8\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "88862091-207c-46d5-989a-db48d6720a57"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "d5c5dd3e-1858-468d-bf7f-33f2833f4872",
-            "createdDateTimeUtc": "2021-07-29T18:26:37.3639687Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:38.3200345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e7188ffe-9202-479a-afe1-01fecc04ad22",
-            "createdDateTimeUtc": "2021-07-29T18:25:33.3238602Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:35.2984814Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "70db07a3-07c0-4d9d-83c5-5f65da69c4f9",
-            "createdDateTimeUtc": "2021-07-29T18:25:26.783298Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:28.2271307Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6a32867d-406a-4da9-a9aa-6d869d895bfd",
-            "createdDateTimeUtc": "2021-07-29T18:25:18.055152Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:21.1616142Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "05e70da4-5e01-4a27-b706-19fcf0adcada",
-            "createdDateTimeUtc": "2021-07-29T18:25:12.7651639Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:14.1490239Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f9b7a393-c7a5-421c-ba1d-a44c02048634",
-            "createdDateTimeUtc": "2021-07-29T18:25:04.3837212Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:07.1327422Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b4902c6f-6289-477e-8f9b-2bcb70c2e924",
-            "createdDateTimeUtc": "2021-07-29T18:24:57.6574082Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:00.1100818Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6048a21b-abc8-4457-b921-b9f3602082dd",
-            "createdDateTimeUtc": "2021-07-29T18:24:51.4511113Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:53.231795Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "72139ec3-ad0b-42cc-9a6c-92c555cc1417",
-            "createdDateTimeUtc": "2021-07-29T18:24:42.1866362Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:46.1095564Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a0efbf77-53fb-4af8-8c69-61df229575cc",
-            "createdDateTimeUtc": "2021-07-29T18:24:18.6490605Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:21.0023446Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f50dd147-dd7a-4589-8f90-b40bdc22e6d9",
-            "createdDateTimeUtc": "2021-07-29T18:24:13.4076008Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:14.9595162Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1769c3a9-a912-4e02-ad76-4ad658e6bd07",
-            "createdDateTimeUtc": "2021-07-29T18:24:06.1419128Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:07.8638717Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7a8a7450-9f6e-4ee0-9c72-caa4303e9649",
-            "createdDateTimeUtc": "2021-07-29T18:23:53.1730982Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:00.9552258Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4b5fd2ee-aa2a-45e2-a64b-69d4b6aa8fef",
-            "createdDateTimeUtc": "2021-07-29T18:23:44.6321958Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:46.0263327Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6d4a7add-df54-4f67-a3dd-bc47675e5131",
-            "createdDateTimeUtc": "2021-07-29T18:23:35.607668Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:38.9203906Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "73a8b048-a34e-4bf9-9a77-9fd7a1fa0eab",
-            "createdDateTimeUtc": "2021-07-29T18:23:22.5480081Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:26.9561971Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3221547b-76a3-45d2-ad5e-28383c397f11",
-            "createdDateTimeUtc": "2021-07-29T18:23:12.8991624Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:16.2575253Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce9f5f49-3336-4ef4-996f-7086e032e208",
-            "createdDateTimeUtc": "2021-07-29T18:11:08.689952Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:11:10.9326895Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a17020af-7225-4a1c-bd1d-f9c86b8e8231",
-            "createdDateTimeUtc": "2021-07-29T18:10:59.594621Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:11:03.8658837Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bcd6fdf4-0572-475d-af9c-6df2e9882564",
-            "createdDateTimeUtc": "2021-07-29T18:10:48.318371Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:53.1219508Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7f7329d9-9d65-4aa0-a19e-c151f45fbfba",
-            "createdDateTimeUtc": "2021-07-29T18:10:36.4711697Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:39.9591092Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8a8759c6-38f8-4587-82c5-551099482e2e",
-            "createdDateTimeUtc": "2021-07-29T18:10:25.3356743Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:29.6315203Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "41696374-9114-4f8d-90f7-6c8a1c7b0607",
-            "createdDateTimeUtc": "2021-07-29T18:10:14.5091385Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:18.8819684Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c1fe9b5d-e1ec-410d-84e1-14780b307360",
-            "createdDateTimeUtc": "2021-07-29T18:10:03.0941124Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:08.0754094Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5f6d6b60-7017-4ae9-b89b-734dbc8df3a2",
-            "createdDateTimeUtc": "2021-07-29T18:09:50.6890119Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:09:54.5512218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "68c61875-9896-4531-8eec-f79a84ec0732",
-            "createdDateTimeUtc": "2021-07-29T18:07:41.3308148Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:43.0283024Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9b825b8-de7f-4ef9-8b15-67f8a05228de",
-            "createdDateTimeUtc": "2021-07-29T18:07:33.4253241Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:35.8948263Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "07266a35-6965-49a7-b488-c6aec774f353",
-            "createdDateTimeUtc": "2021-07-29T18:07:28.0747509Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:29.4732464Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "712bb162-dda9-4e0d-900d-6e32ccb84ce2",
-            "createdDateTimeUtc": "2021-07-29T18:07:21.4384466Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:22.3419567Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8f0a8627-974a-452a-b531-0a7eeba67834",
-            "createdDateTimeUtc": "2021-07-29T18:07:11.9494241Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:13.7989556Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c944ca83-770a-4981-8393-8436509a3ac5",
-            "createdDateTimeUtc": "2021-07-29T18:07:03.4708288Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:04.7948363Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "579fe594-a0ac-46c9-99bc-6337aacf022c",
-            "createdDateTimeUtc": "2021-07-29T18:06:55.3491078Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:57.7260656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b9b9b7a-0467-49b5-a230-d6c2c1c80827",
-            "createdDateTimeUtc": "2021-07-29T18:06:40.9676932Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:46.6887745Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b47abfb4-48de-49de-a4cd-147fe3742a71",
-            "createdDateTimeUtc": "2021-07-29T18:06:35.6198036Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:37.3471477Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5dc846fa-dea1-4528-b9cb-39fba11fb4da",
-            "createdDateTimeUtc": "2021-07-29T18:06:18.7068479Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:26.7025516Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2a1743af-a8b6-4ff4-aacc-709b078c56ad",
-            "createdDateTimeUtc": "2021-07-29T18:02:37.0777259Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:40.6627767Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "cd0f86ef-4325-4732-bb52-a12b6bc460df",
-            "createdDateTimeUtc": "2021-07-29T18:02:26.2775788Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:28.2284503Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "905ec32b-4d49-47e5-825a-167cee386199",
-            "createdDateTimeUtc": "2021-07-29T18:02:02.1798526Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:05.4444688Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5e5d4037-f4be-4678-85f2-6c2d10eb35b0",
-            "createdDateTimeUtc": "2021-07-29T18:01:50.005682Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:01:53.1664365Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "f8e7a8b6-428a-45c1-8046-b00f16793d40",
-            "createdDateTimeUtc": "2021-07-29T18:00:58.4154875Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:01:00.6279809Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "f5aa1906-2807-4db0-bd08-a8f9e56b4750",
-            "createdDateTimeUtc": "2021-07-29T18:00:39.80581Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:00:48.5772657Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "0498c77f-42de-46cb-91fb-529c044d9e2b",
-            "createdDateTimeUtc": "2021-07-29T16:05:46.6656342Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:05:46.8929852Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f97fa266-258a-43be-abf7-3a851dd3438a",
-            "createdDateTimeUtc": "2021-07-29T16:05:43.5493779Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:05:43.798646Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "bfe99a22-0966-4bb8-8f99-a60956e1bd44",
-            "createdDateTimeUtc": "2021-07-29T16:04:43.3132785Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:04:43.6688398Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "364a7f60-b5e0-40ed-8fbe-8c269e757f58",
-            "createdDateTimeUtc": "2021-07-29T16:04:38.8243421Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:04:39.7360075Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "173f4456-92b0-47d4-87f0-d3b3f6b076c8",
-            "createdDateTimeUtc": "2021-07-29T16:00:33.3385235Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:00:33.6856601Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "e2cebd98-9179-47ff-a520-d6e672f9548d",
-            "createdDateTimeUtc": "2021-07-29T15:59:51.7446608Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:59:51.9630722Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d44729c5-7422-414e-9ec8-41be82649bcd",
-            "createdDateTimeUtc": "2021-07-29T15:59:47.8488179Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:59:48.0834023Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "879d0008-1264-4273-9f94-61eaa0d53818",
-            "createdDateTimeUtc": "2021-07-29T15:57:48.4243818Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:48.6367029Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "52a46f0a-80cc-4e51-94e8-6355a5a00782",
-            "createdDateTimeUtc": "2021-07-29T15:57:45.4760932Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:45.6975927Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=400\u0026$top=3\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=400\u0026$top=3\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:29:20.1766912Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-382d16bdf05b2745bad749ebc76a64c8-293a980dca97bb40-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d008df232cef4cedf068befcecb4aebc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4c7ce270-98d8-48df-bac8-7083611f35ff",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:30 GMT",
-        "ETag": "\u0022585C9CC8BEEBE5F3B2D5B00472E42905EE417E44CB185A0C87421B42CC3F78FD\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4c7ce270-98d8-48df-bac8-7083611f35ff"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "1b1df384-0c32-48e3-8539-53619fe9847f",
-            "createdDateTimeUtc": "2021-07-29T15:57:06.0490196Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:06.4194196Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "49e77fae-33ee-486c-aac8-5a9e6e27d6c0",
-            "createdDateTimeUtc": "2021-07-29T15:54:13.5289776Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:54:13.9172691Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "dea162d3-b03d-466e-bd33-fae8e3279b21",
-            "createdDateTimeUtc": "2021-07-29T15:54:09.3707087Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:54:09.7229003Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
             }
           }
         ]
@@ -7295,10 +1589,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-04T22:29:20.1766912\u002B02:00",
+    "DateTimeOffsetNow": "2021-08-26T16:26:24.5965448\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
-    "RandomSeed": "98208171"
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
+    "RandomSeed": "423963248"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedBeforeTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedBeforeTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source728539512?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source428265976?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-fbda9d28c1d96c4696aba7403235a7bf-666dccc8e897f144-00",
+        "traceparent": "00-da778fe77b556040935c222403aa9fba-a56ac5f4f5161e4b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "00de0b5e225cc65c7bb4240df72ed499",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:02 GMT",
+        "x-ms-client-request-id": "8a23a1344fe6af318f2444a7672ab370",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:39 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:02 GMT",
-        "ETag": "\u00220x8D95786C79E0A0C\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:03 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:39 GMT",
+        "ETag": "\u00220x8D9689D84FBF68F\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:39 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "00de0b5e225cc65c7bb4240df72ed499",
-        "x-ms-request-id": "0527e6dd-a01e-003b-396f-896135000000",
+        "x-ms-client-request-id": "8a23a1344fe6af318f2444a7672ab370",
+        "x-ms-request-id": "9acdd753-801e-0061-3586-9a1fdc000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source728539512/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source428265976/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-a0217616ee0eb34c9305827c2397cb32-28b0c0e40d498c45-00",
+        "traceparent": "00-0ee19a0e39a3ee40ba4bf152895b1808-00ab4ea8388b5b4d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "e0665d8c322a0ca9103c8e8db1363836",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:03 GMT",
+        "x-ms-client-request-id": "b6f7f077b917747844139c9ad1faa09e",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:40 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:03 GMT",
-        "ETag": "\u00220x8D95786C7E7E129\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:04 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:39 GMT",
+        "ETag": "\u00220x8D9689D852B04DC\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:40 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "e0665d8c322a0ca9103c8e8db1363836",
+        "x-ms-client-request-id": "b6f7f077b917747844139c9ad1faa09e",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0527e74e-a01e-003b-136f-896135000000",
+        "x-ms-request-id": "9acdd7a1-801e-0061-7886-9a1fdc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target904070184?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1624679117?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-91f53938ecc4cb4e91845317d3164283-25b383211b3ed046-00",
+        "traceparent": "00-b646679071ee164f962ac4f4630a7e4a-2d0cb50dad8b0d4f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "84b6734b218aa4698363c46ea5238e7b",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:03 GMT",
+        "x-ms-client-request-id": "880ca71253ebf3f81b92dc359d8e5b52",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:40 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,27 +76,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:03 GMT",
-        "ETag": "\u00220x8D95786C80F08B1\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:04 GMT",
+        "Date": "Thu, 26 Aug 2021 14:26:39 GMT",
+        "ETag": "\u00220x8D9689D85428275\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:40 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "84b6734b218aa4698363c46ea5238e7b",
-        "x-ms-request-id": "0527e813-a01e-003b-396f-896135000000",
+        "x-ms-client-request-id": "880ca71253ebf3f81b92dc359d8e5b52",
+        "x-ms-request-id": "9acdd81c-801e-0061-6e86-9a1fdc000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ce9e3fb28b648e40ba243288d1c2c2ac-14199a0845016245-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0013bbe84d88622cd2f02093ce14447c",
+        "traceparent": "00-f74437959ad8564d9e0fa96ccd8c2f79-8e410ecce7d92142-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2f92924ae050297bae45d2b296dd9583",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -116,429 +116,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d01f71db-c738-424b-91f3-37c0fa06b3a1",
+        "apim-request-id": "283f1104-7777-4b07-976a-fe38cb0a63e6",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:04 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1ba62433-3859-4df5-af33-cd4c4073e598",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d01f71db-c738-424b-91f3-37c0fa06b3a1"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1ba62433-3859-4df5-af33-cd4c4073e598",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bbace5ed141e3b01fd3ba7cee49d6b18",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "82235fd3-1074-4bf2-b222-a1ca7b669d92",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:04 GMT",
-        "ETag": "\u0022B329C0A1FCE0CBFE0FAE22B1D6EA5FC855EBB0B46F625C7D4AEF404798010B5A\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "82235fd3-1074-4bf2-b222-a1ca7b669d92"
-      },
-      "ResponseBody": {
-        "id": "1ba62433-3859-4df5-af33-cd4c4073e598",
-        "createdDateTimeUtc": "2021-08-04T20:31:04.8312514Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:05.0779339Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1ba62433-3859-4df5-af33-cd4c4073e598",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7bc811003624fda04753b29a00d5d66e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9ecdddfa-1cc3-4069-b1a0-873a8c8e88d5",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:06 GMT",
-        "ETag": "\u002205051DF87273096C85580A5A4AE9F77D1F7E24AA9C2BA8116E36EED2345DD915\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9ecdddfa-1cc3-4069-b1a0-873a8c8e88d5"
-      },
-      "ResponseBody": {
-        "id": "1ba62433-3859-4df5-af33-cd4c4073e598",
-        "createdDateTimeUtc": "2021-08-04T20:31:04.8312514Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:06.0766477Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1ba62433-3859-4df5-af33-cd4c4073e598",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bf81481fd377d45db9d7034ca55e7d35",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f3d49951-c72a-4b61-81e6-489249c5fe20",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:07 GMT",
-        "ETag": "\u002205051DF87273096C85580A5A4AE9F77D1F7E24AA9C2BA8116E36EED2345DD915\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f3d49951-c72a-4b61-81e6-489249c5fe20"
-      },
-      "ResponseBody": {
-        "id": "1ba62433-3859-4df5-af33-cd4c4073e598",
-        "createdDateTimeUtc": "2021-08-04T20:31:04.8312514Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:06.0766477Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1ba62433-3859-4df5-af33-cd4c4073e598",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bd920885c94cb75745ae73ca61673a27",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7d104382-60c2-421e-91e6-36947da58189",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:08 GMT",
-        "ETag": "\u002205051DF87273096C85580A5A4AE9F77D1F7E24AA9C2BA8116E36EED2345DD915\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7d104382-60c2-421e-91e6-36947da58189"
-      },
-      "ResponseBody": {
-        "id": "1ba62433-3859-4df5-af33-cd4c4073e598",
-        "createdDateTimeUtc": "2021-08-04T20:31:04.8312514Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:06.0766477Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1ba62433-3859-4df5-af33-cd4c4073e598",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9caf3965ab1b2da1b3f4c14c335357e9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7ac59758-2e7e-438f-b753-0dfe17fc35d5",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:10 GMT",
-        "ETag": "\u002204B4D5F8B3ADDA09E2D0F52EA6FAE8B7566754DBEBE9964C0E14860A0AF9AF21\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7ac59758-2e7e-438f-b753-0dfe17fc35d5"
-      },
-      "ResponseBody": {
-        "id": "1ba62433-3859-4df5-af33-cd4c4073e598",
-        "createdDateTimeUtc": "2021-08-04T20:31:04.8312514Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:06.0766477Z",
-        "status": "Succeeded",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 1,
-          "inProgress": 0,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 16
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1ba62433-3859-4df5-af33-cd4c4073e598/documents",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f8157cd518435522f0c97ac85f937252",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "55cae6b7-92cc-4115-8dea-31c9b63ce103",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:10 GMT",
-        "ETag": "\u002233A8C657748CC2FD8F76E75563E7027281CE29FB6A1179048F3F85EA81C03A65\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "55cae6b7-92cc-4115-8dea-31c9b63ce103"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target904070184/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source728539512/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:31:05.7972058Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:09.3350994Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000a53ea-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1764309916?restype=container",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-36b3396d8b384d478883fe3e003a8077-b349f528ee685346-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "af6ce7db19e166d9640957080a84f157",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:10 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-04-08"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:09 GMT",
-        "ETag": "\u00220x8D95786CBD8314A\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:10 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "af6ce7db19e166d9640957080a84f157",
-        "x-ms-request-id": "0527f26e-a01e-003b-6e6f-896135000000",
-        "x-ms-version": "2020-04-08"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1764309916/File_0.txt",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "Content-Length": "16",
-        "If-None-Match": "*",
-        "traceparent": "00-08c8943bba161b49b5bc942037c908b2-43208fdbea89de49-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "51e5f48ae441174c59ab5230d8ce2081",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:10 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-04-08"
-      },
-      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:10 GMT",
-        "ETag": "\u00220x8D95786CC20F707\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:11 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "51e5f48ae441174c59ab5230d8ce2081",
-        "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0527f2db-a01e-003b-4c6f-896135000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2020-04-08"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1937948782?restype=container",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "traceparent": "00-0c43b01c826a94418464bb2044ced2d7-f385789157513e4c-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "eb6c57b0f33a3b6391de0fca4de64589",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:10 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-04-08"
-      },
-      "RequestBody": null,
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:10 GMT",
-        "ETag": "\u00220x8D95786CC4E39E1\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:11 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "eb6c57b0f33a3b6391de0fca4de64589",
-        "x-ms-request-id": "0527f3e3-a01e-003b-246f-896135000000",
-        "x-ms-version": "2020-04-08"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Content-Length": "103",
-        "Content-Type": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ad586647fcd5b048adbd988eb067624f-ed2870a9aec8554e-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8d9ed5715a009af7555536c7a98e96e8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "inputs": [
-          {
-            "source": {
-              "sourceUrl": "Sanitized"
-            },
-            "targets": [
-              {
-                "targetUrl": "Sanitized",
-                "language": "fr"
-              }
-            ]
-          }
-        ]
-      },
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "apim-request-id": "cb8da508-b3c7-4b0c-bc0f-78b55df2b732",
-        "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:11 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
+        "Date": "Thu, 26 Aug 2021 14:26:40 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -546,46 +127,46 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cb8da508-b3c7-4b0c-bc0f-78b55df2b732"
+        "X-RequestId": "283f1104-7777-4b07-976a-fe38cb0a63e6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2c5a99d66c8501508215af053c4d0bc5",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8254d9a5e8a79c8cffc3fb269b3fa784",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d0b02e13-29c1-453f-90f0-5d5e73c37ae4",
+        "apim-request-id": "4cec5a52-0af9-4057-802d-1a2b24b4119f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:12 GMT",
-        "ETag": "\u0022F83EE176E03884434A5B45781797350175E1A7DFA877513C3BA4B125C95E3F2D\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:40 GMT",
+        "ETag": "\u0022801CE47F813B54C7D0CA71300280E2FB9BD9887DFE46138C41AD492A82A7CEC0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d0b02e13-29c1-453f-90f0-5d5e73c37ae4"
+        "X-RequestId": "4cec5a52-0af9-4057-802d-1a2b24b4119f"
       },
       "ResponseBody": {
-        "id": "c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
-        "createdDateTimeUtc": "2021-08-04T20:31:11.9333165Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:11.9333168Z",
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:40.7656779Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -599,26 +180,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f967a70df482556e5fd195e4bd9b9203",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "678648416e0e317d2be2d9a580455c3d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "44738fc2-9d31-4ba5-b99b-90f6396f2510",
+        "apim-request-id": "e1722520-0bd7-4a3c-ab2e-8ac5d97cb945",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:13 GMT",
-        "ETag": "\u002235FE70EE553BEE72B9B5F562484C72A6157A9756E9EC1E3BDF3815F02D7FF7D3\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:41 GMT",
+        "ETag": "\u0022D288D4E0C6588BA49E1D13C3177D2E0E6D6B054B4972E154466B99A7E41EFB55\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -628,108 +209,156 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "44738fc2-9d31-4ba5-b99b-90f6396f2510"
+        "X-RequestId": "e1722520-0bd7-4a3c-ab2e-8ac5d97cb945"
       },
       "ResponseBody": {
-        "id": "c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
-        "createdDateTimeUtc": "2021-08-04T20:31:11.9333165Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:13.1538284Z",
-        "status": "Running",
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:41.4213201Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b4f32748188b0403849d0beaaaf15d07",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c48f58fdd83a62aa06f5308ce5548d6f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "37bd93f6-562d-4b68-8ddf-ec27252c13a4",
+        "apim-request-id": "6e6d72db-16dd-4d3d-a208-a874834f7638",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:14 GMT",
-        "ETag": "\u002235FE70EE553BEE72B9B5F562484C72A6157A9756E9EC1E3BDF3815F02D7FF7D3\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:43 GMT",
+        "ETag": "\u0022D288D4E0C6588BA49E1D13C3177D2E0E6D6B054B4972E154466B99A7E41EFB55\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "37bd93f6-562d-4b68-8ddf-ec27252c13a4"
+        "X-RequestId": "6e6d72db-16dd-4d3d-a208-a874834f7638"
       },
       "ResponseBody": {
-        "id": "c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
-        "createdDateTimeUtc": "2021-08-04T20:31:11.9333165Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:13.1538284Z",
-        "status": "Running",
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:41.4213201Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "02b971499c27e2662b05ccb3d66b43e6",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4e714e9e2e5736755b2256c40fe61bb9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "31e2e707-c41a-4c1c-a762-133d0056c4ce",
+        "apim-request-id": "44ac62f1-1c1b-481c-9fca-f83414f99652",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
-        "Content-Length": "289",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:15 GMT",
-        "ETag": "\u002235FE70EE553BEE72B9B5F562484C72A6157A9756E9EC1E3BDF3815F02D7FF7D3\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:44 GMT",
+        "ETag": "\u0022D288D4E0C6588BA49E1D13C3177D2E0E6D6B054B4972E154466B99A7E41EFB55\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "31e2e707-c41a-4c1c-a762-133d0056c4ce"
+        "X-RequestId": "44ac62f1-1c1b-481c-9fca-f83414f99652"
       },
       "ResponseBody": {
-        "id": "c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
-        "createdDateTimeUtc": "2021-08-04T20:31:11.9333165Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:13.1538284Z",
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:41.4213201Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4329be67e2af684a9d2460183ef04cd6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e0f40315-b183-4054-8331-e07e7bd78966",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:45 GMT",
+        "ETag": "\u0022613976A40ADA6532628DB81FE2DEB27B89E892456F250AF80494B083BC2FF048\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e0f40315-b183-4054-8331-e07e7bd78966"
+      },
+      "ResponseBody": {
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:46.0823628Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -743,41 +372,281 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "15bdac835759f539a36274e5e983aa6e",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "32076a550dd4cfe6e359681881e5531f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6b4c7f8f-e3c4-4491-a2f6-9826f348aebb",
+        "apim-request-id": "9743c7ff-c4d2-452c-8216-9aadb51cdaa9",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:17 GMT",
-        "ETag": "\u002270A514841A2456C740EFD6743DF8BC9A5FD73A092FB8B4B305274DD23ED117A1\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:47 GMT",
+        "ETag": "\u0022613976A40ADA6532628DB81FE2DEB27B89E892456F250AF80494B083BC2FF048\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6b4c7f8f-e3c4-4491-a2f6-9826f348aebb"
+        "X-RequestId": "9743c7ff-c4d2-452c-8216-9aadb51cdaa9"
       },
       "ResponseBody": {
-        "id": "c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
-        "createdDateTimeUtc": "2021-08-04T20:31:11.9333165Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:13.1538284Z",
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:46.0823628Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "272576da4a2bbbbf0308b032cd5cf86b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4516015c-29d1-4ad1-8eeb-2865d637ef58",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:48 GMT",
+        "ETag": "\u0022613976A40ADA6532628DB81FE2DEB27B89E892456F250AF80494B083BC2FF048\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "4516015c-29d1-4ad1-8eeb-2865d637ef58"
+      },
+      "ResponseBody": {
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:46.0823628Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a56f7fd5e8de59e5d75a5f567a32e7b8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "47e13026-d534-4b8d-b010-a91e10a22b34",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:49 GMT",
+        "ETag": "\u0022613976A40ADA6532628DB81FE2DEB27B89E892456F250AF80494B083BC2FF048\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "47e13026-d534-4b8d-b010-a91e10a22b34"
+      },
+      "ResponseBody": {
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:46.0823628Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c73e41d125ca0babaa4c2fcb5cb30287",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d11d91bb-5581-4d1f-b02d-1ad9a8d7fc86",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:51 GMT",
+        "ETag": "\u0022613976A40ADA6532628DB81FE2DEB27B89E892456F250AF80494B083BC2FF048\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d11d91bb-5581-4d1f-b02d-1ad9a8d7fc86"
+      },
+      "ResponseBody": {
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:46.0823628Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0142fc60ad76f14090cb4fd1ea6941d1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b50d13c6-dccd-4364-a968-1d1dc6164564",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:52 GMT",
+        "ETag": "\u0022613976A40ADA6532628DB81FE2DEB27B89E892456F250AF80494B083BC2FF048\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "b50d13c6-dccd-4364-a968-1d1dc6164564"
+      },
+      "ResponseBody": {
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:46.0823628Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8b61f820311db0a0d464fa92b91afc23",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1540eb80-7dcc-48fd-b4ea-ac55bdb27ca1",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:26:53 GMT",
+        "ETag": "\u0022532733CD92FC9F348A926C73DA03E16457BBE846204AE96401E942C9416B8278\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "1540eb80-7dcc-48fd-b4ea-ac55bdb27ca1"
+      },
+      "ResponseBody": {
+        "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+        "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:53.1057573Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -791,26 +660,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c1844d4e-91e7-4d27-8306-c4ae872fb0fe/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4a230ac6-103e-424d-a9d8-56939d6596d6/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4c9a8e7390e2abdcc11189864b502e19",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7df5d858e5ef2342004d36fed5da2141",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4931db0-ed66-4981-9eec-5f4ca728313a",
+        "apim-request-id": "05349e39-e29c-4028-a449-45a8b9b22e5f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:17 GMT",
-        "ETag": "\u0022457F79C820288C3C2166730FAC562C0F8190F73711A4338409DC573752001D65\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:53 GMT",
+        "ETag": "\u0022B887B901FF78BA13DEC0FAA9640CD11F2AE6CB8D9083A9121CC87E7BEF6825D6\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -820,835 +689,176 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f4931db0-ed66-4981-9eec-5f4ca728313a"
+        "X-RequestId": "05349e39-e29c-4028-a449-45a8b9b22e5f"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target1937948782/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1764309916/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:31:12.8647343Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:16.3620753Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1624679117/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source428265976/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:26:45.4373735Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:26:53.1057508Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53eb-0000-0000-0000-000000000000",
+            "id": "000b5470-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=\u0026createdDateTimeUtcEnd=2021-08-04T20%3A31%3A10.0631715Z\u0026$orderBy=",
-      "RequestMethod": "GET",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source103650315?restype=container",
+      "RequestMethod": "PUT",
       "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0112af9a049a0439783cec1b6582c54-6bcbf0b9fdc7144e-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fe6724594834f2ae37c45fc42881f8a7",
-        "x-ms-return-client-request-id": "true"
+        "Authorization": "Sanitized",
+        "traceparent": "00-bd1994042faab94983305ee126c78e64-8f0d87e09abbdb47-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5264aa5d69765c2f912d11b3ae3776cf",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
       },
       "RequestBody": null,
-      "StatusCode": 200,
+      "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5a3c6dc4-1c57-4aaa-95d1-4ee6b2f05826",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:17 GMT",
-        "ETag": "\u0022512ABC9E8AE0D6EE85F0AD6498C346ABC5294F057D6CA63342B86340B8FF0934\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "5a3c6dc4-1c57-4aaa-95d1-4ee6b2f05826"
+        "Content-Length": "0",
+        "Date": "Thu, 26 Aug 2021 14:26:53 GMT",
+        "ETag": "\u00220x8D9689D8D6A57E9\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:54 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "5264aa5d69765c2f912d11b3ae3776cf",
+        "x-ms-request-id": "9acdf186-801e-0061-1786-9a1fdc000000",
+        "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "1ba62433-3859-4df5-af33-cd4c4073e598",
-            "createdDateTimeUtc": "2021-08-04T20:31:04.8312514Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:06.0766477Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f7fe9d68-111f-4a6b-a389-0119d4df3805",
-            "createdDateTimeUtc": "2021-08-04T20:30:58.2974422Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:59.07834Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-            "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:52.0223948Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-            "createdDateTimeUtc": "2021-08-04T20:30:35.9657621Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:39.4948082Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-            "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-            "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:14.4305144Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6606d70-e903-4f08-a80d-3d1b65c07303",
-            "createdDateTimeUtc": "2021-08-04T20:30:06.5979195Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:10.7837251Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-            "createdDateTimeUtc": "2021-08-04T20:29:50.3509191Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:51.8150261Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-            "createdDateTimeUtc": "2021-08-04T20:29:43.0044925Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:46.0940111Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-            "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:39.0415286Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "129932a4-ccc4-4702-ae64-ed24fa9ebe30",
-            "createdDateTimeUtc": "2021-08-04T20:29:22.21029Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:23.790485Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-            "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:16.7676912Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-            "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:09.8583078Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-            "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:28:57.0357411Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "de3ae1b9-065c-4a2b-9da3-a413d0e1d828",
-            "createdDateTimeUtc": "2021-08-04T20:13:20.3289712Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:21.8009118Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5e58ffb7-c561-4ada-908a-5fb618214b57",
-            "createdDateTimeUtc": "2021-08-04T20:13:14.1830952Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:16.2626995Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "7349a49c-f2e4-4c35-938e-976306fdf0ec",
-            "createdDateTimeUtc": "2021-08-04T20:13:07.7204022Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:09.4175921Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "dad50132-5081-4e87-9cdb-8305960adaad",
-            "createdDateTimeUtc": "2021-08-04T20:13:00.3134951Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:02.1869029Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5149a480-1a90-4483-b9fe-8c0ae356c975",
-            "createdDateTimeUtc": "2021-08-04T20:12:48.8123001Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:12:52.257366Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "95d1a6fa-cbcc-4eda-b8c5-7f9dea903155",
-            "createdDateTimeUtc": "2021-08-04T20:12:39.6819361Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:12:42.109702Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "ee205c17-3434-4372-9ec8-093d3fc2ab0e",
-            "createdDateTimeUtc": "2021-08-03T21:39:22.1215914Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:24.0088345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "034ac505-8e05-45e9-b69d-4ae5db5c3206",
-            "createdDateTimeUtc": "2021-08-03T21:39:15.57059Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:16.9287241Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1c2e403d-4f5f-4176-ac0b-d6525df7993d",
-            "createdDateTimeUtc": "2021-08-03T21:39:08.8759005Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:09.8373116Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1f96fca2-aaec-427c-92d0-fc8d43372768",
-            "createdDateTimeUtc": "2021-08-03T21:39:02.4121988Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:05.2080796Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "52fa5dc7-49d0-4490-b402-1817331f10f9",
-            "createdDateTimeUtc": "2021-08-03T21:38:57.2193344Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:58.2127609Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "98452bfa-797a-44c2-9bb2-d7fd159fab0d",
-            "createdDateTimeUtc": "2021-08-03T21:38:51.6547083Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:54.3057302Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "32aebb1f-9dd9-4bf4-a684-514bde841fd8",
-            "createdDateTimeUtc": "2021-08-03T21:38:47.6125244Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:53.9775319Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8e25b211-27f2-4793-99d0-6e47f55427a8",
-            "createdDateTimeUtc": "2021-08-03T21:38:30.9134208Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:33.1131258Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "45af44ab-ab27-4533-be94-d14fdc2f1d69",
-            "createdDateTimeUtc": "2021-08-03T21:38:23.1840352Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:26.0456158Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5fe83ec6-8231-4c42-8f7e-a04b75c0fa20",
-            "createdDateTimeUtc": "2021-08-03T21:38:16.5690668Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:19.2704212Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2dcc3a07-d808-4004-8cbc-f8d7047be6ea",
-            "createdDateTimeUtc": "2021-08-03T21:38:08.8344934Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:12.1744445Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d44ccbb4-7c5e-4230-8641-699df49bc974",
-            "createdDateTimeUtc": "2021-08-03T21:38:03.662895Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:05.099967Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b911d708-f339-4c49-b387-3a93b892edca",
-            "createdDateTimeUtc": "2021-08-03T21:37:55.9487829Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:58.091697Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3e1a9fd7-eefa-4140-bb3d-0cae619045c8",
-            "createdDateTimeUtc": "2021-08-03T21:37:49.2093973Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:51.1527605Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5c031e55-d105-4fcd-bddf-341af3c07de3",
-            "createdDateTimeUtc": "2021-08-03T21:37:42.4444943Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:44.066063Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f422877d-d674-4826-855b-6b918a1f8448",
-            "createdDateTimeUtc": "2021-08-03T21:37:35.5232446Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:37.1398344Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6d647efa-7b96-4bb4-b74a-76f2cf63b647",
-            "createdDateTimeUtc": "2021-08-03T21:37:28.0253539Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:30.0244215Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9530409a-3f1c-4184-a932-62f7586ca48c",
-            "createdDateTimeUtc": "2021-08-03T21:37:21.3477618Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:23.0535345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "02188384-3e1d-4fd5-b7b2-1c436155a427",
-            "createdDateTimeUtc": "2021-08-03T21:37:14.5363644Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:15.8789238Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e462cb0b-c257-4a03-8704-bafedb9a34ec",
-            "createdDateTimeUtc": "2021-08-03T21:37:06.740111Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:08.9139737Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9c2aff22-052b-4fe3-a77a-0e3d002157cb",
-            "createdDateTimeUtc": "2021-08-03T21:37:00.1515856Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:01.782922Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cbd315d5-9d09-4805-aeaf-dbf5a09b3f7f",
-            "createdDateTimeUtc": "2021-08-03T21:36:50.9777091Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:54.8378022Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f434c3d-7dd9-4305-8231-52ea7ef8822a",
-            "createdDateTimeUtc": "2021-08-03T21:36:37.1050378Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:39.7392021Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9bb6ced9-7570-404b-ae57-f0f6239284ff",
-            "createdDateTimeUtc": "2021-08-03T21:36:17.4274204Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:24.6427413Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c55e7e92-9f89-4061-b896-c719864f6227",
-            "createdDateTimeUtc": "2021-08-03T21:36:09.0638051Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:10.9653857Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e7d6e45d-7068-410e-b993-c18ad571354f",
-            "createdDateTimeUtc": "2021-08-03T21:35:56.6699145Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:03.8654828Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce58c3d3-4f45-498d-b593-6a5e7e7bd192",
-            "createdDateTimeUtc": "2021-08-03T21:35:47.9412218Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:49.5951191Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1eb03d70-54fd-4310-a4bc-de808f681a39",
-            "createdDateTimeUtc": "2021-08-03T21:35:41.0214036Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:42.5156289Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0554a9e0-53ab-49cc-8f1b-6d102523e16e",
-            "createdDateTimeUtc": "2021-08-03T21:35:34.1373856Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:35.4992558Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2219aa8b-281e-4c42-9605-10c76cc72913",
-            "createdDateTimeUtc": "2021-08-03T21:35:26.2122116Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:28.9695764Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=364\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z"
-      }
+      "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=364\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source103650315/File_0.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-f90951d4e5d11b468edf495906d9eb8a-05b8eb8ebd23704a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "7311782be1c3b63b3d8bd0faa1daf943",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Thu, 26 Aug 2021 14:26:53 GMT",
+        "ETag": "\u00220x8D9689D8D96A79E\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:54 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "7311782be1c3b63b3d8bd0faa1daf943",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "9acdf1f3-801e-0061-7f86-9a1fdc000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1289135801?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-13a8f286ce281f4383c978fe29a759ea-6d328d2d5b0d6e43-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "986f5c87e1d1c66f215eb830705215bf",
+        "x-ms-date": "Thu, 26 Aug 2021 14:26:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 26 Aug 2021 14:26:53 GMT",
+        "ETag": "\u00220x8D9689D8DAEE7AB\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:26:54 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "986f5c87e1d1c66f215eb830705215bf",
+        "x-ms-request-id": "9acdf27f-801e-0061-7f86-9a1fdc000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5768ce61f91a734798533f270898572d-dcb670a6fcf71c4f-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0f61a92f47cd6f7bae14ea9934bab733",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "c7731bc7-b182-4669-8284-5778b217de6b",
+        "Content-Length": "0",
+        "Date": "Thu, 26 Aug 2021 14:26:54 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c7731bc7-b182-4669-8284-5778b217de6b"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b4fd825f4f5204bbe22df9e35e03490-c3995ea1655a114a-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "483f5e5af7d0f204d0125447ceb3aa52",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "db26f9ce3707975aa2ada2838286cd39",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3fe954c6-523e-44e3-b4bb-9e7364740dc2",
+        "apim-request-id": "0e35c675-95d5-4944-a2c8-cbf24a314352",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:18 GMT",
-        "ETag": "\u0022A3527AF5E43049525AFAAF8BD96117D43EF9A94E4866A8FB93B82C8D61A82789\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:55 GMT",
+        "ETag": "\u00225ABB11EF7BE62929A52D80D79FC7990E05878A2055CD694A7B8465CD6D0D3F3C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1658,1575 +868,93 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3fe954c6-523e-44e3-b4bb-9e7364740dc2"
+        "X-RequestId": "0e35c675-95d5-4944-a2c8-cbf24a314352"
       },
       "ResponseBody": {
-        "value": [
-          {
-            "id": "8ed3d7d1-4161-4da8-969f-f9ecd5080ad9",
-            "createdDateTimeUtc": "2021-08-03T21:35:20.7604613Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:21.8167479Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2a132541-29db-4298-8ba7-16244a41d852",
-            "createdDateTimeUtc": "2021-08-03T21:35:07.9761301Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:14.7038749Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "72f0b845-0052-4963-b25f-5e8af00d9b14",
-            "createdDateTimeUtc": "2021-08-03T21:34:58.9227471Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:59.6529936Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "134a4212-2732-497b-8390-42fdd37d21e4",
-            "createdDateTimeUtc": "2021-08-03T21:34:50.9445779Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:52.6686072Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0f9f6f1d-fbb2-4fc0-af0e-6f150e37af73",
-            "createdDateTimeUtc": "2021-08-03T21:34:44.4279088Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:45.6922406Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7ad52735-0cfc-4605-994b-a001b55239da",
-            "createdDateTimeUtc": "2021-08-03T21:34:36.6416807Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:40.3689165Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4a6f90f-809d-49a7-94bd-02b8ca21f03c",
-            "createdDateTimeUtc": "2021-08-03T21:34:23.5791957Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:25.3619831Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7fd3d1ca-a218-465c-8ff4-eb4048c38473",
-            "createdDateTimeUtc": "2021-08-03T21:34:16.1133883Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:18.3802341Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "196b19e9-ecbd-436d-877a-35b530e2c0fe",
-            "createdDateTimeUtc": "2021-08-03T21:34:09.5321065Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:11.3582876Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1fb76e64-f983-4edc-9d22-4f99e100acc3",
-            "createdDateTimeUtc": "2021-08-03T21:33:57.8667531Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:04.2518359Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c89dca35-2a09-4223-aead-e3e3c5d620f7",
-            "createdDateTimeUtc": "2021-08-03T21:33:46.1148308Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:50.7386282Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6c30daea-f0dc-45d2-a5f2-c9c9ca5c454d",
-            "createdDateTimeUtc": "2021-08-03T21:33:40.0877854Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:42.98622Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "06da1349-40ca-40a9-bcbc-bd1e846f3b88",
-            "createdDateTimeUtc": "2021-08-03T21:33:35.9538097Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:38.6215767Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8afbd2b4-c1ed-4724-9e12-85961ac830ea",
-            "createdDateTimeUtc": "2021-08-03T21:33:09.7165208Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:18.2261067Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f14238b7-28ec-48ab-b76f-24d83d6dffb1",
-            "createdDateTimeUtc": "2021-08-03T21:33:01.8426407Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:03.3408766Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "dba26cd3-c01a-41a3-aa8f-8267cf500fec",
-            "createdDateTimeUtc": "2021-08-03T21:32:55.2352866Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:56.1955205Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "658543b1-f494-4515-b258-7df811c67fc4",
-            "createdDateTimeUtc": "2021-08-03T21:32:48.2354429Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:49.1386196Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "909802b6-105c-43b8-b323-1c2a8e3312bb",
-            "createdDateTimeUtc": "2021-08-03T21:32:42.6249984Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:43.7383766Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c0eb9e4b-eb06-4d7a-a1f9-d38af1250cfd",
-            "createdDateTimeUtc": "2021-08-03T21:32:34.5973391Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:36.730268Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "76ebe7f5-60a3-4ef7-a683-49370dad24a6",
-            "createdDateTimeUtc": "2021-08-03T21:32:28.4958568Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:29.6601157Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bb59e6b0-23b7-44e5-9057-2254f90fe98f",
-            "createdDateTimeUtc": "2021-08-03T21:32:20.7234242Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:22.6496271Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "28e02b6f-0895-4f5c-9a9f-2b52422c014c",
-            "createdDateTimeUtc": "2021-08-03T21:32:14.2081813Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:15.7088003Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1dbd7a32-7f17-4aef-9d3c-9dd4cdd2efa5",
-            "createdDateTimeUtc": "2021-08-03T21:32:07.5152962Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:08.641319Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9b3a8bcf-3b59-46f1-b705-7c6baf22c1a5",
-            "createdDateTimeUtc": "2021-08-03T21:32:00.4355607Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:01.5891063Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6318a8e-c90f-4781-92d1-8ce5e24597fe",
-            "createdDateTimeUtc": "2021-08-03T21:31:52.5113337Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:54.509403Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e9b2eeb6-267b-47aa-8fa9-5967c6388d6b",
-            "createdDateTimeUtc": "2021-08-03T21:31:46.0577699Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:47.5253048Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "487aa9c1-42d1-4b50-b8fc-3f85395ad6ac",
-            "createdDateTimeUtc": "2021-08-03T21:31:39.494573Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:40.4162301Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b50424f3-68b3-4e1b-8234-a23451697697",
-            "createdDateTimeUtc": "2021-08-03T21:31:30.3843702Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:34.1919695Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2541716b-10fc-4ab7-b914-f0c77cb139be",
-            "createdDateTimeUtc": "2021-08-03T21:31:14.9137729Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:19.0230031Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fdd7087b-33d3-403d-be85-1ab00fb30319",
-            "createdDateTimeUtc": "2021-08-03T21:31:01.2624907Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:05.3693236Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "203a2eb7-45bb-4bea-a0f8-0c955469a993",
-            "createdDateTimeUtc": "2021-08-03T21:30:48.6999513Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:53.8967855Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8fd4aa26-458e-4039-bb3e-98bbcced99e0",
-            "createdDateTimeUtc": "2021-08-03T21:30:37.0230807Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:38.9030608Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7b349018-5715-4420-a7f0-c43bd66289fc",
-            "createdDateTimeUtc": "2021-08-03T21:30:28.4100426Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:30.2839253Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d26b9cd2-9b7d-4237-a26f-499dc048e311",
-            "createdDateTimeUtc": "2021-08-03T21:30:20.4404126Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:23.9070865Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "052b5b6a-f84c-4230-aa1f-26a61effcde2",
-            "createdDateTimeUtc": "2021-08-03T21:30:13.8603639Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:16.8464878Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ff2b5c18-708a-440f-bf37-efc7110c99ad",
-            "createdDateTimeUtc": "2021-08-03T21:30:06.9759347Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:09.8165024Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "73fead5d-cc86-4599-a092-9cc9d0c2c342",
-            "createdDateTimeUtc": "2021-08-03T21:30:00.4839216Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:02.7580915Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9575e40d-8d1f-448d-8b42-0eab021412d1",
-            "createdDateTimeUtc": "2021-08-03T21:29:53.8576053Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:55.676247Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "acd96228-cfd4-49fb-b646-794db3c9e15e",
-            "createdDateTimeUtc": "2021-08-03T21:29:47.0106537Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:48.6365299Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e77e2fc-38e5-4f47-9cb8-b90cc449a4d8",
-            "createdDateTimeUtc": "2021-08-03T21:29:40.1528777Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:41.6088908Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e37cc03a-bf95-42b7-8e51-518f72b5e87b",
-            "createdDateTimeUtc": "2021-08-03T21:29:32.2421265Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:35.2150657Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "741e8783-65a0-4a78-b0bb-40bb90ca2ce2",
-            "createdDateTimeUtc": "2021-08-03T21:29:22.6625965Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:28.3897554Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b4c5f90d-21f4-4776-a25d-69e2c24c61a2",
-            "createdDateTimeUtc": "2021-08-03T21:26:15.0534924Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:16.4602371Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "160fbcac-6719-48b1-a381-07c96def522c",
-            "createdDateTimeUtc": "2021-08-03T21:26:08.1805962Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:09.0728405Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "21177280-61be-420c-b6a7-99dea8ba6ffa",
-            "createdDateTimeUtc": "2021-08-03T21:26:00.6291023Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:02.0416868Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "9d566e00-1591-47d1-82c0-39a2e5d7b8cc",
-            "createdDateTimeUtc": "2021-08-03T21:25:45.4916681Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:46.9737716Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "61f64340-86f6-42f1-9c8a-d5caca0214bf",
-            "createdDateTimeUtc": "2021-08-03T21:25:30.4527461Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:31.898234Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "bebd6ab4-1fc5-4cc4-8b6e-12d70b67bb67",
-            "createdDateTimeUtc": "2021-08-03T21:25:20.9001519Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:23.1142408Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "3e44fb4d-cf68-45c5-93e1-0475502d2b40",
-            "createdDateTimeUtc": "2021-08-03T21:18:36.5471645Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:37.3185218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3cb0b34a-a92b-4e3e-9800-ee9aa656eebb",
-            "createdDateTimeUtc": "2021-08-03T21:18:32.7278914Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:34.3336582Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=314\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z"
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:54.8740381Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=314\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6ba2b693fcfe8846b2914fa58105d9ca-669a4249e95bf844-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c48b5a33ab1b2b39dfa8141d31178240",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "30723bba339840ebe0ffeabcf6d59166",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cc502aa2-45ee-4e5f-9763-ec473b26da2c",
+        "apim-request-id": "96854a77-b8ba-49aa-aad6-775e240008fe",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:18 GMT",
-        "ETag": "\u0022FD57265947BC45CC29EF200283E09110B0DED271450A5AEA09556990314524D8\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:56 GMT",
+        "ETag": "\u00222E5706231C8C38663844523D112E369DE54DFBA54AF9FDF535CF60BEC0ACF6E9\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cc502aa2-45ee-4e5f-9763-ec473b26da2c"
+        "X-RequestId": "96854a77-b8ba-49aa-aad6-775e240008fe"
       },
       "ResponseBody": {
-        "value": [
-          {
-            "id": "da1c519e-1edf-4635-859d-1978cb2f95df",
-            "createdDateTimeUtc": "2021-08-03T21:18:26.0432979Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:27.3608779Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "450f4c8a-a15d-485c-9cc1-2451642cb05b",
-            "createdDateTimeUtc": "2021-08-03T21:18:19.0642978Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:20.5598666Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fcb39bba-503d-4772-bd60-8d48be8d1ded",
-            "createdDateTimeUtc": "2021-08-03T21:18:12.3671482Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:13.3939974Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "710b0db7-e99c-4736-9798-019d82bb972c",
-            "createdDateTimeUtc": "2021-08-03T21:18:04.4662377Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:06.5663381Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bcd5dbd0-4c9a-4d31-bbb2-38b1fd7a9f17",
-            "createdDateTimeUtc": "2021-08-03T21:17:57.9246063Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:59.5267689Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ea865d15-6652-456a-bc50-a82036d4b55e",
-            "createdDateTimeUtc": "2021-08-03T21:17:49.8058405Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:52.3338079Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "75cd36ab-60aa-4efb-b8ce-89bd8f2482d0",
-            "createdDateTimeUtc": "2021-08-03T21:17:36.2201985Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:37.5230684Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "05e4db62-aed0-4bc9-849c-1d1fa00e9101",
-            "createdDateTimeUtc": "2021-08-03T21:17:23.2025629Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:30.3004066Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a98bd901-115e-485e-a9c3-d6848740d430",
-            "createdDateTimeUtc": "2021-08-03T21:17:10.996439Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:15.4071683Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c0ebf31-6ec7-49ec-ba54-92b3ec4111f6",
-            "createdDateTimeUtc": "2021-08-03T21:17:05.8588787Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:08.1711768Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "565abdcf-3502-4ad2-bdf1-104fa16a21eb",
-            "createdDateTimeUtc": "2021-08-03T21:16:57.3872761Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:01.0170435Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9db34ff3-784f-4ba8-bd65-f9daea73dc84",
-            "createdDateTimeUtc": "2021-08-03T21:16:49.8079754Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:54.0100467Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "be0f4975-feb8-4a4c-99df-58a2eda64759",
-            "createdDateTimeUtc": "2021-08-03T21:16:43.5676725Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:46.9951206Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ad79180b-657e-411d-8214-6e2217f5f16f",
-            "createdDateTimeUtc": "2021-08-03T21:16:37.0494791Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:39.9664948Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a6b4d2cc-dc08-4883-93d5-4e0ce1f67b2b",
-            "createdDateTimeUtc": "2021-08-03T21:16:30.4598878Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:32.9278125Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e7348e3-fa87-4468-852d-3375d2e67dea",
-            "createdDateTimeUtc": "2021-08-03T21:16:22.0289093Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:25.9157037Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e415502b-72a2-46ae-bf89-116f60f159a2",
-            "createdDateTimeUtc": "2021-08-03T21:16:15.7930067Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:18.843387Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "12ae8466-a78d-4b54-96b3-491ff6092290",
-            "createdDateTimeUtc": "2021-08-03T21:16:08.3346723Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:11.9162731Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "972d3dd5-e5ad-435f-b1c0-19994a850368",
-            "createdDateTimeUtc": "2021-08-03T21:16:00.8089969Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:04.8935886Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c03135b1-55fc-49f8-bd8e-1aa9de944109",
-            "createdDateTimeUtc": "2021-08-03T21:15:50.7914559Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:57.8420568Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d3f42fc9-c46c-4c69-8ce8-1fa7951f0feb",
-            "createdDateTimeUtc": "2021-08-03T21:15:39.2462267Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:42.8928599Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2ee8fae6-6649-4264-8a60-005c8c2e33c3",
-            "createdDateTimeUtc": "2021-08-03T21:15:31.6638047Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:35.7812306Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64cf7af2-e9cf-42dd-be76-4c92b21200e5",
-            "createdDateTimeUtc": "2021-08-03T21:15:19.0180291Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:23.7245428Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7e3b360b-3804-4cd9-8ffc-ff8c1069f9a9",
-            "createdDateTimeUtc": "2021-08-03T21:15:07.6620949Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:10.7353955Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6f7243d-95a2-42b2-9277-db3105ffeeae",
-            "createdDateTimeUtc": "2021-08-03T21:14:57.8530134Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:58.6849403Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ff9490ff-1a22-4905-b300-f832c622fcd3",
-            "createdDateTimeUtc": "2021-08-03T21:14:52.4456431Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:55.1385001Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a291a37f-00ff-462c-90f7-af30487cfee0",
-            "createdDateTimeUtc": "2021-08-03T21:14:47.8001603Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:52.8849738Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6fe9dfde-e561-40c2-bdd6-3292556c8b44",
-            "createdDateTimeUtc": "2021-08-03T21:14:35.4879327Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:38.0663837Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "281e1d88-ad9d-4517-90b3-94e74a9c24f0",
-            "createdDateTimeUtc": "2021-08-03T21:14:28.795762Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:31.0494198Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a01a857b-9018-440a-b213-00bf32fd088e",
-            "createdDateTimeUtc": "2021-08-03T21:14:13.7887949Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:17.9704114Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8a449a7e-de6e-428f-85dc-0f5057026964",
-            "createdDateTimeUtc": "2021-08-03T21:14:02.4254824Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:05.9904305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "caf6c070-88b1-4321-8677-cad70417c272",
-            "createdDateTimeUtc": "2021-08-03T21:13:49.8557451Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:52.9922839Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e8f345d1-3424-4c4a-9d47-3008e4990352",
-            "createdDateTimeUtc": "2021-08-03T21:13:41.5900414Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:45.8133665Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5dc5da5c-8efd-4cd6-815e-4b808abb4825",
-            "createdDateTimeUtc": "2021-08-03T21:13:27.7289314Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:31.0005068Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eb91834b-fb6a-4993-9678-5858c3bb1b9b",
-            "createdDateTimeUtc": "2021-08-03T21:13:16.3384857Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:23.7963549Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "806f54be-4e77-4798-a5d5-73f6bad16868",
-            "createdDateTimeUtc": "2021-08-03T21:12:59.5334323Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:00.8743421Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ae03de4-3f6f-4c29-bf1c-1ad94a5e6b7d",
-            "createdDateTimeUtc": "2021-08-03T21:12:53.1067631Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:53.7902656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fc077fb4-83ee-4897-8b1a-5aba8c1bf0a3",
-            "createdDateTimeUtc": "2021-08-03T21:12:45.5070479Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:48.6888907Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "51fc6ec4-8eac-4cc6-ae6f-6c5f36e30f23",
-            "createdDateTimeUtc": "2021-08-03T21:12:30.4582964Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:41.6843136Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "be88aa61-1e9c-4917-a2aa-5c5cdb93a5f6",
-            "createdDateTimeUtc": "2021-08-03T21:12:24.3745624Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:26.5718318Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d0e58fcb-2b27-4914-9654-3d753fa5fc6b",
-            "createdDateTimeUtc": "2021-08-03T21:12:16.9941584Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:19.5227251Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f3a6c730-1d51-404f-8b00-45607cfae421",
-            "createdDateTimeUtc": "2021-08-03T21:12:06.8062009Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:12.5283Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "37992d98-b6d5-423c-89d1-6e54e5ec8773",
-            "createdDateTimeUtc": "2021-08-03T21:11:55.6953795Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:57.438589Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a3508cfe-30da-45d2-bc88-0047a835dd5e",
-            "createdDateTimeUtc": "2021-08-03T21:11:48.3588126Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:50.4206884Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6ab6d6e-5c85-448d-84d5-4223d3a2cd1b",
-            "createdDateTimeUtc": "2021-08-03T21:11:35.4391485Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:38.7780922Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c69177b4-9de0-4961-97f9-42b1b8d3c137",
-            "createdDateTimeUtc": "2021-08-03T21:11:21.7724833Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:23.742779Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3e1ee063-8ed9-4c9d-b237-76ec3a417bac",
-            "createdDateTimeUtc": "2021-08-03T21:11:13.556122Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:15.317426Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6042d94-2cd5-46df-85ad-52c10c998b01",
-            "createdDateTimeUtc": "2021-08-03T21:11:06.2064576Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:08.6641999Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d17081c8-ff50-4d36-8b46-e88c8deb39c5",
-            "createdDateTimeUtc": "2021-08-03T21:10:58.8540771Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:01.679116Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eeb49074-527d-4cbd-95c9-6e2a33a80fe0",
-            "createdDateTimeUtc": "2021-08-03T21:10:52.75482Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:54.5968498Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=150\u0026$top=264\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z"
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:55.3559394Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=150\u0026$top=264\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d7d0cc928aafd14181bb5357b2ef6262-2c543de184786140-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ec2be118e610614820742e21f3662483",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "766184a63a2bf8b84fca6d20a4f7ec27",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb7551dc-8120-4df2-8b56-0b5fbf6cc2d2",
+        "apim-request-id": "64c44149-03c5-438f-b3fa-004381d8897f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:19 GMT",
-        "ETag": "\u00221C93F3CCDF8ECEED17A7FE7444951B891FA35D8E28818E634839A8B6906ECFB0\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:57 GMT",
+        "ETag": "\u00222E5706231C8C38663844523D112E369DE54DFBA54AF9FDF535CF60BEC0ACF6E9\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -3236,1575 +964,93 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cb7551dc-8120-4df2-8b56-0b5fbf6cc2d2"
+        "X-RequestId": "64c44149-03c5-438f-b3fa-004381d8897f"
       },
       "ResponseBody": {
-        "value": [
-          {
-            "id": "c6244025-4303-4989-a816-b905e1a30d9e",
-            "createdDateTimeUtc": "2021-08-03T21:10:46.6679174Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:47.5413043Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7515a3ad-6e5e-446b-8aea-c4cc53d12feb",
-            "createdDateTimeUtc": "2021-08-03T21:10:38.7741733Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:40.5334622Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "95aff118-ace4-4193-828d-2ae77311df6f",
-            "createdDateTimeUtc": "2021-08-03T21:10:32.6760697Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:33.4547546Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "97597b48-5a0e-4dad-8d71-2591f76bf2b6",
-            "createdDateTimeUtc": "2021-08-03T21:10:25.297809Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:26.4222067Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c21ed6b-a48d-4909-92cb-73bc8274b9d2",
-            "createdDateTimeUtc": "2021-08-03T21:10:17.9312928Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:19.3974656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9fc1780-0cbf-4e09-af18-b05ab8132e1f",
-            "createdDateTimeUtc": "2021-08-03T21:10:05.2725918Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:12.5542351Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0636e96b-8ca2-44f8-a04b-a9a1c38694c4",
-            "createdDateTimeUtc": "2021-08-03T21:04:35.2211988Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:37.0514288Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce731aed-e42d-4219-a382-133b032d5f1c",
-            "createdDateTimeUtc": "2021-08-03T21:04:28.9135303Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:29.9918727Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d86704b4-8468-4fd2-a932-fd5224d0ebed",
-            "createdDateTimeUtc": "2021-08-03T21:04:14.1901594Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:19.7321506Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9f05357-c328-48b9-a611-c3732bab678d",
-            "createdDateTimeUtc": "2021-08-03T21:04:03.8683312Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:05.0527645Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0cbb6b74-7d09-4126-992c-831741492982",
-            "createdDateTimeUtc": "2021-08-03T21:03:51.6462874Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:54.7314609Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5f03f16e-de27-42b4-b2e2-844706de4b44",
-            "createdDateTimeUtc": "2021-08-03T21:03:45.1124183Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:47.674769Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "23c77867-65e6-4ad0-be05-9bdb30d3ad5e",
-            "createdDateTimeUtc": "2021-08-03T21:03:37.8720722Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:40.5848208Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f28ba69-dc12-4f0c-a4a1-e7b60934ad43",
-            "createdDateTimeUtc": "2021-08-03T21:03:32.2879169Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:33.7858305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7d8b4c2b-bae7-45ca-b351-4e9904d6ee65",
-            "createdDateTimeUtc": "2021-08-02T16:24:41.2089693Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:43.0994742Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6eb19d5e-da21-40c2-b5ac-31638a9d5834",
-            "createdDateTimeUtc": "2021-08-02T16:24:32.9603519Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:35.3478084Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8f83e37a-9fd2-4a27-acf9-fdf90c5ca88e",
-            "createdDateTimeUtc": "2021-08-02T16:24:25.3701107Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:28.2843485Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fa2f0660-ee60-44dc-891e-1807fe027001",
-            "createdDateTimeUtc": "2021-08-02T16:24:19.0661656Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:20.9267399Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9a921d78-9a3f-4fb0-bd3e-e9e85adfb5c7",
-            "createdDateTimeUtc": "2021-08-02T16:24:14.084628Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:14.8551961Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "35491096-d4b6-4f64-a475-3a8f425bda13",
-            "createdDateTimeUtc": "2021-08-02T16:24:08.8499137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:13.2168149Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d6516cd6-00bc-4dd4-81e0-ac3531a9ef9a",
-            "createdDateTimeUtc": "2021-08-02T16:24:04.9124096Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:09.2033129Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "53f7b772-34ef-4eb8-8296-85141574c168",
-            "createdDateTimeUtc": "2021-08-02T16:23:45.9322442Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:47.766539Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ee6fbf3b-4339-4bf7-a0e4-c6c4a43e713d",
-            "createdDateTimeUtc": "2021-08-02T16:23:39.6959419Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:40.4416417Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "136046f1-61bb-4d7a-abda-5d762ed48da2",
-            "createdDateTimeUtc": "2021-08-02T16:23:32.246383Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:33.6102582Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4c808776-ef91-44b3-b985-030778694e82",
-            "createdDateTimeUtc": "2021-08-02T16:23:24.7815606Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:25.6039914Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bbcb51e9-e16a-4575-b115-000e9df2a45e",
-            "createdDateTimeUtc": "2021-08-02T16:23:14.7939144Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:18.5400236Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "420e65a3-84f2-4784-8e76-0dbc11b9767d",
-            "createdDateTimeUtc": "2021-08-02T16:23:00.0350545Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:03.9941424Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3bed775d-83fb-4252-9f8a-52dacdb26ade",
-            "createdDateTimeUtc": "2021-08-02T16:22:48.7883283Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:53.2388717Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6ef1e57a-03d3-4eee-b0c1-cabd5862da1f",
-            "createdDateTimeUtc": "2021-08-02T16:22:35.1281238Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:38.165101Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "40a5525c-6988-4e7e-a203-d01a5a19add6",
-            "createdDateTimeUtc": "2021-08-02T16:22:22.6116988Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:28.2009407Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b12700de-181b-4bfb-a9ea-ab2920d66ba8",
-            "createdDateTimeUtc": "2021-08-02T16:22:11.0963198Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:13.2382617Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "588176c1-fb41-4077-9ce2-52eaefe1e6ec",
-            "createdDateTimeUtc": "2021-08-02T16:22:00.7493371Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:02.6302967Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eeddf064-09ac-4f8d-8571-dd1bb7fa4343",
-            "createdDateTimeUtc": "2021-08-02T16:21:54.4828121Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:57.0883721Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "86f769d2-0eb0-497c-a670-4b283cfcdfdf",
-            "createdDateTimeUtc": "2021-08-02T16:21:47.7892819Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:50.5734898Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ef96694-d6c5-4f51-9c7e-250c692cb5dd",
-            "createdDateTimeUtc": "2021-08-02T16:21:41.4813356Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:42.5383836Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "adf11117-52ab-486b-985c-bfea752c8125",
-            "createdDateTimeUtc": "2021-08-02T16:21:32.7479396Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:35.3424695Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8d9ccbdb-0672-4c0a-9776-0392c918c98f",
-            "createdDateTimeUtc": "2021-08-02T16:21:15.2775709Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:19.7632985Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8791b215-1f41-41d4-bb91-98341c1dd33c",
-            "createdDateTimeUtc": "2021-08-02T16:21:05.1178323Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:07.2972934Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6aba7c68-ce53-473d-a0ec-8a507ed316c9",
-            "createdDateTimeUtc": "2021-08-02T16:20:50.7351339Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:54.4492988Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7d30db48-4d73-41d8-997d-4a617c4004c9",
-            "createdDateTimeUtc": "2021-08-02T16:20:40.6756633Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:42.4301335Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d04c84d8-3802-49e5-bfed-513a24bd9d5a",
-            "createdDateTimeUtc": "2021-08-02T16:20:24.7609666Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:29.1667159Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bc6cf0b2-7fc1-40ee-ad43-98b0b5150223",
-            "createdDateTimeUtc": "2021-08-02T16:20:12.6767136Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:16.3662875Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "478fdbe7-fffd-4d69-baa1-b359ab0bf87e",
-            "createdDateTimeUtc": "2021-08-02T16:19:59.5448266Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:03.7580865Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8ac17a7c-0ef2-44e6-815e-11ca7283f7f0",
-            "createdDateTimeUtc": "2021-08-02T16:19:47.7119701Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:52.0454421Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9299720b-5702-4fd8-9b84-07d18770d0c9",
-            "createdDateTimeUtc": "2021-08-02T16:19:33.0940413Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:36.063599Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c53f5ac-5ae0-4186-986d-59db8052bd87",
-            "createdDateTimeUtc": "2021-08-02T16:19:25.5258566Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:27.5995027Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5fabbdd0-d3df-482e-80c5-751f5c65184b",
-            "createdDateTimeUtc": "2021-08-02T16:19:17.4593598Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:19.4263901Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f116c06f-6f87-406d-b1f6-79fb90dce630",
-            "createdDateTimeUtc": "2021-08-02T16:19:10.7346Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:12.2459497Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8d24c7aa-d4f7-4c8f-8540-10499063139f",
-            "createdDateTimeUtc": "2021-08-02T16:19:02.0656904Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:03.0995071Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f9b9346c-2649-429f-a88e-3bd5fa834aea",
-            "createdDateTimeUtc": "2021-08-02T16:18:52.7109118Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:57.1201114Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=200\u0026$top=214\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z"
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:55.3559394Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=200\u0026$top=214\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4c9ec43036b932439d473cf00b946b0c-ca4ebc62b645d746-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cd910c1a34f5af8c24146828e2e6c1b8",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f9deb14786489b9b0de6fa074c9ea0cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb554a3e-69e4-4649-bc49-e2bd07ba5931",
+        "apim-request-id": "7822ef55-d895-4b95-acad-ce3347696552",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:19 GMT",
-        "ETag": "\u0022903CE6A63E2115FA590A62FBE876A2F565135DB3B9A62A310051541CA40CAB08\u0022",
+        "Date": "Thu, 26 Aug 2021 14:26:58 GMT",
+        "ETag": "\u00222E5706231C8C38663844523D112E369DE54DFBA54AF9FDF535CF60BEC0ACF6E9\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cb554a3e-69e4-4649-bc49-e2bd07ba5931"
+        "X-RequestId": "7822ef55-d895-4b95-acad-ce3347696552"
       },
       "ResponseBody": {
-        "value": [
-          {
-            "id": "c4676529-3017-4ca1-b2a8-dbb9c74ca6f0",
-            "createdDateTimeUtc": "2021-08-02T16:18:36.7769716Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:41.5280761Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d59e0316-c5eb-4011-a6ea-ba35c6977966",
-            "createdDateTimeUtc": "2021-08-02T16:18:23.3012061Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:29.1989939Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "28779945-5117-434b-9137-14e9c170d450",
-            "createdDateTimeUtc": "2021-08-02T16:18:11.1236727Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:16.2904795Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b661b7e-cdbd-461e-8540-93e2e7135084",
-            "createdDateTimeUtc": "2021-08-02T16:17:57.8044821Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:02.1356502Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "826e3203-8188-4a90-92db-b65e12b7a6e6",
-            "createdDateTimeUtc": "2021-08-02T16:17:49.6808861Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:51.33726Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ec3e1c4c-3509-4f5a-86ee-3be559f978cf",
-            "createdDateTimeUtc": "2021-08-02T16:17:43.4479159Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:46.1484498Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "cd18395a-adb6-4566-a35d-4b7394ce7e7c",
-            "createdDateTimeUtc": "2021-08-02T16:17:39.2236317Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:42.3718498Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2ab88ed2-f62f-442c-a8d4-e0fe953d60f8",
-            "createdDateTimeUtc": "2021-08-02T16:17:13.5251717Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:17.8853964Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b9deb0a-7a56-440e-b9c3-51407a716f91",
-            "createdDateTimeUtc": "2021-08-02T16:17:00.3732482Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:04.8610025Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1451731d-cb81-45b9-abb6-c0ebd8d688ff",
-            "createdDateTimeUtc": "2021-08-02T16:16:46.3333522Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:51.499965Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "139c594a-e573-42bc-ac76-79592e783b4d",
-            "createdDateTimeUtc": "2021-08-02T16:16:34.5666571Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:39.7565449Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ea6a654-e1da-4712-9ade-698b4fa08cee",
-            "createdDateTimeUtc": "2021-08-02T16:16:20.2815511Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:26.1888498Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bb4649a1-1b3a-4ffe-a85e-7c42bae169e0",
-            "createdDateTimeUtc": "2021-08-02T16:16:12.5610209Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:14.670096Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fe16f7a4-60a7-47e5-af19-ae95f1ec681e",
-            "createdDateTimeUtc": "2021-08-02T16:16:02.1273592Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:06.1364515Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4aa714c0-4bf6-4938-87a1-434a1f4a7ebb",
-            "createdDateTimeUtc": "2021-08-02T16:15:47.0562229Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:50.6173263Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "026bf666-4189-437c-83aa-64695c311c08",
-            "createdDateTimeUtc": "2021-08-02T16:15:31.2491656Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:35.1652117Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bdd91bff-b609-4b0f-a2c0-c647662d414d",
-            "createdDateTimeUtc": "2021-08-02T16:15:16.5679328Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:20.3039847Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0498cf00-abbb-40b5-adab-e7725b8570f7",
-            "createdDateTimeUtc": "2021-08-02T16:15:09.9911137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:11.9184442Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "21177c94-70c4-44e1-8cff-235b74d0b99a",
-            "createdDateTimeUtc": "2021-08-02T16:14:55.1654786Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:00.1764926Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "85670b87-e8d6-4d6d-8ea2-c25d36c5ab31",
-            "createdDateTimeUtc": "2021-08-02T16:14:43.5832687Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:46.5409074Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6120317e-0084-4d39-be37-4a22da834f5d",
-            "createdDateTimeUtc": "2021-08-02T16:14:27.9772355Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:34.8024586Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6af7eb57-f9c1-42e2-82d7-1f12e5b212fe",
-            "createdDateTimeUtc": "2021-08-02T16:14:17.0902143Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:21.24705Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cd6a2e5d-84e2-41b1-9337-a69dad3d47c1",
-            "createdDateTimeUtc": "2021-08-02T16:14:07.7724718Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:08.5411317Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c2ef1201-4b72-4500-af9d-6c46e43d9c8b",
-            "createdDateTimeUtc": "2021-08-02T16:14:00.4820687Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:02.206196Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e02cc96c-f613-4d31-b301-64b1ba8f087d",
-            "createdDateTimeUtc": "2021-08-02T16:13:52.654235Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:53.9684859Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "56985d49-4f45-4bf5-bc5a-815be0a31d77",
-            "createdDateTimeUtc": "2021-08-02T16:13:44.4222786Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:46.3632429Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f277b4e7-6107-4fce-9843-57ea37403cd0",
-            "createdDateTimeUtc": "2021-08-02T16:13:36.1118921Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:38.5818188Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cb2ae958-26f6-497c-a0d2-0f24b680a296",
-            "createdDateTimeUtc": "2021-08-02T16:13:28.2526551Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:31.4669162Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e44cb835-83cf-4568-af90-37dc0bfc591f",
-            "createdDateTimeUtc": "2021-08-02T16:13:21.6945505Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:24.3971649Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "53732eaf-861e-4cc7-ab1b-7fe8f2c59f72",
-            "createdDateTimeUtc": "2021-08-02T16:13:09.3426779Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:09.9894448Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "22467b38-820b-496e-af13-6118e55f474f",
-            "createdDateTimeUtc": "2021-08-02T16:12:54.8368437Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:02.7871782Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f2db3e76-05f6-487e-8f7a-71ff84a07c41",
-            "createdDateTimeUtc": "2021-08-02T16:12:46.1722803Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:47.8187574Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6fa6124a-382c-4cae-a8e8-bafa8771ffb4",
-            "createdDateTimeUtc": "2021-08-02T16:12:38.3102608Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:40.6814713Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "08077374-25ed-4062-8157-d2aaf376a00c",
-            "createdDateTimeUtc": "2021-08-02T16:12:26.6208936Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:33.2913497Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a94a2a28-a797-4f76-91cd-b51148e62b16",
-            "createdDateTimeUtc": "2021-08-02T16:12:13.1684199Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:18.4618218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bc4c4898-1c22-4525-a645-7ce619839b24",
-            "createdDateTimeUtc": "2021-08-02T16:11:56.0176535Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:03.7809247Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e84c225d-6eac-485e-a02c-27944ff4dbdb",
-            "createdDateTimeUtc": "2021-08-02T16:05:51.141745Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:55.0127867Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "7c879c56-18e3-404d-a749-27467f12e635",
-            "createdDateTimeUtc": "2021-08-02T16:05:45.2156446Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:46.3340871Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "a475da26-6ac8-4c57-ad1f-a95856f88516",
-            "createdDateTimeUtc": "2021-08-02T16:05:36.590968Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:39.4988016Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "54a2e7ba-61be-4704-9a1b-2e4b36baa088",
-            "createdDateTimeUtc": "2021-08-02T16:05:21.5609955Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:24.9840622Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "7afd5c7e-13d8-4691-abd0-abde4ce5474e",
-            "createdDateTimeUtc": "2021-08-02T16:05:02.9540382Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:05.7674713Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "557f2c23-bc72-40b7-a138-4561429fa9aa",
-            "createdDateTimeUtc": "2021-08-02T16:04:47.8352521Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:04:50.2573908Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "3e9a5d00-90d9-4256-9d62-f1dfa1577da0",
-            "createdDateTimeUtc": "2021-08-01T16:20:07.4673305Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:13.4203616Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "fc266ece-821c-4ad7-9448-1813652fd6ec",
-            "createdDateTimeUtc": "2021-08-01T16:20:03.3145089Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:12.698585Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "09bd712a-8979-4a10-b5cd-e9f10cd67d10",
-            "createdDateTimeUtc": "2021-08-01T16:19:46.7079557Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:49.1799156Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d7a02f06-f676-408e-b3c1-c15c6bba0b44",
-            "createdDateTimeUtc": "2021-08-01T16:19:40.2888558Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:42.0951378Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c225a85d-2f4e-4823-bed5-aafc11420317",
-            "createdDateTimeUtc": "2021-08-01T16:19:32.7591319Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:35.0214842Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8afe93e5-55f8-4b29-aad7-e52aafa852e9",
-            "createdDateTimeUtc": "2021-08-01T16:19:26.4656956Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:27.9695511Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d2d58232-7d45-4649-8eee-884989571d14",
-            "createdDateTimeUtc": "2021-08-01T16:19:20.0951281Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:20.9141679Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9d74505c-4ec7-4849-a25e-347c9ca83531",
-            "createdDateTimeUtc": "2021-08-01T16:19:14.3845766Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:19.1001524Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=250\u0026$top=164\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z"
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:55.3559394Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=250\u0026$top=164\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3fc0dc2ae101c54dab1ff89b6d5ddf57-a024b2c633e5f447-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ed2f1390bd884d421229a3a67d183779",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fedc3b1b5624800d8379e1cdc6ca9be9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e336e82-558e-47d4-8c0e-d5e76775ac66",
+        "apim-request-id": "a8cec8ff-763b-418e-894e-982ee48c1510",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:20 GMT",
-        "ETag": "\u0022516813C84CFBE8B3B84FF59DCD6DFE85B7434986E0CA024E1F5B44943C00D4A4\u0022",
+        "Date": "Thu, 26 Aug 2021 14:27:00 GMT",
+        "ETag": "\u00222E5706231C8C38663844523D112E369DE54DFBA54AF9FDF535CF60BEC0ACF6E9\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -4814,14 +1060,408 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2e336e82-558e-47d4-8c0e-d5e76775ac66"
+        "X-RequestId": "a8cec8ff-763b-418e-894e-982ee48c1510"
+      },
+      "ResponseBody": {
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:26:55.3559394Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4574c21297f6201ee9c669453fb0abb0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "742e3b3f-3969-445f-ae27-afc09841ac0a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:27:01 GMT",
+        "ETag": "\u0022A93174097A87BCA3A679B616070EB5FDD2972BA480FEEA1206D1170FE97649EB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "742e3b3f-3969-445f-ae27-afc09841ac0a"
+      },
+      "ResponseBody": {
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:27:01.0372629Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6905a02aee1af103a35e76cea4cdd442",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5c6886ae-a319-493a-9eb4-21415181f0c3",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:27:02 GMT",
+        "ETag": "\u0022A93174097A87BCA3A679B616070EB5FDD2972BA480FEEA1206D1170FE97649EB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "5c6886ae-a319-493a-9eb4-21415181f0c3"
+      },
+      "ResponseBody": {
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:27:01.0372629Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8af4114a5a2a83d61cbc145dedc840d2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3babeccf-2335-4107-8d06-04c5e2437a8f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:27:03 GMT",
+        "ETag": "\u0022A93174097A87BCA3A679B616070EB5FDD2972BA480FEEA1206D1170FE97649EB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "3babeccf-2335-4107-8d06-04c5e2437a8f"
+      },
+      "ResponseBody": {
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:27:01.0372629Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "25a331cd32c524cebe83a19721507b1b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "849f538a-4f26-441a-98a9-a66d4a0c34ad",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:27:04 GMT",
+        "ETag": "\u002239C3257A6E891204D4D30FE2E5C5B45038DBC339A5028894E0CFE14990DDA142\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "849f538a-4f26-441a-98a9-a66d4a0c34ad"
+      },
+      "ResponseBody": {
+        "id": "ccef0dea-59fb-4705-a85a-ddd3a77a2ee8",
+        "createdDateTimeUtc": "2021-08-26T14:26:54.8740378Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:27:04.9387924Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 1,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 16
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/ccef0dea-59fb-4705-a85a-ddd3a77a2ee8/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2efa26f120bbcf86ca814c5ed9a504db",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c6ac596f-b4d2-4209-822d-6122b1dfc18a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:27:05 GMT",
+        "ETag": "\u0022E423859C69057573384868F7778A8241D51FAFB2DBB2D5974009EAAEC15773EB\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c6ac596f-b4d2-4209-822d-6122b1dfc18a"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "5263795e-4551-4f48-94da-32a53c735650",
-            "createdDateTimeUtc": "2021-08-01T16:19:10.3372901Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:18.7374885Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1289135801/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source103650315/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:27:00.5323898Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:27:04.9387863Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b5471-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2021-08-26T13%3A26%3A54.0590780Z\u0026createdDateTimeUtcEnd=2021-08-26T14%3A26%3A54.0590780Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dc9c3baadfac974d84b5cfd6e1722fc7-e5898f3914da5d4c-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7300a31eaf2a187c42d0cca7b93e62cc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d905d1cf-4729-44f0-9393-f00191adf13d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:27:05 GMT",
+        "ETag": "\u00224DADF8061129B8FE953BB92DF28E425E1458DB5E73C42FBA26155E40AE4D8017\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d905d1cf-4729-44f0-9393-f00191adf13d"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "4a230ac6-103e-424d-a9d8-56939d6596d6",
+            "createdDateTimeUtc": "2021-08-26T14:26:40.7656774Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:26:53.1057573Z",
+            "status": "Succeeded",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 1,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 16
+            }
+          },
+          {
+            "id": "6967a5c1-7e38-4a12-a2f8-ba46d0de1382",
+            "createdDateTimeUtc": "2021-08-26T14:26:25.7309717Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:26:37.7800382Z",
+            "status": "Succeeded",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 1,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 16
+            }
+          },
+          {
+            "id": "a11da8bf-52c5-4ded-b29e-0e2607a91a47",
+            "createdDateTimeUtc": "2021-08-26T14:26:10.7838787Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:26:22.750038Z",
+            "status": "Succeeded",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 1,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 16
+            }
+          },
+          {
+            "id": "bb45a362-13a0-449e-90dc-d69533d8d6ac",
+            "createdDateTimeUtc": "2021-08-26T14:17:29.5270404Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:17:34.9950826Z",
+            "status": "Succeeded",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 1,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 16
+            }
+          },
+          {
+            "id": "27afbfd6-2719-4056-96a9-139c27a71cda",
+            "createdDateTimeUtc": "2021-08-26T14:17:24.3347057Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:17:28.1450972Z",
+            "status": "Succeeded",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 1,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 16
+            }
+          },
+          {
+            "id": "ec3c7f81-c26e-4839-b30b-49b33f053911",
+            "createdDateTimeUtc": "2021-08-26T14:17:18.1117495Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:17:21.3046774Z",
+            "status": "Succeeded",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 1,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 16
+            }
+          },
+          {
+            "id": "f242782c-459d-4398-b7e4-3e0e0c6e84db",
+            "createdDateTimeUtc": "2021-08-26T14:17:05.0963349Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:17:16.3535435Z",
+            "status": "Succeeded",
+            "summary": {
+              "total": 1,
+              "failed": 0,
+              "success": 1,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 0,
+              "totalCharacterCharged": 16
+            }
+          },
+          {
+            "id": "3c773c25-3b05-48cb-92b3-fe321b99ca9d",
+            "createdDateTimeUtc": "2021-08-26T14:07:14.0385355Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:07:21.6924944Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -4834,9 +1474,9 @@
             }
           },
           {
-            "id": "b51a5572-a945-4b96-a953-c59a894ef975",
-            "createdDateTimeUtc": "2021-08-01T16:18:54.1999881Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:57.9280154Z",
+            "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+            "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:07:06.928173Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -4849,2658 +1489,33 @@
             }
           },
           {
-            "id": "ed28552f-7298-466f-be5d-d72fc1596544",
-            "createdDateTimeUtc": "2021-08-01T16:18:47.7220195Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:50.8569952Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c0ebd77c-0245-4fa7-b3e7-83694b3734fe",
-            "createdDateTimeUtc": "2021-08-01T16:18:41.3753213Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:43.9537812Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64716ad2-d3e2-4bcf-9a75-0fc0c9a5f4c8",
-            "createdDateTimeUtc": "2021-08-01T16:18:34.7356044Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:36.8659384Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "48155210-6958-4ce0-9863-e3747a64c145",
-            "createdDateTimeUtc": "2021-08-01T16:18:20.2854234Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:30.0642323Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9453ca0c-5d2e-4071-ab7f-442df231b85f",
-            "createdDateTimeUtc": "2021-08-01T16:15:01.5996298Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:15:05.5361722Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b0f1d39d-b564-4cd9-8032-6a12e1a9d05b",
-            "createdDateTimeUtc": "2021-08-01T16:14:55.2901759Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:58.5033728Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "59da2c26-8f14-4221-ab40-ac76b9501ad1",
-            "createdDateTimeUtc": "2021-08-01T16:14:47.6768806Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:51.4645762Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "497af134-1eb1-4531-96cf-2b6426d21b25",
-            "createdDateTimeUtc": "2021-08-01T16:14:43.8701994Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:44.532919Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "49417fb3-b2f3-4a94-a5bf-adf21b10f5d6",
-            "createdDateTimeUtc": "2021-08-01T16:14:36.2995057Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:37.5066305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3a12cc5a-b95b-4934-8fd5-f338b1e8ffca",
-            "createdDateTimeUtc": "2021-08-01T16:14:29.7501476Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:30.4496382Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f30dfeae-5899-4b4a-ab89-d6d04d0efe74",
-            "createdDateTimeUtc": "2021-08-01T16:14:22.1534158Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:26.376851Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e65c1cc-310e-4cc2-b8cb-94549af2f62e",
-            "createdDateTimeUtc": "2021-08-01T16:14:15.8071242Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:19.3429665Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3bb426c3-ecc1-4316-bc03-730dc1f3653b",
-            "createdDateTimeUtc": "2021-08-01T16:14:08.2125728Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:12.4635748Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ddf0085d-dbdf-4cba-990c-3ba10a7e1a66",
-            "createdDateTimeUtc": "2021-08-01T16:14:03.1671065Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:05.4704945Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "329cec92-7703-4747-ae44-5990a8726d8f",
-            "createdDateTimeUtc": "2021-08-01T16:13:54.1407053Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:58.3447181Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b8f07233-7e1c-4c08-80cf-1a15eb328e81",
-            "createdDateTimeUtc": "2021-08-01T16:13:47.8669235Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:51.5406534Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "77cdd294-733d-41f8-819f-92003e64ceb5",
-            "createdDateTimeUtc": "2021-08-01T16:13:40.2946017Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:44.3266783Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e0991fae-123b-4f43-bff0-cab0009d9523",
-            "createdDateTimeUtc": "2021-08-01T16:13:36.5057131Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:37.2374588Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5ca898b1-422a-4871-abb7-1ce16766fe75",
-            "createdDateTimeUtc": "2021-08-01T16:13:28.8893885Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:30.2057848Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "71c20eb7-04ac-4b18-8147-170d958cf215",
-            "createdDateTimeUtc": "2021-08-01T16:13:14.9186078Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:23.1567567Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0f6623cf-56f0-49c2-8b2d-92a7d173e656",
-            "createdDateTimeUtc": "2021-08-01T16:13:07.2768816Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:08.1446081Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "51452eaa-72c0-4d09-aece-3ce74ea05c2d",
-            "createdDateTimeUtc": "2021-08-01T16:12:58.3531499Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:00.9818419Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "83122575-c3e0-40cf-a740-bb3ab9fc56be",
-            "createdDateTimeUtc": "2021-08-01T16:12:43.7935713Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:12:49.3598783Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ab3adbcc-1036-4e0b-903d-681b154f1c19",
-            "createdDateTimeUtc": "2021-08-01T16:12:34.5845034Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:12:35.9467789Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "39c76fc2-bb64-4a08-a91a-023f467170c8",
-            "createdDateTimeUtc": "2021-08-01T16:10:30.7671066Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:33.9996641Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1946e12f-48c9-479d-a14d-957a52af4819",
-            "createdDateTimeUtc": "2021-08-01T16:10:24.4268864Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:26.950039Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "061184c9-b5cc-4622-9536-a088ef98ef51",
-            "createdDateTimeUtc": "2021-08-01T16:10:16.7322617Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:20.8210184Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6dab8cd8-4b45-4244-b5a3-1df6ce3e6e9e",
-            "createdDateTimeUtc": "2021-08-01T16:10:10.3791367Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:13.7755381Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ccecf223-30d9-427f-baac-d28fabd2ba91",
-            "createdDateTimeUtc": "2021-08-01T16:09:56.0857482Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:01.8186959Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "686c032b-f1f9-461c-b591-19be033130a6",
-            "createdDateTimeUtc": "2021-08-01T16:09:47.6916292Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:48.7555826Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f1fb728-a50b-4279-b98e-8f70a89cba26",
-            "createdDateTimeUtc": "2021-08-01T16:09:35.1147989Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:41.7039641Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ac064e9c-9558-4940-81b6-6591e24b22b0",
-            "createdDateTimeUtc": "2021-08-01T16:09:23.6462928Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:26.7238672Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f7dfd6e7-2149-4ed6-9118-1f50a9badde5",
-            "createdDateTimeUtc": "2021-08-01T16:09:15.6989555Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:16.6008152Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a37bd766-988f-4d35-93b4-82b678984a0b",
-            "createdDateTimeUtc": "2021-08-01T16:09:10.2798543Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:11.6248087Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "dd3207eb-c63b-4ee9-8d71-303a17f6831a",
-            "createdDateTimeUtc": "2021-08-01T16:09:02.3812973Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:04.6501124Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c2017771-02a1-4c4d-89c6-e53ddc375b6c",
-            "createdDateTimeUtc": "2021-08-01T16:08:54.6514534Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:57.5553054Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8e675672-c991-4b00-9f3b-151fff0ba025",
-            "createdDateTimeUtc": "2021-08-01T16:08:50.6903241Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:51.5542816Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "86d50aab-06b7-4674-94f1-d78f62cfcd3c",
-            "createdDateTimeUtc": "2021-08-01T16:08:42.9294372Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:44.5249817Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64eee42e-3b77-4308-b66b-6dfd687dfcb8",
-            "createdDateTimeUtc": "2021-08-01T16:08:29.0253923Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:37.4953732Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ec95d30a-ca29-44c2-a3d3-7f1e81768232",
-            "createdDateTimeUtc": "2021-08-01T16:08:20.5267131Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:22.4653843Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "baa67a70-f2c2-4798-af85-bf4039800973",
-            "createdDateTimeUtc": "2021-08-01T16:08:14.027446Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:15.5419027Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9fd64070-3063-4a1f-b6c7-a5433ce879c1",
-            "createdDateTimeUtc": "2021-08-01T16:08:07.3241133Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:08.3919937Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eca524e6-f052-4f33-9f75-849aa58968f2",
-            "createdDateTimeUtc": "2021-08-01T16:07:59.6488045Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:02.4292358Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e4553a79-86bc-4607-93ba-acd98eef29a8",
-            "createdDateTimeUtc": "2021-08-01T16:07:51.7754119Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:07:55.6059096Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3733384b-4378-49e9-9d6c-eb777dd951e7",
-            "createdDateTimeUtc": "2021-08-01T16:03:47.7295123Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:50.0428444Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5af0415d-d065-4223-8377-8c4b476b1e51",
-            "createdDateTimeUtc": "2021-08-01T16:03:41.2997619Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:43.1057319Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "19825a18-d71e-4d71-ad50-ac9efde28439",
-            "createdDateTimeUtc": "2021-08-01T16:03:33.0672128Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:36.0643347Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2126372c-82d1-4ca5-99cd-6320189e4456",
-            "createdDateTimeUtc": "2021-08-01T16:03:21.6139816Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:29.0787165Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=300\u0026$top=114\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=300\u0026$top=114\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ed584fdb6caf4940bb41b77464d77ad4-afdb091a4c7caa42-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "25039184b486e34a547bc7fc7e207e39",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a09010c6-ec74-44c7-b65e-c2839f099601",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:20 GMT",
-        "ETag": "\u0022A67ED033046552748A42CEABDD07528DCD3835BDD81017A6E5F034BFE8EA0E00\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a09010c6-ec74-44c7-b65e-c2839f099601"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "351567c2-21d9-44d7-80cd-ae88bcfc86c1",
-            "createdDateTimeUtc": "2021-08-01T16:03:11.2412744Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:14.0681571Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3687fbc7-cfc7-4946-abbd-d20c2c47872b",
-            "createdDateTimeUtc": "2021-08-01T16:02:54.8769861Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:59.157192Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "75b82710-29d5-4a29-b31d-b4b276547f85",
-            "createdDateTimeUtc": "2021-08-01T16:02:42.7637598Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:44.4525561Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "45e52c50-a5d3-4185-ad9c-302fb18b86fb",
-            "createdDateTimeUtc": "2021-08-01T16:02:33.7748165Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:37.1302955Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0794e1ae-1cbb-4ce3-a359-5baea72b7f4f",
-            "createdDateTimeUtc": "2021-08-01T15:59:52.4064413Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:54.8434933Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6bf80ca-523f-424b-bb16-43b74851cd72",
-            "createdDateTimeUtc": "2021-08-01T15:59:46.146435Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:47.7975734Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f151cf31-9668-4c64-9fa3-1eab66bd54de",
-            "createdDateTimeUtc": "2021-08-01T15:59:38.6998762Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:41.734894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eab2ef7c-cccd-4b8d-9c28-43fa1246a6ec",
-            "createdDateTimeUtc": "2021-08-01T15:59:33.1867669Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:34.7568857Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fe3b6f5b-2f4f-4ba6-87b0-b49ce11a40f1",
-            "createdDateTimeUtc": "2021-08-01T15:59:23.8646186Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:27.6910914Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c688f16b-c48f-4d93-ae25-97e9419cf990",
-            "createdDateTimeUtc": "2021-08-01T15:59:20.0728064Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:20.6633025Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "65b3ecb9-b44e-45cb-9b48-4c3dc410ea83",
-            "createdDateTimeUtc": "2021-08-01T15:59:09.2524163Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:13.6285104Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4dc36f8-1a47-4082-9e74-55b17a656aee",
-            "createdDateTimeUtc": "2021-08-01T15:58:55.2515733Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:02.9435279Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f3021ca2-9cec-4123-8750-e48d70416733",
-            "createdDateTimeUtc": "2021-08-01T15:56:37.0490386Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:38.4486071Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6b145029-9721-429c-a6a7-09c88b0985bf",
-            "createdDateTimeUtc": "2021-08-01T15:56:30.7478816Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:31.4431875Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bd39da52-dc84-4165-bd31-8b4e3386e291",
-            "createdDateTimeUtc": "2021-08-01T15:56:23.0776782Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:27.4828878Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fa4f24ae-2898-4a3f-99c4-1cb3803f90f9",
-            "createdDateTimeUtc": "2021-08-01T15:56:16.7471751Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:20.4937894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7ab33b72-ce13-4ddb-8201-c3c334eae327",
-            "createdDateTimeUtc": "2021-08-01T15:56:03.8859689Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:05.4735936Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ab288e5d-b6b4-44e3-abf9-6faa8c4be7ec",
-            "createdDateTimeUtc": "2021-08-01T15:55:55.0121462Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:56.3540986Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f93cafa9-8dd4-4b3b-8b51-1e2171088923",
-            "createdDateTimeUtc": "2021-08-01T15:55:47.3645091Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:49.3078416Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e4b8104a-b73b-4412-9053-8e5ebec49801",
-            "createdDateTimeUtc": "2021-08-01T15:55:40.55381Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:42.2818894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5d43cd87-26c7-4c64-a7c6-b594408e7335",
-            "createdDateTimeUtc": "2021-08-01T15:55:32.9887665Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:35.2182692Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2136b292-19b7-4256-8c19-5fa788b76984",
-            "createdDateTimeUtc": "2021-08-01T15:55:25.9783249Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:28.383526Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0517cacc-3271-4281-a3d5-104ef81a6787",
-            "createdDateTimeUtc": "2021-08-01T13:52:26.3146047Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:27.02053Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "13dc0dc6-55d9-4815-925b-53831ccd5b1a",
-            "createdDateTimeUtc": "2021-08-01T13:52:20.0346113Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:20.7450313Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d63c2da4-ba89-4240-8ca3-3303a99b2321",
-            "createdDateTimeUtc": "2021-08-01T13:52:11.7638283Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:14.351392Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5c4dd9bb-d4c3-4154-b014-5b999af767fc",
-            "createdDateTimeUtc": "2021-08-01T13:51:59.0858938Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:06.7430348Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fba3ac3e-5074-4ae6-b21b-77e83ddd5728",
-            "createdDateTimeUtc": "2021-08-01T13:51:50.096311Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:51.9229238Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "919b875a-ac8a-4168-9f5d-2b002e2e990b",
-            "createdDateTimeUtc": "2021-08-01T13:51:36.2700242Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:44.8851496Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b65dd502-78d8-41eb-a5c2-e38841e8a64d",
-            "createdDateTimeUtc": "2021-08-01T13:51:29.279615Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:29.8684676Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f31e8014-63fa-40b4-99c8-0bcd7b0e55c8",
-            "createdDateTimeUtc": "2021-08-01T13:51:18.8649454Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:23.0945034Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "03ff545e-1823-45a4-b776-69f0e04acc30",
-            "createdDateTimeUtc": "2021-08-01T13:47:29.3049005Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:31.3629345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ba88a76e-c3d3-4ea6-a53c-b85651fcf2e3",
-            "createdDateTimeUtc": "2021-08-01T13:47:23.0010181Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:24.2943392Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "74a8ff69-cb7a-4499-86df-c3a2d3832f35",
-            "createdDateTimeUtc": "2021-08-01T13:47:15.4214201Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:17.6049061Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d34a947d-dbfe-4629-94ca-583ba3135c38",
-            "createdDateTimeUtc": "2021-08-01T13:47:09.0574092Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:10.5667782Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "292e0fc5-31f9-4bbe-a16d-118e79c6447d",
-            "createdDateTimeUtc": "2021-08-01T13:46:55.8006784Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:03.6165324Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "46cfff21-a830-4bfe-bcf7-7845dea12314",
-            "createdDateTimeUtc": "2021-08-01T13:46:47.3054Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:49.2160598Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "992cdea9-d5e3-4518-a34f-463b467802b8",
-            "createdDateTimeUtc": "2021-08-01T13:46:39.1556709Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:42.1830707Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1b93d4c5-0c5a-4c53-9d0b-123580370ac4",
-            "createdDateTimeUtc": "2021-08-01T13:46:34.0334308Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:35.0748515Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c10423c1-70a0-4249-9b44-c4e35fa531cf",
-            "createdDateTimeUtc": "2021-08-01T13:46:27.7441155Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:28.5230851Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "762b843d-5634-4e71-8998-3c269c5aa71a",
-            "createdDateTimeUtc": "2021-08-01T13:46:14.8806312Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:21.7377245Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8c396dd4-a4d4-4fd6-b49c-9bf293bc5b22",
-            "createdDateTimeUtc": "2021-08-01T13:39:53.2223797Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:59.6350234Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "15fa9332-a622-4903-9c2d-30ec419c019f",
-            "createdDateTimeUtc": "2021-08-01T13:39:40.8849092Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:45.8189345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "4eba9692-8936-433d-8277-37297439855f",
-            "createdDateTimeUtc": "2021-08-01T13:39:25.8159637Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:34.600318Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "d7d61b86-c02c-44a7-9d94-1b3bf73ea68c",
-            "createdDateTimeUtc": "2021-08-01T13:39:18.4391794Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:19.4610126Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "501ab4fe-6bb1-4f2f-bc60-0ed6375ff114",
-            "createdDateTimeUtc": "2021-08-01T13:39:08.0207097Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:12.3862208Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "92b4bf08-9a7b-4e86-bf5f-6287b863b2f8",
-            "createdDateTimeUtc": "2021-08-01T13:38:54.8712186Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:01.0996993Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "e89ae3bd-9e8e-4035-91c8-1110271964f5",
-            "createdDateTimeUtc": "2021-07-29T18:56:30.5852007Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:32.8561054Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "80f86e77-a61c-4fb6-a924-86ed9fd9dcdb",
-            "createdDateTimeUtc": "2021-07-29T18:56:17.7021902Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:25.2356539Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bfebe6ca-0904-4142-8deb-def8890749cc",
-            "createdDateTimeUtc": "2021-07-29T18:56:08.9244466Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:10.2588454Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c627c2f9-4605-4e98-92d7-d9814db0bfff",
-            "createdDateTimeUtc": "2021-07-29T18:55:56.0217273Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:03.7770256Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=350\u0026$top=64\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=350\u0026$top=64\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-975bd9ed3cfe8246b515cd60b3dfffb5-e26d81a31aa4b94b-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e09176b336365cfbc943bbcb90e5320c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6cc9dc16-2488-45a3-ac7a-07ba2628991d",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:21 GMT",
-        "ETag": "\u002239D10B00CF7F4E3A6FD3CBD685DBA0D093504C8BA02BEC768E57F4500DA0A351\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6cc9dc16-2488-45a3-ac7a-07ba2628991d"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "7cff621d-1a6d-432e-8fa5-df00eb8e076e",
-            "createdDateTimeUtc": "2021-07-29T18:55:47.2424877Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:48.0765309Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4338311b-280f-4aa3-844a-a7fb7236879d",
-            "createdDateTimeUtc": "2021-07-29T18:55:36.922933Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:41.5171516Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8794c5c1-f497-4a83-8293-da713258faa8",
-            "createdDateTimeUtc": "2021-07-29T18:55:23.3488567Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:30.3458735Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b86b6998-282c-4594-81a4-a6cb6d123953",
-            "createdDateTimeUtc": "2021-07-29T18:55:14.0853219Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:16.7959039Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "af92572b-d7d2-4d21-9ec7-411116a78904",
-            "createdDateTimeUtc": "2021-07-29T18:27:48.249869Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:48.9487415Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a7725a19-0c98-4ffd-947f-4d574615fd1e",
-            "createdDateTimeUtc": "2021-07-29T18:27:35.1676798Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:41.9314655Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bf5cbc3b-2921-4372-bcae-ffd87391abef",
-            "createdDateTimeUtc": "2021-07-29T18:27:27.7901646Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:28.4614677Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "69b858d0-ff26-4cfd-911e-37e3f73bb4f7",
-            "createdDateTimeUtc": "2021-07-29T18:27:19.8707951Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:21.4611112Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "14721933-e03d-4f8a-8f21-83219f03b279",
-            "createdDateTimeUtc": "2021-07-29T18:27:03.2894117Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:10.3609678Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8375af4f-848a-46ff-891e-a8b844ca0856",
-            "createdDateTimeUtc": "2021-07-29T18:26:52.907266Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:56.3528141Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "23dfbdb4-cf55-45bb-ab9c-02e3167a29e1",
-            "createdDateTimeUtc": "2021-07-29T18:26:45.3554314Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:46.2619525Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d5c5dd3e-1858-468d-bf7f-33f2833f4872",
-            "createdDateTimeUtc": "2021-07-29T18:26:37.3639687Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:38.3200345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e7188ffe-9202-479a-afe1-01fecc04ad22",
-            "createdDateTimeUtc": "2021-07-29T18:25:33.3238602Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:35.2984814Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "70db07a3-07c0-4d9d-83c5-5f65da69c4f9",
-            "createdDateTimeUtc": "2021-07-29T18:25:26.783298Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:28.2271307Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6a32867d-406a-4da9-a9aa-6d869d895bfd",
-            "createdDateTimeUtc": "2021-07-29T18:25:18.055152Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:21.1616142Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "05e70da4-5e01-4a27-b706-19fcf0adcada",
-            "createdDateTimeUtc": "2021-07-29T18:25:12.7651639Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:14.1490239Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f9b7a393-c7a5-421c-ba1d-a44c02048634",
-            "createdDateTimeUtc": "2021-07-29T18:25:04.3837212Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:07.1327422Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b4902c6f-6289-477e-8f9b-2bcb70c2e924",
-            "createdDateTimeUtc": "2021-07-29T18:24:57.6574082Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:00.1100818Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6048a21b-abc8-4457-b921-b9f3602082dd",
-            "createdDateTimeUtc": "2021-07-29T18:24:51.4511113Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:53.231795Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "72139ec3-ad0b-42cc-9a6c-92c555cc1417",
-            "createdDateTimeUtc": "2021-07-29T18:24:42.1866362Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:46.1095564Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a0efbf77-53fb-4af8-8c69-61df229575cc",
-            "createdDateTimeUtc": "2021-07-29T18:24:18.6490605Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:21.0023446Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f50dd147-dd7a-4589-8f90-b40bdc22e6d9",
-            "createdDateTimeUtc": "2021-07-29T18:24:13.4076008Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:14.9595162Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1769c3a9-a912-4e02-ad76-4ad658e6bd07",
-            "createdDateTimeUtc": "2021-07-29T18:24:06.1419128Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:07.8638717Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7a8a7450-9f6e-4ee0-9c72-caa4303e9649",
-            "createdDateTimeUtc": "2021-07-29T18:23:53.1730982Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:00.9552258Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4b5fd2ee-aa2a-45e2-a64b-69d4b6aa8fef",
-            "createdDateTimeUtc": "2021-07-29T18:23:44.6321958Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:46.0263327Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6d4a7add-df54-4f67-a3dd-bc47675e5131",
-            "createdDateTimeUtc": "2021-07-29T18:23:35.607668Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:38.9203906Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "73a8b048-a34e-4bf9-9a77-9fd7a1fa0eab",
-            "createdDateTimeUtc": "2021-07-29T18:23:22.5480081Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:26.9561971Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3221547b-76a3-45d2-ad5e-28383c397f11",
-            "createdDateTimeUtc": "2021-07-29T18:23:12.8991624Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:16.2575253Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce9f5f49-3336-4ef4-996f-7086e032e208",
-            "createdDateTimeUtc": "2021-07-29T18:11:08.689952Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:11:10.9326895Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a17020af-7225-4a1c-bd1d-f9c86b8e8231",
-            "createdDateTimeUtc": "2021-07-29T18:10:59.594621Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:11:03.8658837Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bcd6fdf4-0572-475d-af9c-6df2e9882564",
-            "createdDateTimeUtc": "2021-07-29T18:10:48.318371Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:53.1219508Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7f7329d9-9d65-4aa0-a19e-c151f45fbfba",
-            "createdDateTimeUtc": "2021-07-29T18:10:36.4711697Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:39.9591092Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8a8759c6-38f8-4587-82c5-551099482e2e",
-            "createdDateTimeUtc": "2021-07-29T18:10:25.3356743Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:29.6315203Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "41696374-9114-4f8d-90f7-6c8a1c7b0607",
-            "createdDateTimeUtc": "2021-07-29T18:10:14.5091385Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:18.8819684Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c1fe9b5d-e1ec-410d-84e1-14780b307360",
-            "createdDateTimeUtc": "2021-07-29T18:10:03.0941124Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:08.0754094Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5f6d6b60-7017-4ae9-b89b-734dbc8df3a2",
-            "createdDateTimeUtc": "2021-07-29T18:09:50.6890119Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:09:54.5512218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "68c61875-9896-4531-8eec-f79a84ec0732",
-            "createdDateTimeUtc": "2021-07-29T18:07:41.3308148Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:43.0283024Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9b825b8-de7f-4ef9-8b15-67f8a05228de",
-            "createdDateTimeUtc": "2021-07-29T18:07:33.4253241Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:35.8948263Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "07266a35-6965-49a7-b488-c6aec774f353",
-            "createdDateTimeUtc": "2021-07-29T18:07:28.0747509Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:29.4732464Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "712bb162-dda9-4e0d-900d-6e32ccb84ce2",
-            "createdDateTimeUtc": "2021-07-29T18:07:21.4384466Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:22.3419567Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8f0a8627-974a-452a-b531-0a7eeba67834",
-            "createdDateTimeUtc": "2021-07-29T18:07:11.9494241Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:13.7989556Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c944ca83-770a-4981-8393-8436509a3ac5",
-            "createdDateTimeUtc": "2021-07-29T18:07:03.4708288Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:04.7948363Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "579fe594-a0ac-46c9-99bc-6337aacf022c",
-            "createdDateTimeUtc": "2021-07-29T18:06:55.3491078Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:57.7260656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b9b9b7a-0467-49b5-a230-d6c2c1c80827",
-            "createdDateTimeUtc": "2021-07-29T18:06:40.9676932Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:46.6887745Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b47abfb4-48de-49de-a4cd-147fe3742a71",
-            "createdDateTimeUtc": "2021-07-29T18:06:35.6198036Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:37.3471477Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5dc846fa-dea1-4528-b9cb-39fba11fb4da",
-            "createdDateTimeUtc": "2021-07-29T18:06:18.7068479Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:26.7025516Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2a1743af-a8b6-4ff4-aacc-709b078c56ad",
-            "createdDateTimeUtc": "2021-07-29T18:02:37.0777259Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:40.6627767Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "cd0f86ef-4325-4732-bb52-a12b6bc460df",
-            "createdDateTimeUtc": "2021-07-29T18:02:26.2775788Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:28.2284503Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "905ec32b-4d49-47e5-825a-167cee386199",
-            "createdDateTimeUtc": "2021-07-29T18:02:02.1798526Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:05.4444688Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5e5d4037-f4be-4678-85f2-6c2d10eb35b0",
-            "createdDateTimeUtc": "2021-07-29T18:01:50.005682Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:01:53.1664365Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=400\u0026$top=14\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=400\u0026$top=14\u0026$maxpagesize=50\u0026createdDateTimeUtcEnd=2021-08-04T20:31:10.0631715Z",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ef81e963cb25f245bb744f8099514639-a5b902709a4f0d4a-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "51a3eedc9ce3db32c94b980cf646cef1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "012e7f60-0e7d-4d9b-a6a5-d53ef6c72a2f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:21 GMT",
-        "ETag": "\u002262EE97A40E2E656A76A643438060AD1B3C6620003107C9F36068E5DF75DFBC67\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "012e7f60-0e7d-4d9b-a6a5-d53ef6c72a2f"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "f8e7a8b6-428a-45c1-8046-b00f16793d40",
-            "createdDateTimeUtc": "2021-07-29T18:00:58.4154875Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:01:00.6279809Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "f5aa1906-2807-4db0-bd08-a8f9e56b4750",
-            "createdDateTimeUtc": "2021-07-29T18:00:39.80581Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:00:48.5772657Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "0498c77f-42de-46cb-91fb-529c044d9e2b",
-            "createdDateTimeUtc": "2021-07-29T16:05:46.6656342Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:05:46.8929852Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
+            "id": "f81d5c81-f7db-41da-baa7-dff063bd88c4",
+            "createdDateTimeUtc": "2021-08-26T14:06:50.6689792Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:06:55.7249243Z",
+            "status": "Cancelled",
             "summary": {
-              "total": 0,
+              "total": 20,
               "failed": 0,
               "success": 0,
               "inProgress": 0,
               "notYetStarted": 0,
-              "cancelled": 0,
+              "cancelled": 20,
               "totalCharacterCharged": 0
             }
           },
           {
-            "id": "f97fa266-258a-43be-abf7-3a851dd3438a",
-            "createdDateTimeUtc": "2021-07-29T16:05:43.5493779Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:05:43.798646Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
+            "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+            "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:06:43.2132613Z",
+            "status": "Succeeded",
             "summary": {
-              "total": 0,
+              "total": 1,
               "failed": 0,
-              "success": 0,
+              "success": 1,
               "inProgress": 0,
               "notYetStarted": 0,
               "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "bfe99a22-0966-4bb8-8f99-a60956e1bd44",
-            "createdDateTimeUtc": "2021-07-29T16:04:43.3132785Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:04:43.6688398Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "364a7f60-b5e0-40ed-8fbe-8c269e757f58",
-            "createdDateTimeUtc": "2021-07-29T16:04:38.8243421Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:04:39.7360075Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "173f4456-92b0-47d4-87f0-d3b3f6b076c8",
-            "createdDateTimeUtc": "2021-07-29T16:00:33.3385235Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:00:33.6856601Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "e2cebd98-9179-47ff-a520-d6e672f9548d",
-            "createdDateTimeUtc": "2021-07-29T15:59:51.7446608Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:59:51.9630722Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d44729c5-7422-414e-9ec8-41be82649bcd",
-            "createdDateTimeUtc": "2021-07-29T15:59:47.8488179Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:59:48.0834023Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "879d0008-1264-4273-9f94-61eaa0d53818",
-            "createdDateTimeUtc": "2021-07-29T15:57:48.4243818Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:48.6367029Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "52a46f0a-80cc-4e51-94e8-6355a5a00782",
-            "createdDateTimeUtc": "2021-07-29T15:57:45.4760932Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:45.6975927Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "1b1df384-0c32-48e3-8539-53619fe9847f",
-            "createdDateTimeUtc": "2021-07-29T15:57:06.0490196Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:06.4194196Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "49e77fae-33ee-486c-aac8-5a9e6e27d6c0",
-            "createdDateTimeUtc": "2021-07-29T15:54:13.5289776Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:54:13.9172691Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "dea162d3-b03d-466e-bd33-fae8e3279b21",
-            "createdDateTimeUtc": "2021-07-29T15:54:09.3707087Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:54:09.7229003Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
+              "totalCharacterCharged": 16
             }
           }
         ]
@@ -7508,10 +1523,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-04T22:31:10.0631715\u002B02:00",
+    "DateTimeOffsetNow": "2021-08-26T16:26:54.0590780\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
-    "RandomSeed": "54712059"
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
+    "RandomSeed": "694278655"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByIdsTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByIdsTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source500231395?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source500231395?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-2fc183643063cb4ca082a44a637b523d-ab8e81991ea04a4c-00",
+        "traceparent": "00-d62c4f7ae396e144b523e3a7106b7d04-1fb0522681edde4b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "f9259529056fd5ab079e9f234bfd0ba8",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:31 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:43:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:30 GMT",
-        "ETag": "\u00220x8D9578690D149B6\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:31 GMT",
+        "Date": "Thu, 26 Aug 2021 12:43:37 GMT",
+        "ETag": "\u00220x8D9688F205BB098\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:43:38 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "f9259529056fd5ab079e9f234bfd0ba8",
-        "x-ms-request-id": "052742db-a01e-003b-676f-896135000000",
+        "x-ms-request-id": "77d05ff0-e01e-0067-0877-9a2c63000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source500231395/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source500231395/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-ee85faf590736d4c95dba1990281e23d-8dd5acb5c5a56a46-00",
+        "traceparent": "00-812765704c972a49901a96de9a62eb10-f31b2126b5f85842-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "016d1d5187a1bae0c74bf1a9c06f19bf",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:31 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:43:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:31 GMT",
-        "ETag": "\u00220x8D95786911C0828\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:32 GMT",
+        "Date": "Thu, 26 Aug 2021 12:43:38 GMT",
+        "ETag": "\u00220x8D9688F20A60897\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:43:38 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "016d1d5187a1bae0c74bf1a9c06f19bf",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05274337-a01e-003b-3e6f-896135000000",
+        "x-ms-request-id": "77d06067-e01e-0067-6877-9a2c63000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1397849996?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1397849996?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e6759cec6a38454cbbca6a93747cb460-6aef0e980692ca46-00",
+        "traceparent": "00-2bb63c83d72ca947b279ca79de81b293-dae5fc29807bd344-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "ea50707d53220a7756078a90f3e76335",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:31 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:43:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:31 GMT",
-        "ETag": "\u00220x8D957869141AC03\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:32 GMT",
+        "Date": "Thu, 26 Aug 2021 12:43:38 GMT",
+        "ETag": "\u00220x8D9688F20BD9184\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:43:38 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "ea50707d53220a7756078a90f3e76335",
-        "x-ms-request-id": "05274411-a01e-003b-7b6f-896135000000",
+        "x-ms-request-id": "77d06184-e01e-0067-6c77-9a2c63000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e65460d31d2a074390b9df5cf5f5edfd-af6cdd92bdec2f4e-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ff241cbb3cda4948bc347268334c5a60-1c489c7d5d09814f-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "ec94e7764281b5a16b32241302159885",
         "x-ms-return-client-request-id": "true"
       },
@@ -116,10 +116,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a1e1fbbf-260e-4d0b-a921-c259d22f0a9f",
+        "apim-request-id": "0a53aa01-3b6d-4ae0-bbdd-1424b30a72e6",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:32 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+        "Date": "Thu, 26 Aug 2021 12:43:39 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -127,46 +127,46 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a1e1fbbf-260e-4d0b-a921-c259d22f0a9f"
+        "X-RequestId": "0a53aa01-3b6d-4ae0-bbdd-1424b30a72e6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "8dcd96e0bebbca2ef6f74b805529d464",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8f98a7dd-a757-4fea-8c0d-331c26d1d10b",
+        "apim-request-id": "55b02324-4d03-4562-bafd-1227b471fd5e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:32 GMT",
-        "ETag": "\u0022E89E36E2FCED300CCCB03DD736254F3C5B7DDAED9EF425B29AB0FE646C88A554\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:39 GMT",
+        "ETag": "\u00225F454D410D5DCD6F3F0DEE7CBB0446DB8D7582D63B4F9C83FF75E5B80B1B5B1A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8f98a7dd-a757-4fea-8c0d-331c26d1d10b"
+        "X-RequestId": "55b02324-4d03-4562-bafd-1227b471fd5e"
       },
       "ResponseBody": {
-        "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-        "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:32.9101445Z",
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:40.2351432Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,26 +180,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "8849738ed2853b0bcf9a7ef02f630840",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "442fd26e-45eb-4400-b4e2-67559cea56c9",
+        "apim-request-id": "79405c98-5b1d-4bde-b419-772d9213163f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:33 GMT",
-        "ETag": "\u0022642E68E91A063BB6566F9E23B54B381A92294724B554A06E1126EEB2DD9DBDA6\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:41 GMT",
+        "ETag": "\u002248D96CB0D1A958C8227B44C49507FF9BC63D58DEDFB685BD385A562AE62774BE\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -209,12 +209,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "442fd26e-45eb-4400-b4e2-67559cea56c9"
+        "X-RequestId": "79405c98-5b1d-4bde-b419-772d9213163f"
       },
       "ResponseBody": {
-        "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-        "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:33.1659771Z",
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:41.0820653Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -228,41 +228,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "5caf046fd619b879b8c9f68af7215f42",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "11e382ef-232c-49f6-8643-426042e6516b",
+        "apim-request-id": "1cb6715c-1e15-4a16-9a95-f07a4504a501",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:34 GMT",
-        "ETag": "\u0022642E68E91A063BB6566F9E23B54B381A92294724B554A06E1126EEB2DD9DBDA6\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:42 GMT",
+        "ETag": "\u002248D96CB0D1A958C8227B44C49507FF9BC63D58DEDFB685BD385A562AE62774BE\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "11e382ef-232c-49f6-8643-426042e6516b"
+        "X-RequestId": "1cb6715c-1e15-4a16-9a95-f07a4504a501"
       },
       "ResponseBody": {
-        "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-        "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:33.1659771Z",
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:41.0820653Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -276,26 +276,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "8e85bf5d10cb0d008b92be203f3e9a92",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "66e8f224-706b-48cd-8e6f-56c8916cd63e",
+        "apim-request-id": "b201cf64-4312-4abb-924a-802ef7dcf03d",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:36 GMT",
-        "ETag": "\u0022642E68E91A063BB6566F9E23B54B381A92294724B554A06E1126EEB2DD9DBDA6\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:43 GMT",
+        "ETag": "\u002248D96CB0D1A958C8227B44C49507FF9BC63D58DEDFB685BD385A562AE62774BE\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -305,12 +305,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "66e8f224-706b-48cd-8e6f-56c8916cd63e"
+        "X-RequestId": "b201cf64-4312-4abb-924a-802ef7dcf03d"
       },
       "ResponseBody": {
-        "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-        "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:33.1659771Z",
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:41.0820653Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -324,41 +324,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "50100aee7779b74af991cfbbdc8044ad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "12743fd3-0fce-4e98-b12f-6d986bc0409b",
+        "apim-request-id": "3fa59daf-4423-46da-aa10-9f0ed37c7a66",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:38 GMT",
-        "ETag": "\u0022642E68E91A063BB6566F9E23B54B381A92294724B554A06E1126EEB2DD9DBDA6\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:44 GMT",
+        "ETag": "\u002248D96CB0D1A958C8227B44C49507FF9BC63D58DEDFB685BD385A562AE62774BE\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "12743fd3-0fce-4e98-b12f-6d986bc0409b"
+        "X-RequestId": "3fa59daf-4423-46da-aa10-9f0ed37c7a66"
       },
       "ResponseBody": {
-        "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-        "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:33.1659771Z",
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:41.0820653Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -372,26 +372,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "6f923c3b79de5f7404a1d0861859787a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4d0cb339-036a-4a7f-8750-97b21e56e484",
+        "apim-request-id": "484ab3f2-9f35-47cd-a832-f4b18e25adc8",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:39 GMT",
-        "ETag": "\u0022CD0EC31E88C7ABB8E4A0A7D446D36B96359422806053F2AB47964FA3A18992FA\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:45 GMT",
+        "ETag": "\u00221FC1C97D676328CC1B79503C087276AC5D1A97C99FBC50298B45B4940CC2B7C3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -401,12 +401,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4d0cb339-036a-4a7f-8750-97b21e56e484"
+        "X-RequestId": "484ab3f2-9f35-47cd-a832-f4b18e25adc8"
       },
       "ResponseBody": {
-        "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-        "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:39.0415286Z",
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:45.9884459Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -420,41 +420,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "ec9b632f0e10e5c875cd953a4045300b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f59b4309-bacf-4b1d-b911-8b37215e7e90",
+        "apim-request-id": "c1ef2787-fcbc-4e9b-9f20-9f145ae91e3e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:40 GMT",
-        "ETag": "\u0022CD0EC31E88C7ABB8E4A0A7D446D36B96359422806053F2AB47964FA3A18992FA\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:48 GMT",
+        "ETag": "\u0022F0E381B32E3C52B57F3882E670BB4D59BCF5A523B4FD4DEAF050491F44C55A1B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f59b4309-bacf-4b1d-b911-8b37215e7e90"
+        "X-RequestId": "c1ef2787-fcbc-4e9b-9f20-9f145ae91e3e"
       },
       "ResponseBody": {
-        "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-        "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:39.0415286Z",
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:47.4653196Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -468,26 +468,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "03e5104e2bab74b396b14cd7a7c39fa0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "debd8302-a81e-42c5-bca8-b9248de67e33",
+        "apim-request-id": "2d8bae2f-144f-430e-83b1-d4d98bbbcc54",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:41 GMT",
-        "ETag": "\u00229945A3302DCA66161C305B9F8DC5892E6DE2A7F0D46E01C37FFAFE5002FD35BF\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:49 GMT",
+        "ETag": "\u0022F0E381B32E3C52B57F3882E670BB4D59BCF5A523B4FD4DEAF050491F44C55A1B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -497,12 +497,348 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "debd8302-a81e-42c5-bca8-b9248de67e33"
+        "X-RequestId": "2d8bae2f-144f-430e-83b1-d4d98bbbcc54"
       },
       "ResponseBody": {
-        "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-        "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:39.0415286Z",
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:47.4653196Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "788b551957e52c9c74acfa11e43a1ebf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "019ceb53-341c-4b2c-8259-f20662e57897",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:43:50 GMT",
+        "ETag": "\u0022F0E381B32E3C52B57F3882E670BB4D59BCF5A523B4FD4DEAF050491F44C55A1B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "019ceb53-341c-4b2c-8259-f20662e57897"
+      },
+      "ResponseBody": {
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:47.4653196Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0738c570747404ceb026565ec2f03eb1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "05d7f727-cdca-4de0-919b-7e517f8d060b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:43:51 GMT",
+        "ETag": "\u0022F0E381B32E3C52B57F3882E670BB4D59BCF5A523B4FD4DEAF050491F44C55A1B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "05d7f727-cdca-4de0-919b-7e517f8d060b"
+      },
+      "ResponseBody": {
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:47.4653196Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ea21f42db8b9f62573b88efe30a2905b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bb550697-af96-4ca9-90b8-983ba1dffba5",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:43:52 GMT",
+        "ETag": "\u0022F0E381B32E3C52B57F3882E670BB4D59BCF5A523B4FD4DEAF050491F44C55A1B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "bb550697-af96-4ca9-90b8-983ba1dffba5"
+      },
+      "ResponseBody": {
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:47.4653196Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e1678d93988ba42c8687c8be013d6984",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e5e673a9-9bdf-4adf-aecb-02a51bc8b061",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:43:53 GMT",
+        "ETag": "\u0022F0E381B32E3C52B57F3882E670BB4D59BCF5A523B4FD4DEAF050491F44C55A1B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e5e673a9-9bdf-4adf-aecb-02a51bc8b061"
+      },
+      "ResponseBody": {
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:47.4653196Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f0e3496e3319b8059f4293bbe6d0d30d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "93c03a62-0bbc-4ed2-afbc-3124d0d3bea8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:43:55 GMT",
+        "ETag": "\u0022F0E381B32E3C52B57F3882E670BB4D59BCF5A523B4FD4DEAF050491F44C55A1B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "93c03a62-0bbc-4ed2-afbc-3124d0d3bea8"
+      },
+      "ResponseBody": {
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:47.4653196Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "35cbfa965d899526c77c6331ef67f535",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c59f7781-c15d-4bf4-be51-edd88dca1bb0",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:43:56 GMT",
+        "ETag": "\u0022F0E381B32E3C52B57F3882E670BB4D59BCF5A523B4FD4DEAF050491F44C55A1B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c59f7781-c15d-4bf4-be51-edd88dca1bb0"
+      },
+      "ResponseBody": {
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:47.4653196Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e7900a4ea0bf5f4287ae41490470beb6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9ad2eb51-e380-4f8c-a980-2251c913686b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:43:57 GMT",
+        "ETag": "\u0022058220CD55E476FEC49C2B9BA261EE705C070BE7C6F03D4834BBA283CF0DA149\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9ad2eb51-e380-4f8c-a980-2251c913686b"
+      },
+      "ResponseBody": {
+        "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+        "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:57.2368869Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -516,63 +852,63 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/a5cb9bb3-5100-40c6-bfae-a02a9099ce01/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/889cc470-e814-4a3a-bad5-b418af08bfea/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "788b551957e52c9c74acfa11e43a1ebf",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0628bbb4347210fb224d289ccfd3c938",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "20769fc7-e9a0-463f-801e-cb6ff2569533",
+        "apim-request-id": "2eb05ca8-3b68-45e5-9617-ffa6919a55ee",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:42 GMT",
-        "ETag": "\u0022D21BA034719D62D2F16361CE134D1756D1835883409B2D9AEF7CA31FAD099FA1\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:57 GMT",
+        "ETag": "\u0022696BFF544BBA4D482537D2DFF850C66622AA3547D75494C44E2D66344D58EF77\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "20769fc7-e9a0-463f-801e-cb6ff2569533"
+        "X-RequestId": "2eb05ca8-3b68-45e5-9617-ffa6919a55ee"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target1397849996/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source500231395/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:29:38.7320904Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:41.3816336Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1397849996/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source500231395/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:43:46.0144038Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:43:57.2368717Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53ce-0000-0000-0000-000000000000",
+            "id": "000b468b-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target2029705840?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1571676748?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-b800b832c97588418dce9965e6c69f1f-d46220aca3a31e41-00",
+        "traceparent": "00-a1262b8c8594a64ab901a36558a01a47-5f5627be27cc4e49-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "740738c5ce74b00426565ec2f03eb12d",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:41 GMT",
+        "x-ms-client-request-id": "3fdb6d5e4eebb7f66caddb1bdd9156be",
+        "x-ms-date": "Thu, 26 Aug 2021 12:43:58 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -580,27 +916,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:41 GMT",
-        "ETag": "\u00220x8D95786974C2C14\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:42 GMT",
+        "Date": "Thu, 26 Aug 2021 12:43:57 GMT",
+        "ETag": "\u00220x8D9688F2C52C7BB\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:43:58 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "740738c5ce74b00426565ec2f03eb12d",
-        "x-ms-request-id": "052754ed-a01e-003b-776f-896135000000",
+        "x-ms-client-request-id": "3fdb6d5e4eebb7f66caddb1bdd9156be",
+        "x-ms-request-id": "77d09407-e01e-0067-6778-9a2c63000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4f202e03beaa1342a9b929e594047c78-4c2f489968fa2f4f-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b9ea21f425b873f6b88efe30a2905b93",
+        "traceparent": "00-ebc73a73ea4f274faa0b62bd43ecc273-2719914462a92f41-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3f347dadc3ee0f1a7fc47177a68fb3e4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -620,57 +956,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "c3c55890-c9c4-412a-bb16-ac4767f71fa6",
+        "apim-request-id": "22e73bb8-5f20-4939-9a7a-83b664ffdbc5",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:42 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e75bd705-e165-4fcf-b6ad-e6da946f44bd",
+        "Date": "Thu, 26 Aug 2021 12:43:58 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8c41234c-dc31-479f-8fd8-520b520e02df",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c3c55890-c9c4-412a-bb16-ac4767f71fa6"
+        "X-RequestId": "22e73bb8-5f20-4939-9a7a-83b664ffdbc5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e75bd705-e165-4fcf-b6ad-e6da946f44bd",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8c41234c-dc31-479f-8fd8-520b520e02df",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8be1678d2c9886a487c8be013d69846e",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "03a5fc0977e26cc8314e058620f545bb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ee4bff3c-c2ca-4355-b52a-5314cad4dc68",
+        "apim-request-id": "efb97446-50f6-4a0a-9e6d-e9076086cf89",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:43 GMT",
-        "ETag": "\u0022147AEA73351598A8038BAF80EDFA39CC720117DAD859EC78259E20C21D1FF8E8\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:58 GMT",
+        "ETag": "\u002289EFD3E4F24EE50CE3804B31EC7BBD0D13CC0E1E23FC0B900BE00D0AAD72E3D3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ee4bff3c-c2ca-4355-b52a-5314cad4dc68"
+        "X-RequestId": "efb97446-50f6-4a0a-9e6d-e9076086cf89"
       },
       "ResponseBody": {
-        "id": "e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-        "createdDateTimeUtc": "2021-08-04T20:29:43.0044925Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:43.0044928Z",
+        "id": "8c41234c-dc31-479f-8fd8-520b520e02df",
+        "createdDateTimeUtc": "2021-08-26T12:43:58.5526958Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:58.5526961Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -684,41 +1020,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e75bd705-e165-4fcf-b6ad-e6da946f44bd",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8c41234c-dc31-479f-8fd8-520b520e02df",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "19f0e34905339fb84293bbe6d0d30d96",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5522ddd1f8959a5d52ccbf27dc7e11dd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1f78775f-bd92-4da4-bf47-b3c369397fd6",
+        "apim-request-id": "07b45cdc-9954-40aa-848e-5f5d5c2b18be",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:44 GMT",
-        "ETag": "\u00220DDBFCCF65FE04FD7F700AE290E5727A5B0DCA346F79EB6F9857BF725BC17FE4\u0022",
+        "Date": "Thu, 26 Aug 2021 12:43:59 GMT",
+        "ETag": "\u0022B55A953F01541FC6CD3187F0E72A0821A35531E9FB90A1CFF956D902F0A8EAC3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1f78775f-bd92-4da4-bf47-b3c369397fd6"
+        "X-RequestId": "07b45cdc-9954-40aa-848e-5f5d5c2b18be"
       },
       "ResponseBody": {
-        "id": "e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-        "createdDateTimeUtc": "2021-08-04T20:29:43.0044925Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:43.2545966Z",
+        "id": "8c41234c-dc31-479f-8fd8-520b520e02df",
+        "createdDateTimeUtc": "2021-08-26T12:43:58.5526958Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:43:59.4462066Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -732,74 +1068,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e75bd705-e165-4fcf-b6ad-e6da946f44bd",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8c41234c-dc31-479f-8fd8-520b520e02df",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8935cbfa265dc7957c6331ef67f5354e",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e011f6fa52eb36dbb5c70da0be93ef8a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e66793c8-7c6c-4bae-88d1-127b8b95a4e8",
+        "apim-request-id": "710e6aa3-4d94-4227-99a4-609cc942d4ca",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:45 GMT",
-        "ETag": "\u00223FAFAA983E135C52E262503BDFBE26FADFDF05247875081B2185E5171101F65A\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e66793c8-7c6c-4bae-88d1-127b8b95a4e8"
-      },
-      "ResponseBody": {
-        "id": "e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-        "createdDateTimeUtc": "2021-08-04T20:29:43.0044925Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:45.7365608Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bfe7900a42a0875fae41490470beb6b4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a445949e-3c9e-4f2b-a3f6-da67031d1bc2",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:46 GMT",
-        "ETag": "\u002266B5FAE3A3F7CAE180C1D66DA2D8B9893FE6C209A65C6E84F4CBAEC63AE10189\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:00 GMT",
+        "ETag": "\u0022CCEFD30E2934F60DD5CDCE7C2672C31AA84D79EF2CD4C6F206306C629F86D26D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -809,12 +1097,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a445949e-3c9e-4f2b-a3f6-da67031d1bc2"
+        "X-RequestId": "710e6aa3-4d94-4227-99a4-609cc942d4ca"
       },
       "ResponseBody": {
-        "id": "e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-        "createdDateTimeUtc": "2021-08-04T20:29:43.0044925Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:46.0940111Z",
+        "id": "8c41234c-dc31-479f-8fd8-520b520e02df",
+        "createdDateTimeUtc": "2021-08-26T12:43:58.5526958Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:00.8323292Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -828,41 +1116,137 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e75bd705-e165-4fcf-b6ad-e6da946f44bd",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8c41234c-dc31-479f-8fd8-520b520e02df",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "720628bbfb3422104d289ccfd3c9384c",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c8a6b57e5e6c104e9e0bb116b7a090b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ad4c6a46-e216-4244-810d-66b7a2bfc805",
+        "apim-request-id": "cf03a32a-4c55-4900-9e00-c42f3dfe1f45",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:48 GMT",
-        "ETag": "\u0022A1D2000D7F1429148D460786D6DCDEC60B7FCD366DED1A664CA66C3AA9A0C40C\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:02 GMT",
+        "ETag": "\u002202EDF245671870BB1FFA4E2F3D37B3D8009A128361C3EA4D8CA5C57C6089ECF9\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ad4c6a46-e216-4244-810d-66b7a2bfc805"
+        "X-RequestId": "cf03a32a-4c55-4900-9e00-c42f3dfe1f45"
       },
       "ResponseBody": {
-        "id": "e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-        "createdDateTimeUtc": "2021-08-04T20:29:43.0044925Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:46.0940111Z",
+        "id": "8c41234c-dc31-479f-8fd8-520b520e02df",
+        "createdDateTimeUtc": "2021-08-26T12:43:58.5526958Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:01.3735177Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8c41234c-dc31-479f-8fd8-520b520e02df",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "298c283d64e37ecf01ec9fceeabddcbf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "756e79f4-6a43-427b-b066-6ec3cec7c41e",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:03 GMT",
+        "ETag": "\u002202EDF245671870BB1FFA4E2F3D37B3D8009A128361C3EA4D8CA5C57C6089ECF9\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "756e79f4-6a43-427b-b066-6ec3cec7c41e"
+      },
+      "ResponseBody": {
+        "id": "8c41234c-dc31-479f-8fd8-520b520e02df",
+        "createdDateTimeUtc": "2021-08-26T12:43:58.5526958Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:01.3735177Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8c41234c-dc31-479f-8fd8-520b520e02df",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "26a835dd48d89b70a70142e0a1c57e14",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "96f4eaac-1670-4b93-99bd-01af357605d6",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:04 GMT",
+        "ETag": "\u00228D7EF89D0B5E876CE2606D398D6FD48A0F57278586774F56474280EF54051A14\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "96f4eaac-1670-4b93-99bd-01af357605d6"
+      },
+      "ResponseBody": {
+        "id": "8c41234c-dc31-479f-8fd8-520b520e02df",
+        "createdDateTimeUtc": "2021-08-26T12:43:58.5526958Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:03.7937645Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -876,26 +1260,75 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/e75bd705-e165-4fcf-b6ad-e6da946f44bd/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8c41234c-dc31-479f-8fd8-520b520e02df/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3fdb6d5e4eebb7f66caddb1bdd9156be",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "96625a36c5071aa7e528c680be8025e0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a641afa8-6b5b-44f2-a734-53801a31d20d",
+        "apim-request-id": "938afa14-4776-4feb-baf8-c45edae3e855",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:48 GMT",
-        "ETag": "\u00220DA859588E26CCE50493878A1C66984F6AC9BAA1A745ABC99A3AF7E1A33B6195\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:04 GMT",
+        "ETag": "\u00223103216DA31F1BF483F903A77D1C0C4DC49FE010577735B4B433D63DF412C17D\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "938afa14-4776-4feb-baf8-c45edae3e855"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1571676748/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source500231395/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:44:00.8479002Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:44:03.7937586Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b468c-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=889cc470-e814-4a3a-bad5-b418af08bfea",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3c84fa51e0a241439252fdfbfef80eb8-6542f2b94dfe2e48-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8239f12e69f8f4dab7f081e222efdc3c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "349e1ec4-895d-4d89-b33b-7fc024e10c4a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:05 GMT",
+        "ETag": "\u0022501B2710E614BF9CE72EEB7620118D6CD95B2403D2648425BD549E350C378609\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -905,63 +1338,14 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a641afa8-6b5b-44f2-a734-53801a31d20d"
+        "X-RequestId": "349e1ec4-895d-4d89-b33b-7fc024e10c4a"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target2029705840/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source500231395/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:29:45.7434564Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:48.0795494Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000a53cf-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=a5cb9bb3-5100-40c6-bfae-a02a9099ce01\u0026statuses=\u0026$orderBy=",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b124e5cc657eb74d98ba6f737801a2a9-20ae384b2f249542-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3f347dadc3ee0f1a7fc47177a68fb3e4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "2ec03733-fbf3-4eb4-9602-29eef9ec3723",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:48 GMT",
-        "ETag": "\u002262F2AD3EA867BA6E0DBBD8CF0916271DF22A328E01FB4F3148F9803EDA432019\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2ec03733-fbf3-4eb4-9602-29eef9ec3723"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-            "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:39.0415286Z",
+            "id": "889cc470-e814-4a3a-bad5-b418af08bfea",
+            "createdDateTimeUtc": "2021-08-26T12:43:40.2351428Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:43:57.2368869Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -979,8 +1363,8 @@
   ],
   "Variables": {
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
     "RandomSeed": "1738101713"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByIdsTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByIdsTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1584166319?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1584166319?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7912995cd4ac1d4e80cbeded09887ece-900b265501aaef44-00",
+        "traceparent": "00-55e2e089e2f9d0448ad717e24402e9ae-279ea7365b89c041-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "cffe6ade3ecf1ffe6efd31351176c29c",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:22 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:44:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:21 GMT",
-        "ETag": "\u00220x8D95786D2FA957E\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:22 GMT",
+        "Date": "Thu, 26 Aug 2021 12:44:16 GMT",
+        "ETag": "\u00220x8D9688F377CCCC9\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:44:17 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "cffe6ade3ecf1ffe6efd31351176c29c",
-        "x-ms-request-id": "05280782-a01e-003b-206f-896135000000",
+        "x-ms-request-id": "77d0ba80-e01e-0067-5c78-9a2c63000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1584166319/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1584166319/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-7ba450b2d4192f4e86091a43bf941576-2ab721f65625e04b-00",
+        "traceparent": "00-485fd8adb678474d902536bf8483dea9-9fc4cde7b3d33a4a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "9b364dcefc593936548e0d0f9745d3e6",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:22 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:44:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:22 GMT",
-        "ETag": "\u00220x8D95786D34865D7\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:23 GMT",
+        "Date": "Thu, 26 Aug 2021 12:44:16 GMT",
+        "ETag": "\u00220x8D9688F37B02358\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:44:17 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "9b364dcefc593936548e0d0f9745d3e6",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052807e3-a01e-003b-706f-896135000000",
+        "x-ms-request-id": "77d0bae5-e01e-0067-3578-9a2c63000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1740265226?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1740265226?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-696bd766bfcfaa4b87990892cd86521d-03be2aaf0a08f74a-00",
+        "traceparent": "00-23e6ace38eb7df4bb046cfeec524295d-e646d4f0a0c3184e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "7627cdcbf4f5c4f435a2cdeaef43edbf",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:22 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:44:17 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:22 GMT",
-        "ETag": "\u00220x8D95786D36D9051\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:23 GMT",
+        "Date": "Thu, 26 Aug 2021 12:44:17 GMT",
+        "ETag": "\u00220x8D9688F37C81445\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:44:17 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "7627cdcbf4f5c4f435a2cdeaef43edbf",
-        "x-ms-request-id": "052808b9-a01e-003b-2e6f-896135000000",
+        "x-ms-request-id": "77d0bbae-e01e-0067-6878-9a2c63000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b9361372f9b7c14ca16bdef2373bc95f-9df01d1d37606b41-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-886c773a256b8744ab4ae0df11f3099f-47986ed7a137a442-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "be534d3156a134e1c57a4131ef882929",
         "x-ms-return-client-request-id": "true"
       },
@@ -116,57 +116,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1d11c6b9-644a-4ff7-944d-03f596d0c832",
+        "apim-request-id": "00bec636-5f3b-40cd-92e6-ac9bc62933a6",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:23 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365",
+        "Date": "Thu, 26 Aug 2021 12:44:17 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1d11c6b9-644a-4ff7-944d-03f596d0c832"
+        "X-RequestId": "00bec636-5f3b-40cd-92e6-ac9bc62933a6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "a8462a4b269a58d841d7235a684e654a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5df52f28-c8f0-473a-8727-0aa6a0f56d99",
+        "apim-request-id": "05ed5afd-032f-4da9-8504-22ded32b9ffd",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:23 GMT",
-        "ETag": "\u002210CA64F412EAA40970C78A38F23FE413D49977819FEC9D8F3CDEF0AAB067C34A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:17 GMT",
+        "ETag": "\u0022B4AEB447B3AA836D8EA22E9A7678067E611A91BC9F1E178EDF3A83E34942A833\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "5df52f28-c8f0-473a-8727-0aa6a0f56d99"
+        "X-RequestId": "05ed5afd-032f-4da9-8504-22ded32b9ffd"
       },
       "ResponseBody": {
-        "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-        "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:23.8865053Z",
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:17.7817011Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,41 +180,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "f7654f1f27807569ecf2b17bb3c3d5ad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a2a79692-d136-4c2e-a70b-6ca9c536c76d",
+        "apim-request-id": "86e52329-9140-4596-a732-018d9781892f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:25 GMT",
-        "ETag": "\u002207611B3F7C7DCAFAA38879AD0A563C2EC6FC2F549726647996528D6312694566\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:18 GMT",
+        "ETag": "\u00229A63F84EA6A5DB41D7E335E49DEE95B2036F305E1150DC9CF4608F234A3C6A7E\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a2a79692-d136-4c2e-a70b-6ca9c536c76d"
+        "X-RequestId": "86e52329-9140-4596-a732-018d9781892f"
       },
       "ResponseBody": {
-        "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-        "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:24.1651942Z",
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:18.4016262Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -228,41 +228,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "c49fa37945fd0b2574fb7cca3286cb76",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6e155975-cf94-47ed-a96a-b45c8c998deb",
+        "apim-request-id": "556a7aa5-be4b-4118-b7f3-34475b78b72d",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:26 GMT",
-        "ETag": "\u002207611B3F7C7DCAFAA38879AD0A563C2EC6FC2F549726647996528D6312694566\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:19 GMT",
+        "ETag": "\u00229A63F84EA6A5DB41D7E335E49DEE95B2036F305E1150DC9CF4608F234A3C6A7E\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6e155975-cf94-47ed-a96a-b45c8c998deb"
+        "X-RequestId": "556a7aa5-be4b-4118-b7f3-34475b78b72d"
       },
       "ResponseBody": {
-        "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-        "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:24.1651942Z",
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:18.4016262Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -276,122 +276,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "9f11f615322223a8c1d1bca8745da47e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e0677615-f561-4260-86a7-271cdeb168c6",
+        "apim-request-id": "dcf3c2fd-caf4-4a19-8063-febaeefb5528",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:27 GMT",
-        "ETag": "\u0022F6BCF65E8ED43E893DF746C6543E97E246DF55AA82FE6237F7A6D882F9A30E64\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:20 GMT",
+        "ETag": "\u00229A63F84EA6A5DB41D7E335E49DEE95B2036F305E1150DC9CF4608F234A3C6A7E\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e0677615-f561-4260-86a7-271cdeb168c6"
+        "X-RequestId": "dcf3c2fd-caf4-4a19-8063-febaeefb5528"
       },
       "ResponseBody": {
-        "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-        "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:27.9404978Z",
-        "status": "Running",
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:18.4016262Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "c4e17602a0afda4d2a5a8285ab9e4265",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8a2c03bf-e712-4d04-a527-ac5d31bf8abd",
+        "apim-request-id": "78e51270-1a1b-4719-ab12-152a8d92c05c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:28 GMT",
-        "ETag": "\u00227C0CFAE54A8D038D9F78592E33C67A3042BD397FA2340172AA2585A99F62EF39\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8a2c03bf-e712-4d04-a527-ac5d31bf8abd"
-      },
-      "ResponseBody": {
-        "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-        "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:28.2809993Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bc653b2735b1468afb7b022c897c9617",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e10cf90a-9d78-4e58-a6f7-513aa2a974f3",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:30 GMT",
-        "ETag": "\u00227C0CFAE54A8D038D9F78592E33C67A3042BD397FA2340172AA2585A99F62EF39\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:22 GMT",
+        "ETag": "\u00229A63F84EA6A5DB41D7E335E49DEE95B2036F305E1150DC9CF4608F234A3C6A7E\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -401,12 +353,204 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e10cf90a-9d78-4e58-a6f7-513aa2a974f3"
+        "X-RequestId": "78e51270-1a1b-4719-ab12-152a8d92c05c"
       },
       "ResponseBody": {
-        "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-        "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:28.2809993Z",
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:18.4016262Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bc653b2735b1468afb7b022c897c9617",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "79d5b3f8-2264-4c10-8992-dff2f88166b2",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:23 GMT",
+        "ETag": "\u00229A63F84EA6A5DB41D7E335E49DEE95B2036F305E1150DC9CF4608F234A3C6A7E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "79d5b3f8-2264-4c10-8992-dff2f88166b2"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:18.4016262Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bbc8fd5606a575c6a93675c7af237823",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f3195d60-9258-443e-bed8-05663f9a743d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:24 GMT",
+        "ETag": "\u00229A63F84EA6A5DB41D7E335E49DEE95B2036F305E1150DC9CF4608F234A3C6A7E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f3195d60-9258-443e-bed8-05663f9a743d"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:18.4016262Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3980568ee8f8cccdeb9ac9349d2051ad",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cf7fab60-c48c-440d-a719-673ada4b4fdb",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:26 GMT",
+        "ETag": "\u00229A63F84EA6A5DB41D7E335E49DEE95B2036F305E1150DC9CF4608F234A3C6A7E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "cf7fab60-c48c-440d-a719-673ada4b4fdb"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:18.4016262Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ad2e6bc486d620bf74f0127bbfc397d7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "65cbe6a3-afbb-444d-a948-8b9180d386ab",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:27 GMT",
+        "ETag": "\u0022467D682EC58BDC5EA3ED1CFA30B0F4D2E14A135B78BB404C280D0053C0A3B700\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "65cbe6a3-afbb-444d-a948-8b9180d386ab"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:27.7359016Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -420,41 +564,377 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bbc8fd5606a575c6a93675c7af237823",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "329edf025dfc6e1e30fbd00b3c91d789",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fd294c5c-b9e3-4609-a673-f76c7a3ec098",
+        "apim-request-id": "84455acb-d5b9-457b-9307-1c59cf248957",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:31 GMT",
-        "ETag": "\u002262AB1AFA25266CAE26EF9F060539E38EC82F560F6F70A06AD7A584D448BB5EA0\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:29 GMT",
+        "ETag": "\u0022467D682EC58BDC5EA3ED1CFA30B0F4D2E14A135B78BB404C280D0053C0A3B700\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "fd294c5c-b9e3-4609-a673-f76c7a3ec098"
+        "X-RequestId": "84455acb-d5b9-457b-9307-1c59cf248957"
       },
       "ResponseBody": {
-        "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-        "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:28.2809993Z",
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:27.7359016Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4303c8e5caf4074c9660c407d5520c28",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f0b2d927-f214-4311-94d1-e0f2804df443",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:30 GMT",
+        "ETag": "\u0022467D682EC58BDC5EA3ED1CFA30B0F4D2E14A135B78BB404C280D0053C0A3B700\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f0b2d927-f214-4311-94d1-e0f2804df443"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:27.7359016Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "be31f2021e8267b14cc07ddab6b4e3e2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1a06baab-48d3-4302-8d36-087642c72272",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:31 GMT",
+        "ETag": "\u0022467D682EC58BDC5EA3ED1CFA30B0F4D2E14A135B78BB404C280D0053C0A3B700\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "1a06baab-48d3-4302-8d36-087642c72272"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:27.7359016Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f795891953bf37e292969c9c981799de",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6979cb88-f595-4c64-b5a7-b811191ab1a8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:32 GMT",
+        "ETag": "\u0022467D682EC58BDC5EA3ED1CFA30B0F4D2E14A135B78BB404C280D0053C0A3B700\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "6979cb88-f595-4c64-b5a7-b811191ab1a8"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:27.7359016Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4a08a7ee1960c606179cf7344d7250e1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5283f981-e152-49b5-b500-1db3daa801ed",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:34 GMT",
+        "ETag": "\u0022467D682EC58BDC5EA3ED1CFA30B0F4D2E14A135B78BB404C280D0053C0A3B700\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "5283f981-e152-49b5-b500-1db3daa801ed"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:27.7359016Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4beee17c15bcaf690ff92beb8215ce35",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b342c21b-e711-4d32-9bc8-8a2348cd036a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:35 GMT",
+        "ETag": "\u0022467D682EC58BDC5EA3ED1CFA30B0F4D2E14A135B78BB404C280D0053C0A3B700\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "b342c21b-e711-4d32-9bc8-8a2348cd036a"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:27.7359016Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0fec9e2799acff8282cfe0235caeea20",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "df1bc6e5-93e8-4465-a4d0-90d4c41a6a42",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:36 GMT",
+        "ETag": "\u0022467D682EC58BDC5EA3ED1CFA30B0F4D2E14A135B78BB404C280D0053C0A3B700\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "df1bc6e5-93e8-4465-a4d0-90d4c41a6a42"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:27.7359016Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b61fba454d28d9223e593a66ed1a4302",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "30892999-f42a-4efa-9605-910db3451bd1",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:37 GMT",
+        "ETag": "\u00223D1CDE5D9A535D55CD0C49AEE493D739670258A89C9E2CBEB187109173587423\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "30892999-f42a-4efa-9605-910db3451bd1"
+      },
+      "ResponseBody": {
+        "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+        "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:37.1925872Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -468,63 +948,63 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7577037f-17ab-4851-b00c-08c9990ab365/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3980568ee8f8cccdeb9ac9349d2051ad",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ae0dc1cd4186e3355eeec9ec34455261",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "53aba566-0235-4aaa-a42a-e1bf2fd52368",
+        "apim-request-id": "4c4bced6-a50b-47bb-8830-dc6e9284f7f5",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
+        "Content-Length": "414",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:31 GMT",
-        "ETag": "\u00229F58C630BE4842A6BC31F7B644E4B7EA18373304D16C908031EC16456E834F63\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:37 GMT",
+        "ETag": "\u0022B5D5B424D1EAD4F2C70FF53CE0D50A1AB64973CB15BC0DDCFB9CBAC42F920521\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "53aba566-0235-4aaa-a42a-e1bf2fd52368"
+        "X-RequestId": "4c4bced6-a50b-47bb-8830-dc6e9284f7f5"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target1740265226/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1584166319/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:31:27.9472768Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:31.3897611Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1740265226/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1584166319/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:44:26.9203427Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:44:37.1925774Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53ec-0000-0000-0000-000000000000",
+            "id": "000b468d-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target578180804?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1788105743?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0b090c6fa4bbe54ab81109d04af6599f-f194261ca4610d45-00",
+        "traceparent": "00-176377434b16784683e20ebc0f72d187-e2eb73e3d997a44e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "d6ad2e6bbf867420f0127bbfc397d702",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:31 GMT",
+        "x-ms-client-request-id": "f5c7a60a0d177cd912d1535e1c11678c",
+        "x-ms-date": "Thu, 26 Aug 2021 12:44:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -532,27 +1012,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:31 GMT",
-        "ETag": "\u00220x8D95786D8B07DB4\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:32 GMT",
+        "Date": "Thu, 26 Aug 2021 12:44:37 GMT",
+        "ETag": "\u00220x8D9688F4428AF0E\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:44:38 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d6ad2e6bbf867420f0127bbfc397d702",
-        "x-ms-request-id": "05281b76-a01e-003b-186f-896135000000",
+        "x-ms-client-request-id": "f5c7a60a0d177cd912d1535e1c11678c",
+        "x-ms-request-id": "77d0e21c-e01e-0067-5978-9a2c63000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-69375530bb88d24ebbf68d0f1bbd1978-15de82fe4c5dc64b-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fc329edf1e5d306efbd00b3c91d789e5",
+        "traceparent": "00-f56be1f50577834fab8b30a3b1ae7058-32f315a07d05634e-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a09a55de9a3b85043c57398435a4f806",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -572,57 +1052,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "99448baf-aba9-4616-abae-30148e2ac0e2",
+        "apim-request-id": "d1fcd664-4f99-48d4-a63d-066e2fd734d8",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:32 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "99448baf-aba9-4616-abae-30148e2ac0e2"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f44303c84cca960760c407d5520c2802",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e4c345f2-ccd8-40ee-8a33-5c53c9e3d5ab",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:32 GMT",
-        "ETag": "\u002203087087DE0246344CE44AF9C16D0B8A978C32CA2BAF3594FD8BFC86DD70FDDB\u0022",
-        "Retry-After": "1",
+        "Date": "Thu, 26 Aug 2021 12:44:38 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cd6120f3-d39b-4f81-93d5-b1209eebc609",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d1fcd664-4f99-48d4-a63d-066e2fd734d8"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cd6120f3-d39b-4f81-93d5-b1209eebc609",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "74e256d90c7bb4b533317370e28442dc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fb960dda-89ce-4245-b0c5-33271f280fa7",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:38 GMT",
+        "ETag": "\u00226BCBA8BFCF02C36763F3EE59D20A00A1CE758B311317310C7B20B2CD05BB48B5\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e4c345f2-ccd8-40ee-8a33-5c53c9e3d5ab"
+        "X-RequestId": "fb960dda-89ce-4245-b0c5-33271f280fa7"
       },
       "ResponseBody": {
-        "id": "b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-        "createdDateTimeUtc": "2021-08-04T20:31:32.7483449Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:32.7483454Z",
+        "id": "cd6120f3-d39b-4f81-93d5-b1209eebc609",
+        "createdDateTimeUtc": "2021-08-26T12:44:38.5585231Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:38.5585235Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -636,74 +1116,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cd6120f3-d39b-4f81-93d5-b1209eebc609",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "82be31f2b11e4c67c07ddab6b4e3e219",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ef566061c1b770d4a142b8c0d355476e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f562335a-ac0a-4652-b108-4ae5db02a458",
+        "apim-request-id": "7f1ae83c-33b9-48b7-a29a-f4b3dbf9f264",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:33 GMT",
-        "ETag": "\u002289FB334EF3896A688E7727D1C40ED407B06527B0F4DC7BCAF4817CC319BAC31F\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f562335a-ac0a-4652-b108-4ae5db02a458"
-      },
-      "ResponseBody": {
-        "id": "b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-        "createdDateTimeUtc": "2021-08-04T20:31:32.7483449Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:34.1688642Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bff79589e2539237969c9c981799deee",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "69f6c8c7-d7de-4e18-b67b-e603971ea282",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:35 GMT",
-        "ETag": "\u0022D6D2FCF726AD008E7E3A21EA1591D5645F35B99002A8638BDFA31999A66ABAB1\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:39 GMT",
+        "ETag": "\u00229BE58A88CC62E54D8A653DFE80164B9DC9736B3BF46A6C139DFCA4C36315A747\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -713,60 +1145,108 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "69f6c8c7-d7de-4e18-b67b-e603971ea282"
+        "X-RequestId": "7f1ae83c-33b9-48b7-a29a-f4b3dbf9f264"
       },
       "ResponseBody": {
-        "id": "b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-        "createdDateTimeUtc": "2021-08-04T20:31:32.7483449Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:34.465173Z",
-        "status": "Running",
+        "id": "cd6120f3-d39b-4f81-93d5-b1209eebc609",
+        "createdDateTimeUtc": "2021-08-26T12:44:38.5585231Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:39.1248585Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cd6120f3-d39b-4f81-93d5-b1209eebc609",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "604a08a7061917c69cf7344d7250e17c",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c6844cd8f32fd110a0e66c092694a2b7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7f534b3f-8395-4306-963d-0dbb9335275a",
+        "apim-request-id": "01e608cf-ae85-4e80-9727-44f394c06f08",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:36 GMT",
-        "ETag": "\u0022D6D2FCF726AD008E7E3A21EA1591D5645F35B99002A8638BDFA31999A66ABAB1\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:41 GMT",
+        "ETag": "\u00229BE58A88CC62E54D8A653DFE80164B9DC9736B3BF46A6C139DFCA4C36315A747\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7f534b3f-8395-4306-963d-0dbb9335275a"
+        "X-RequestId": "01e608cf-ae85-4e80-9727-44f394c06f08"
       },
       "ResponseBody": {
-        "id": "b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-        "createdDateTimeUtc": "2021-08-04T20:31:32.7483449Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:34.465173Z",
+        "id": "cd6120f3-d39b-4f81-93d5-b1209eebc609",
+        "createdDateTimeUtc": "2021-08-26T12:44:38.5585231Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:39.1248585Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cd6120f3-d39b-4f81-93d5-b1209eebc609",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d5235c15084e184f8172d33854f5e0de",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8ad97a71-5400-4431-b364-7ba5145894ce",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Length": "288",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:42 GMT",
+        "ETag": "\u00223550A4A010FF904E8661A302F0A3F214A345CCF085B7DD975CCBCD5983B6BC57\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "8ad97a71-5400-4431-b364-7ba5145894ce"
+      },
+      "ResponseBody": {
+        "id": "cd6120f3-d39b-4f81-93d5-b1209eebc609",
+        "createdDateTimeUtc": "2021-08-26T12:44:38.5585231Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:42.493729Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -780,26 +1260,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cd6120f3-d39b-4f81-93d5-b1209eebc609",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bc4beee169150faff92beb8215ce3527",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "959705ea7c006ead4f844fd154ca490d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "03887bec-3b94-4ffb-b8f0-2332f216cb07",
+        "apim-request-id": "63dcbe8f-7a37-4824-ba41-02d9c7c549e9",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:37 GMT",
-        "ETag": "\u0022D6D2FCF726AD008E7E3A21EA1591D5645F35B99002A8638BDFA31999A66ABAB1\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:43 GMT",
+        "ETag": "\u00223550A4A010FF904E8661A302F0A3F214A345CCF085B7DD975CCBCD5983B6BC57\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "63dcbe8f-7a37-4824-ba41-02d9c7c549e9"
+      },
+      "ResponseBody": {
+        "id": "cd6120f3-d39b-4f81-93d5-b1209eebc609",
+        "createdDateTimeUtc": "2021-08-26T12:44:38.5585231Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:42.493729Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cd6120f3-d39b-4f81-93d5-b1209eebc609",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "77aa009f7132cf1ffd6c44bc1fd77daa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1dd902b3-5de4-462a-bc88-cc677b0af71a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:44 GMT",
+        "ETag": "\u0022843A027628EAC2D80B595365873A3C6CF238420533D5DB367D4D2AA35BA4EB9C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -809,60 +1337,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "03887bec-3b94-4ffb-b8f0-2332f216cb07"
+        "X-RequestId": "1dd902b3-5de4-462a-bc88-cc677b0af71a"
       },
       "ResponseBody": {
-        "id": "b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-        "createdDateTimeUtc": "2021-08-04T20:31:32.7483449Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:34.465173Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ac0fec9e829982ffcfe0235caeea2045",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f7e7ca41-c052-46be-a835-4207d02004ae",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:38 GMT",
-        "ETag": "\u0022A7A180F423E80F456D98FE6F7EF720E62A2B8B32381EE08B3B73A28248BB6255\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f7e7ca41-c052-46be-a835-4207d02004ae"
-      },
-      "ResponseBody": {
-        "id": "b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-        "createdDateTimeUtc": "2021-08-04T20:31:32.7483449Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:34.465173Z",
+        "id": "cd6120f3-d39b-4f81-93d5-b1209eebc609",
+        "createdDateTimeUtc": "2021-08-26T12:44:38.5585231Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:44:44.32701Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -876,26 +1356,75 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b47a1878-eba6-4fd1-bd91-28a8278dc7c9/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cd6120f3-d39b-4f81-93d5-b1209eebc609/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "28b61fba224d3ed9593a66ed1a4302cd",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "211e8e050dfc99b7aeb485c9b97dc3b7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9bc98302-4a2d-4060-95ec-1cebd3a39e86",
+        "apim-request-id": "2655e0cb-3beb-415a-8bdb-f826dfd5f46f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:39 GMT",
-        "ETag": "\u0022C0944F0DC8BB42EEB13B3633AD1BE3E8C943D5724484A05AA7359E734F0F4783\u0022",
+        "Date": "Thu, 26 Aug 2021 12:44:44 GMT",
+        "ETag": "\u0022E3ACB37DB90D06CA7A9505B787BC8EFEDBE7D8C78A777B2E68E669818BF9562E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2655e0cb-3beb-415a-8bdb-f826dfd5f46f"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1788105743/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1584166319/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:44:41.9517241Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:44:44.3270027Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b468e-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b52d91add247d547b0bdc01667897e10-98dbee2bb8086e49-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5399c528694a79ace5c7989337f14e78",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4b1cb9d8-618b-4e52-af8a-5100793ac9d4",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:44:45 GMT",
+        "ETag": "\u002279B8C8F5B401DAE6A94ED2753889C75C027D3A730D61C8218DF4558EF21F0A1B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -905,63 +1434,14 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9bc98302-4a2d-4060-95ec-1cebd3a39e86"
+        "X-RequestId": "4b1cb9d8-618b-4e52-af8a-5100793ac9d4"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target578180804/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1584166319/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:31:34.1784213Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:38.4374088Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000a53ed-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=7577037f-17ab-4851-b00c-08c9990ab365\u0026statuses=\u0026$orderBy=",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8af2767da9940e4bbc3f00320aed3196-8851cfed1dcded43-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "86ae0dc135415ee3eec9ec344552610f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "476852d9-f722-48dc-ac01-6dbf09fffe17",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:39 GMT",
-        "ETag": "\u002237050D9623C5C7386E19F240E09515B38E6F9DD3521F078B7112518AF2395C71\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "476852d9-f722-48dc-ac01-6dbf09fffe17"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-            "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:28.2809993Z",
+            "id": "51158dc0-bdf2-4ddf-810b-0cc78ed7ae1c",
+            "createdDateTimeUtc": "2021-08-26T12:44:17.7817008Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:44:37.1925872Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -979,8 +1459,8 @@
   ],
   "Variables": {
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
     "RandomSeed": "41321183"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1645503099?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1645503099?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-e3a33d827dacbf448b383f5834b607d9-1069a72ff134774e-00",
+        "traceparent": "00-ed9ba83903b12249b67bc7f0966ef511-b479c85b12fa464b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "2b5ca98ba7f97f0c2fd02a5e1fe6bfea",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:48 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:36 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:48 GMT",
-        "ETag": "\u00220x8D957869B371396\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:49 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:36 GMT",
+        "ETag": "\u00220x8D967D38268A57B\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:37 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "2b5ca98ba7f97f0c2fd02a5e1fe6bfea",
-        "x-ms-request-id": "05275f7e-a01e-003b-1e6f-896135000000",
+        "x-ms-request-id": "df48313e-c01e-002d-13bc-998fec000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1645503099/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1645503099/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-a96b4e4a1fd3cf4e9ab967091f7e4997-3b67e51ca32cb445-00",
+        "traceparent": "00-a0e13cc0bb2cd4469f2ac93c52d635de-874c2adbaca5bb4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "eda9eea294921abdf9af6b33aa3b2f62",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:48 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:48 GMT",
-        "ETag": "\u00220x8D957869B8703C2\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:49 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:37 GMT",
+        "ETag": "\u00220x8D967D382A060F5\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:37 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "eda9eea294921abdf9af6b33aa3b2f62",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05276000-a01e-003b-156f-896135000000",
+        "x-ms-request-id": "df48319a-c01e-002d-67bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target674250945?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target674250945?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1cf393c11f832749ad29d24ad56f89bf-9b873b48377cab4f-00",
+        "traceparent": "00-406ffbaee9dc3d4caa1ddee59af8b08f-8010ecae5cd9774b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "af5b0476616d7386c743a460107b73de",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:49 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:38 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:49 GMT",
-        "ETag": "\u00220x8D957869BACF521\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:49 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:37 GMT",
+        "ETag": "\u00220x8D967D382B7E582\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:37 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "af5b0476616d7386c743a460107b73de",
-        "x-ms-request-id": "052760ac-a01e-003b-356f-896135000000",
+        "x-ms-request-id": "df483214-c01e-002d-55bc-998fec000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cb999dd20e0bb34884f540be53ef01b2-63e707ff3037694f-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ce81540c934f3c4baccd6dda8d8c415b-97aa29f715cc824a-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "5ea6d7e0e988ecf741314a3cd8d4f4a1",
         "x-ms-return-client-request-id": "true"
       },
@@ -116,57 +116,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b150ceaf-41e6-4281-92a7-c04f8a429b7b",
+        "apim-request-id": "cda705f6-5c0c-4cd2-820d-49c5387179c1",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:50 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
+        "Date": "Wed, 25 Aug 2021 14:20:39 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b150ceaf-41e6-4281-92a7-c04f8a429b7b"
+        "X-RequestId": "cda705f6-5c0c-4cd2-820d-49c5387179c1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "e1a89dc73a638c35237acb5018bae833",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "09165f26-e680-4764-994c-cacf6ddecb19",
+        "apim-request-id": "4cb2f053-8e10-45e7-a2f8-44576820dd94",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:50 GMT",
-        "ETag": "\u0022CBD286A126EC21D3BF27AE8E9C11357D29280644D8982277D811037F9FEA35FC\u0022",
+        "Date": "Wed, 25 Aug 2021 14:20:39 GMT",
+        "ETag": "\u0022CAD4F81BEDA96BF14F578FB635059897322687E6CFD664C428834D751833C51B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "09165f26-e680-4764-994c-cacf6ddecb19"
+        "X-RequestId": "4cb2f053-8e10-45e7-a2f8-44576820dd94"
       },
       "ResponseBody": {
-        "id": "4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-        "createdDateTimeUtc": "2021-08-04T20:29:50.3509191Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:50.3509194Z",
+        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
+        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:20:39.3312147Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,122 +180,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "64ca55f703888c380d6f6e3b17499bf2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7c2f7c1a-01cf-4177-bb7e-bbc21e8ccb52",
+        "apim-request-id": "3d1f1ff9-82ad-48ef-9e96-083b8474ed68",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:51 GMT",
-        "ETag": "\u00226B2B13A1E0A90B4068623A47A90CDF0BFECD9CC9B4C103875B52A083EBA43718\u0022",
+        "Date": "Wed, 25 Aug 2021 14:20:40 GMT",
+        "ETag": "\u00224375061DCB1161201E42637FF340A0F5B6BC96FF3B1B590CD59CD58CE332C547\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7c2f7c1a-01cf-4177-bb7e-bbc21e8ccb52"
+        "X-RequestId": "3d1f1ff9-82ad-48ef-9e96-083b8474ed68"
       },
       "ResponseBody": {
-        "id": "4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-        "createdDateTimeUtc": "2021-08-04T20:29:50.3509191Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:51.8150261Z",
-        "status": "Running",
+        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
+        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:20:39.9936125Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "7398034f91d3a57aa1193b0e1ea6d486",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "09462a44-707b-4a90-95a3-6b5ad872f758",
+        "apim-request-id": "3943d06e-3dab-45f2-97f3-7ccae6152474",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:52 GMT",
-        "ETag": "\u00226B2B13A1E0A90B4068623A47A90CDF0BFECD9CC9B4C103875B52A083EBA43718\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "09462a44-707b-4a90-95a3-6b5ad872f758"
-      },
-      "ResponseBody": {
-        "id": "4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-        "createdDateTimeUtc": "2021-08-04T20:29:50.3509191Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:51.8150261Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "824417498f0ac318641bd3f3ccfa75da",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "53470df1-b3a0-4672-bb85-800e7a872e7c",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:53 GMT",
-        "ETag": "\u00226B2B13A1E0A90B4068623A47A90CDF0BFECD9CC9B4C103875B52A083EBA43718\u0022",
+        "Date": "Wed, 25 Aug 2021 14:20:42 GMT",
+        "ETag": "\u00224375061DCB1161201E42637FF340A0F5B6BC96FF3B1B590CD59CD58CE332C547\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -305,12 +257,60 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "53470df1-b3a0-4672-bb85-800e7a872e7c"
+        "X-RequestId": "3943d06e-3dab-45f2-97f3-7ccae6152474"
       },
       "ResponseBody": {
-        "id": "4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-        "createdDateTimeUtc": "2021-08-04T20:29:50.3509191Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:51.8150261Z",
+        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
+        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:20:39.9936125Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "824417498f0ac318641bd3f3ccfa75da",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f4910b74-4b92-4736-b8fe-26fcfe502bba",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:20:43 GMT",
+        "ETag": "\u00221AE52BDDD83D396BEBE64C09F3E082064985AA0291C08D4089B557847C2C0265\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f4910b74-4b92-4736-b8fe-26fcfe502bba"
+      },
+      "ResponseBody": {
+        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
+        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:20:42.8285102Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -324,41 +324,89 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "1401d8df7521665fda25c26fc82a6e66",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7cb2258b-1c69-4e4d-9214-80a1af9a4559",
+        "apim-request-id": "c5e07781-f815-4ae0-8754-849d4b3bfa8c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:55 GMT",
-        "ETag": "\u0022D0E904A644BA01AB3B28C518B07DE8AD29343673EB9DAE68BBC9EFF9BFA3D168\u0022",
+        "Date": "Wed, 25 Aug 2021 14:20:44 GMT",
+        "ETag": "\u002261ABD5964916BC6E1FF052BA8DF56D7038A48F86D4334FF41054DDA4F5D0F177\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7cb2258b-1c69-4e4d-9214-80a1af9a4559"
+        "X-RequestId": "c5e07781-f815-4ae0-8754-849d4b3bfa8c"
       },
       "ResponseBody": {
-        "id": "4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-        "createdDateTimeUtc": "2021-08-04T20:29:50.3509191Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:29:51.8150261Z",
+        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
+        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:20:43.5536361Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fff2e79b1804bfe7ebd50eb7be86d8a7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ec26b51d-39f6-4f92-99ae-ff8bf891c2ce",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:20:45 GMT",
+        "ETag": "\u00220E731382223635D905628CB1152BB847744F8928927228CCC33A6C0B4A3D1D21\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ec26b51d-39f6-4f92-99ae-ff8bf891c2ce"
+      },
+      "ResponseBody": {
+        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
+        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:20:45.9490476Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -372,26 +420,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4d28332b-55aa-4fe2-bc8d-221c43ab0c79/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fff2e79b1804bfe7ebd50eb7be86d8a7",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "452e61a3bfa5d365b7dea7e5cda9fb3a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d0b7c8f8-d3d2-4c1a-97fe-9d678627c4f5",
+        "apim-request-id": "ab44f55a-ad15-4d74-aebf-0b918db4e7fa",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:29:55 GMT",
-        "ETag": "\u0022C1A1CA685B1CD64A8C130B0F6A933A9AFB04F7D683AF9975A625301600C9E8D5\u0022",
+        "Date": "Wed, 25 Aug 2021 14:20:46 GMT",
+        "ETag": "\u0022BF7BF56592EF056DA2488E3801AA5385F06411468A8F6B82C3EE4FA2BD52CDEA\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -401,34 +449,34 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d0b7c8f8-d3d2-4c1a-97fe-9d678627c4f5"
+        "X-RequestId": "ab44f55a-ad15-4d74-aebf-0b918db4e7fa"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target674250945/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1645503099/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:29:51.5678408Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:55.0842895Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target674250945/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1645503099/File_0.txt",
+            "createdDateTimeUtc": "2021-08-25T14:20:42.8495809Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:20:45.9490415Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53d0-0000-0000-0000-000000000000",
+            "id": "000b44b9-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-9dca28919598be42a45fb11a66d89548-03b54a9a5e526a4f-00",
+        "traceparent": "00-bf03564a30e35d4ba69b89ad0f6245d9-ab09ff8ef8caa145-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "a5452e6165bfb7d3dea7e5cda9fb3aad",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:55 GMT",
+        "x-ms-client-request-id": "08e4586dd576f1c641294c66a8a7534c",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -436,60 +484,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:29:55 GMT",
-        "ETag": "\u00220x8D957869F6D1B6C\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:56 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:45 GMT",
+        "ETag": "\u00220x8D967D387D6F507\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "a5452e6165bfb7d3dea7e5cda9fb3aad",
-        "x-ms-request-id": "05276a7d-a01e-003b-596f-896135000000",
+        "x-ms-client-request-id": "08e4586dd576f1c641294c66a8a7534c",
+        "x-ms-request-id": "df4844f1-c01e-002d-12bc-998fec000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-37a5d898ddec0649b0f28fd46939d112-f0ea2142faaa8346-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "08e4586dd576f1c641294c66a8a7534c",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:55 GMT",
-        "x-ms-return-client-request-id": "true",
-        "x-ms-version": "2020-04-08"
-      },
-      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
-      "StatusCode": 201,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:55 GMT",
-        "ETag": "\u00220x8D957869FB5B77B\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:56 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "08e4586dd576f1c641294c66a8a7534c",
-        "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05276ac9-a01e-003b-1a6f-896135000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2020-04-08"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_1.txt",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "Content-Length": "16",
-        "If-None-Match": "*",
-        "traceparent": "00-3ea1c34401f7834bace39b0735693568-d9cc893aed3b1b47-00",
+        "traceparent": "00-37b9e911d2123041b5be1d1709b6d9d6-ffd1cd91ae699744-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "fb67cb1ac02881db1e47257102f142d9",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:56 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -498,30 +514,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:56 GMT",
-        "ETag": "\u00220x8D957869FFE3F3F\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:57 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:46 GMT",
+        "ETag": "\u00220x8D967D388033D56\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "fb67cb1ac02881db1e47257102f142d9",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05276b7e-a01e-003b-2f6f-896135000000",
+        "x-ms-request-id": "df48454f-c01e-002d-6abc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_2.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-8016f339688820439f168cf6d51262c7-4848a3298e6f044f-00",
+        "traceparent": "00-b76c2eb1d066db47b3c10e63ac456128-e86dc78f8e9b5d47-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "2e5109d49ff48b2d67546496196c0f37",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:56 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -530,30 +546,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:56 GMT",
-        "ETag": "\u00220x8D95786A04678DF\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:57 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:46 GMT",
+        "ETag": "\u00220x8D967D3882FD3CB\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:47 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "2e5109d49ff48b2d67546496196c0f37",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05276c8a-a01e-003b-066f-896135000000",
+        "x-ms-request-id": "df4845d2-c01e-002d-56bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_3.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_2.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c08cb68e731cb34ca66791d5d57c9652-68139babbe44f549-00",
+        "traceparent": "00-258edb6f3a0dca43810d8a8a01d0b043-4d9c290a4f714647-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ddb299533e94ac847d62e92eb055ef4f",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:57 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -562,30 +578,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:57 GMT",
-        "ETag": "\u00220x8D95786A08E8B6E\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:58 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:46 GMT",
+        "ETag": "\u00220x8D967D3885B7FC7\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:47 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "ddb299533e94ac847d62e92eb055ef4f",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05276d91-a01e-003b-6e6f-896135000000",
+        "x-ms-request-id": "df484671-c01e-002d-66bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_4.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_3.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-0e8af15022165a4094f3bd0ebf43b459-498523983dfa0f4b-00",
+        "traceparent": "00-cf869a1d7f94da489d4ddc54e5831e4b-82eab6b170760e42-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "9e9272e625567b589ddc94d45c4568b1",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:57 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:48 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -594,30 +610,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:57 GMT",
-        "ETag": "\u00220x8D95786A0D76165\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:58 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "ETag": "\u00220x8D967D388872BD0\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:47 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "9e9272e625567b589ddc94d45c4568b1",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05276e7f-a01e-003b-2b6f-896135000000",
+        "x-ms-request-id": "df484710-c01e-002d-6bbc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_5.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_4.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-572f015adea9a047a220416ebcdb139f-5440ae558ac91b49-00",
+        "traceparent": "00-d62b1d50fabfba4d923a3a52b6f935e1-77cecdd6be7a9a40-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "681dee38643f964585a5b091b5ffda12",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:58 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:48 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -626,30 +642,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:58 GMT",
-        "ETag": "\u00220x8D95786A1205E72\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:59 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "ETag": "\u00220x8D967D388B37416\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:47 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "681dee38643f964585a5b091b5ffda12",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05276f50-a01e-003b-656f-896135000000",
+        "x-ms-request-id": "df4847de-c01e-002d-20bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_6.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_5.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-d2cc11ad9ad9474fac6e511558ddf111-af8f386783e69e4c-00",
+        "traceparent": "00-79ea4be74890cb41895431cbdf9cc532-25e3103c368af84d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "a7af146570da2de0413640b7aaaf4f38",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:58 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:48 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -658,30 +674,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:58 GMT",
-        "ETag": "\u00220x8D95786A168980D\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:59 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "ETag": "\u00220x8D967D388DF6E36\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:48 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "a7af146570da2de0413640b7aaaf4f38",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05277000-a01e-003b-7b6f-896135000000",
+        "x-ms-request-id": "df484869-c01e-002d-20bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_7.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_6.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-3f5db83da4845b4db8b7dd26a6458b82-4c5be830bd99af40-00",
+        "traceparent": "00-8e2c495514082d468c91781b69545f95-cc461ec41df63949-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "c1f537fa863782102cfc19b175c6c69e",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:59 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -690,30 +706,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:59 GMT",
-        "ETag": "\u00220x8D95786A1B20A65\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:29:59 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "ETag": "\u00220x8D967D3890EEB6E\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:48 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "c1f537fa863782102cfc19b175c6c69e",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052770fc-a01e-003b-546f-896135000000",
+        "x-ms-request-id": "df4848f0-c01e-002d-1fbc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_8.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_7.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-dfde9e667674de4393231bc4bd4ef3f8-09da09aed5f91548-00",
+        "traceparent": "00-0fef92ef1913244884223a24190f8007-b893e5e195720346-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "486f8101c195c8d70def2708248eebd5",
-        "x-ms-date": "Wed, 04 Aug 2021 20:29:59 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -722,30 +738,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:29:59 GMT",
-        "ETag": "\u00220x8D95786A1FB7CB8\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:00 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "ETag": "\u00220x8D967D3893A9760\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:48 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "486f8101c195c8d70def2708248eebd5",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052771c0-a01e-003b-7d6f-896135000000",
+        "x-ms-request-id": "df48496f-c01e-002d-10bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_9.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_8.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-37f369189e77bd4ab798c2286abae088-14773bceee05224b-00",
+        "traceparent": "00-80c2a0862a576e41bfed07b29ff7a415-527cc868f61ec548-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "7d9778551809deda032c7add562fb87a",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:00 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -754,30 +770,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:00 GMT",
-        "ETag": "\u00220x8D95786A24452B0\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:00 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "ETag": "\u00220x8D967D389666A4D\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:49 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "7d9778551809deda032c7add562fb87a",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0527727d-a01e-003b-176f-896135000000",
+        "x-ms-request-id": "df484a0b-c01e-002d-1fbc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_10.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_9.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-bd33f66f38f31642b90f7cc515018290-b5f28ae6a2948645-00",
+        "traceparent": "00-ef875c90be551c43bc95dcd776c6e963-7efad2c5ff64c043-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "28b6a170063f39a25f2db3485e085e9e",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:00 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -786,30 +802,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:00 GMT",
-        "ETag": "\u00220x8D95786A28DEC21\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:01 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "ETag": "\u00220x8D967D38991EF33\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:49 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "28b6a170063f39a25f2db3485e085e9e",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0527733f-a01e-003b-3a6f-896135000000",
+        "x-ms-request-id": "df484a99-c01e-002d-22bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_11.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_10.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c6dbd1d315b6ac4bad1f293b9a410f03-b7dde86fce8ef044-00",
+        "traceparent": "00-377ca7ebc108384c9bdd4f88a6df0552-f701eb713308a748-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "fc5b4310482fe895a790456846fa71de",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:01 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -818,30 +834,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:01 GMT",
-        "ETag": "\u00220x8D95786A2D6E936\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:01 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "ETag": "\u00220x8D967D389C47A20\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:49 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "fc5b4310482fe895a790456846fa71de",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052773fe-a01e-003b-616f-896135000000",
+        "x-ms-request-id": "df484b17-c01e-002d-14bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_12.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_11.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-5c21669e0ba2214ca2a1744551e754d4-949248dfbb9a7e44-00",
+        "traceparent": "00-da3b6a7a447cfe428f2e3066faea3123-7b1e0623f7183140-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "8297ad37c3d74f95d55d1ddc649280fa",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:01 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -850,30 +866,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:01 GMT",
-        "ETag": "\u00220x8D95786A3371BF4\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:02 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "ETag": "\u00220x8D967D389F09B4D\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:49 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "8297ad37c3d74f95d55d1ddc649280fa",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052774fb-a01e-003b-3f6f-896135000000",
+        "x-ms-request-id": "df484b97-c01e-002d-0cbc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_13.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_12.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-72ddae1cfa49b14aa4f548fe185fb668-8d1747df7bc31f40-00",
+        "traceparent": "00-c5708e21d044314ca7944a1cc814cd4d-791774dc1fa86948-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "13ccdccebbd3274a0ccd81afc13af365",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:02 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -882,30 +898,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:02 GMT",
-        "ETag": "\u00220x8D95786A37F0765\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:02 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "ETag": "\u00220x8D967D38A1D0AA8\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "13ccdccebbd3274a0ccd81afc13af365",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052775c3-a01e-003b-656f-896135000000",
+        "x-ms-request-id": "df484c22-c01e-002d-0ebc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_14.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_13.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-5ae73775c561c546afc7867937799b0c-47ba92bbc6947342-00",
+        "traceparent": "00-dccc1f01e0fbab48a78dde7e325a919e-1bda73ed1b51a04c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "b110d5bbdc704cc6ae0c27d22bb88314",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:02 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -914,30 +930,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:02 GMT",
-        "ETag": "\u00220x8D95786A3C7B643\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:03 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "ETag": "\u00220x8D967D38A48B696\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "b110d5bbdc704cc6ae0c27d22bb88314",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0527769c-a01e-003b-2c6f-896135000000",
+        "x-ms-request-id": "df484ca6-c01e-002d-06bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_15.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_14.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-26eb5c62a8776140848d70f78a626b16-b10299fd3203c64b-00",
+        "traceparent": "00-10074d9eb5c94e449b04d032cdffb754-0652c4a3c458244d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "699a4a105e2d7c0b6270750a42e68d9b",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:03 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -946,30 +962,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:03 GMT",
-        "ETag": "\u00220x8D95786A40FEFE7\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:03 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "ETag": "\u00220x8D967D38A7A7E24\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "699a4a105e2d7c0b6270750a42e68d9b",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05277773-a01e-003b-606f-896135000000",
+        "x-ms-request-id": "df484d46-c01e-002d-14bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_16.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_15.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-981bdc59ce864049b364eecd7f3c2e61-9bb79a3ef69add4f-00",
+        "traceparent": "00-09983a2ac27a7f4da3ff6501d7bc8bd2-e50512593464f146-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "8f20b86ace81f289158064c79378fc53",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:03 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -978,30 +994,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:03 GMT",
-        "ETag": "\u00220x8D95786A45877AC\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:04 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "ETag": "\u00220x8D967D38AA6511E\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:51 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "8f20b86ace81f289158064c79378fc53",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05277841-a01e-003b-136f-896135000000",
+        "x-ms-request-id": "df484e06-c01e-002d-41bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_17.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_16.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-826b06177951894695966d32b4826138-38ee217d50f2804d-00",
+        "traceparent": "00-58f0496d6272c048962b90244d344c73-8e7fd36fd697e84e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "769e6c49899f5c38ca944e0066bc0ac7",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:04 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1010,30 +1026,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:04 GMT",
-        "ETag": "\u00220x8D95786A4A0631D\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:04 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "ETag": "\u00220x8D967D38AD3AB0D\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:51 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "769e6c49899f5c38ca944e0066bc0ac7",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05277902-a01e-003b-3a6f-896135000000",
+        "x-ms-request-id": "df484ec3-c01e-002d-6dbc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_18.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_17.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-2625c82d2f729646bdd988fa0e058a25-0336329966e09b48-00",
+        "traceparent": "00-2975b06cf2bae54d87e4f86167d1f94f-de47798dbbba3849-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "73678c7ef3974293c1a854adf943e8e9",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:04 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:52 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1042,30 +1058,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:04 GMT",
-        "ETag": "\u00220x8D95786A4E9FC8F\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:05 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "ETag": "\u00220x8D967D38AFFA520\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:51 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "73678c7ef3974293c1a854adf943e8e9",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052779d0-a01e-003b-706f-896135000000",
+        "x-ms-request-id": "df484f99-c01e-002d-36bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1664784547/File_19.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_18.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-031ba0b8eac42d40b9da92dda6aaa9ea-678022fc18c10247-00",
+        "traceparent": "00-70ad958a8ca45b4f9230015cb2705680-03c04b0ef61bb941-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "d6c021741748e1fb7fc4c5ed7f898b59",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:04 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:52 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1074,28 +1090,60 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:05 GMT",
-        "ETag": "\u00220x8D95786A5323625\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:05 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "ETag": "\u00220x8D967D38B2B9F38\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:52 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "d6c021741748e1fb7fc4c5ed7f898b59",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05277a76-a01e-003b-7a6f-896135000000",
+        "x-ms-request-id": "df485014-c01e-002d-24bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1288421237?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_19.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-50c885fdf839514db0dd1d8b3f5af527-c8b550cbf341fc46-00",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-e4717e15d9ea4e45827bc7acc369fdc5-879b3a4b6cd65749-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "07489d75881155bcd85cb5f7358a6386",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "ETag": "\u00220x8D967D38B57E77E\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "07489d75881155bcd85cb5f7358a6386",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "df48509c-c01e-002d-21bc-998fec000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target703350700?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-cf60e27c63c57a46889de4426fb2d747-295e8e05b3208b4a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "1107489dbc88d8555cb5f7358a6386ac",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:05 GMT",
+        "x-ms-client-request-id": "fb448b657e33906785f3d32ea5c2371c",
+        "x-ms-date": "Wed, 25 Aug 2021 14:20:53 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1103,27 +1151,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:05 GMT",
-        "ETag": "\u00220x8D95786A5578AB2\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:06 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "ETag": "\u00220x8D967D38B6E8072\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:20:52 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "1107489dbc88d8555cb5f7358a6386ac",
-        "x-ms-request-id": "05277b4b-a01e-003b-316f-896135000000",
+        "x-ms-client-request-id": "fb448b657e33906785f3d32ea5c2371c",
+        "x-ms-request-id": "df48513d-c01e-002d-37bc-998fec000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-39b191ccae03ae45b6bb1fa1327fb11a-961c35c40c99564a-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fb448b657e33906785f3d32ea5c2371c",
+        "traceparent": "00-6a3c5ba2acd4d54f8be0d2c1e3301204-388baddba632b542-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fb5c37fad8e065eb6afdec6203acf561",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1143,37 +1191,37 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "75bff913-383b-4f72-abcb-d2e6994c8aed",
+        "apim-request-id": "ba669205-a03e-4955-9af8-25ac0aec4ade",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:05 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b6606d70-e903-4f08-a80d-3d1b65c07303",
+        "Date": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c8b61454-5adf-4d70-b81b-5573dcbd5f58",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "75bff913-383b-4f72-abcb-d2e6994c8aed"
+        "X-RequestId": "ba669205-a03e-4955-9af8-25ac0aec4ade"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/b6606d70-e903-4f08-a80d-3d1b65c07303",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c8b61454-5adf-4d70-b81b-5573dcbd5f58",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fb5c37fad8e065eb6afdec6203acf561",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fd1a413f5d471e41e1768b95e8273399",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9a89271f-90a8-4ee8-80db-9be63ac6686a",
+        "apim-request-id": "93b31eb7-9e77-436a-a973-72688c843250",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:06 GMT",
+        "Date": "Wed, 25 Aug 2021 14:20:52 GMT",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1183,12 +1231,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9a89271f-90a8-4ee8-80db-9be63ac6686a"
+        "X-RequestId": "93b31eb7-9e77-436a-a973-72688c843250"
       },
       "ResponseBody": {
-        "id": "b6606d70-e903-4f08-a80d-3d1b65c07303",
-        "createdDateTimeUtc": "2021-08-04T20:30:06.5979195Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:06.8654153Z",
+        "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
+        "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:20:52.9875659Z",
         "status": "Cancelling",
         "summary": {
           "total": 0,
@@ -1202,44 +1250,44 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=Cancelled%2CCancelling\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=c8b61454-5adf-4d70-b81b-5573dcbd5f58\u0026statuses=\u0026$orderBy=",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fd18903660538a4bb35e103b53befca8-b1910da811543444-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fd1a413f5d471e41e1768b95e8273399",
+        "traceparent": "00-f44a378689762542a5a781cd9b540d7e-412fab85e2600c4f-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "533adb7d8a068ccba0de913692048dd9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8511b76c-322c-44d1-950e-5648594f57d9",
+        "apim-request-id": "e3628cda-4eb6-4748-90a2-53d1ab51fb00",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:10 GMT",
-        "ETag": "\u0022247D63C12AE7BC003E85B60943EA939E5A8892AB72E2887400A944BC2C55A12B\u0022",
+        "Date": "Wed, 25 Aug 2021 14:20:57 GMT",
+        "ETag": "\u0022B07DBAB5ED72FFFA07C0D2E4089F63B35A94B87F6D7CE9B2DA3E373E13AF59A4\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8511b76c-322c-44d1-950e-5648594f57d9"
+        "X-RequestId": "e3628cda-4eb6-4748-90a2-53d1ab51fb00"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "b6606d70-e903-4f08-a80d-3d1b65c07303",
-            "createdDateTimeUtc": "2021-08-04T20:30:06.5979195Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:08.9706851Z",
+            "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
+            "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:20:55.9089938Z",
             "status": "Cancelling",
             "summary": {
               "total": 20,
@@ -1250,11 +1298,102 @@
               "cancelled": 0,
               "totalCharacterCharged": 0
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=c8b61454-5adf-4d70-b81b-5573dcbd5f58\u0026statuses=\u0026$orderBy=",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a3d08ffd26237a459d2727727a43f715-dcdd97e06bb79e49-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "64ef72fe39a79dd4f63d1a694d567c43",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ac10e2b3-4789-4d66-ad7f-b52db8c459cd",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:21:03 GMT",
+        "ETag": "\u0022DBC07BC1DBD8BCFFA300D700B4CAF66260409BDAE36DE2A887AE5295A58041DF\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ac10e2b3-4789-4d66-ad7f-b52db8c459cd"
+      },
+      "ResponseBody": {
+        "value": [
           {
-            "id": "98452bfa-797a-44c2-9bb2-d7fd159fab0d",
-            "createdDateTimeUtc": "2021-08-03T21:38:51.6547083Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:54.3057302Z",
+            "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
+            "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:20:58.7274706Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=Cancelled%2CCancelling\u0026$orderBy=",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1c791182096bfc41a3bf474eeb4263d0-713f0baad1c47140-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "28e452caa171b45a758d5d68cc0b8bdc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2e8029d5-d909-487f-b5f4-34f2144dc010",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:21:03 GMT",
+        "ETag": "\u0022C5CB861F2A8689254FBF79DDF93D13B28053A90B3AECDE88D1FF8A47E6B88B5B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2e8029d5-d909-487f-b5f4-34f2144dc010"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
+            "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:20:58.7274706Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1267,9 +1406,9 @@
             }
           },
           {
-            "id": "32aebb1f-9dd9-4bf4-a684-514bde841fd8",
-            "createdDateTimeUtc": "2021-08-03T21:38:47.6125244Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:53.9775319Z",
+            "id": "253d9f25-18d2-4cc7-8669-4d8407b22a9c",
+            "createdDateTimeUtc": "2021-08-25T14:19:05.8329604Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:19:10.6795351Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1282,9 +1421,9 @@
             }
           },
           {
-            "id": "6c30daea-f0dc-45d2-a5f2-c9c9ca5c454d",
-            "createdDateTimeUtc": "2021-08-03T21:33:40.0877854Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:42.98622Z",
+            "id": "60db663e-f771-4adb-b08f-6854b85696e1",
+            "createdDateTimeUtc": "2021-08-25T14:18:43.8946636Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:18:51.4148389Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1297,9 +1436,9 @@
             }
           },
           {
-            "id": "06da1349-40ca-40a9-bcbc-bd1e846f3b88",
-            "createdDateTimeUtc": "2021-08-03T21:33:35.9538097Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:38.6215767Z",
+            "id": "5acc56a1-33c3-4542-9370-5f7b9b19f5ab",
+            "createdDateTimeUtc": "2021-08-25T14:15:39.7803188Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:15:43.1246356Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1312,9 +1451,9 @@
             }
           },
           {
-            "id": "ff9490ff-1a22-4905-b300-f832c622fcd3",
-            "createdDateTimeUtc": "2021-08-03T21:14:52.4456431Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:55.1385001Z",
+            "id": "2597203e-1311-41c4-886f-f465cd164759",
+            "createdDateTimeUtc": "2021-08-25T14:15:19.2437991Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:15:23.9402734Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1327,9 +1466,9 @@
             }
           },
           {
-            "id": "a291a37f-00ff-462c-90f7-af30487cfee0",
-            "createdDateTimeUtc": "2021-08-03T21:14:47.8001603Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:52.8849738Z",
+            "id": "f4b9df36-266a-40d0-ba29-fc0e67dd4887",
+            "createdDateTimeUtc": "2021-08-25T14:14:35.4257961Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:14:41.4038969Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1342,9 +1481,9 @@
             }
           },
           {
-            "id": "35491096-d4b6-4f64-a475-3a8f425bda13",
-            "createdDateTimeUtc": "2021-08-02T16:24:08.8499137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:13.2168149Z",
+            "id": "a5c6c285-da24-494d-a971-919266469088",
+            "createdDateTimeUtc": "2021-08-25T14:14:14.5070628Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:14:19.0578249Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1357,9 +1496,9 @@
             }
           },
           {
-            "id": "d6516cd6-00bc-4dd4-81e0-ac3531a9ef9a",
-            "createdDateTimeUtc": "2021-08-02T16:24:04.9124096Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:09.2033129Z",
+            "id": "533c3361-dfbe-4bd2-a517-9491e071775a",
+            "createdDateTimeUtc": "2021-08-25T14:13:34.7214701Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:13:39.5494326Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1372,9 +1511,9 @@
             }
           },
           {
-            "id": "ec3e1c4c-3509-4f5a-86ee-3be559f978cf",
-            "createdDateTimeUtc": "2021-08-02T16:17:43.4479159Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:46.1484498Z",
+            "id": "a23b53f3-ed01-458b-947e-867a553eb591",
+            "createdDateTimeUtc": "2021-08-25T14:13:13.8939951Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:13:19.2252019Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1387,9 +1526,9 @@
             }
           },
           {
-            "id": "cd18395a-adb6-4566-a35d-4b7394ce7e7c",
-            "createdDateTimeUtc": "2021-08-02T16:17:39.2236317Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:42.3718498Z",
+            "id": "0d4b8b20-a460-469a-b3aa-588300fef2e0",
+            "createdDateTimeUtc": "2021-08-25T14:08:25.2665312Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:08:32.3285477Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1402,9 +1541,9 @@
             }
           },
           {
-            "id": "3e9a5d00-90d9-4256-9d62-f1dfa1577da0",
-            "createdDateTimeUtc": "2021-08-01T16:20:07.4673305Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:13.4203616Z",
+            "id": "2aecc1c5-d3da-45b9-93c5-d2a260d6aedf",
+            "createdDateTimeUtc": "2021-08-25T14:08:02.4909754Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:08:06.9807983Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1417,9 +1556,9 @@
             }
           },
           {
-            "id": "fc266ece-821c-4ad7-9448-1813652fd6ec",
-            "createdDateTimeUtc": "2021-08-01T16:20:03.3145089Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:12.698585Z",
+            "id": "b0607637-8b27-4120-8b39-6194b5755e92",
+            "createdDateTimeUtc": "2021-08-25T14:06:09.5993734Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:06:14.8816421Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1432,9 +1571,9 @@
             }
           },
           {
-            "id": "9d74505c-4ec7-4849-a25e-347c9ca83531",
-            "createdDateTimeUtc": "2021-08-01T16:19:14.3845766Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:19.1001524Z",
+            "id": "b7f3c08a-c2c0-4228-9f8a-c92be3b7737d",
+            "createdDateTimeUtc": "2021-08-25T14:05:44.5683358Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:05:49.4108643Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1447,9 +1586,1917 @@
             }
           },
           {
-            "id": "5263795e-4551-4f48-94da-32a53c735650",
-            "createdDateTimeUtc": "2021-08-01T16:19:10.3372901Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:18.7374885Z",
+            "id": "0d5c55f5-91e2-4d2f-88f8-9c7ae1de5505",
+            "createdDateTimeUtc": "2021-08-25T14:05:07.8586943Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:05:11.277379Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b4f56a1c-3b5d-42a2-a94e-1c949dfe776f",
+            "createdDateTimeUtc": "2021-08-25T14:04:41.9246386Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:04:48.5055613Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ff62a2bd-4c6f-47e8-b557-f429dd7e6f3a",
+            "createdDateTimeUtc": "2021-08-25T14:03:49.5697452Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:03:53.7964747Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "9eb1fcae-bc60-4b93-90eb-64a52c473672",
+            "createdDateTimeUtc": "2021-08-25T14:03:24.5425451Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:03:31.821667Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "eb67646e-c215-4fa3-8eb3-da0770064e5f",
+            "createdDateTimeUtc": "2021-08-25T13:57:19.6278599Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:57:30.2946248Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "727d5bf9-f9fb-4ddf-9a38-828f22910b12",
+            "createdDateTimeUtc": "2021-08-25T13:53:59.4231523Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:54:05.5775816Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "4809cfc7-d5ae-4225-868e-05544f489358",
+            "createdDateTimeUtc": "2021-08-25T13:53:29.8911657Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:53:33.6911548Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d493956c-db6d-4a17-a5f0-028becb4ccfa",
+            "createdDateTimeUtc": "2021-08-25T13:52:31.0854759Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:52:34.9946496Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b6a8fa53-920e-4932-8c81-f3c73c0b2988",
+            "createdDateTimeUtc": "2021-08-25T13:51:53.8772741Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:52:00.7948926Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c2301f1f-c87f-4772-9f9c-5a9d7548b349",
+            "createdDateTimeUtc": "2021-08-25T13:45:19.087893Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:45:23.5227282Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d8ecc615-eeeb-4787-a601-851daef7b268",
+            "createdDateTimeUtc": "2021-08-25T13:44:54.582286Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:44:58.230487Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "14f3ad4c-7135-415e-859d-9b5f431ae6da",
+            "createdDateTimeUtc": "2021-08-25T13:44:08.2452291Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:44:16.8544217Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "9bb35643-eeb4-475b-8344-c3ae46655123",
+            "createdDateTimeUtc": "2021-08-25T13:43:37.812651Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:43:45.7364219Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ea604b93-8058-4d72-af48-81ad3ed99057",
+            "createdDateTimeUtc": "2021-08-25T13:41:46.5703013Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:41:50.3292734Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "501bfb81-87b7-4a4e-8f2a-67df97de6546",
+            "createdDateTimeUtc": "2021-08-25T13:41:24.0184265Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:41:27.7675607Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "42029254-a247-4c0b-ba14-52b9856051a4",
+            "createdDateTimeUtc": "2021-08-25T13:40:13.0836214Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:40:17.2772553Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d0ed4aa1-8314-4eff-8794-7d71942ebb55",
+            "createdDateTimeUtc": "2021-08-25T13:39:50.5251217Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:39:54.8052147Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "92252ab6-aeee-429c-8eca-f02e13be2348",
+            "createdDateTimeUtc": "2021-08-25T13:36:06.2711907Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:36:11.6241286Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "0e476571-3f2d-4999-bab6-7d3487603d22",
+            "createdDateTimeUtc": "2021-08-25T13:29:53.0363818Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:29:58.8829377Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "9feff3a9-0b8c-4c47-b780-664c7d90d549",
+            "createdDateTimeUtc": "2021-08-25T13:26:04.1635563Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:26:08.1645944Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c2f031b9-55db-42a9-9ecc-afdd741985bf",
+            "createdDateTimeUtc": "2021-08-25T13:25:45.2888951Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:25:49.1040561Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "500ffbb8-db58-417a-9bbc-98fd0d5e0f6e",
+            "createdDateTimeUtc": "2021-08-25T13:24:28.73101Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:24:32.7396137Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6385a3f7-9a39-4389-a9e3-0b533e19561d",
+            "createdDateTimeUtc": "2021-08-25T13:24:08.1547203Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:24:11.935914Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "040d09c1-a792-48a1-8b09-368ad940703c",
+            "createdDateTimeUtc": "2021-08-25T13:23:09.2673068Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:23:17.3461036Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a4720b7c-5aff-451d-9168-4aaeb46810ec",
+            "createdDateTimeUtc": "2021-08-25T13:22:47.9668002Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:22:51.8319732Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "53665f6e-2451-47ad-872e-0b60048296bc",
+            "createdDateTimeUtc": "2021-08-25T13:21:59.6468367Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:22:04.1049272Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "4d02dc0e-82d0-4106-9601-2b67d4895887",
+            "createdDateTimeUtc": "2021-08-25T13:21:41.2699303Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:21:45.685377Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "2f83a75e-3690-478a-b2c1-838a3c87780f",
+            "createdDateTimeUtc": "2021-08-25T13:20:00.4021268Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:20:04.4540659Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "79358abe-ca1d-4a34-a9dc-251d35f38d88",
+            "createdDateTimeUtc": "2021-08-25T13:19:40.6697383Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:19:47.1202077Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "aa883068-64e5-435b-8663-bc9573b2e917",
+            "createdDateTimeUtc": "2021-08-25T10:56:20.2363383Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:56:27.0780797Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "90c0a544-4504-4020-8396-0544b00c18c6",
+            "createdDateTimeUtc": "2021-08-25T10:55:55.9293426Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:56:05.0797274Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "614afed7-f7f1-4d74-9ad7-eff593103cd6",
+            "createdDateTimeUtc": "2021-08-25T10:29:21.1938146Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:29:24.7004537Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "f74ec5a8-15e9-4b8c-b8b6-c33ddd521c63",
+            "createdDateTimeUtc": "2021-08-25T10:29:02.5870188Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:29:05.9331656Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "fc864d53-0ddb-4fad-85ac-2d7451de0350",
+            "createdDateTimeUtc": "2021-08-25T10:28:05.7449329Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:28:15.1486564Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "30bc281b-3a6c-4a97-92c2-43de98e83aa4",
+            "createdDateTimeUtc": "2021-08-25T10:27:43.633836Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:27:50.5077585Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6f160aba-7e60-4748-a972-d0a146b3196e",
+            "createdDateTimeUtc": "2021-08-25T10:26:50.4040903Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:26:54.3204806Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ca6e611e-7b53-4d7f-b638-afe8d00bb725",
+            "createdDateTimeUtc": "2021-08-25T10:26:26.2866155Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:26:30.7154518Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          }
+        ],
+        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=86\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=86\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3f3c00c03923fe4f9b072f539b2f2e04-b6ed44e606ec3542-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7696b1e9ce3843f2069d5cc970623f49",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7d6b874c-0c27-498f-9a82-dda45da64ac2",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:21:05 GMT",
+        "ETag": "\u00220F33D9A50AFD534ED7982409B9B5289EE29A85BC97BCAE1795C0CCBDAD904F00\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7d6b874c-0c27-498f-9a82-dda45da64ac2"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "5d4b8b67-af0b-4c12-9c75-0869a2ba66df",
+            "createdDateTimeUtc": "2021-08-25T10:24:14.9778475Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:24:23.0381859Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "57bc3d42-2f4c-4dd1-ad51-791847d581d4",
+            "createdDateTimeUtc": "2021-08-25T10:23:51.1332076Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:23:58.0469266Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c55b120e-d8e1-48de-b0af-0e8d45c2b960",
+            "createdDateTimeUtc": "2021-08-25T10:09:55.7948842Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:10:02.821391Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8e66ffc9-0ac3-48a0-82ae-7609c6a6050a",
+            "createdDateTimeUtc": "2021-08-25T10:09:31.391233Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:09:35.8564693Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "63fb087b-4dd8-46d8-ac10-48bb79ce86d3",
+            "createdDateTimeUtc": "2021-08-25T10:07:25.2633442Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:07:31.8339883Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "cb2faa2d-95b1-46f9-bd39-4c5ffaf3d066",
+            "createdDateTimeUtc": "2021-08-25T10:07:01.8887184Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:07:06.5864174Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "73489fba-e1e8-4fb6-9f08-1eec3698f3e3",
+            "createdDateTimeUtc": "2021-08-25T10:05:29.2026751Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:05:41.024571Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d5015b23-d0d7-46f0-af5e-50e2228f4841",
+            "createdDateTimeUtc": "2021-08-25T10:05:07.1839969Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:05:15.5031116Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8f3aefad-b2fc-41cf-968d-18b0497b5fb3",
+            "createdDateTimeUtc": "2021-08-25T10:01:07.121612Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:01:13.8095906Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "609f5c8f-80e1-424b-9801-5d3e804c134e",
+            "createdDateTimeUtc": "2021-08-25T09:47:51.4646326Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:47:59.0397057Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "cc873f8b-e71f-4617-a277-00b299907c0e",
+            "createdDateTimeUtc": "2021-08-25T09:47:17.2200753Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:47:25.0694763Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "92c6004e-733f-41af-8d2f-89b41bb279c6",
+            "createdDateTimeUtc": "2021-08-25T09:44:03.9368379Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:44:09.2827307Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "0699ddc0-9394-43b7-8335-99b582ac7af5",
+            "createdDateTimeUtc": "2021-08-25T09:43:07.3141327Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:43:12.1318918Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "686ae6d7-ffc1-4c0c-a4b1-49a57d03524b",
+            "createdDateTimeUtc": "2021-08-25T09:42:39.886955Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:42:45.1118961Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "77edc600-d50a-4740-ba35-9fc276ae7415",
+            "createdDateTimeUtc": "2021-08-25T09:19:31.6344382Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:19:39.3248571Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8afe0ff5-a724-4d21-acce-da44c26b3ffe",
+            "createdDateTimeUtc": "2021-08-25T09:19:10.8844738Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:19:17.2753878Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "02acf584-26b6-40d3-a958-e34734f20ef5",
+            "createdDateTimeUtc": "2021-08-25T09:18:05.5949331Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:18:10.700436Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "da3b7f1b-eaf1-4ef3-b1d7-34cb12c58f5f",
+            "createdDateTimeUtc": "2021-08-25T09:17:41.6284086Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:17:46.8467624Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "e2fdfa9b-eef5-4285-84f2-394dc3ee0cde",
+            "createdDateTimeUtc": "2021-08-25T09:16:55.2621789Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:17:00.0474197Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8107b309-29ed-4fc0-b2e1-cfeb96210550",
+            "createdDateTimeUtc": "2021-08-25T09:16:27.1861354Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:16:31.6226169Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d33cd5ae-28a9-4560-980d-3cd99decdb56",
+            "createdDateTimeUtc": "2021-08-25T09:15:20.2067568Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:15:30.5710243Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ea961c29-189c-4dbc-b375-61167cf15a17",
+            "createdDateTimeUtc": "2021-08-25T09:14:55.2312472Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:15:04.6298687Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "eb8efceb-d78d-4dcf-aedb-c3edde6cbc7e",
+            "createdDateTimeUtc": "2021-08-24T19:55:47.1477025Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:55:51.5061055Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "534d90e6-5360-471e-bfd0-54d23d28aa3f",
+            "createdDateTimeUtc": "2021-08-24T19:53:32.6469602Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:53:40.4258421Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a10ef07d-101a-4e0c-9194-ab61b49cba8a",
+            "createdDateTimeUtc": "2021-08-24T19:53:07.1127838Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:53:15.4049994Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "223a9ccf-7935-4581-995a-60605ee335a5",
+            "createdDateTimeUtc": "2021-08-24T19:50:41.7797004Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:50:48.506789Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "4dbe99ed-ca2d-4dbe-8bcd-2643d5bbe7f4",
+            "createdDateTimeUtc": "2021-08-24T19:50:16.0211307Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:50:26.0420851Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "f80c73e0-e8ec-4d35-a4d4-27179f0ed4bf",
+            "createdDateTimeUtc": "2021-08-24T19:49:10.6527877Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:49:15.2215103Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "18d1d2d0-c3e1-4864-833c-8ab189be6fc1",
+            "createdDateTimeUtc": "2021-08-24T19:48:44.5805808Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:48:49.1109041Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "5a457f72-8bd8-450c-ac60-da04df2cc2ab",
+            "createdDateTimeUtc": "2021-08-24T19:46:10.1997622Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:46:17.9106435Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "60ff13d3-9f94-431f-ac62-58f42f771630",
+            "createdDateTimeUtc": "2021-08-24T19:45:44.4022212Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:45:48.9866813Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "195c51ce-0ef1-491b-9ec2-db1542402a32",
+            "createdDateTimeUtc": "2021-08-24T19:44:53.1308296Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:45:02.5998496Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6a18a4bd-f2cc-42cc-b195-cd1cdb22eaf6",
+            "createdDateTimeUtc": "2021-08-24T19:44:31.5620308Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:44:38.2064648Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c562e87c-1fb3-4e9f-8748-803d34fe7b11",
+            "createdDateTimeUtc": "2021-08-24T19:42:08.6323717Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:42:16.6949486Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "2c8d2c87-1dd9-42af-aa73-9052cb89123c",
+            "createdDateTimeUtc": "2021-08-24T19:41:44.486071Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:41:49.5437122Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a8018349-6083-4c7b-be65-a0d93cd7f9f1",
+            "createdDateTimeUtc": "2021-08-24T19:26:28.685069Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:26:35.6712921Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "93c8fbe5-2509-4e26-aa38-5b44ae36abb9",
+            "createdDateTimeUtc": "2021-08-24T19:25:53.9806028Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:25:59.7724431Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b981ecff-a052-4239-975b-2f4ed45aa2e7",
+            "createdDateTimeUtc": "2021-08-24T19:25:32.5560562Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:25:36.3150668Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "5fce870f-5805-48fe-9e55-d978c0a44a96",
+            "createdDateTimeUtc": "2021-08-24T19:24:49.8512423Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:24:54.7359674Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "58dd2537-2390-41ce-8e66-cf5d991a0ef0",
+            "createdDateTimeUtc": "2021-08-24T19:24:28.0491081Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:24:32.8824749Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "309c5ab2-ab6e-42d2-b341-3d273507090b",
+            "createdDateTimeUtc": "2021-08-24T19:19:16.359635Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:19:26.45727Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6621b15c-9956-44d8-8bd2-de6d1dd3d518",
+            "createdDateTimeUtc": "2021-08-24T19:18:15.2019519Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:18:20.6814382Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b39c5530-1a07-4898-b0cf-d1b81c31958c",
+            "createdDateTimeUtc": "2021-08-24T19:17:00.6801855Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:17:04.7751099Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ab5f7b09-0873-4d2d-942c-5a76b6296264",
+            "createdDateTimeUtc": "2021-08-24T19:16:35.6588021Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:16:45.7609068Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c0c4e53a-6bc5-4d35-be29-4e9d088d6b70",
+            "createdDateTimeUtc": "2021-08-24T15:36:55.7864604Z",
+            "lastActionDateTimeUtc": "2021-08-24T15:37:01.6474825Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "161de4ac-0924-4527-8170-a4bec6eb38c8",
+            "createdDateTimeUtc": "2021-08-24T15:36:21.2461429Z",
+            "lastActionDateTimeUtc": "2021-08-24T15:36:28.9384829Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "49840bd2-de72-4b7d-9bf4-47f746ecc5bb",
+            "createdDateTimeUtc": "2021-08-23T17:47:33.9921789Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:47:40.5970502Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6e3b9367-513c-4d20-8c07-ee3568440b7c",
+            "createdDateTimeUtc": "2021-08-23T17:47:11.3828547Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:47:15.2840674Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b2d0e15f-95ef-40d4-bfb0-9a4f203a54ba",
+            "createdDateTimeUtc": "2021-08-23T17:35:20.3985579Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:35:27.6518861Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "15bb936d-c180-4255-9ba2-a07bec5806dd",
+            "createdDateTimeUtc": "2021-08-23T17:34:58.0354643Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:35:03.3355533Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          }
+        ],
+        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=36\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=36\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4b5e48bc76f41c4fa462618550e3fb64-f482469f74b1d846-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "406c4d6164205c67183bef19dc6bd0ea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "60c5c8ef-d19a-485a-8c15-a6a0d6c4863d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:21:05 GMT",
+        "ETag": "\u0022983AA875931A2A58A44AE216386830FB617F4097CCAFA9D15DF4AEA47BF37EC1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "60c5c8ef-d19a-485a-8c15-a6a0d6c4863d"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "29353a68-850e-4c04-bce3-ce98e0ee567f",
+            "createdDateTimeUtc": "2021-08-23T17:33:06.4539736Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:33:14.3872677Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "40f6ee23-324d-49fd-b74b-fcdcbb410299",
+            "createdDateTimeUtc": "2021-08-23T17:32:44.9924751Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:32:51.3694131Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "1617b829-c0a3-4971-92d4-c2964babd030",
+            "createdDateTimeUtc": "2021-08-23T17:32:09.2406517Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:32:18.6614602Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a577fd72-5713-466c-8bc7-a1c81c9ce690",
+            "createdDateTimeUtc": "2021-08-23T17:31:48.2758423Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:31:53.1076136Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "3ef3e1fd-9489-4036-a76d-adf8121073a9",
+            "createdDateTimeUtc": "2021-08-23T17:28:59.4940221Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:29:05.3839228Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "795298f9-c99d-46ad-9be8-756171a64d47",
+            "createdDateTimeUtc": "2021-08-23T17:28:37.2538866Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:28:47.3380251Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "38136150-8f48-470f-93d0-efd2167ad0df",
+            "createdDateTimeUtc": "2021-08-23T17:28:06.0935977Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:28:15.7031915Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8f25593f-63ad-413a-9e0b-2f7b935e53f7",
+            "createdDateTimeUtc": "2021-08-23T17:27:42.2908433Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:27:51.9149141Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "032a3bb1-cdbf-4162-b3c7-7b3618379c7f",
+            "createdDateTimeUtc": "2021-08-23T17:27:09.7358524Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:27:19.680071Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ab879574-fcf3-41e3-b77e-6ea15d44b413",
+            "createdDateTimeUtc": "2021-08-23T17:26:47.3142089Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:26:56.5225722Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "98743da0-d863-41c4-bf57-56fa90b43eb4",
+            "createdDateTimeUtc": "2021-08-23T17:25:45.600667Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:25:49.2127676Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "183d6c88-fdae-4ea5-aa68-340f1ad84f77",
+            "createdDateTimeUtc": "2021-08-23T17:25:24.3498398Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:25:31.0082101Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "09960070-bdf0-46b1-99af-928e4a626f69",
+            "createdDateTimeUtc": "2021-08-23T17:24:31.4385114Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:24:35.5546122Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d8405784-fa6b-4267-b830-d8513a4f658d",
+            "createdDateTimeUtc": "2021-08-23T17:24:00.3396396Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:24:05.6562369Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "43b2701d-cae4-47b5-8287-f00ef452a7ce",
+            "createdDateTimeUtc": "2021-08-23T17:23:35.5630305Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:23:45.0431691Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "464de745-a68f-43db-b2af-61ccf62acc73",
+            "createdDateTimeUtc": "2021-08-23T17:20:31.3475187Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:20:40.1632632Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "3591ae2c-a6f1-44f4-8f8b-802ccb41fb0d",
+            "createdDateTimeUtc": "2021-08-23T17:19:56.3627557Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:20:04.8977529Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c5addf28-55a0-4cf7-a193-452c47aba219",
+            "createdDateTimeUtc": "2021-08-23T17:19:36.4200341Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:19:43.8168428Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "7570de08-6a5c-4a7d-9862-65db205744e2",
+            "createdDateTimeUtc": "2021-08-23T17:16:04.5109438Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:16:14.2207404Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c2b12a8c-a64e-486a-8cb8-6f533fa14d9a",
+            "createdDateTimeUtc": "2021-08-23T17:12:39.1494425Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:12:48.7856928Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d0b76907-0261-4277-884c-f0823f9ec122",
+            "createdDateTimeUtc": "2021-08-23T17:12:16.3765099Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:12:22.483808Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b6bd137e-2a00-4427-bbda-215b9dcdbff1",
+            "createdDateTimeUtc": "2021-08-23T17:11:35.4166713Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:11:41.9836701Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "68dba74a-e802-486b-a389-28977cbd191c",
+            "createdDateTimeUtc": "2021-08-23T17:11:11.1146708Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:11:15.5935992Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "e1bc7687-0156-45f5-9428-e63c022dbafd",
+            "createdDateTimeUtc": "2021-08-23T17:09:30.3557278Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:09:38.0232919Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "4ad591be-f6a3-424a-a368-a5ac3338c68e",
+            "createdDateTimeUtc": "2021-08-23T17:09:05.6068524Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:09:14.2949945Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "fb02d26f-4b4a-44c7-8512-1dc605b4760d",
+            "createdDateTimeUtc": "2021-08-23T17:08:01.2644983Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:08:07.3426569Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "3fe85a3c-4db1-4dc5-baf8-b4956f535c2f",
+            "createdDateTimeUtc": "2021-08-23T16:59:08.3574297Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:59:16.4935524Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "5afefe59-d1b7-4df4-ad58-0c7665aa1167",
+            "createdDateTimeUtc": "2021-08-23T16:58:22.7200327Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:58:30.9323045Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "da52052a-d809-46b3-a65f-4b0b4366462b",
+            "createdDateTimeUtc": "2021-08-23T16:57:50.2799217Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:57:55.6175942Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "bf798bca-7a93-47a3-a1ff-ccdf90015328",
+            "createdDateTimeUtc": "2021-08-23T16:53:14.9104004Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:53:20.0243492Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "de676d42-097d-499d-b424-63c44ff0fd85",
+            "createdDateTimeUtc": "2021-08-23T16:41:50.025133Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:41:55.021436Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "144d63b0-b972-47da-be48-e8369610d9d0",
+            "createdDateTimeUtc": "2021-08-23T16:41:24.3300611Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:41:27.9762437Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ae29411c-ed5f-45e6-be84-e97c675599ed",
+            "createdDateTimeUtc": "2021-08-23T16:39:53.6000673Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:39:59.431849Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6924c556-8704-4b02-9148-45101d5a8791",
+            "createdDateTimeUtc": "2021-08-23T16:39:31.6451911Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:39:36.1986712Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "f1ce52fa-8234-47ec-9772-934b3a24bb70",
+            "createdDateTimeUtc": "2021-08-16T09:59:08.2257882Z",
+            "lastActionDateTimeUtc": "2021-08-16T09:59:14.4683656Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6e7b03fa-1abe-4524-82df-9efccd37df2f",
+            "createdDateTimeUtc": "2021-08-16T09:57:10.9273883Z",
+            "lastActionDateTimeUtc": "2021-08-16T09:57:17.7325207Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1467,8 +3514,8 @@
   ],
   "Variables": {
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
     "RandomSeed": "729221446"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source158586476?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source641895703?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6d172d4d0dccbb438fbe3ffe1f42a02a-f5024458e5940047-00",
+        "traceparent": "00-1a7dbe836062034facf2d1158e85f47f-4ee4c0f6d6415444-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "3c982c0dbc3dd292cd8b4a74b0a93a18",
-        "x-ms-date": "Wed, 25 Aug 2021 18:44:50 GMT",
+        "x-ms-client-request-id": "b8ab16b63bdf7f09a645bdf16c6b52d3",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:27 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:44:50 GMT",
-        "ETag": "\u00220x8D967F86B976679\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:44:50 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:28 GMT",
+        "ETag": "\u00220x8D9689AB2D02EFC\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:28 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3c982c0dbc3dd292cd8b4a74b0a93a18",
-        "x-ms-request-id": "97603e77-d01e-0088-4fe1-99d996000000",
+        "x-ms-client-request-id": "b8ab16b63bdf7f09a645bdf16c6b52d3",
+        "x-ms-request-id": "3ddef110-201e-0057-1a83-9a92ac000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source158586476/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source641895703/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-33b08773a01a0d46839f026337df579e-ead3012f45ee3141-00",
+        "traceparent": "00-cfcaf041eaeacd4ea59567377fbbf0a1-929386e46378e440-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "67cf809ddabdf4a3dd4ae6c33a914733",
-        "x-ms-date": "Wed, 25 Aug 2021 18:44:51 GMT",
+        "x-ms-client-request-id": "528025f2f3faa6690a3a9dc1b5634aa0",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:28 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:44:50 GMT",
-        "ETag": "\u00220x8D967F86BE161C1\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:44:50 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:28 GMT",
+        "ETag": "\u00220x8D9689AB3156FA5\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:28 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "67cf809ddabdf4a3dd4ae6c33a914733",
+        "x-ms-client-request-id": "528025f2f3faa6690a3a9dc1b5634aa0",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97603ecd-d01e-0088-13e1-99d996000000",
+        "x-ms-request-id": "3ddef180-201e-0057-7d83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target485781887?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1701160954?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-7d134f2d48836046a05801b07316cd8a-5c24b7ef46229442-00",
+        "traceparent": "00-a4dad8144441cb43a94bc5fbd4437be3-911ac123865ff244-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "647b5b7caf8112829452acd684ab424a",
-        "x-ms-date": "Wed, 25 Aug 2021 18:44:51 GMT",
+        "x-ms-client-request-id": "aaa55d96a33bfb3dae1bb1b7520d268b",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:28 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,12 +76,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:44:51 GMT",
-        "ETag": "\u00220x8D967F86BFBE005\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:44:51 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:28 GMT",
+        "ETag": "\u00220x8D9689AB330B01D\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:29 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "647b5b7caf8112829452acd684ab424a",
-        "x-ms-request-id": "97603f1f-d01e-0088-4ee1-99d996000000",
+        "x-ms-client-request-id": "aaa55d96a33bfb3dae1bb1b7520d268b",
+        "x-ms-request-id": "3ddef1ca-201e-0057-4183-9a92ac000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -94,9 +94,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-edac0d22b82bcd488a5708eea3ebad2a-8642fa8a45605240-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "936ed464ae518933a35ff2d5ce983c43",
+        "traceparent": "00-6e99233ac6ec8543896f1a865ed111da-a74951b75e67d74c-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9c8d56871d57adc304aea59e47c942fb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -116,10 +116,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3c5dac2f-9fbb-4251-b575-3353b589c540",
+        "apim-request-id": "c6713f90-6b66-41c3-bd67-4c2fd0f6e63b",
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:44:52 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "Date": "Thu, 26 Aug 2021 14:06:30 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -127,31 +127,31 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3c5dac2f-9fbb-4251-b575-3353b589c540"
+        "X-RequestId": "c6713f90-6b66-41c3-bd67-4c2fd0f6e63b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4e33f516b3bfd11c4c552887f61e599f",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0dd6f61d28ad81b642574bd8b7eeb72d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80f59075-fe34-48fb-aa53-306c64cd86bf",
+        "apim-request-id": "b4397d8e-1498-401e-9b75-085b90849fa4",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:44:52 GMT",
-        "ETag": "\u0022631B2AED74FB1AE582D4F7E7D7F7B932854B6D1319811F5E04F697F72414DFFD\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:30 GMT",
+        "ETag": "\u00223F994E422A47F84C60736D2DF1E19141C48B51FD2F03F1516913E67A1ACFDE0C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -161,12 +161,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "80f59075-fe34-48fb-aa53-306c64cd86bf"
+        "X-RequestId": "b4397d8e-1498-401e-9b75-085b90849fa4"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:44:52.9237743Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:30.6010023Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,26 +180,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bcd579a3a0d9cd2d27f2c121bcad43fb",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0c2e367603bd79a39af7a68cfe9fb3e5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bec13b12-3d03-4bc0-b66a-502f2329ca3e",
+        "apim-request-id": "25ff7e94-060d-4033-8085-5728631543d9",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:44:54 GMT",
-        "ETag": "\u0022031E5E99658ECA8B4D11B6EAE52531EF8BF3E33B06B1133793BCD4AA9BB0E1EC\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:31 GMT",
+        "ETag": "\u0022868385B796A33645E62C26934D0880D9CB63D43B540519C92875F4C54309C66D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -209,12 +209,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "bec13b12-3d03-4bc0-b66a-502f2329ca3e"
+        "X-RequestId": "25ff7e94-060d-4033-8085-5728631543d9"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:44:53.8203771Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:31.5455637Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -228,26 +228,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8ebf6816f477b08bb89c46fc86ab9285",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5b9ab6d819365edea00b5affd1ebf516",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "150cd29c-3a80-4e3f-bd01-cbeb30fb7a47",
+        "apim-request-id": "5b769a36-fdd4-4a4b-8337-9ef474bafd43",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:44:55 GMT",
-        "ETag": "\u0022031E5E99658ECA8B4D11B6EAE52531EF8BF3E33B06B1133793BCD4AA9BB0E1EC\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:32 GMT",
+        "ETag": "\u0022868385B796A33645E62C26934D0880D9CB63D43B540519C92875F4C54309C66D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -257,12 +257,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "150cd29c-3a80-4e3f-bd01-cbeb30fb7a47"
+        "X-RequestId": "5b769a36-fdd4-4a4b-8337-9ef474bafd43"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:44:53.8203771Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:31.5455637Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -276,26 +276,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "553152067fc2766ac86526ccf2fa149e",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "112778f6369a1a3e525c73b5822983a2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "15b02c76-b9a3-4017-801f-b3d909ee5614",
+        "apim-request-id": "ff6d00e1-44e7-41cc-a711-c134a4dd089b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:44:56 GMT",
-        "ETag": "\u0022031E5E99658ECA8B4D11B6EAE52531EF8BF3E33B06B1133793BCD4AA9BB0E1EC\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:34 GMT",
+        "ETag": "\u002201497D84380D801DD14D61FD9B89F2DBA9EA60AE81F84ED52F2A3F5DBEEEEBB8\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -305,45 +305,45 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "15b02c76-b9a3-4017-801f-b3d909ee5614"
+        "X-RequestId": "ff6d00e1-44e7-41cc-a711-c134a4dd089b"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:44:53.8203771Z",
-        "status": "NotStarted",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:34.3431281Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8d702c11ca5eaf27ee25043c5930477c",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "010066a45c545cf657cf6bb1a9a3a8ae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f246e84a-f2c8-44ea-9569-56a8b0ed43ea",
+        "apim-request-id": "682f619f-670e-4cc4-9611-aabe87440808",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:44:57 GMT",
-        "ETag": "\u0022031E5E99658ECA8B4D11B6EAE52531EF8BF3E33B06B1133793BCD4AA9BB0E1EC\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:35 GMT",
+        "ETag": "\u002214D15265975511376A4B1DA7928CB225790357FE896CBEA466065FED2EC598E0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -353,45 +353,45 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f246e84a-f2c8-44ea-9569-56a8b0ed43ea"
+        "X-RequestId": "682f619f-670e-4cc4-9611-aabe87440808"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:44:53.8203771Z",
-        "status": "NotStarted",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:35.3828733Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "691b3c5fee7b9639fe49c512cebebebe",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "86969002a178a14a778008daa629dc76",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d3fcf6f1-7722-499a-92da-5aaed1b5c786",
+        "apim-request-id": "70a9283d-4220-459f-b1e9-97833f01a8b3",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:44:59 GMT",
-        "ETag": "\u0022C0DA890031A93BC0480F486AB38E355144066D952553EC77B30C1D26AE68C897\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:36 GMT",
+        "ETag": "\u002214D15265975511376A4B1DA7928CB225790357FE896CBEA466065FED2EC598E0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -401,12 +401,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d3fcf6f1-7722-499a-92da-5aaed1b5c786"
+        "X-RequestId": "70a9283d-4220-459f-b1e9-97833f01a8b3"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:44:59.1527186Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:35.3828733Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -420,26 +420,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "59eba788043b3b262b82669d7b2d1c97",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6a5bb787f3eb9ac181cabacaca8c70af",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "88941430-41b5-468d-97e6-f0f9e00da236",
+        "apim-request-id": "27748fcf-9136-4087-b825-3601525e2d9c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:00 GMT",
-        "ETag": "\u002209B1A5D61BD225D1DD944F11860A63F1264F7EFB627F1AA28875AE69082A73E1\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:37 GMT",
+        "ETag": "\u002214D15265975511376A4B1DA7928CB225790357FE896CBEA466065FED2EC598E0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -449,12 +449,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "88941430-41b5-468d-97e6-f0f9e00da236"
+        "X-RequestId": "27748fcf-9136-4087-b825-3601525e2d9c"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:00.0620521Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:35.3828733Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -468,26 +468,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b66caa1eabdf2223f3da8f140415e130",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f2b2c4b4fd93022a1b5e89d4531cb62d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aeb21b42-f857-4e06-83b4-53c8a24ffbf8",
+        "apim-request-id": "30da723a-826c-4199-b305-3457aed93e98",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:02 GMT",
-        "ETag": "\u002209B1A5D61BD225D1DD944F11860A63F1264F7EFB627F1AA28875AE69082A73E1\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:38 GMT",
+        "ETag": "\u002214D15265975511376A4B1DA7928CB225790357FE896CBEA466065FED2EC598E0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -497,12 +497,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "aeb21b42-f857-4e06-83b4-53c8a24ffbf8"
+        "X-RequestId": "30da723a-826c-4199-b305-3457aed93e98"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:00.0620521Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:35.3828733Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -516,26 +516,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b1b44567ed455b4015df3ef9889b1bd1",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f12af5f33d470ec3cefb04ade77fd6eb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9b45feb1-ff49-40fe-b8ce-b648ece13d89",
+        "apim-request-id": "d4873376-3e6e-43b0-b5f8-64cdad470158",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:03 GMT",
-        "ETag": "\u002209B1A5D61BD225D1DD944F11860A63F1264F7EFB627F1AA28875AE69082A73E1\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:40 GMT",
+        "ETag": "\u002214D15265975511376A4B1DA7928CB225790357FE896CBEA466065FED2EC598E0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -545,12 +545,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9b45feb1-ff49-40fe-b8ce-b648ece13d89"
+        "X-RequestId": "d4873376-3e6e-43b0-b5f8-64cdad470158"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:00.0620521Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:35.3828733Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -564,26 +564,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "23f42e2d0751dcde84c8666175123615",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e126590fe9778ae38c594f8c6aed4765",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0724b70f-085e-4cc0-8b51-8b15b721cb4d",
+        "apim-request-id": "5bcead06-7a1c-4b0e-b890-ef7c5fe2db06",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:04 GMT",
-        "ETag": "\u002209B1A5D61BD225D1DD944F11860A63F1264F7EFB627F1AA28875AE69082A73E1\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:41 GMT",
+        "ETag": "\u002214D15265975511376A4B1DA7928CB225790357FE896CBEA466065FED2EC598E0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -593,12 +593,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0724b70f-085e-4cc0-8b51-8b15b721cb4d"
+        "X-RequestId": "5bcead06-7a1c-4b0e-b890-ef7c5fe2db06"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:00.0620521Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:35.3828733Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -612,26 +612,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "353635a06b7930526911a1006c299a57",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d5d78c137e62766701a42397f87d1b9b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e5e91522-b38e-484b-8355-40615315055c",
+        "apim-request-id": "cc56b2ef-7f8d-464b-872c-05d41c9949cb",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:05 GMT",
-        "ETag": "\u00227C6C0A95C87D778EE442D5A818551AD0BD84B8C585B0556D086C00253ABE24C1\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:43 GMT",
+        "ETag": "\u0022D017AC8EAEB3492255403A8A63AE480526B1679788DDCB48B5C844B540EA5B96\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -641,12 +641,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e5e91522-b38e-484b-8355-40615315055c"
+        "X-RequestId": "cc56b2ef-7f8d-464b-872c-05d41c9949cb"
       },
       "ResponseBody": {
-        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
-        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:05.0514792Z",
+        "id": "4b79afcc-7f32-4358-9244-05070b29f29f",
+        "createdDateTimeUtc": "2021-08-26T14:06:30.601002Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:43.2132613Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -660,26 +660,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4b79afcc-7f32-4358-9244-05070b29f29f/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d6e7bebebd215fdf67d72c7d87dfe602",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f9c59e88d5f60ab6129f65eeee36a4e1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "59f0708f-b81a-425c-aa72-8146ae4b1d72",
+        "apim-request-id": "c11a96c8-bbfb-40e6-bbb7-b9824fc9041f",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:06 GMT",
-        "ETag": "\u0022D79456AA3654DF88AEA6856B8B2390406A533F3A764C54B5A1D2DDC181CF32DE\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:43 GMT",
+        "ETag": "\u002210EF69F19F345D5BB4D4D3BAC022208B0CFEFE0C9762C154A91A2C557209EF79\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -689,34 +689,34 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "59f0708f-b81a-425c-aa72-8146ae4b1d72"
+        "X-RequestId": "c11a96c8-bbfb-40e6-bbb7-b9824fc9041f"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target485781887/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source158586476/File_0.txt",
-            "createdDateTimeUtc": "2021-08-25T18:44:59.1610319Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:05.051457Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1701160954/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source641895703/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:06:34.3588831Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:06:43.2132419Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000b462f-0000-0000-0000-000000000000",
+            "id": "000b50e3-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-63ee544659137d47b7b13a2d7fa20b99-057ebfbb8621174a-00",
+        "traceparent": "00-8969f04744b19646a325ca541101ce94-d6ea0ca380f4e948-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "6552582858e5dcc1c3b93f66de705b2e",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "x-ms-client-request-id": "a85a999f8800f290afe0d2c54b910e3d",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -724,28 +724,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:06 GMT",
-        "ETag": "\u00220x8D967F8752D8B93\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:06 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:43 GMT",
+        "ETag": "\u00220x8D9689ABC24F7BF\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "6552582858e5dcc1c3b93f66de705b2e",
-        "x-ms-request-id": "97604cc3-d01e-0088-08e1-99d996000000",
+        "x-ms-client-request-id": "a85a999f8800f290afe0d2c54b910e3d",
+        "x-ms-request-id": "3ddf0640-201e-0057-3b83-9a92ac000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-6db73b0c7925494fb348d7d32b4a6925-fdb3f63161db7049-00",
+        "traceparent": "00-d3f997747c62d241b9e22884e26450e5-77f6bfb422a8824c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "2ab7a20ef45f56e3d6cea13ed4a88a2b",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "x-ms-client-request-id": "28cb04b36f4dd53eccc3c2197888caff",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -754,30 +754,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:06 GMT",
-        "ETag": "\u00220x8D967F8756250C7\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:06 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:44 GMT",
+        "ETag": "\u00220x8D9689ABC541994\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "2ab7a20ef45f56e3d6cea13ed4a88a2b",
+        "x-ms-client-request-id": "28cb04b36f4dd53eccc3c2197888caff",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97604d09-d01e-0088-46e1-99d996000000",
+        "x-ms-request-id": "3ddf06a9-201e-0057-1c83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-9e067d2f140fbc47b1f2f0fd3fe3c183-9271bba15333d540-00",
+        "traceparent": "00-5c7b33b92c8f9247b746e67bbe88c301-7f983cd74a400344-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d044579ef24765d925fa5d039ff88867",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "x-ms-client-request-id": "e459e342f2c11587340646f4e344c70e",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -786,30 +786,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:07 GMT",
-        "ETag": "\u00220x8D967F8758D3944\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:44 GMT",
+        "ETag": "\u00220x8D9689ABC836FAA\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d044579ef24765d925fa5d039ff88867",
+        "x-ms-client-request-id": "e459e342f2c11587340646f4e344c70e",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97604d5c-d01e-0088-10e1-99d996000000",
+        "x-ms-request-id": "3ddf074d-201e-0057-3183-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_2.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_2.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-18914ae3b2730a45b6960b9ed11114d2-fd34f16f6ee48a47-00",
+        "traceparent": "00-88414cbc08355e49abe64de3283282ab-367b8be3dfbf9d4f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3d784fd0d72e334875fb8e16b683071a",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "x-ms-client-request-id": "323ab156b9d82f665a84db3dc6767a26",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -818,30 +818,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:07 GMT",
-        "ETag": "\u00220x8D967F875B821B7\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:44 GMT",
+        "ETag": "\u00220x8D9689ABCB2779A\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3d784fd0d72e334875fb8e16b683071a",
+        "x-ms-client-request-id": "323ab156b9d82f665a84db3dc6767a26",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97604d9e-d01e-0088-4fe1-99d996000000",
+        "x-ms-request-id": "3ddf07bb-201e-0057-1a83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_3.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_3.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-3f5e6a1745d83642b6f9a7830f693e21-972cccae6a4c1447-00",
+        "traceparent": "00-19dcb0c096956440b2e93fa9d6cf09ec-1d68a096d5ce2746-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "87c7142f8b2b1ce6c851056597dfb7de",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "x-ms-client-request-id": "6783d3152a37c07c7cb5f3462849f188",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -850,30 +850,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:07 GMT",
-        "ETag": "\u00220x8D967F875E35854\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:45 GMT",
+        "ETag": "\u00220x8D9689ABCDFAA67\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:45 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "87c7142f8b2b1ce6c851056597dfb7de",
+        "x-ms-client-request-id": "6783d3152a37c07c7cb5f3462849f188",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97604ddc-d01e-0088-06e1-99d996000000",
+        "x-ms-request-id": "3ddf0843-201e-0057-0d83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_4.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_4.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-7919ae585e662d498b9e5adb00c88c61-7d13307821811047-00",
+        "traceparent": "00-0073707cfd22444d9da638559843fb81-9dc8d83c6af48343-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "856d3a454d30c6fc0e105a4b63c2afa2",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "x-ms-client-request-id": "c7c3b4fc974e89267d29893c174a4fbe",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -882,30 +882,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:07 GMT",
-        "ETag": "\u00220x8D967F8760EB61C\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:45 GMT",
+        "ETag": "\u00220x8D9689ABD0EB36E\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:45 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "856d3a454d30c6fc0e105a4b63c2afa2",
+        "x-ms-client-request-id": "c7c3b4fc974e89267d29893c174a4fbe",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97604e21-d01e-0088-41e1-99d996000000",
+        "x-ms-request-id": "3ddf08bd-201e-0057-7b83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_5.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_5.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-93f1edbb8338ff4ca3364cc108675c92-a41c4cfefa7fb64d-00",
+        "traceparent": "00-d95881918322134b94708e90b23eaeba-6325c8f02eb1f545-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "8bd442f30130453b685c74ddd2e39c96",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "x-ms-client-request-id": "10df1f8c5fc12bd63479b622c61f0710",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -914,30 +914,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:08 GMT",
-        "ETag": "\u00220x8D967F87639ECBE\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:45 GMT",
+        "ETag": "\u00220x8D9689ABD3BE546\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:45 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "8bd442f30130453b685c74ddd2e39c96",
+        "x-ms-client-request-id": "10df1f8c5fc12bd63479b622c61f0710",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97604e8e-d01e-0088-26e1-99d996000000",
+        "x-ms-request-id": "3ddf0956-201e-0057-0b83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_6.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_6.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-8d92bac7b3630c409e0fec21ea9cb2be-26d81afe8e31c449-00",
+        "traceparent": "00-c8bdd011ea03fc41a5ae1d04423ca477-5525c4a1ab6dc742-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "7cd1b0448116e2ea1701781b319ab906",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "x-ms-client-request-id": "11415393b2b37ed8acf9ea0da040a931",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -946,30 +946,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:08 GMT",
-        "ETag": "\u00220x8D967F87665BFB8\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:46 GMT",
+        "ETag": "\u00220x8D9689ABD6E7055\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "7cd1b0448116e2ea1701781b319ab906",
+        "x-ms-client-request-id": "11415393b2b37ed8acf9ea0da040a931",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97604f22-d01e-0088-2fe1-99d996000000",
+        "x-ms-request-id": "3ddf09bd-201e-0057-6b83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_7.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_7.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-754a241313356b4ca7e6d938ef910193-8b76e86461febd40-00",
+        "traceparent": "00-bbdb9c3328136a4d8c4a7bbdd37a98a2-114c299d55ab4f44-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "547162a22b0a44adfe281cd4d81ef32b",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "x-ms-client-request-id": "08ba3566e16a9cc6dd9792d4e103c25d",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -978,30 +978,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:08 GMT",
-        "ETag": "\u00220x8D967F876911D89\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:46 GMT",
+        "ETag": "\u00220x8D9689ABDB3754D\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "547162a22b0a44adfe281cd4d81ef32b",
+        "x-ms-client-request-id": "08ba3566e16a9cc6dd9792d4e103c25d",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97604fac-d01e-0088-2be1-99d996000000",
+        "x-ms-request-id": "3ddf0a42-201e-0057-5e83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_8.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_8.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-bf496226aaa0024594190cd2a390889f-2a92d502ce8e1146-00",
+        "traceparent": "00-8142b4466a2be841b27b9a7aa6877d64-fdf26d30c9cd7241-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b207c37432f1728c58f1732f892014ce",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "x-ms-client-request-id": "c3a979223d09d90a476063c775c98bf4",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1010,30 +1010,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:09 GMT",
-        "ETag": "\u00220x8D967F876BE5072\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:46 GMT",
+        "ETag": "\u00220x8D9689ABDE1447B\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b207c37432f1728c58f1732f892014ce",
+        "x-ms-client-request-id": "c3a979223d09d90a476063c775c98bf4",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97605026-d01e-0088-14e1-99d996000000",
+        "x-ms-request-id": "3ddf0ab4-201e-0057-4483-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_9.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_9.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-6a1490b15d763d4aaff91e36a397fc25-a8b925de3f4f6044-00",
+        "traceparent": "00-01d4c6882bc1d643b2777d5dda76c9e2-2e7735c4c5781143-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "6f3b6da24871198b038c7ded641609f9",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "x-ms-client-request-id": "90bc85cffe65b1a58da4341c20049ca8",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1042,30 +1042,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:09 GMT",
-        "ETag": "\u00220x8D967F876E9D553\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:47 GMT",
+        "ETag": "\u00220x8D9689ABE0E0205\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:47 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "6f3b6da24871198b038c7ded641609f9",
+        "x-ms-client-request-id": "90bc85cffe65b1a58da4341c20049ca8",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97605095-d01e-0088-7ee1-99d996000000",
+        "x-ms-request-id": "3ddf0b22-201e-0057-2a83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_10.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_10.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-5f6c9b2bfc101744b1215782fb1b9055-abe9d436a6f75446-00",
+        "traceparent": "00-fa4f943a4730b440b1f3da44856a100d-ee11ef4cdc7f484f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "6da74c0d06936f15d6fffc19b87ebbde",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "x-ms-client-request-id": "27ea8c36e69728282ae0c1097dfe2714",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1074,30 +1074,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:09 GMT",
-        "ETag": "\u00220x8D967F87715F68C\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:47 GMT",
+        "ETag": "\u00220x8D9689ABE3B34D6\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:47 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "6da74c0d06936f15d6fffc19b87ebbde",
+        "x-ms-client-request-id": "27ea8c36e69728282ae0c1097dfe2714",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97605106-d01e-0088-64e1-99d996000000",
+        "x-ms-request-id": "3ddf0b9c-201e-0057-1a83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_11.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_11.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-cfcaed38c60f0e48afa5dbc0a8e8b62a-4c4771f0aae0a545-00",
+        "traceparent": "00-58dee1f72013a14289ea953231f6d39d-2c9351cfeae2f941-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "6b314e1383e32cb937eeaf64b49e0d41",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "x-ms-client-request-id": "5c049d0b324624f7d3f7366409edb943",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1106,30 +1106,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:09 GMT",
-        "ETag": "\u00220x8D967F877446217\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:47 GMT",
+        "ETag": "\u00220x8D9689ABE68B5DA\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:47 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "6b314e1383e32cb937eeaf64b49e0d41",
+        "x-ms-client-request-id": "5c049d0b324624f7d3f7366409edb943",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97605183-d01e-0088-5ae1-99d996000000",
+        "x-ms-request-id": "3ddf0c25-201e-0057-1283-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_12.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_12.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-2f73d6b6329eda468f44fe95af64aa36-f052108fa52e6741-00",
+        "traceparent": "00-9d82e6c250b6964cbf13890fe980d67d-e247e262dcfc6146-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3c217ae7a6799c3b58cb99724b726084",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "x-ms-client-request-id": "e890bbc464dee95d5d9465853c9b348e",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1138,30 +1138,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:10 GMT",
-        "ETag": "\u00220x8D967F8776F4A86\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:47 GMT",
+        "ETag": "\u00220x8D9689ABE9ACB8D\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:48 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3c217ae7a6799c3b58cb99724b726084",
+        "x-ms-client-request-id": "e890bbc464dee95d5d9465853c9b348e",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9760521d-d01e-0088-6ae1-99d996000000",
+        "x-ms-request-id": "3ddf0c82-201e-0057-6983-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_13.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_13.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-b2befbed3e7a57419af21e24029d29a2-23f17bb3cb7b5248-00",
+        "traceparent": "00-4f1026c1c8be71429c38839be10bbb3b-2dc77d0440df634b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "16da9fd19ee58915937a36a456b0bb38",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "x-ms-client-request-id": "82101f7d40ff046194c6539fafc31e3c",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:48 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1170,30 +1170,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:10 GMT",
-        "ETag": "\u00220x8D967F8779BE0F6\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:48 GMT",
+        "ETag": "\u00220x8D9689ABEC7620A\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:48 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "16da9fd19ee58915937a36a456b0bb38",
+        "x-ms-client-request-id": "82101f7d40ff046194c6539fafc31e3c",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976052ab-d01e-0088-71e1-99d996000000",
+        "x-ms-request-id": "3ddf0cee-201e-0057-4b83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_14.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_14.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c8696d71662e8a42b6daeadb6e3c3db6-75aaae8ed57a9240-00",
+        "traceparent": "00-36c14629c2315744a464756fb93c1e78-613e4a05138fb745-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3d31baf17e5c6d6513951217ea46e0c4",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "x-ms-client-request-id": "c2457e263e6da735401affb2cc72e738",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:48 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1202,30 +1202,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:10 GMT",
-        "ETag": "\u00220x8D967F877C8ECB2\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:48 GMT",
+        "ETag": "\u00220x8D9689ABEF5CD8C\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:48 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3d31baf17e5c6d6513951217ea46e0c4",
+        "x-ms-client-request-id": "c2457e263e6da735401affb2cc72e738",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97605318-d01e-0088-52e1-99d996000000",
+        "x-ms-request-id": "3ddf0d51-201e-0057-2383-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_15.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_15.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-63b9bd641bcf09468e32d7bbd0d09351-ac30d7cd0ba0c14c-00",
+        "traceparent": "00-ab056e999388e44fa8f1f2a2cb81dd35-6bc5027869e8e246-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "14932a8df7c3495c6498a9fe709645a8",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "x-ms-client-request-id": "e9e7a8c336dd8343598c531810bd3999",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:48 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1234,30 +1234,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:11 GMT",
-        "ETag": "\u00220x8D967F877F47187\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:48 GMT",
+        "ETag": "\u00220x8D9689ABF232777\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:49 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "14932a8df7c3495c6498a9fe709645a8",
+        "x-ms-client-request-id": "e9e7a8c336dd8343598c531810bd3999",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9760538e-d01e-0088-37e1-99d996000000",
+        "x-ms-request-id": "3ddf0d99-201e-0057-6783-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_16.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_16.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c0311599ca87504484e1f3612461d2f3-18ad675c3296a24b-00",
+        "traceparent": "00-96e60c0a2332ad45b3c410571f708634-95a4fb3df4747646-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "91816010234152283a6d024f8cfe9f4c",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "x-ms-client-request-id": "be5e287671553f20ea6842e441af3822",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1266,30 +1266,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:11 GMT",
-        "ETag": "\u00220x8D967F8781FF65B\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:49 GMT",
+        "ETag": "\u00220x8D9689ABF4FBDF5\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:49 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "91816010234152283a6d024f8cfe9f4c",
+        "x-ms-client-request-id": "be5e287671553f20ea6842e441af3822",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976053e9-d01e-0088-0ae1-99d996000000",
+        "x-ms-request-id": "3ddf0de5-201e-0057-3183-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_17.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_17.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-72415a276e693945b5cbd1a1aa621f31-2f3e2e7738f7a341-00",
+        "traceparent": "00-2c9e520fb8375546a2f82b1a4adea855-1c6dbffd4e189f46-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "2c17719aa61df9745de7d8c4d567fc7c",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "x-ms-client-request-id": "07dc1bde34dcf05f3ac268e1ea1d9782",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1298,30 +1298,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:11 GMT",
-        "ETag": "\u00220x8D967F8784B05E8\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:49 GMT",
+        "ETag": "\u00220x8D9689ABF7D3F11\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:49 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "2c17719aa61df9745de7d8c4d567fc7c",
+        "x-ms-client-request-id": "07dc1bde34dcf05f3ac268e1ea1d9782",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97605476-d01e-0088-11e1-99d996000000",
+        "x-ms-request-id": "3ddf0e2a-201e-0057-7383-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_18.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_18.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c46403f87585c546bcdee64feb9e5287-72e6762d6be31045-00",
+        "traceparent": "00-9ac2fca524c0fd4a9964aca07b6eb518-456a4b3a6e70a645-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "8a066a4f4fc569830240da56f40cbd65",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "x-ms-client-request-id": "a33c65e1281351e287a7ff74f35e42a9",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:49 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1330,30 +1330,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:11 GMT",
-        "ETag": "\u00220x8D967F87878ADFC\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:49 GMT",
+        "ETag": "\u00220x8D9689ABFA9FCA8\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:49 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "8a066a4f4fc569830240da56f40cbd65",
+        "x-ms-client-request-id": "a33c65e1281351e287a7ff74f35e42a9",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976054c2-d01e-0088-53e1-99d996000000",
+        "x-ms-request-id": "3ddf0e96-201e-0057-4d83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_19.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source699635124/File_19.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-ceebba0448199f469900837d0548da2e-d32877ba5f8a2041-00",
+        "traceparent": "00-b570578fd680ea409a87cf54424f3aef-d78d3d7995bd4145-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "ff635df9197e6a8beb8733594a647dd3",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "x-ms-client-request-id": "f539315331e141bdc96e8393083e54cc",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1362,28 +1362,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:12 GMT",
-        "ETag": "\u00220x8D967F878A62EF8\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:50 GMT",
+        "ETag": "\u00220x8D9689ABFD6E156\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ff635df9197e6a8beb8733594a647dd3",
+        "x-ms-client-request-id": "f539315331e141bdc96e8393083e54cc",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97605516-d01e-0088-24e1-99d996000000",
+        "x-ms-request-id": "3ddf0eef-201e-0057-1c83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1367849328?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1665220817?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-eac33e30834a2645a094a0bf8af8f152-51322a6a20a0ce48-00",
+        "traceparent": "00-488da5e505c9214ea3f616efff834713-5103596ff0cdb649-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "f82200858615ed4bad2adccb1d04512a",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:13 GMT",
+        "x-ms-client-request-id": "73db03bf0e9538b58a803435ebfcdb7f",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1391,12 +1391,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:12 GMT",
-        "ETag": "\u00220x8D967F878BF6F6D\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:50 GMT",
+        "ETag": "\u00220x8D9689ABFEFF6FD\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "f82200858615ed4bad2adccb1d04512a",
-        "x-ms-request-id": "9760557b-d01e-0088-7ee1-99d996000000",
+        "x-ms-client-request-id": "73db03bf0e9538b58a803435ebfcdb7f",
+        "x-ms-request-id": "3ddf0f51-201e-0057-6f83-9a92ac000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -1409,9 +1409,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-63ef84d89926154c8facca9820519ab8-b7f1b0e46079a24f-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0378cb73fefddf369b9e3e1b291f9dc3",
+        "traceparent": "00-8a734e5d7d39b341ac7a3bdea1d83ab9-a6675f625a70c84a-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e4b98ebfa1a1a8affadaa5a54e484953",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1431,10 +1431,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "69ce1d1b-5e41-41c6-afb1-902bdcd5a300",
+        "apim-request-id": "8175db35-8205-42a7-aded-0cd88876703e",
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:12 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/69c933d1-698c-42ed-967d-40253aee437f",
+        "Date": "Thu, 26 Aug 2021 14:06:50 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f81d5c81-f7db-41da-baa7-dff063bd88c4",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -1442,26 +1442,26 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "69ce1d1b-5e41-41c6-afb1-902bdcd5a300"
+        "X-RequestId": "8175db35-8205-42a7-aded-0cd88876703e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/69c933d1-698c-42ed-967d-40253aee437f",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f81d5c81-f7db-41da-baa7-dff063bd88c4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0c6fe6076d9ad6e31711d1efae9fce82",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5b34a233366622be83bc56b1880cde72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ffb2af97-f029-4461-b7c7-f487adb2d626",
+        "apim-request-id": "6b8efdf9-4487-4ba6-8a29-5b13f4406e3a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:50 GMT",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1471,12 +1471,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ffb2af97-f029-4461-b7c7-f487adb2d626"
+        "X-RequestId": "6b8efdf9-4487-4ba6-8a29-5b13f4406e3a"
       },
       "ResponseBody": {
-        "id": "69c933d1-698c-42ed-967d-40253aee437f",
-        "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:13.0496708Z",
+        "id": "f81d5c81-f7db-41da-baa7-dff063bd88c4",
+        "createdDateTimeUtc": "2021-08-26T14:06:50.6689792Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:50.9152942Z",
         "status": "Cancelling",
         "summary": {
           "total": 0,
@@ -1490,27 +1490,27 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=69c933d1-698c-42ed-967d-40253aee437f",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=f81d5c81-f7db-41da-baa7-dff063bd88c4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-33889e6d0c16e04d800eee923dacff49-5322371615f0a549-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "99d72fe2cf058773c9425c76472fc48e",
+        "traceparent": "00-eb8031b542e5d24ea8958d215a8adebb-8bf815abb3274543-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b04913a7e89a1e30543378bb6910ea42",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb78ff4f-1b0e-41c2-88ba-622b64df9a16",
+        "apim-request-id": "8ae509a6-f5ff-4f34-af71-81cf62d30691",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:18 GMT",
-        "ETag": "\u0022E878D4BC987CA6511D1BAB5A080522F99196EED62957EBEDCB8147C32D3781F8\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:56 GMT",
+        "ETag": "\u00221254637B5E09DF0F54D46FCC7C434740D8DBCAE333D988C7E3B3B1807DE221FC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1520,67 +1520,14 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "bb78ff4f-1b0e-41c2-88ba-622b64df9a16"
+        "X-RequestId": "8ae509a6-f5ff-4f34-af71-81cf62d30691"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "69c933d1-698c-42ed-967d-40253aee437f",
-            "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:16.0423646Z",
-            "status": "Cancelling",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 20,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=69c933d1-698c-42ed-967d-40253aee437f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b838c5862cb9ba49b1c5f2aab4cf14a2-6f78b57f1905e74a-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "37c3198c4495058fe7a1ebeb2d4730fc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "74655775-e4a1-462d-b199-288b5e73b04e",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:23 GMT",
-        "ETag": "\u002215E48B3C6F6C3DAFB337B72309ACEEAC1B5B8AE9CC50D1CCFCFEDBD02E4186DD\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "74655775-e4a1-462d-b199-288b5e73b04e"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "69c933d1-698c-42ed-967d-40253aee437f",
-            "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:21.5359358Z",
+            "id": "f81d5c81-f7db-41da-baa7-dff063bd88c4",
+            "createdDateTimeUtc": "2021-08-26T14:06:50.6689792Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:06:55.7249243Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1596,816 +1543,27 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?statuses=Cancelled%2CCancelling",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?statuses=Cancelled%2CCancelling\u0026createdDateTimeUtcStart=2021-08-26T08%3A06%3A56.3794114Z",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a0c46b2a46f1b64db84352b81b5fe888-2da69db646a7ae4d-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fa39bcd0044838bd72e74357116d8ee8",
+        "traceparent": "00-3f7fbf23e219244992c74f7206f19bc3-daa42b7c3d7ba84b-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4801e03780c88819d09760e44bfd1fee",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "48de7c3d-de0e-48f1-b0e2-5dbc59533af9",
+        "apim-request-id": "f4853e8f-1e78-4d64-a09c-11349e567a06",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:23 GMT",
-        "ETag": "\u00222DBB480CEF01030109F9996E73455487EACB973D1B2730B78C1DC8239D022B09\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "48de7c3d-de0e-48f1-b0e2-5dbc59533af9"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "69c933d1-698c-42ed-967d-40253aee437f",
-            "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:21.5359358Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "decfe908-d309-4d44-838b-7b12aa38d315",
-            "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:21:38.0583554Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
-            "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:20:58.7274706Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "253d9f25-18d2-4cc7-8669-4d8407b22a9c",
-            "createdDateTimeUtc": "2021-08-25T14:19:05.8329604Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:19:10.6795351Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "60db663e-f771-4adb-b08f-6854b85696e1",
-            "createdDateTimeUtc": "2021-08-25T14:18:43.8946636Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:18:51.4148389Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5acc56a1-33c3-4542-9370-5f7b9b19f5ab",
-            "createdDateTimeUtc": "2021-08-25T14:15:39.7803188Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:15:43.1246356Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2597203e-1311-41c4-886f-f465cd164759",
-            "createdDateTimeUtc": "2021-08-25T14:15:19.2437991Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:15:23.9402734Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f4b9df36-266a-40d0-ba29-fc0e67dd4887",
-            "createdDateTimeUtc": "2021-08-25T14:14:35.4257961Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:14:41.4038969Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a5c6c285-da24-494d-a971-919266469088",
-            "createdDateTimeUtc": "2021-08-25T14:14:14.5070628Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:14:19.0578249Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "533c3361-dfbe-4bd2-a517-9491e071775a",
-            "createdDateTimeUtc": "2021-08-25T14:13:34.7214701Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:13:39.5494326Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a23b53f3-ed01-458b-947e-867a553eb591",
-            "createdDateTimeUtc": "2021-08-25T14:13:13.8939951Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:13:19.2252019Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "0d4b8b20-a460-469a-b3aa-588300fef2e0",
-            "createdDateTimeUtc": "2021-08-25T14:08:25.2665312Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:08:32.3285477Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2aecc1c5-d3da-45b9-93c5-d2a260d6aedf",
-            "createdDateTimeUtc": "2021-08-25T14:08:02.4909754Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:08:06.9807983Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b0607637-8b27-4120-8b39-6194b5755e92",
-            "createdDateTimeUtc": "2021-08-25T14:06:09.5993734Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:06:14.8816421Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b7f3c08a-c2c0-4228-9f8a-c92be3b7737d",
-            "createdDateTimeUtc": "2021-08-25T14:05:44.5683358Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:05:49.4108643Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "0d5c55f5-91e2-4d2f-88f8-9c7ae1de5505",
-            "createdDateTimeUtc": "2021-08-25T14:05:07.8586943Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:05:11.277379Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b4f56a1c-3b5d-42a2-a94e-1c949dfe776f",
-            "createdDateTimeUtc": "2021-08-25T14:04:41.9246386Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:04:48.5055613Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ff62a2bd-4c6f-47e8-b557-f429dd7e6f3a",
-            "createdDateTimeUtc": "2021-08-25T14:03:49.5697452Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:03:53.7964747Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "9eb1fcae-bc60-4b93-90eb-64a52c473672",
-            "createdDateTimeUtc": "2021-08-25T14:03:24.5425451Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:03:31.821667Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "eb67646e-c215-4fa3-8eb3-da0770064e5f",
-            "createdDateTimeUtc": "2021-08-25T13:57:19.6278599Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:57:30.2946248Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "727d5bf9-f9fb-4ddf-9a38-828f22910b12",
-            "createdDateTimeUtc": "2021-08-25T13:53:59.4231523Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:54:05.5775816Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4809cfc7-d5ae-4225-868e-05544f489358",
-            "createdDateTimeUtc": "2021-08-25T13:53:29.8911657Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:53:33.6911548Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d493956c-db6d-4a17-a5f0-028becb4ccfa",
-            "createdDateTimeUtc": "2021-08-25T13:52:31.0854759Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:52:34.9946496Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b6a8fa53-920e-4932-8c81-f3c73c0b2988",
-            "createdDateTimeUtc": "2021-08-25T13:51:53.8772741Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:52:00.7948926Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c2301f1f-c87f-4772-9f9c-5a9d7548b349",
-            "createdDateTimeUtc": "2021-08-25T13:45:19.087893Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:45:23.5227282Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d8ecc615-eeeb-4787-a601-851daef7b268",
-            "createdDateTimeUtc": "2021-08-25T13:44:54.582286Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:44:58.230487Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "14f3ad4c-7135-415e-859d-9b5f431ae6da",
-            "createdDateTimeUtc": "2021-08-25T13:44:08.2452291Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:44:16.8544217Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "9bb35643-eeb4-475b-8344-c3ae46655123",
-            "createdDateTimeUtc": "2021-08-25T13:43:37.812651Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:43:45.7364219Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ea604b93-8058-4d72-af48-81ad3ed99057",
-            "createdDateTimeUtc": "2021-08-25T13:41:46.5703013Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:41:50.3292734Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "501bfb81-87b7-4a4e-8f2a-67df97de6546",
-            "createdDateTimeUtc": "2021-08-25T13:41:24.0184265Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:41:27.7675607Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "42029254-a247-4c0b-ba14-52b9856051a4",
-            "createdDateTimeUtc": "2021-08-25T13:40:13.0836214Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:40:17.2772553Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d0ed4aa1-8314-4eff-8794-7d71942ebb55",
-            "createdDateTimeUtc": "2021-08-25T13:39:50.5251217Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:39:54.8052147Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "92252ab6-aeee-429c-8eca-f02e13be2348",
-            "createdDateTimeUtc": "2021-08-25T13:36:06.2711907Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:36:11.6241286Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "0e476571-3f2d-4999-bab6-7d3487603d22",
-            "createdDateTimeUtc": "2021-08-25T13:29:53.0363818Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:29:58.8829377Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "9feff3a9-0b8c-4c47-b780-664c7d90d549",
-            "createdDateTimeUtc": "2021-08-25T13:26:04.1635563Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:26:08.1645944Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c2f031b9-55db-42a9-9ecc-afdd741985bf",
-            "createdDateTimeUtc": "2021-08-25T13:25:45.2888951Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:25:49.1040561Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "500ffbb8-db58-417a-9bbc-98fd0d5e0f6e",
-            "createdDateTimeUtc": "2021-08-25T13:24:28.73101Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:24:32.7396137Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6385a3f7-9a39-4389-a9e3-0b533e19561d",
-            "createdDateTimeUtc": "2021-08-25T13:24:08.1547203Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:24:11.935914Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "040d09c1-a792-48a1-8b09-368ad940703c",
-            "createdDateTimeUtc": "2021-08-25T13:23:09.2673068Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:23:17.3461036Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a4720b7c-5aff-451d-9168-4aaeb46810ec",
-            "createdDateTimeUtc": "2021-08-25T13:22:47.9668002Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:22:51.8319732Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "53665f6e-2451-47ad-872e-0b60048296bc",
-            "createdDateTimeUtc": "2021-08-25T13:21:59.6468367Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:22:04.1049272Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4d02dc0e-82d0-4106-9601-2b67d4895887",
-            "createdDateTimeUtc": "2021-08-25T13:21:41.2699303Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:21:45.685377Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2f83a75e-3690-478a-b2c1-838a3c87780f",
-            "createdDateTimeUtc": "2021-08-25T13:20:00.4021268Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:20:04.4540659Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "79358abe-ca1d-4a34-a9dc-251d35f38d88",
-            "createdDateTimeUtc": "2021-08-25T13:19:40.6697383Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:19:47.1202077Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "aa883068-64e5-435b-8663-bc9573b2e917",
-            "createdDateTimeUtc": "2021-08-25T10:56:20.2363383Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:56:27.0780797Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "90c0a544-4504-4020-8396-0544b00c18c6",
-            "createdDateTimeUtc": "2021-08-25T10:55:55.9293426Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:56:05.0797274Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "614afed7-f7f1-4d74-9ad7-eff593103cd6",
-            "createdDateTimeUtc": "2021-08-25T10:29:21.1938146Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:29:24.7004537Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f74ec5a8-15e9-4b8c-b8b6-c33ddd521c63",
-            "createdDateTimeUtc": "2021-08-25T10:29:02.5870188Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:29:05.9331656Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "fc864d53-0ddb-4fad-85ac-2d7451de0350",
-            "createdDateTimeUtc": "2021-08-25T10:28:05.7449329Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:28:15.1486564Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "30bc281b-3a6c-4a97-92c2-43de98e83aa4",
-            "createdDateTimeUtc": "2021-08-25T10:27:43.633836Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:27:50.5077585Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          }
-        ],
-        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=88\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=88\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b3c559178b79994eba5c427c814c02d0-09d647cb6675264a-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9462424d96db9dec9fd2b263e3885a81",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "096c5727-cb8c-4bda-bc52-a5f9a9f90f2f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:24 GMT",
-        "ETag": "\u0022F93D2105F399D115E6184992514BEA0DE3AF3422EA74E4E85CBFC6E7A38DCD41\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:56 GMT",
+        "ETag": "\u00221BC5205A2AF41EF85CB1D21934A0FCA8119DD81ABCE6974E5E82F202841FC1FD\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -2415,14 +1573,14 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "096c5727-cb8c-4bda-bc52-a5f9a9f90f2f"
+        "X-RequestId": "f4853e8f-1e78-4d64-a09c-11349e567a06"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "6f160aba-7e60-4748-a972-d0a146b3196e",
-            "createdDateTimeUtc": "2021-08-25T10:26:50.4040903Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:26:54.3204806Z",
+            "id": "f81d5c81-f7db-41da-baa7-dff063bd88c4",
+            "createdDateTimeUtc": "2021-08-26T14:06:50.6689792Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:06:55.7249243Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -2435,9 +1593,9 @@
             }
           },
           {
-            "id": "ca6e611e-7b53-4d7f-b638-afe8d00bb725",
-            "createdDateTimeUtc": "2021-08-25T10:26:26.2866155Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:26:30.7154518Z",
+            "id": "cbd0280d-ed6b-4ad0-818d-eee8d0d19808",
+            "createdDateTimeUtc": "2021-08-26T13:23:52.7354145Z",
+            "lastActionDateTimeUtc": "2021-08-26T13:23:57.8859353Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -2450,9 +1608,9 @@
             }
           },
           {
-            "id": "5d4b8b67-af0b-4c12-9c75-0869a2ba66df",
-            "createdDateTimeUtc": "2021-08-25T10:24:14.9778475Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:24:23.0381859Z",
+            "id": "2bd0dab9-918e-48f8-9919-94dcff13c8d4",
+            "createdDateTimeUtc": "2021-08-26T13:23:21.2191695Z",
+            "lastActionDateTimeUtc": "2021-08-26T13:23:25.3549473Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -2465,9 +1623,9 @@
             }
           },
           {
-            "id": "57bc3d42-2f4c-4dd1-ad51-791847d581d4",
-            "createdDateTimeUtc": "2021-08-25T10:23:51.1332076Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:23:58.0469266Z",
+            "id": "7c03da23-0463-456b-bdd7-c37865f5aa61",
+            "createdDateTimeUtc": "2021-08-26T13:06:16.8917739Z",
+            "lastActionDateTimeUtc": "2021-08-26T13:06:20.2226075Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -2480,1293 +1638,9 @@
             }
           },
           {
-            "id": "c55b120e-d8e1-48de-b0af-0e8d45c2b960",
-            "createdDateTimeUtc": "2021-08-25T10:09:55.7948842Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:10:02.821391Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8e66ffc9-0ac3-48a0-82ae-7609c6a6050a",
-            "createdDateTimeUtc": "2021-08-25T10:09:31.391233Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:09:35.8564693Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "63fb087b-4dd8-46d8-ac10-48bb79ce86d3",
-            "createdDateTimeUtc": "2021-08-25T10:07:25.2633442Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:07:31.8339883Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "cb2faa2d-95b1-46f9-bd39-4c5ffaf3d066",
-            "createdDateTimeUtc": "2021-08-25T10:07:01.8887184Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:07:06.5864174Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "73489fba-e1e8-4fb6-9f08-1eec3698f3e3",
-            "createdDateTimeUtc": "2021-08-25T10:05:29.2026751Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:05:41.024571Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d5015b23-d0d7-46f0-af5e-50e2228f4841",
-            "createdDateTimeUtc": "2021-08-25T10:05:07.1839969Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:05:15.5031116Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8f3aefad-b2fc-41cf-968d-18b0497b5fb3",
-            "createdDateTimeUtc": "2021-08-25T10:01:07.121612Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:01:13.8095906Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "609f5c8f-80e1-424b-9801-5d3e804c134e",
-            "createdDateTimeUtc": "2021-08-25T09:47:51.4646326Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:47:59.0397057Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "cc873f8b-e71f-4617-a277-00b299907c0e",
-            "createdDateTimeUtc": "2021-08-25T09:47:17.2200753Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:47:25.0694763Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "92c6004e-733f-41af-8d2f-89b41bb279c6",
-            "createdDateTimeUtc": "2021-08-25T09:44:03.9368379Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:44:09.2827307Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "0699ddc0-9394-43b7-8335-99b582ac7af5",
-            "createdDateTimeUtc": "2021-08-25T09:43:07.3141327Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:43:12.1318918Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "686ae6d7-ffc1-4c0c-a4b1-49a57d03524b",
-            "createdDateTimeUtc": "2021-08-25T09:42:39.886955Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:42:45.1118961Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "77edc600-d50a-4740-ba35-9fc276ae7415",
-            "createdDateTimeUtc": "2021-08-25T09:19:31.6344382Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:19:39.3248571Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8afe0ff5-a724-4d21-acce-da44c26b3ffe",
-            "createdDateTimeUtc": "2021-08-25T09:19:10.8844738Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:19:17.2753878Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "02acf584-26b6-40d3-a958-e34734f20ef5",
-            "createdDateTimeUtc": "2021-08-25T09:18:05.5949331Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:18:10.700436Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "da3b7f1b-eaf1-4ef3-b1d7-34cb12c58f5f",
-            "createdDateTimeUtc": "2021-08-25T09:17:41.6284086Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:17:46.8467624Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "e2fdfa9b-eef5-4285-84f2-394dc3ee0cde",
-            "createdDateTimeUtc": "2021-08-25T09:16:55.2621789Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:17:00.0474197Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8107b309-29ed-4fc0-b2e1-cfeb96210550",
-            "createdDateTimeUtc": "2021-08-25T09:16:27.1861354Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:16:31.6226169Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d33cd5ae-28a9-4560-980d-3cd99decdb56",
-            "createdDateTimeUtc": "2021-08-25T09:15:20.2067568Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:15:30.5710243Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ea961c29-189c-4dbc-b375-61167cf15a17",
-            "createdDateTimeUtc": "2021-08-25T09:14:55.2312472Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:15:04.6298687Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "eb8efceb-d78d-4dcf-aedb-c3edde6cbc7e",
-            "createdDateTimeUtc": "2021-08-24T19:55:47.1477025Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:55:51.5061055Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "534d90e6-5360-471e-bfd0-54d23d28aa3f",
-            "createdDateTimeUtc": "2021-08-24T19:53:32.6469602Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:53:40.4258421Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a10ef07d-101a-4e0c-9194-ab61b49cba8a",
-            "createdDateTimeUtc": "2021-08-24T19:53:07.1127838Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:53:15.4049994Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "223a9ccf-7935-4581-995a-60605ee335a5",
-            "createdDateTimeUtc": "2021-08-24T19:50:41.7797004Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:50:48.506789Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4dbe99ed-ca2d-4dbe-8bcd-2643d5bbe7f4",
-            "createdDateTimeUtc": "2021-08-24T19:50:16.0211307Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:50:26.0420851Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f80c73e0-e8ec-4d35-a4d4-27179f0ed4bf",
-            "createdDateTimeUtc": "2021-08-24T19:49:10.6527877Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:49:15.2215103Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "18d1d2d0-c3e1-4864-833c-8ab189be6fc1",
-            "createdDateTimeUtc": "2021-08-24T19:48:44.5805808Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:48:49.1109041Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5a457f72-8bd8-450c-ac60-da04df2cc2ab",
-            "createdDateTimeUtc": "2021-08-24T19:46:10.1997622Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:46:17.9106435Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "60ff13d3-9f94-431f-ac62-58f42f771630",
-            "createdDateTimeUtc": "2021-08-24T19:45:44.4022212Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:45:48.9866813Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "195c51ce-0ef1-491b-9ec2-db1542402a32",
-            "createdDateTimeUtc": "2021-08-24T19:44:53.1308296Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:45:02.5998496Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6a18a4bd-f2cc-42cc-b195-cd1cdb22eaf6",
-            "createdDateTimeUtc": "2021-08-24T19:44:31.5620308Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:44:38.2064648Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c562e87c-1fb3-4e9f-8748-803d34fe7b11",
-            "createdDateTimeUtc": "2021-08-24T19:42:08.6323717Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:42:16.6949486Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2c8d2c87-1dd9-42af-aa73-9052cb89123c",
-            "createdDateTimeUtc": "2021-08-24T19:41:44.486071Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:41:49.5437122Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a8018349-6083-4c7b-be65-a0d93cd7f9f1",
-            "createdDateTimeUtc": "2021-08-24T19:26:28.685069Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:26:35.6712921Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "93c8fbe5-2509-4e26-aa38-5b44ae36abb9",
-            "createdDateTimeUtc": "2021-08-24T19:25:53.9806028Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:25:59.7724431Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b981ecff-a052-4239-975b-2f4ed45aa2e7",
-            "createdDateTimeUtc": "2021-08-24T19:25:32.5560562Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:25:36.3150668Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5fce870f-5805-48fe-9e55-d978c0a44a96",
-            "createdDateTimeUtc": "2021-08-24T19:24:49.8512423Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:24:54.7359674Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "58dd2537-2390-41ce-8e66-cf5d991a0ef0",
-            "createdDateTimeUtc": "2021-08-24T19:24:28.0491081Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:24:32.8824749Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "309c5ab2-ab6e-42d2-b341-3d273507090b",
-            "createdDateTimeUtc": "2021-08-24T19:19:16.359635Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:19:26.45727Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6621b15c-9956-44d8-8bd2-de6d1dd3d518",
-            "createdDateTimeUtc": "2021-08-24T19:18:15.2019519Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:18:20.6814382Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b39c5530-1a07-4898-b0cf-d1b81c31958c",
-            "createdDateTimeUtc": "2021-08-24T19:17:00.6801855Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:17:04.7751099Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ab5f7b09-0873-4d2d-942c-5a76b6296264",
-            "createdDateTimeUtc": "2021-08-24T19:16:35.6588021Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:16:45.7609068Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c0c4e53a-6bc5-4d35-be29-4e9d088d6b70",
-            "createdDateTimeUtc": "2021-08-24T15:36:55.7864604Z",
-            "lastActionDateTimeUtc": "2021-08-24T15:37:01.6474825Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "161de4ac-0924-4527-8170-a4bec6eb38c8",
-            "createdDateTimeUtc": "2021-08-24T15:36:21.2461429Z",
-            "lastActionDateTimeUtc": "2021-08-24T15:36:28.9384829Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "49840bd2-de72-4b7d-9bf4-47f746ecc5bb",
-            "createdDateTimeUtc": "2021-08-23T17:47:33.9921789Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:47:40.5970502Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6e3b9367-513c-4d20-8c07-ee3568440b7c",
-            "createdDateTimeUtc": "2021-08-23T17:47:11.3828547Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:47:15.2840674Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          }
-        ],
-        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=38\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=38\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f44813656cfc29499e7356e083384d2c-0a43beb0b7b5a740-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8ba65f12c9f688455b8bc5ae0137f37a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d2e73cfc-90d1-4063-8bf1-af9eb7fa304b",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:25 GMT",
-        "ETag": "\u0022365497CD112BCBB73250DFA8E68476F00A951A03223C86AD07CC87E4515B7C10\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d2e73cfc-90d1-4063-8bf1-af9eb7fa304b"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "b2d0e15f-95ef-40d4-bfb0-9a4f203a54ba",
-            "createdDateTimeUtc": "2021-08-23T17:35:20.3985579Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:35:27.6518861Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "15bb936d-c180-4255-9ba2-a07bec5806dd",
-            "createdDateTimeUtc": "2021-08-23T17:34:58.0354643Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:35:03.3355533Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "29353a68-850e-4c04-bce3-ce98e0ee567f",
-            "createdDateTimeUtc": "2021-08-23T17:33:06.4539736Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:33:14.3872677Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "40f6ee23-324d-49fd-b74b-fcdcbb410299",
-            "createdDateTimeUtc": "2021-08-23T17:32:44.9924751Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:32:51.3694131Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "1617b829-c0a3-4971-92d4-c2964babd030",
-            "createdDateTimeUtc": "2021-08-23T17:32:09.2406517Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:32:18.6614602Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a577fd72-5713-466c-8bc7-a1c81c9ce690",
-            "createdDateTimeUtc": "2021-08-23T17:31:48.2758423Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:31:53.1076136Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "3ef3e1fd-9489-4036-a76d-adf8121073a9",
-            "createdDateTimeUtc": "2021-08-23T17:28:59.4940221Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:29:05.3839228Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "795298f9-c99d-46ad-9be8-756171a64d47",
-            "createdDateTimeUtc": "2021-08-23T17:28:37.2538866Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:28:47.3380251Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "38136150-8f48-470f-93d0-efd2167ad0df",
-            "createdDateTimeUtc": "2021-08-23T17:28:06.0935977Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:28:15.7031915Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8f25593f-63ad-413a-9e0b-2f7b935e53f7",
-            "createdDateTimeUtc": "2021-08-23T17:27:42.2908433Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:27:51.9149141Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "032a3bb1-cdbf-4162-b3c7-7b3618379c7f",
-            "createdDateTimeUtc": "2021-08-23T17:27:09.7358524Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:27:19.680071Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ab879574-fcf3-41e3-b77e-6ea15d44b413",
-            "createdDateTimeUtc": "2021-08-23T17:26:47.3142089Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:26:56.5225722Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "98743da0-d863-41c4-bf57-56fa90b43eb4",
-            "createdDateTimeUtc": "2021-08-23T17:25:45.600667Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:25:49.2127676Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "183d6c88-fdae-4ea5-aa68-340f1ad84f77",
-            "createdDateTimeUtc": "2021-08-23T17:25:24.3498398Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:25:31.0082101Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "09960070-bdf0-46b1-99af-928e4a626f69",
-            "createdDateTimeUtc": "2021-08-23T17:24:31.4385114Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:24:35.5546122Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d8405784-fa6b-4267-b830-d8513a4f658d",
-            "createdDateTimeUtc": "2021-08-23T17:24:00.3396396Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:24:05.6562369Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "43b2701d-cae4-47b5-8287-f00ef452a7ce",
-            "createdDateTimeUtc": "2021-08-23T17:23:35.5630305Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:23:45.0431691Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "464de745-a68f-43db-b2af-61ccf62acc73",
-            "createdDateTimeUtc": "2021-08-23T17:20:31.3475187Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:20:40.1632632Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "3591ae2c-a6f1-44f4-8f8b-802ccb41fb0d",
-            "createdDateTimeUtc": "2021-08-23T17:19:56.3627557Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:20:04.8977529Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c5addf28-55a0-4cf7-a193-452c47aba219",
-            "createdDateTimeUtc": "2021-08-23T17:19:36.4200341Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:19:43.8168428Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "7570de08-6a5c-4a7d-9862-65db205744e2",
-            "createdDateTimeUtc": "2021-08-23T17:16:04.5109438Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:16:14.2207404Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c2b12a8c-a64e-486a-8cb8-6f533fa14d9a",
-            "createdDateTimeUtc": "2021-08-23T17:12:39.1494425Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:12:48.7856928Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d0b76907-0261-4277-884c-f0823f9ec122",
-            "createdDateTimeUtc": "2021-08-23T17:12:16.3765099Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:12:22.483808Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b6bd137e-2a00-4427-bbda-215b9dcdbff1",
-            "createdDateTimeUtc": "2021-08-23T17:11:35.4166713Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:11:41.9836701Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "68dba74a-e802-486b-a389-28977cbd191c",
-            "createdDateTimeUtc": "2021-08-23T17:11:11.1146708Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:11:15.5935992Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "e1bc7687-0156-45f5-9428-e63c022dbafd",
-            "createdDateTimeUtc": "2021-08-23T17:09:30.3557278Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:09:38.0232919Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4ad591be-f6a3-424a-a368-a5ac3338c68e",
-            "createdDateTimeUtc": "2021-08-23T17:09:05.6068524Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:09:14.2949945Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "fb02d26f-4b4a-44c7-8512-1dc605b4760d",
-            "createdDateTimeUtc": "2021-08-23T17:08:01.2644983Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:08:07.3426569Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "3fe85a3c-4db1-4dc5-baf8-b4956f535c2f",
-            "createdDateTimeUtc": "2021-08-23T16:59:08.3574297Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:59:16.4935524Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5afefe59-d1b7-4df4-ad58-0c7665aa1167",
-            "createdDateTimeUtc": "2021-08-23T16:58:22.7200327Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:58:30.9323045Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "da52052a-d809-46b3-a65f-4b0b4366462b",
-            "createdDateTimeUtc": "2021-08-23T16:57:50.2799217Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:57:55.6175942Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "bf798bca-7a93-47a3-a1ff-ccdf90015328",
-            "createdDateTimeUtc": "2021-08-23T16:53:14.9104004Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:53:20.0243492Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "de676d42-097d-499d-b424-63c44ff0fd85",
-            "createdDateTimeUtc": "2021-08-23T16:41:50.025133Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:41:55.021436Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "144d63b0-b972-47da-be48-e8369610d9d0",
-            "createdDateTimeUtc": "2021-08-23T16:41:24.3300611Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:41:27.9762437Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ae29411c-ed5f-45e6-be84-e97c675599ed",
-            "createdDateTimeUtc": "2021-08-23T16:39:53.6000673Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:39:59.431849Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6924c556-8704-4b02-9148-45101d5a8791",
-            "createdDateTimeUtc": "2021-08-23T16:39:31.6451911Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:39:36.1986712Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f1ce52fa-8234-47ec-9772-934b3a24bb70",
-            "createdDateTimeUtc": "2021-08-16T09:59:08.2257882Z",
-            "lastActionDateTimeUtc": "2021-08-16T09:59:14.4683656Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6e7b03fa-1abe-4524-82df-9efccd37df2f",
-            "createdDateTimeUtc": "2021-08-16T09:57:10.9273883Z",
-            "lastActionDateTimeUtc": "2021-08-16T09:57:17.7325207Z",
+            "id": "e31993ab-f254-49ec-afdd-3f0ba829dbbb",
+            "createdDateTimeUtc": "2021-08-26T13:05:57.8600906Z",
+            "lastActionDateTimeUtc": "2021-08-26T13:06:02.713723Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -3783,9 +1657,10 @@
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2021-08-26T16:06:56.3794114\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "1917340198"
+    "RandomSeed": "2085586814"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1645503099?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source158586476?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-ed9ba83903b12249b67bc7f0966ef511-b479c85b12fa464b-00",
+        "traceparent": "00-6d172d4d0dccbb438fbe3ffe1f42a02a-f5024458e5940047-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "2b5ca98ba7f97f0c2fd02a5e1fe6bfea",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:36 GMT",
+        "x-ms-client-request-id": "3c982c0dbc3dd292cd8b4a74b0a93a18",
+        "x-ms-date": "Wed, 25 Aug 2021 18:44:50 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:20:36 GMT",
-        "ETag": "\u00220x8D967D38268A57B\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:37 GMT",
+        "Date": "Wed, 25 Aug 2021 18:44:50 GMT",
+        "ETag": "\u00220x8D967F86B976679\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:44:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "2b5ca98ba7f97f0c2fd02a5e1fe6bfea",
-        "x-ms-request-id": "df48313e-c01e-002d-13bc-998fec000000",
+        "x-ms-client-request-id": "3c982c0dbc3dd292cd8b4a74b0a93a18",
+        "x-ms-request-id": "97603e77-d01e-0088-4fe1-99d996000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1645503099/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source158586476/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-a0e13cc0bb2cd4469f2ac93c52d635de-874c2adbaca5bb4e-00",
+        "traceparent": "00-33b08773a01a0d46839f026337df579e-ead3012f45ee3141-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "eda9eea294921abdf9af6b33aa3b2f62",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:38 GMT",
+        "x-ms-client-request-id": "67cf809ddabdf4a3dd4ae6c33a914733",
+        "x-ms-date": "Wed, 25 Aug 2021 18:44:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:37 GMT",
-        "ETag": "\u00220x8D967D382A060F5\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:37 GMT",
+        "Date": "Wed, 25 Aug 2021 18:44:50 GMT",
+        "ETag": "\u00220x8D967F86BE161C1\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:44:50 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "eda9eea294921abdf9af6b33aa3b2f62",
+        "x-ms-client-request-id": "67cf809ddabdf4a3dd4ae6c33a914733",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df48319a-c01e-002d-67bc-998fec000000",
+        "x-ms-request-id": "97603ecd-d01e-0088-13e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target674250945?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target485781887?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-406ffbaee9dc3d4caa1ddee59af8b08f-8010ecae5cd9774b-00",
+        "traceparent": "00-7d134f2d48836046a05801b07316cd8a-5c24b7ef46229442-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "af5b0476616d7386c743a460107b73de",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:38 GMT",
+        "x-ms-client-request-id": "647b5b7caf8112829452acd684ab424a",
+        "x-ms-date": "Wed, 25 Aug 2021 18:44:51 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,12 +76,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:20:37 GMT",
-        "ETag": "\u00220x8D967D382B7E582\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:37 GMT",
+        "Date": "Wed, 25 Aug 2021 18:44:51 GMT",
+        "ETag": "\u00220x8D967F86BFBE005\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:44:51 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "af5b0476616d7386c743a460107b73de",
-        "x-ms-request-id": "df483214-c01e-002d-55bc-998fec000000",
+        "x-ms-client-request-id": "647b5b7caf8112829452acd684ab424a",
+        "x-ms-request-id": "97603f1f-d01e-0088-4ee1-99d996000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -94,9 +94,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ce81540c934f3c4baccd6dda8d8c415b-97aa29f715cc824a-00",
+        "traceparent": "00-edac0d22b82bcd488a5708eea3ebad2a-8642fa8a45605240-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5ea6d7e0e988ecf741314a3cd8d4f4a1",
+        "x-ms-client-request-id": "936ed464ae518933a35ff2d5ce983c43",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -116,10 +116,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cda705f6-5c0c-4cd2-820d-49c5387179c1",
+        "apim-request-id": "3c5dac2f-9fbb-4251-b575-3353b589c540",
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:20:39 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+        "Date": "Wed, 25 Aug 2021 18:44:52 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -127,31 +127,31 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cda705f6-5c0c-4cd2-820d-49c5387179c1"
+        "X-RequestId": "3c5dac2f-9fbb-4251-b575-3353b589c540"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e1a89dc73a638c35237acb5018bae833",
+        "x-ms-client-request-id": "4e33f516b3bfd11c4c552887f61e599f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4cb2f053-8e10-45e7-a2f8-44576820dd94",
+        "apim-request-id": "80f59075-fe34-48fb-aa53-306c64cd86bf",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:39 GMT",
-        "ETag": "\u0022CAD4F81BEDA96BF14F578FB635059897322687E6CFD664C428834D751833C51B\u0022",
+        "Date": "Wed, 25 Aug 2021 18:44:52 GMT",
+        "ETag": "\u0022631B2AED74FB1AE582D4F7E7D7F7B932854B6D1319811F5E04F697F72414DFFD\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -161,12 +161,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4cb2f053-8e10-45e7-a2f8-44576820dd94"
+        "X-RequestId": "80f59075-fe34-48fb-aa53-306c64cd86bf"
       },
       "ResponseBody": {
-        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
-        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:20:39.3312147Z",
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:44:52.9237743Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,26 +180,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "64ca55f703888c380d6f6e3b17499bf2",
+        "x-ms-client-request-id": "bcd579a3a0d9cd2d27f2c121bcad43fb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3d1f1ff9-82ad-48ef-9e96-083b8474ed68",
+        "apim-request-id": "bec13b12-3d03-4bc0-b66a-502f2329ca3e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:40 GMT",
-        "ETag": "\u00224375061DCB1161201E42637FF340A0F5B6BC96FF3B1B590CD59CD58CE332C547\u0022",
+        "Date": "Wed, 25 Aug 2021 18:44:54 GMT",
+        "ETag": "\u0022031E5E99658ECA8B4D11B6EAE52531EF8BF3E33B06B1133793BCD4AA9BB0E1EC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -209,12 +209,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3d1f1ff9-82ad-48ef-9e96-083b8474ed68"
+        "X-RequestId": "bec13b12-3d03-4bc0-b66a-502f2329ca3e"
       },
       "ResponseBody": {
-        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
-        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:20:39.9936125Z",
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:44:53.8203771Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -228,26 +228,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7398034f91d3a57aa1193b0e1ea6d486",
+        "x-ms-client-request-id": "8ebf6816f477b08bb89c46fc86ab9285",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3943d06e-3dab-45f2-97f3-7ccae6152474",
+        "apim-request-id": "150cd29c-3a80-4e3f-bd01-cbeb30fb7a47",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:42 GMT",
-        "ETag": "\u00224375061DCB1161201E42637FF340A0F5B6BC96FF3B1B590CD59CD58CE332C547\u0022",
+        "Date": "Wed, 25 Aug 2021 18:44:55 GMT",
+        "ETag": "\u0022031E5E99658ECA8B4D11B6EAE52531EF8BF3E33B06B1133793BCD4AA9BB0E1EC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -257,12 +257,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3943d06e-3dab-45f2-97f3-7ccae6152474"
+        "X-RequestId": "150cd29c-3a80-4e3f-bd01-cbeb30fb7a47"
       },
       "ResponseBody": {
-        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
-        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:20:39.9936125Z",
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:44:53.8203771Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -276,26 +276,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "824417498f0ac318641bd3f3ccfa75da",
+        "x-ms-client-request-id": "553152067fc2766ac86526ccf2fa149e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4910b74-4b92-4736-b8fe-26fcfe502bba",
+        "apim-request-id": "15b02c76-b9a3-4017-801f-b3d909ee5614",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:43 GMT",
-        "ETag": "\u00221AE52BDDD83D396BEBE64C09F3E082064985AA0291C08D4089B557847C2C0265\u0022",
+        "Date": "Wed, 25 Aug 2021 18:44:56 GMT",
+        "ETag": "\u0022031E5E99658ECA8B4D11B6EAE52531EF8BF3E33B06B1133793BCD4AA9BB0E1EC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -305,45 +305,45 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f4910b74-4b92-4736-b8fe-26fcfe502bba"
+        "X-RequestId": "15b02c76-b9a3-4017-801f-b3d909ee5614"
       },
       "ResponseBody": {
-        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
-        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:20:42.8285102Z",
-        "status": "Running",
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:44:53.8203771Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1401d8df7521665fda25c26fc82a6e66",
+        "x-ms-client-request-id": "8d702c11ca5eaf27ee25043c5930477c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c5e07781-f815-4ae0-8754-849d4b3bfa8c",
+        "apim-request-id": "f246e84a-f2c8-44ea-9569-56a8b0ed43ea",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:44 GMT",
-        "ETag": "\u002261ABD5964916BC6E1FF052BA8DF56D7038A48F86D4334FF41054DDA4F5D0F177\u0022",
+        "Date": "Wed, 25 Aug 2021 18:44:57 GMT",
+        "ETag": "\u0022031E5E99658ECA8B4D11B6EAE52531EF8BF3E33B06B1133793BCD4AA9BB0E1EC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -353,12 +353,60 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c5e07781-f815-4ae0-8754-849d4b3bfa8c"
+        "X-RequestId": "f246e84a-f2c8-44ea-9569-56a8b0ed43ea"
       },
       "ResponseBody": {
-        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
-        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:20:43.5536361Z",
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:44:53.8203771Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "691b3c5fee7b9639fe49c512cebebebe",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d3fcf6f1-7722-499a-92da-5aaed1b5c786",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:44:59 GMT",
+        "ETag": "\u0022C0DA890031A93BC0480F486AB38E355144066D952553EC77B30C1D26AE68C897\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d3fcf6f1-7722-499a-92da-5aaed1b5c786"
+      },
+      "ResponseBody": {
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:44:59.1527186Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -372,26 +420,74 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fff2e79b1804bfe7ebd50eb7be86d8a7",
+        "x-ms-client-request-id": "59eba788043b3b262b82669d7b2d1c97",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ec26b51d-39f6-4f92-99ae-ff8bf891c2ce",
+        "apim-request-id": "88941430-41b5-468d-97e6-f0f9e00da236",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:45 GMT",
-        "ETag": "\u00220E731382223635D905628CB1152BB847744F8928927228CCC33A6C0B4A3D1D21\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:00 GMT",
+        "ETag": "\u002209B1A5D61BD225D1DD944F11860A63F1264F7EFB627F1AA28875AE69082A73E1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "88941430-41b5-468d-97e6-f0f9e00da236"
+      },
+      "ResponseBody": {
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:00.0620521Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b66caa1eabdf2223f3da8f140415e130",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "aeb21b42-f857-4e06-83b4-53c8a24ffbf8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:02 GMT",
+        "ETag": "\u002209B1A5D61BD225D1DD944F11860A63F1264F7EFB627F1AA28875AE69082A73E1\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -401,12 +497,156 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ec26b51d-39f6-4f92-99ae-ff8bf891c2ce"
+        "X-RequestId": "aeb21b42-f857-4e06-83b4-53c8a24ffbf8"
       },
       "ResponseBody": {
-        "id": "8267f24e-aa50-4d94-9142-86671cfcd777",
-        "createdDateTimeUtc": "2021-08-25T14:20:39.3312142Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:20:45.9490476Z",
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:00.0620521Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b1b44567ed455b4015df3ef9889b1bd1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9b45feb1-ff49-40fe-b8ce-b648ece13d89",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:03 GMT",
+        "ETag": "\u002209B1A5D61BD225D1DD944F11860A63F1264F7EFB627F1AA28875AE69082A73E1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9b45feb1-ff49-40fe-b8ce-b648ece13d89"
+      },
+      "ResponseBody": {
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:00.0620521Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "23f42e2d0751dcde84c8666175123615",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0724b70f-085e-4cc0-8b51-8b15b721cb4d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:04 GMT",
+        "ETag": "\u002209B1A5D61BD225D1DD944F11860A63F1264F7EFB627F1AA28875AE69082A73E1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "0724b70f-085e-4cc0-8b51-8b15b721cb4d"
+      },
+      "ResponseBody": {
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:00.0620521Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "353635a06b7930526911a1006c299a57",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e5e91522-b38e-484b-8355-40615315055c",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:05 GMT",
+        "ETag": "\u00227C6C0A95C87D778EE442D5A818551AD0BD84B8C585B0556D086C00253ABE24C1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e5e91522-b38e-484b-8355-40615315055c"
+      },
+      "ResponseBody": {
+        "id": "dda2e987-385e-40bf-ad9e-79fdb48bfde8",
+        "createdDateTimeUtc": "2021-08-25T18:44:52.9237688Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:05.0514792Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -420,63 +660,63 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8267f24e-aa50-4d94-9142-86671cfcd777/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/dda2e987-385e-40bf-ad9e-79fdb48bfde8/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "452e61a3bfa5d365b7dea7e5cda9fb3a",
+        "x-ms-client-request-id": "d6e7bebebd215fdf67d72c7d87dfe602",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ab44f55a-ad15-4d74-aebf-0b918db4e7fa",
+        "apim-request-id": "59f0708f-b81a-425c-aa72-8146ae4b1d72",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:46 GMT",
-        "ETag": "\u0022BF7BF56592EF056DA2488E3801AA5385F06411468A8F6B82C3EE4FA2BD52CDEA\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:06 GMT",
+        "ETag": "\u0022D79456AA3654DF88AEA6856B8B2390406A533F3A764C54B5A1D2DDC181CF32DE\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ab44f55a-ad15-4d74-aebf-0b918db4e7fa"
+        "X-RequestId": "59f0708f-b81a-425c-aa72-8146ae4b1d72"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target674250945/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1645503099/File_0.txt",
-            "createdDateTimeUtc": "2021-08-25T14:20:42.8495809Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:20:45.9490415Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target485781887/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source158586476/File_0.txt",
+            "createdDateTimeUtc": "2021-08-25T18:44:59.1610319Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:05.051457Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000b44b9-0000-0000-0000-000000000000",
+            "id": "000b462f-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-bf03564a30e35d4ba69b89ad0f6245d9-ab09ff8ef8caa145-00",
+        "traceparent": "00-63ee544659137d47b7b13a2d7fa20b99-057ebfbb8621174a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "08e4586dd576f1c641294c66a8a7534c",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "x-ms-client-request-id": "6552582858e5dcc1c3b93f66de705b2e",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -484,28 +724,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:20:45 GMT",
-        "ETag": "\u00220x8D967D387D6F507\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:46 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:06 GMT",
+        "ETag": "\u00220x8D967F8752D8B93\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:06 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "08e4586dd576f1c641294c66a8a7534c",
-        "x-ms-request-id": "df4844f1-c01e-002d-12bc-998fec000000",
+        "x-ms-client-request-id": "6552582858e5dcc1c3b93f66de705b2e",
+        "x-ms-request-id": "97604cc3-d01e-0088-08e1-99d996000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-37b9e911d2123041b5be1d1709b6d9d6-ffd1cd91ae699744-00",
+        "traceparent": "00-6db73b0c7925494fb348d7d32b4a6925-fdb3f63161db7049-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "fb67cb1ac02881db1e47257102f142d9",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "x-ms-client-request-id": "2ab7a20ef45f56e3d6cea13ed4a88a2b",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -514,30 +754,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:46 GMT",
-        "ETag": "\u00220x8D967D388033D56\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:46 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:06 GMT",
+        "ETag": "\u00220x8D967F8756250C7\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:06 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "fb67cb1ac02881db1e47257102f142d9",
+        "x-ms-client-request-id": "2ab7a20ef45f56e3d6cea13ed4a88a2b",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df48454f-c01e-002d-6abc-998fec000000",
+        "x-ms-request-id": "97604d09-d01e-0088-46e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-b76c2eb1d066db47b3c10e63ac456128-e86dc78f8e9b5d47-00",
+        "traceparent": "00-9e067d2f140fbc47b1f2f0fd3fe3c183-9271bba15333d540-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "2e5109d49ff48b2d67546496196c0f37",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "x-ms-client-request-id": "d044579ef24765d925fa5d039ff88867",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -546,30 +786,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:46 GMT",
-        "ETag": "\u00220x8D967D3882FD3CB\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "ETag": "\u00220x8D967F8758D3944\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:07 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "2e5109d49ff48b2d67546496196c0f37",
+        "x-ms-client-request-id": "d044579ef24765d925fa5d039ff88867",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df4845d2-c01e-002d-56bc-998fec000000",
+        "x-ms-request-id": "97604d5c-d01e-0088-10e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_2.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_2.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-258edb6f3a0dca43810d8a8a01d0b043-4d9c290a4f714647-00",
+        "traceparent": "00-18914ae3b2730a45b6960b9ed11114d2-fd34f16f6ee48a47-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "ddb299533e94ac847d62e92eb055ef4f",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "x-ms-client-request-id": "3d784fd0d72e334875fb8e16b683071a",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -578,30 +818,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:46 GMT",
-        "ETag": "\u00220x8D967D3885B7FC7\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "ETag": "\u00220x8D967F875B821B7\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:07 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ddb299533e94ac847d62e92eb055ef4f",
+        "x-ms-client-request-id": "3d784fd0d72e334875fb8e16b683071a",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484671-c01e-002d-66bc-998fec000000",
+        "x-ms-request-id": "97604d9e-d01e-0088-4fe1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_3.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_3.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-cf869a1d7f94da489d4ddc54e5831e4b-82eab6b170760e42-00",
+        "traceparent": "00-3f5e6a1745d83642b6f9a7830f693e21-972cccae6a4c1447-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "9e9272e625567b589ddc94d45c4568b1",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "x-ms-client-request-id": "87c7142f8b2b1ce6c851056597dfb7de",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -610,30 +850,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:47 GMT",
-        "ETag": "\u00220x8D967D388872BD0\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "ETag": "\u00220x8D967F875E35854\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:07 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "9e9272e625567b589ddc94d45c4568b1",
+        "x-ms-client-request-id": "87c7142f8b2b1ce6c851056597dfb7de",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484710-c01e-002d-6bbc-998fec000000",
+        "x-ms-request-id": "97604ddc-d01e-0088-06e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_4.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_4.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-d62b1d50fabfba4d923a3a52b6f935e1-77cecdd6be7a9a40-00",
+        "traceparent": "00-7919ae585e662d498b9e5adb00c88c61-7d13307821811047-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "681dee38643f964585a5b091b5ffda12",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "x-ms-client-request-id": "856d3a454d30c6fc0e105a4b63c2afa2",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -642,30 +882,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:47 GMT",
-        "ETag": "\u00220x8D967D388B37416\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:47 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:07 GMT",
+        "ETag": "\u00220x8D967F8760EB61C\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:07 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "681dee38643f964585a5b091b5ffda12",
+        "x-ms-client-request-id": "856d3a454d30c6fc0e105a4b63c2afa2",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df4847de-c01e-002d-20bc-998fec000000",
+        "x-ms-request-id": "97604e21-d01e-0088-41e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_5.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_5.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-79ea4be74890cb41895431cbdf9cc532-25e3103c368af84d-00",
+        "traceparent": "00-93f1edbb8338ff4ca3364cc108675c92-a41c4cfefa7fb64d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "a7af146570da2de0413640b7aaaf4f38",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "x-ms-client-request-id": "8bd442f30130453b685c74ddd2e39c96",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -674,30 +914,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:47 GMT",
-        "ETag": "\u00220x8D967D388DF6E36\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "ETag": "\u00220x8D967F87639ECBE\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "a7af146570da2de0413640b7aaaf4f38",
+        "x-ms-client-request-id": "8bd442f30130453b685c74ddd2e39c96",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484869-c01e-002d-20bc-998fec000000",
+        "x-ms-request-id": "97604e8e-d01e-0088-26e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_6.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_6.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-8e2c495514082d468c91781b69545f95-cc461ec41df63949-00",
+        "traceparent": "00-8d92bac7b3630c409e0fec21ea9cb2be-26d81afe8e31c449-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "c1f537fa863782102cfc19b175c6c69e",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "x-ms-client-request-id": "7cd1b0448116e2ea1701781b319ab906",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -706,30 +946,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:47 GMT",
-        "ETag": "\u00220x8D967D3890EEB6E\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "ETag": "\u00220x8D967F87665BFB8\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "c1f537fa863782102cfc19b175c6c69e",
+        "x-ms-client-request-id": "7cd1b0448116e2ea1701781b319ab906",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df4848f0-c01e-002d-1fbc-998fec000000",
+        "x-ms-request-id": "97604f22-d01e-0088-2fe1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_7.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_7.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-0fef92ef1913244884223a24190f8007-b893e5e195720346-00",
+        "traceparent": "00-754a241313356b4ca7e6d938ef910193-8b76e86461febd40-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "486f8101c195c8d70def2708248eebd5",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "x-ms-client-request-id": "547162a22b0a44adfe281cd4d81ef32b",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -738,30 +978,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:48 GMT",
-        "ETag": "\u00220x8D967D3893A9760\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:48 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:08 GMT",
+        "ETag": "\u00220x8D967F876911D89\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "486f8101c195c8d70def2708248eebd5",
+        "x-ms-client-request-id": "547162a22b0a44adfe281cd4d81ef32b",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df48496f-c01e-002d-10bc-998fec000000",
+        "x-ms-request-id": "97604fac-d01e-0088-2be1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_8.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_8.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-80c2a0862a576e41bfed07b29ff7a415-527cc868f61ec548-00",
+        "traceparent": "00-bf496226aaa0024594190cd2a390889f-2a92d502ce8e1146-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "7d9778551809deda032c7add562fb87a",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "x-ms-client-request-id": "b207c37432f1728c58f1732f892014ce",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -770,30 +1010,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:48 GMT",
-        "ETag": "\u00220x8D967D389666A4D\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "ETag": "\u00220x8D967F876BE5072\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "7d9778551809deda032c7add562fb87a",
+        "x-ms-client-request-id": "b207c37432f1728c58f1732f892014ce",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484a0b-c01e-002d-1fbc-998fec000000",
+        "x-ms-request-id": "97605026-d01e-0088-14e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_9.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_9.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-ef875c90be551c43bc95dcd776c6e963-7efad2c5ff64c043-00",
+        "traceparent": "00-6a1490b15d763d4aaff91e36a397fc25-a8b925de3f4f6044-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "28b6a170063f39a25f2db3485e085e9e",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "x-ms-client-request-id": "6f3b6da24871198b038c7ded641609f9",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -802,30 +1042,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:48 GMT",
-        "ETag": "\u00220x8D967D38991EF33\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "ETag": "\u00220x8D967F876E9D553\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "28b6a170063f39a25f2db3485e085e9e",
+        "x-ms-client-request-id": "6f3b6da24871198b038c7ded641609f9",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484a99-c01e-002d-22bc-998fec000000",
+        "x-ms-request-id": "97605095-d01e-0088-7ee1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_10.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_10.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-377ca7ebc108384c9bdd4f88a6df0552-f701eb713308a748-00",
+        "traceparent": "00-5f6c9b2bfc101744b1215782fb1b9055-abe9d436a6f75446-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "fc5b4310482fe895a790456846fa71de",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "x-ms-client-request-id": "6da74c0d06936f15d6fffc19b87ebbde",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:10 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -834,30 +1074,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:49 GMT",
-        "ETag": "\u00220x8D967D389C47A20\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "ETag": "\u00220x8D967F87715F68C\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "fc5b4310482fe895a790456846fa71de",
+        "x-ms-client-request-id": "6da74c0d06936f15d6fffc19b87ebbde",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484b17-c01e-002d-14bc-998fec000000",
+        "x-ms-request-id": "97605106-d01e-0088-64e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_11.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_11.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-da3b6a7a447cfe428f2e3066faea3123-7b1e0623f7183140-00",
+        "traceparent": "00-cfcaed38c60f0e48afa5dbc0a8e8b62a-4c4771f0aae0a545-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "8297ad37c3d74f95d55d1ddc649280fa",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "x-ms-client-request-id": "6b314e1383e32cb937eeaf64b49e0d41",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:10 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -866,30 +1106,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:49 GMT",
-        "ETag": "\u00220x8D967D389F09B4D\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:49 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:09 GMT",
+        "ETag": "\u00220x8D967F877446217\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:10 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "8297ad37c3d74f95d55d1ddc649280fa",
+        "x-ms-client-request-id": "6b314e1383e32cb937eeaf64b49e0d41",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484b97-c01e-002d-0cbc-998fec000000",
+        "x-ms-request-id": "97605183-d01e-0088-5ae1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_12.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_12.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c5708e21d044314ca7944a1cc814cd4d-791774dc1fa86948-00",
+        "traceparent": "00-2f73d6b6329eda468f44fe95af64aa36-f052108fa52e6741-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "13ccdccebbd3274a0ccd81afc13af365",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "x-ms-client-request-id": "3c217ae7a6799c3b58cb99724b726084",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:10 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -898,30 +1138,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:49 GMT",
-        "ETag": "\u00220x8D967D38A1D0AA8\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "ETag": "\u00220x8D967F8776F4A86\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:10 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "13ccdccebbd3274a0ccd81afc13af365",
+        "x-ms-client-request-id": "3c217ae7a6799c3b58cb99724b726084",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484c22-c01e-002d-0ebc-998fec000000",
+        "x-ms-request-id": "9760521d-d01e-0088-6ae1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_13.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_13.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-dccc1f01e0fbab48a78dde7e325a919e-1bda73ed1b51a04c-00",
+        "traceparent": "00-b2befbed3e7a57419af21e24029d29a2-23f17bb3cb7b5248-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b110d5bbdc704cc6ae0c27d22bb88314",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "x-ms-client-request-id": "16da9fd19ee58915937a36a456b0bb38",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:11 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -930,30 +1170,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:50 GMT",
-        "ETag": "\u00220x8D967D38A48B696\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "ETag": "\u00220x8D967F8779BE0F6\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:10 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b110d5bbdc704cc6ae0c27d22bb88314",
+        "x-ms-client-request-id": "16da9fd19ee58915937a36a456b0bb38",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484ca6-c01e-002d-06bc-998fec000000",
+        "x-ms-request-id": "976052ab-d01e-0088-71e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_14.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_14.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-10074d9eb5c94e449b04d032cdffb754-0652c4a3c458244d-00",
+        "traceparent": "00-c8696d71662e8a42b6daeadb6e3c3db6-75aaae8ed57a9240-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "699a4a105e2d7c0b6270750a42e68d9b",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "x-ms-client-request-id": "3d31baf17e5c6d6513951217ea46e0c4",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:11 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -962,30 +1202,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:50 GMT",
-        "ETag": "\u00220x8D967D38A7A7E24\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:50 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:10 GMT",
+        "ETag": "\u00220x8D967F877C8ECB2\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:10 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "699a4a105e2d7c0b6270750a42e68d9b",
+        "x-ms-client-request-id": "3d31baf17e5c6d6513951217ea46e0c4",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484d46-c01e-002d-14bc-998fec000000",
+        "x-ms-request-id": "97605318-d01e-0088-52e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_15.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_15.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-09983a2ac27a7f4da3ff6501d7bc8bd2-e50512593464f146-00",
+        "traceparent": "00-63b9bd641bcf09468e32d7bbd0d09351-ac30d7cd0ba0c14c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "8f20b86ace81f289158064c79378fc53",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "x-ms-client-request-id": "14932a8df7c3495c6498a9fe709645a8",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:11 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -994,30 +1234,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:50 GMT",
-        "ETag": "\u00220x8D967D38AA6511E\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "ETag": "\u00220x8D967F877F47187\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:11 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "8f20b86ace81f289158064c79378fc53",
+        "x-ms-client-request-id": "14932a8df7c3495c6498a9fe709645a8",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484e06-c01e-002d-41bc-998fec000000",
+        "x-ms-request-id": "9760538e-d01e-0088-37e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_16.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_16.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-58f0496d6272c048962b90244d344c73-8e7fd36fd697e84e-00",
+        "traceparent": "00-c0311599ca87504484e1f3612461d2f3-18ad675c3296a24b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "769e6c49899f5c38ca944e0066bc0ac7",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "x-ms-client-request-id": "91816010234152283a6d024f8cfe9f4c",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:12 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1026,30 +1266,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:50 GMT",
-        "ETag": "\u00220x8D967D38AD3AB0D\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "ETag": "\u00220x8D967F8781FF65B\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:11 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "769e6c49899f5c38ca944e0066bc0ac7",
+        "x-ms-client-request-id": "91816010234152283a6d024f8cfe9f4c",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484ec3-c01e-002d-6dbc-998fec000000",
+        "x-ms-request-id": "976053e9-d01e-0088-0ae1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_17.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_17.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-2975b06cf2bae54d87e4f86167d1f94f-de47798dbbba3849-00",
+        "traceparent": "00-72415a276e693945b5cbd1a1aa621f31-2f3e2e7738f7a341-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "73678c7ef3974293c1a854adf943e8e9",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "x-ms-client-request-id": "2c17719aa61df9745de7d8c4d567fc7c",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:12 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1058,30 +1298,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:51 GMT",
-        "ETag": "\u00220x8D967D38AFFA520\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:51 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "ETag": "\u00220x8D967F8784B05E8\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:11 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "73678c7ef3974293c1a854adf943e8e9",
+        "x-ms-client-request-id": "2c17719aa61df9745de7d8c4d567fc7c",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df484f99-c01e-002d-36bc-998fec000000",
+        "x-ms-request-id": "97605476-d01e-0088-11e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_18.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_18.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-70ad958a8ca45b4f9230015cb2705680-03c04b0ef61bb941-00",
+        "traceparent": "00-c46403f87585c546bcdee64feb9e5287-72e6762d6be31045-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d6c021741748e1fb7fc4c5ed7f898b59",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "x-ms-client-request-id": "8a066a4f4fc569830240da56f40cbd65",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:12 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1090,30 +1330,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:51 GMT",
-        "ETag": "\u00220x8D967D38B2B9F38\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:11 GMT",
+        "ETag": "\u00220x8D967F87878ADFC\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:12 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d6c021741748e1fb7fc4c5ed7f898b59",
+        "x-ms-client-request-id": "8a066a4f4fc569830240da56f40cbd65",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df485014-c01e-002d-24bc-998fec000000",
+        "x-ms-request-id": "976054c2-d01e-0088-53e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964131245/File_19.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1178611624/File_19.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-e4717e15d9ea4e45827bc7acc369fdc5-879b3a4b6cd65749-00",
+        "traceparent": "00-ceebba0448199f469900837d0548da2e-d32877ba5f8a2041-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "07489d75881155bcd85cb5f7358a6386",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "x-ms-client-request-id": "ff635df9197e6a8beb8733594a647dd3",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:12 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1122,28 +1362,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:20:51 GMT",
-        "ETag": "\u00220x8D967D38B57E77E\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "ETag": "\u00220x8D967F878A62EF8\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:12 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "07489d75881155bcd85cb5f7358a6386",
+        "x-ms-client-request-id": "ff635df9197e6a8beb8733594a647dd3",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df48509c-c01e-002d-21bc-998fec000000",
+        "x-ms-request-id": "97605516-d01e-0088-24e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target703350700?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1367849328?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-cf60e27c63c57a46889de4426fb2d747-295e8e05b3208b4a-00",
+        "traceparent": "00-eac33e30834a2645a094a0bf8af8f152-51322a6a20a0ce48-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "fb448b657e33906785f3d32ea5c2371c",
-        "x-ms-date": "Wed, 25 Aug 2021 14:20:53 GMT",
+        "x-ms-client-request-id": "f82200858615ed4bad2adccb1d04512a",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1151,12 +1391,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:20:51 GMT",
-        "ETag": "\u00220x8D967D38B6E8072\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:20:52 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "ETag": "\u00220x8D967F878BF6F6D\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:12 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "fb448b657e33906785f3d32ea5c2371c",
-        "x-ms-request-id": "df48513d-c01e-002d-37bc-998fec000000",
+        "x-ms-client-request-id": "f82200858615ed4bad2adccb1d04512a",
+        "x-ms-request-id": "9760557b-d01e-0088-7ee1-99d996000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -1169,9 +1409,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6a3c5ba2acd4d54f8be0d2c1e3301204-388baddba632b542-00",
+        "traceparent": "00-63ef84d89926154c8facca9820519ab8-b7f1b0e46079a24f-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fb5c37fad8e065eb6afdec6203acf561",
+        "x-ms-client-request-id": "0378cb73fefddf369b9e3e1b291f9dc3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1191,52 +1431,52 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ba669205-a03e-4955-9af8-25ac0aec4ade",
+        "apim-request-id": "69ce1d1b-5e41-41c6-afb1-902bdcd5a300",
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:20:52 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c8b61454-5adf-4d70-b81b-5573dcbd5f58",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ba669205-a03e-4955-9af8-25ac0aec4ade"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c8b61454-5adf-4d70-b81b-5573dcbd5f58",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fd1a413f5d471e41e1768b95e8273399",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "93b31eb7-9e77-436a-a973-72688c843250",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:52 GMT",
-        "Retry-After": "1",
+        "Date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/69c933d1-698c-42ed-967d-40253aee437f",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "69ce1d1b-5e41-41c6-afb1-902bdcd5a300"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/69c933d1-698c-42ed-967d-40253aee437f",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0c6fe6076d9ad6e31711d1efae9fce82",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ffb2af97-f029-4461-b7c7-f487adb2d626",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:12 GMT",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "93b31eb7-9e77-436a-a973-72688c843250"
+        "X-RequestId": "ffb2af97-f029-4461-b7c7-f487adb2d626"
       },
       "ResponseBody": {
-        "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
-        "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:20:52.9875659Z",
+        "id": "69c933d1-698c-42ed-967d-40253aee437f",
+        "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:13.0496708Z",
         "status": "Cancelling",
         "summary": {
           "total": 0,
@@ -1250,44 +1490,44 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=c8b61454-5adf-4d70-b81b-5573dcbd5f58\u0026statuses=\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=69c933d1-698c-42ed-967d-40253aee437f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f44a378689762542a5a781cd9b540d7e-412fab85e2600c4f-00",
+        "traceparent": "00-33889e6d0c16e04d800eee923dacff49-5322371615f0a549-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "533adb7d8a068ccba0de913692048dd9",
+        "x-ms-client-request-id": "99d72fe2cf058773c9425c76472fc48e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e3628cda-4eb6-4748-90a2-53d1ab51fb00",
+        "apim-request-id": "bb78ff4f-1b0e-41c2-88ba-622b64df9a16",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:20:57 GMT",
-        "ETag": "\u0022B07DBAB5ED72FFFA07C0D2E4089F63B35A94B87F6D7CE9B2DA3E373E13AF59A4\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:18 GMT",
+        "ETag": "\u0022E878D4BC987CA6511D1BAB5A080522F99196EED62957EBEDCB8147C32D3781F8\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e3628cda-4eb6-4748-90a2-53d1ab51fb00"
+        "X-RequestId": "bb78ff4f-1b0e-41c2-88ba-622b64df9a16"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
-            "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:20:55.9089938Z",
+            "id": "69c933d1-698c-42ed-967d-40253aee437f",
+            "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:16.0423646Z",
             "status": "Cancelling",
             "summary": {
               "total": 20,
@@ -1303,44 +1543,44 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=c8b61454-5adf-4d70-b81b-5573dcbd5f58\u0026statuses=\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=69c933d1-698c-42ed-967d-40253aee437f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a3d08ffd26237a459d2727727a43f715-dcdd97e06bb79e49-00",
+        "traceparent": "00-b838c5862cb9ba49b1c5f2aab4cf14a2-6f78b57f1905e74a-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "64ef72fe39a79dd4f63d1a694d567c43",
+        "x-ms-client-request-id": "37c3198c4495058fe7a1ebeb2d4730fc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ac10e2b3-4789-4d66-ad7f-b52db8c459cd",
+        "apim-request-id": "74655775-e4a1-462d-b199-288b5e73b04e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:03 GMT",
-        "ETag": "\u0022DBC07BC1DBD8BCFFA300D700B4CAF66260409BDAE36DE2A887AE5295A58041DF\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:23 GMT",
+        "ETag": "\u002215E48B3C6F6C3DAFB337B72309ACEEAC1B5B8AE9CC50D1CCFCFEDBD02E4186DD\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ac10e2b3-4789-4d66-ad7f-b52db8c459cd"
+        "X-RequestId": "74655775-e4a1-462d-b199-288b5e73b04e"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
-            "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:20:58.7274706Z",
+            "id": "69c933d1-698c-42ed-967d-40253aee437f",
+            "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:21.5359358Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1356,40 +1596,70 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=Cancelled%2CCancelling\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?statuses=Cancelled%2CCancelling",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1c791182096bfc41a3bf474eeb4263d0-713f0baad1c47140-00",
+        "traceparent": "00-a0c46b2a46f1b64db84352b81b5fe888-2da69db646a7ae4d-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "28e452caa171b45a758d5d68cc0b8bdc",
+        "x-ms-client-request-id": "fa39bcd0044838bd72e74357116d8ee8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e8029d5-d909-487f-b5f4-34f2144dc010",
+        "apim-request-id": "48de7c3d-de0e-48f1-b0e2-5dbc59533af9",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:03 GMT",
-        "ETag": "\u0022C5CB861F2A8689254FBF79DDF93D13B28053A90B3AECDE88D1FF8A47E6B88B5B\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:23 GMT",
+        "ETag": "\u00222DBB480CEF01030109F9996E73455487EACB973D1B2730B78C1DC8239D022B09\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2e8029d5-d909-487f-b5f4-34f2144dc010"
+        "X-RequestId": "48de7c3d-de0e-48f1-b0e2-5dbc59533af9"
       },
       "ResponseBody": {
         "value": [
+          {
+            "id": "69c933d1-698c-42ed-967d-40253aee437f",
+            "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:21.5359358Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "decfe908-d309-4d44-838b-7b12aa38d315",
+            "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:21:38.0583554Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
           {
             "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
             "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
@@ -2109,7 +2379,46 @@
               "cancelled": 20,
               "totalCharacterCharged": 0
             }
-          },
+          }
+        ],
+        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=88\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=88\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b3c559178b79994eba5c427c814c02d0-09d647cb6675264a-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9462424d96db9dec9fd2b263e3885a81",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "096c5727-cb8c-4bda-bc52-a5f9a9f90f2f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:24 GMT",
+        "ETag": "\u0022F93D2105F399D115E6184992514BEA0DE3AF3422EA74E4E85CBFC6E7A38DCD41\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "096c5727-cb8c-4bda-bc52-a5f9a9f90f2f"
+      },
+      "ResponseBody": {
+        "value": [
           {
             "id": "6f160aba-7e60-4748-a972-d0a146b3196e",
             "createdDateTimeUtc": "2021-08-25T10:26:50.4040903Z",
@@ -2139,46 +2448,7 @@
               "cancelled": 20,
               "totalCharacterCharged": 0
             }
-          }
-        ],
-        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=86\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=86\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3f3c00c03923fe4f9b072f539b2f2e04-b6ed44e606ec3542-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7696b1e9ce3843f2069d5cc970623f49",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7d6b874c-0c27-498f-9a82-dda45da64ac2",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:05 GMT",
-        "ETag": "\u00220F33D9A50AFD534ED7982409B9B5289EE29A85BC97BCAE1795C0CCBDAD904F00\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7d6b874c-0c27-498f-9a82-dda45da64ac2"
-      },
-      "ResponseBody": {
-        "value": [
+          },
           {
             "id": "5d4b8b67-af0b-4c12-9c75-0869a2ba66df",
             "createdDateTimeUtc": "2021-08-25T10:24:14.9778475Z",
@@ -2898,7 +3168,46 @@
               "cancelled": 20,
               "totalCharacterCharged": 0
             }
-          },
+          }
+        ],
+        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=38\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=38\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f44813656cfc29499e7356e083384d2c-0a43beb0b7b5a740-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8ba65f12c9f688455b8bc5ae0137f37a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d2e73cfc-90d1-4063-8bf1-af9eb7fa304b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:25 GMT",
+        "ETag": "\u0022365497CD112BCBB73250DFA8E68476F00A951A03223C86AD07CC87E4515B7C10\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d2e73cfc-90d1-4063-8bf1-af9eb7fa304b"
+      },
+      "ResponseBody": {
+        "value": [
           {
             "id": "b2d0e15f-95ef-40d4-bfb0-9a4f203a54ba",
             "createdDateTimeUtc": "2021-08-23T17:35:20.3985579Z",
@@ -2928,46 +3237,7 @@
               "cancelled": 20,
               "totalCharacterCharged": 0
             }
-          }
-        ],
-        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=36\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=36\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4b5e48bc76f41c4fa462618550e3fb64-f482469f74b1d846-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "406c4d6164205c67183bef19dc6bd0ea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "60c5c8ef-d19a-485a-8c15-a6a0d6c4863d",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:05 GMT",
-        "ETag": "\u0022983AA875931A2A58A44AE216386830FB617F4097CCAFA9D15DF4AEA47BF37EC1\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "60c5c8ef-d19a-485a-8c15-a6a0d6c4863d"
-      },
-      "ResponseBody": {
-        "value": [
+          },
           {
             "id": "29353a68-850e-4c04-bce3-ce98e0ee567f",
             "createdDateTimeUtc": "2021-08-23T17:33:06.4539736Z",
@@ -3516,6 +3786,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "729221446"
+    "RandomSeed": "1917340198"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source317602543?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source317602543?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-17d57f4881d80046945c3772cd65d2c7-e92103ea97169048-00",
+        "traceparent": "00-09782d694aed65429d224fa0401bee25-992c11f01fbb4144-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "ab5814afaff8957adcbde78e3c863dfa",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:39 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:39 GMT",
-        "ETag": "\u00220x8D95786DD60AD91\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:40 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:15 GMT",
+        "ETag": "\u00220x8D967D39938B79F\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:15 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "ab5814afaff8957adcbde78e3c863dfa",
-        "x-ms-request-id": "05282bbe-a01e-003b-296f-896135000000",
+        "x-ms-request-id": "df4883cb-c01e-002d-01bc-998fec000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source317602543/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source317602543/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-3732a05269e76c4d9b522450f1deae5d-ce0db5368f183f48-00",
+        "traceparent": "00-8a3dcd2048baa540aa7e2628fb70b86a-8f6efdee3138894f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "5467b7ecb173ad8566ae54bd05391a3c",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:39 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:39 GMT",
-        "ETag": "\u00220x8D95786DDAECCB8\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:40 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:15 GMT",
+        "ETag": "\u00220x8D967D3996688AA\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:15 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "5467b7ecb173ad8566ae54bd05391a3c",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05282c4e-a01e-003b-176f-896135000000",
+        "x-ms-request-id": "df488421-c01e-002d-51bc-998fec000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target123362359?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target123362359?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-da5e19c8e69270498a622f76e53f11c4-cb79bbe029d20a47-00",
+        "traceparent": "00-bcee858206959141ad433a44697d5ef8-07c82f191e9cbb45-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "14a7d2ed197afecad0a3a46c7eae3890",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:40 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:16 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:39 GMT",
-        "ETag": "\u00220x8D95786DDD46BD1\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:40 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:15 GMT",
+        "ETag": "\u00220x8D967D3998006E9\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:16 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "14a7d2ed197afecad0a3a46c7eae3890",
-        "x-ms-request-id": "05282d45-a01e-003b-5f6f-896135000000",
+        "x-ms-request-id": "df4884b4-c01e-002d-50bc-998fec000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-06e26591139fda45b410910c3540f615-0487138bd6cf224f-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-34167d261f88b94da3c3976d801f7bce-c5804cd8a0fb6e4b-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "3e62ed3d7be68ffdaa454a5bbc8fa2a2",
         "x-ms-return-client-request-id": "true"
       },
@@ -116,10 +116,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "87e523b8-c67f-41d8-a8b2-ca6f5838ab66",
+        "apim-request-id": "74b79387-aaee-432e-a831-8fdd4ead3edd",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:40 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
+        "Date": "Wed, 25 Aug 2021 14:21:16 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -127,46 +127,46 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "87e523b8-c67f-41d8-a8b2-ca6f5838ab66"
+        "X-RequestId": "74b79387-aaee-432e-a831-8fdd4ead3edd"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "b34e57abe5969e729c55a30ee041e700",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "09b81fb6-cdcf-475c-8573-459f7dd314f6",
+        "apim-request-id": "9c064ee9-4e11-43f9-825b-57cd0f2ce211",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:41 GMT",
-        "ETag": "\u0022DADEAF80BFB292581EF7A17CCEACA0F72411F69B060F7FAB36F577C031F34534\u0022",
+        "Date": "Wed, 25 Aug 2021 14:21:16 GMT",
+        "ETag": "\u0022613F5D9CF0AF31FA4F55056389E38480052AF016C0565F19DF9481F4688A5A98\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "09b81fb6-cdcf-475c-8573-459f7dd314f6"
+        "X-RequestId": "9c064ee9-4e11-43f9-825b-57cd0f2ce211"
       },
       "ResponseBody": {
-        "id": "4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
-        "createdDateTimeUtc": "2021-08-04T20:31:41.3401888Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:41.3401891Z",
+        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
+        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:21:16.426564Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,26 +180,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "4cc82d1bfdb87250d4186935ce6f4141",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "667ebdcc-24d0-49f0-8410-df7c60f54c8e",
+        "apim-request-id": "7bd09e18-476b-4a23-a279-b00ec2bbf3eb",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:42 GMT",
-        "ETag": "\u00220EF1DF92F863CEBC5E930C1E5D5E5E64BC3715267F67FA72DCFF4C677ECEE2D8\u0022",
+        "Date": "Wed, 25 Aug 2021 14:21:17 GMT",
+        "ETag": "\u0022BDA5571009B9665A913B0CC9B03ACBA63B853500F6E118EEF761D891FE099FBE\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -209,12 +209,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "667ebdcc-24d0-49f0-8410-df7c60f54c8e"
+        "X-RequestId": "7bd09e18-476b-4a23-a279-b00ec2bbf3eb"
       },
       "ResponseBody": {
-        "id": "4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
-        "createdDateTimeUtc": "2021-08-04T20:31:41.3401888Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:41.6054541Z",
+        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
+        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:21:17.4300021Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -228,41 +228,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "26c00101845f57fa7bc4a190d8efae68",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b5d86cfb-c700-486e-a55d-186b57e76da8",
+        "apim-request-id": "ebd76be9-6b11-4444-a3b9-ac1adffdedef",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:43 GMT",
-        "ETag": "\u00228C809C8F528FEBEC2DF343AD75A26A985F014F592CB4259D0D24076721BE5027\u0022",
+        "Date": "Wed, 25 Aug 2021 14:21:19 GMT",
+        "ETag": "\u0022DC72A71591EBAFEB70BDCB34EB913AFE46F2B86D355AB217C6E444EABBAA204E\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b5d86cfb-c700-486e-a55d-186b57e76da8"
+        "X-RequestId": "ebd76be9-6b11-4444-a3b9-ac1adffdedef"
       },
       "ResponseBody": {
-        "id": "4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
-        "createdDateTimeUtc": "2021-08-04T20:31:41.3401888Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:43.2981058Z",
+        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
+        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:21:19.2324216Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -276,26 +276,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "8f404a5d55c7adea06dcdf7d7b3ccf2d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4f7618d6-c66d-4600-b31c-a3804bb611a1",
+        "apim-request-id": "1a0f9def-9c06-46ee-a3c8-f2e324eea132",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:44 GMT",
-        "ETag": "\u00228C809C8F528FEBEC2DF343AD75A26A985F014F592CB4259D0D24076721BE5027\u0022",
+        "Date": "Wed, 25 Aug 2021 14:21:20 GMT",
+        "ETag": "\u0022DC72A71591EBAFEB70BDCB34EB913AFE46F2B86D355AB217C6E444EABBAA204E\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -305,12 +305,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4f7618d6-c66d-4600-b31c-a3804bb611a1"
+        "X-RequestId": "1a0f9def-9c06-46ee-a3c8-f2e324eea132"
       },
       "ResponseBody": {
-        "id": "4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
-        "createdDateTimeUtc": "2021-08-04T20:31:41.3401888Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:43.2981058Z",
+        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
+        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:21:19.2324216Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -324,41 +324,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "de0c6113c18096a03370d1f35cbf99e4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a567f06d-d841-4fd4-b4ff-d4cb6b656992",
+        "apim-request-id": "d2b58234-13c0-4b8c-a2b1-073e3ecc68ea",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
-        "Content-Length": "292",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:46 GMT",
-        "ETag": "\u00223AE96FCD740C3CC5FDFAF35EC7E9EF44674139760863E2452391CA9B1E7B85A8\u0022",
+        "Date": "Wed, 25 Aug 2021 14:21:21 GMT",
+        "ETag": "\u00220640856F2525F6541BC6FB41DFB34E1ED1F461E7999B7FBE402EF507F2938149\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a567f06d-d841-4fd4-b4ff-d4cb6b656992"
+        "X-RequestId": "d2b58234-13c0-4b8c-a2b1-073e3ecc68ea"
       },
       "ResponseBody": {
-        "id": "4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
-        "createdDateTimeUtc": "2021-08-04T20:31:41.3401888Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:43.2981058Z",
+        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
+        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:21:19.2324216Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -372,26 +372,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4fd4f892-ac98-445b-9e2e-6dec4bd0ee53/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "84d70069b22eab7a17121f83a57cdb3e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "63d8676e-751e-4337-ad0f-d42f7f7b9b13",
+        "apim-request-id": "f8d6cf82-01e7-4490-be2a-4261c81259ee",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:46 GMT",
-        "ETag": "\u0022ABCDD18E87B52B5EFFE63EDBE17C9714EACA8B72480A9582119E7A7C12046BB6\u0022",
+        "Date": "Wed, 25 Aug 2021 14:21:22 GMT",
+        "ETag": "\u0022D48AB8309D2B6AB46128CD70072BB3AC7DE22DF961856141178A393579444E31\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -401,34 +401,34 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "63d8676e-751e-4337-ad0f-d42f7f7b9b13"
+        "X-RequestId": "f8d6cf82-01e7-4490-be2a-4261c81259ee"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target123362359/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source317602543/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:31:43.0112405Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:45.4475824Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target123362359/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source317602543/File_0.txt",
+            "createdDateTimeUtc": "2021-08-25T14:21:18.7566981Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:21:21.4599642Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53ee-0000-0000-0000-000000000000",
+            "id": "000b44f7-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-01086216d1c6634d877ef72a251bfef6-2518da5755580a4f-00",
+        "traceparent": "00-1b9c6264e048bd4083f9eaeccc0b2cb6-745347ad0e9fbf44-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "e3767d74e8cfa99ca95c5683f7514742",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:46 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -436,28 +436,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:46 GMT",
-        "ETag": "\u00220x8D95786E1964020\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:47 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:23 GMT",
+        "ETag": "\u00220x8D967D39E39078B\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:23 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "e3767d74e8cfa99ca95c5683f7514742",
-        "x-ms-request-id": "05283b4a-a01e-003b-566f-896135000000",
+        "x-ms-request-id": "9964b698-501e-0000-7abc-993c9f000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-4b5941fcb14eff49ba1d89f881f138e1-1343fb0d057acd42-00",
+        "traceparent": "00-7f666162a09d92448bf135e9ad464a05-5328a6c86630954d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "657a14fbfe4ae76161c76da11df1b795",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:46 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:24 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -466,30 +466,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:46 GMT",
-        "ETag": "\u00220x8D95786E1DEE04C\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:47 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:24 GMT",
+        "ETag": "\u00220x8D967D39E70FBD2\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:24 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "657a14fbfe4ae76161c76da11df1b795",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05283bcc-a01e-003b-386f-896135000000",
+        "x-ms-request-id": "9964b6e6-501e-0000-39bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-5f3740589c790541ad3a93b5cbd6a7d5-0258501445af7947-00",
+        "traceparent": "00-bd9951dc8694a24daacfd08990d97c80-a9764e51a8a5104d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "42e8fe930123189a3bdb8556232720c1",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:47 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -498,30 +498,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:47 GMT",
-        "ETag": "\u00220x8D95786E22852A8\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:48 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:24 GMT",
+        "ETag": "\u00220x8D967D39EA4E697\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:24 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "42e8fe930123189a3bdb8556232720c1",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05283cca-a01e-003b-0a6f-896135000000",
+        "x-ms-request-id": "9964b7d2-501e-0000-0fbc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_2.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_2.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-d2ef7a461b26024ab3da58659414687e-93fffb7fec284840-00",
+        "traceparent": "00-16b5101d401d27488c526c91eae8a598-a8a0613e03bb7e4f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "67a941d8d86075aa1c8e81077afb8cb8",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:47 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -530,30 +530,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:47 GMT",
-        "ETag": "\u00220x8D95786E27176C5\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:48 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:24 GMT",
+        "ETag": "\u00220x8D967D39EE61A49\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:25 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "67a941d8d86075aa1c8e81077afb8cb8",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05283dae-a01e-003b-586f-896135000000",
+        "x-ms-request-id": "9964b8cf-501e-0000-78bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_3.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_3.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-4e381d2d0c48d5448bbf38fcc7dbd0de-1b9260219419d84a-00",
+        "traceparent": "00-c9536e5130f6fc4e9f9b0944632795c2-4104fea2ddefcf44-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "f8f0c1a40469f91e7a622a6f790bc439",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:48 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:25 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -562,30 +562,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:48 GMT",
-        "ETag": "\u00220x8D95786E2BDA8B8\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:49 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "ETag": "\u00220x8D967D39F15E59E\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:25 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "f8f0c1a40469f91e7a622a6f790bc439",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05283e9d-a01e-003b-226f-896135000000",
+        "x-ms-request-id": "9964ba51-501e-0000-47bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_4.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_4.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-cad40ba33978574ba4a15f97292fab1f-5393846964a2b647-00",
+        "traceparent": "00-2bc246751fc3a94ea9465850e1d4dbcd-a142e59f9b50f04c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "dcc8aca74f47ba34547225947f929e40",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:48 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -594,30 +594,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:48 GMT",
-        "ETag": "\u00220x8D95786E3071B10\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:49 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "ETag": "\u00220x8D967D39F442A13\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:25 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "dcc8aca74f47ba34547225947f929e40",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05283f76-a01e-003b-546f-896135000000",
+        "x-ms-request-id": "9964bae4-501e-0000-4bbc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_5.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_5.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-25ee2b43e9cc0b428c1cc7433c87e485-a29953e2ab09af4d-00",
+        "traceparent": "00-2f295d2025af034080a1e32d177d3538-5ff15179aabf834a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "62b1cd4e2737d35822b0edfeae3afb11",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:49 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -626,30 +626,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:49 GMT",
-        "ETag": "\u00220x8D95786E34FA2D9\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:50 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "ETag": "\u00220x8D967D39F7135D4\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:26 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "62b1cd4e2737d35822b0edfeae3afb11",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284077-a01e-003b-186f-896135000000",
+        "x-ms-request-id": "9964bb73-501e-0000-4dbc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_6.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_6.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-7801e0ec1805564bb726a950c54030e7-11a2996923341e4d-00",
+        "traceparent": "00-79afcbef48597144b84581a7009e93b4-d8542d3e6028d848-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "cd5f48caaf3255708c35a4f6df897ae7",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:49 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:26 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -658,30 +658,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:49 GMT",
-        "ETag": "\u00220x8D95786E3989FEE\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:50 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:26 GMT",
+        "ETag": "\u00220x8D967D39FB7C1A7\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:26 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "cd5f48caaf3255708c35a4f6df897ae7",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284170-a01e-003b-746f-896135000000",
+        "x-ms-request-id": "9964bc6d-501e-0000-19bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_7.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_7.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-7593b4c2e80ce04d8115e887400d66cd-700f9cf66eb70041-00",
+        "traceparent": "00-63edd678185aef4d92158e57948ed0d2-0b249c6be5365b4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ac20e9c36159800254f4b99761350b19",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:50 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:27 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -690,30 +690,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:50 GMT",
-        "ETag": "\u00220x8D95786E3E14ED5\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:51 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:26 GMT",
+        "ETag": "\u00220x8D967D39FE89EA5\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:26 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "ac20e9c36159800254f4b99761350b19",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284276-a01e-003b-4d6f-896135000000",
+        "x-ms-request-id": "9964bd07-501e-0000-29bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_8.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_8.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-01c3c7e09a153146b12cba8b42d3b314-1a5df69728c8e846-00",
+        "traceparent": "00-01c9cb6f21c8c643b2951b6850ba4981-acc7a1fef863514b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "37ca1476d1329e0d5c5bd5018361f498",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:50 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:27 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -722,30 +722,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:50 GMT",
-        "ETag": "\u00220x8D95786E42BD2C3\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:51 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:27 GMT",
+        "ETag": "\u00220x8D967D3A02DA398\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:27 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "37ca1476d1329e0d5c5bd5018361f498",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284367-a01e-003b-236f-896135000000",
+        "x-ms-request-id": "9964bdfb-501e-0000-03bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_9.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_9.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-2b95ecef00788d4392cc617e391a5f20-c41229300ef37246-00",
+        "traceparent": "00-029559ab77e9fa408b1b71a2f60d0a2c-d77718a4de2fab42-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "c43b06354f1a68b746df793ef6d9f357",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:51 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:28 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -754,30 +754,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:51 GMT",
-        "ETag": "\u00220x8D95786E474337C\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:51 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:27 GMT",
+        "ETag": "\u00220x8D967D3A063D8C0\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:27 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "c43b06354f1a68b746df793ef6d9f357",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0528446c-a01e-003b-6f6f-896135000000",
+        "x-ms-request-id": "9964be90-501e-0000-07bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_10.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_10.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-d2d742d3e0bfb449bc5fbd295a392465-5f93a7e9b1fc8148-00",
+        "traceparent": "00-c75ad6e99bbdbf45bc02cc34885fd52f-ccebf6103570874e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "ca7f8a2a43bff2b4dc8150fe8b00fcf2",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:51 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:28 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -786,30 +786,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:51 GMT",
-        "ETag": "\u00220x8D95786E4BC942C\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:52 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:27 GMT",
+        "ETag": "\u00220x8D967D3A08F84AD\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:27 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "ca7f8a2a43bff2b4dc8150fe8b00fcf2",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284540-a01e-003b-2c6f-896135000000",
+        "x-ms-request-id": "9964bf1b-501e-0000-7abc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_11.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_11.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-66bd63da122c2b449b59c87e31ae6eb4-09248fc2e85c984d-00",
+        "traceparent": "00-ff1727c95c3e9848a606e71d5c014f1e-6e7761c79600044b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "5b6121ff46fa27ff5c61f05357cfa882",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:52 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:28 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -818,30 +818,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:52 GMT",
-        "ETag": "\u00220x8D95786E510B6D3\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:52 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "ETag": "\u00220x8D967D3A0C03A96\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:28 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "5b6121ff46fa27ff5c61f05357cfa882",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052845f1-a01e-003b-4f6f-896135000000",
+        "x-ms-request-id": "9964bf9d-501e-0000-68bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_12.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_12.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-09b402304407e84895fbf50339282442-539435bce0075f42-00",
+        "traceparent": "00-9194f9e7278abb4181abab737a452bd8-f61a3c10f9485c44-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "f9d67e672ae2f2d85148e898ffb9dc45",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:52 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:29 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -850,30 +850,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:52 GMT",
-        "ETag": "\u00220x8D95786E56E5113\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:53 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "ETag": "\u00220x8D967D3A0EE09C0\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:28 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "f9d67e672ae2f2d85148e898ffb9dc45",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0528471b-a01e-003b-536f-896135000000",
+        "x-ms-request-id": "9964c028-501e-0000-55bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_13.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_13.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-8c7b3f1506c9d84d831b00fb981fa097-703894a718577d45-00",
+        "traceparent": "00-9e745318253cc34d8c058834c388dde9-17787cc488f8c14c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "d43e86e29877e35c8a576e5d52619a0c",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:53 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:29 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -882,30 +882,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:53 GMT",
-        "ETag": "\u00220x8D95786E5D14371\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:54 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "ETag": "\u00220x8D967D3A11F0DDC\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:28 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "d43e86e29877e35c8a576e5d52619a0c",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "0528482f-a01e-003b-3c6f-896135000000",
+        "x-ms-request-id": "9964c0d8-501e-0000-6bbc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_14.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_14.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-04779c1055eb374eb3864b103aa6a5df-5aea2124b9e0eb47-00",
+        "traceparent": "00-cdb0ea9c2567ec48b92cc4c7f11f4512-e3397a0650ae5f4a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "0d96cdd80329d510486f0ab15e6728a3",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:53 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:29 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -914,30 +914,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:53 GMT",
-        "ETag": "\u00220x8D95786E619A42E\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:54 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "ETag": "\u00220x8D967D3A14F0057\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:29 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "0d96cdd80329d510486f0ab15e6728a3",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052848ec-a01e-003b-616f-896135000000",
+        "x-ms-request-id": "9964c1ad-501e-0000-32bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_15.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_15.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-1c920f9e312f904a938b3b2930e0f464-8ed3fefb254da248-00",
+        "traceparent": "00-10b799dc27c11046a6d743f71274a5d7-5f34ecffdcdec142-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "d170ab84d491cf0a21f36e8abc7b9fef",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:54 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -946,30 +946,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:54 GMT",
-        "ETag": "\u00220x8D95786E664764A\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:55 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "ETag": "\u00220x8D967D3A18200A5\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:29 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "d170ab84d491cf0a21f36e8abc7b9fef",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052849b0-a01e-003b-046f-896135000000",
+        "x-ms-request-id": "9964c2af-501e-0000-17bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_16.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_16.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-9bfe2ed0bd161b41a9d125c7c85df985-5fb98d823b7d1a40-00",
+        "traceparent": "00-9f97ae90ec66124ea082b27b1f553ad2-d09a35722f89704b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "31bfdbaecf22df1b75688c088eab8523",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:54 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -978,30 +978,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:54 GMT",
-        "ETag": "\u00220x8D95786E6AC88C8\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:55 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "ETag": "\u00220x8D967D3A1BF8A3F\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:29 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "31bfdbaecf22df1b75688c088eab8523",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284a86-a01e-003b-386f-896135000000",
+        "x-ms-request-id": "9964c38d-501e-0000-5fbc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_17.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_17.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-49af785da8b27442925de79669c1ec79-ed8e222e00b94c45-00",
+        "traceparent": "00-e3bcb98f4d56244d8caa19a5a9978415-61ea1700af44e947-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "a7d8ca2fc9f1047bc2c6eb36958619cd",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:55 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1010,30 +1010,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:55 GMT",
-        "ETag": "\u00220x8D95786E6F67067\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:56 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:30 GMT",
+        "ETag": "\u00220x8D967D3A1F486BF\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:30 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "a7d8ca2fc9f1047bc2c6eb36958619cd",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284b83-a01e-003b-7f6f-896135000000",
+        "x-ms-request-id": "9964c4bb-501e-0000-76bc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_18.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_18.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-a0c07468f0116146960fdd17eed35bc8-39d5394ff60ddf41-00",
+        "traceparent": "00-9ecf06323978024fbf654cc05b24fa2f-70df5a79bea6dd4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "82031acff7a7b5808f905b2847024176",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:55 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1042,30 +1042,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:55 GMT",
-        "ETag": "\u00220x8D95786E73ED11B\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:56 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:30 GMT",
+        "ETag": "\u00220x8D967D3A232D3BA\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:30 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "82031acff7a7b5808f905b2847024176",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284c89-a01e-003b-696f-896135000000",
+        "x-ms-request-id": "9964c5b2-501e-0000-4ebc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source123007989/File_19.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_19.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-757fd536303e3448995ffb6c90a3bbc7-5087c98180cac44c-00",
+        "traceparent": "00-9fb174b476769245a5b02eae995284b3-dabdd9b645b1e04e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "f15a4a6df8a2e5fd5fba6e5be3e54aee",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:56 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1074,28 +1074,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:31:56 GMT",
-        "ETag": "\u00220x8D95786E7870ABB\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:57 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:30 GMT",
+        "ETag": "\u00220x8D967D3A270D27E\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:31 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "f15a4a6df8a2e5fd5fba6e5be3e54aee",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05284d1b-a01e-003b-676f-896135000000",
+        "x-ms-request-id": "9964c6c1-501e-0000-3dbc-993c9f000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target847432015?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target847432015?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d6c2f1d5db222442a96003944b8b4da9-55b4c0e4277e0c47-00",
+        "traceparent": "00-85a44c236c737f45a2455384c4634463-c3ff4da7e2ee6545-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "a87339bf7b034a382318606d53bcc085",
-        "x-ms-date": "Wed, 04 Aug 2021 20:31:56 GMT",
+        "x-ms-date": "Wed, 25 Aug 2021 14:21:31 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1103,26 +1103,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:56 GMT",
-        "ETag": "\u00220x8D95786E7AC826E\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:31:57 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:31 GMT",
+        "ETag": "\u00220x8D967D3A289539A\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 14:21:31 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "a87339bf7b034a382318606d53bcc085",
-        "x-ms-request-id": "05284df8-a01e-003b-206f-896135000000",
+        "x-ms-request-id": "9964c72f-501e-0000-1cbc-993c9f000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-38bd368007ac3d4ebcb4ff02fb69ca4b-ff60af2477d7eb4c-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cc643edccdc1c54eb60444caaee6564a-350d03c22870c844-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "2c4ac9742a281cd61d22ec8824d1aa46",
         "x-ms-return-client-request-id": "true"
       },
@@ -1143,37 +1143,37 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3b058cf4-0fd1-4047-84d5-96c5ecb6442d",
+        "apim-request-id": "69b4500b-51a4-47a2-8c42-52218bb19f5b",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:31:57 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/62e69318-c19f-4cd0-98ff-d35fd903af13",
+        "Date": "Wed, 25 Aug 2021 14:21:31 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/decfe908-d309-4d44-838b-7b12aa38d315",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3b058cf4-0fd1-4047-84d5-96c5ecb6442d"
+        "X-RequestId": "69b4500b-51a4-47a2-8c42-52218bb19f5b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/62e69318-c19f-4cd0-98ff-d35fd903af13",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/decfe908-d309-4d44-838b-7b12aa38d315",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "c888d86ccececf6922a67ee09d770cfe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4a0b546-7b92-47e4-b659-7fdf7ea1b59c",
+        "apim-request-id": "2fbdeae9-a461-45ef-aa4f-39eab1f53e68",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:31:57 GMT",
+        "Date": "Wed, 25 Aug 2021 14:21:31 GMT",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1183,12 +1183,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e4a0b546-7b92-47e4-b659-7fdf7ea1b59c"
+        "X-RequestId": "2fbdeae9-a461-45ef-aa4f-39eab1f53e68"
       },
       "ResponseBody": {
-        "id": "62e69318-c19f-4cd0-98ff-d35fd903af13",
-        "createdDateTimeUtc": "2021-08-04T20:31:57.8581636Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:31:58.1090578Z",
+        "id": "decfe908-d309-4d44-838b-7b12aa38d315",
+        "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
+        "lastActionDateTimeUtc": "2021-08-25T14:21:31.8375024Z",
         "status": "Cancelling",
         "summary": {
           "total": 0,
@@ -1202,44 +1202,44 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=Cancelled%2CCancelling\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=decfe908-d309-4d44-838b-7b12aa38d315\u0026statuses=\u0026$orderBy=",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dbd2eea966b11a42937c2466722f0971-6101c27fd3b3bf49-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-156f36a6eec3c642bc6280254a810a3c-5ad62e431d6e104a-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "1b6fd6adc200942762568ae08eaf2651",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9138efe6-10f3-4534-aa1b-269c79b232f8",
+        "apim-request-id": "655b59d2-ef3a-4b11-bac8-2bb480e69fd4",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:00 GMT",
-        "ETag": "\u002277631C31816CE31111C7B93A8ED541D14D28C05B0666B15DC172A87857C7E824\u0022",
+        "Date": "Wed, 25 Aug 2021 14:21:36 GMT",
+        "ETag": "\u002275227BBA0DD34B849BD7797011B75C20D3E5DD80B07364161D2B515B13A7D5F4\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9138efe6-10f3-4534-aa1b-269c79b232f8"
+        "X-RequestId": "655b59d2-ef3a-4b11-bac8-2bb480e69fd4"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "62e69318-c19f-4cd0-98ff-d35fd903af13",
-            "createdDateTimeUtc": "2021-08-04T20:31:57.8581636Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:32:00.1619182Z",
+            "id": "decfe908-d309-4d44-838b-7b12aa38d315",
+            "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:21:34.8683111Z",
             "status": "Cancelling",
             "summary": {
               "total": 20,
@@ -1250,11 +1250,102 @@
               "cancelled": 0,
               "totalCharacterCharged": 0
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=decfe908-d309-4d44-838b-7b12aa38d315\u0026statuses=\u0026$orderBy=",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dc7f063f6a7cfb40b4af7fd06ac2a3ef-abda0f47f1c3594e-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7a01196df833a6b75f7a0a81acf67fa6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b37a17c0-771d-4cd4-bb49-c8b471ddb3d9",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:21:41 GMT",
+        "ETag": "\u0022732ABB2837401B3F6A0F90133FF4B1711A1C3C5FBF94817E57237224A3EEF835\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "b37a17c0-771d-4cd4-bb49-c8b471ddb3d9"
+      },
+      "ResponseBody": {
+        "value": [
           {
-            "id": "b6606d70-e903-4f08-a80d-3d1b65c07303",
-            "createdDateTimeUtc": "2021-08-04T20:30:06.5979195Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:10.7837251Z",
+            "id": "decfe908-d309-4d44-838b-7b12aa38d315",
+            "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:21:38.0583554Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=Cancelled%2CCancelling\u0026$orderBy=",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9fce7c44b6565d4cb6e9463de4d3cc7f-5407679a156e5d41-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4ddbee168e62a946b1f4667844894072",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bc2c9c69-8d2a-4c9a-9982-e9c4bf9b88e4",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:21:42 GMT",
+        "ETag": "\u0022AE2803377D32EB9E222C539470DF2BDE4BA768D0E8EC6A3FE3E9641D136F77E1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "bc2c9c69-8d2a-4c9a-9982-e9c4bf9b88e4"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "decfe908-d309-4d44-838b-7b12aa38d315",
+            "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:21:38.0583554Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1267,9 +1358,9 @@
             }
           },
           {
-            "id": "98452bfa-797a-44c2-9bb2-d7fd159fab0d",
-            "createdDateTimeUtc": "2021-08-03T21:38:51.6547083Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:54.3057302Z",
+            "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
+            "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:20:58.7274706Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1282,9 +1373,9 @@
             }
           },
           {
-            "id": "32aebb1f-9dd9-4bf4-a684-514bde841fd8",
-            "createdDateTimeUtc": "2021-08-03T21:38:47.6125244Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:53.9775319Z",
+            "id": "253d9f25-18d2-4cc7-8669-4d8407b22a9c",
+            "createdDateTimeUtc": "2021-08-25T14:19:05.8329604Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:19:10.6795351Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1297,9 +1388,9 @@
             }
           },
           {
-            "id": "6c30daea-f0dc-45d2-a5f2-c9c9ca5c454d",
-            "createdDateTimeUtc": "2021-08-03T21:33:40.0877854Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:42.98622Z",
+            "id": "60db663e-f771-4adb-b08f-6854b85696e1",
+            "createdDateTimeUtc": "2021-08-25T14:18:43.8946636Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:18:51.4148389Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1312,9 +1403,9 @@
             }
           },
           {
-            "id": "06da1349-40ca-40a9-bcbc-bd1e846f3b88",
-            "createdDateTimeUtc": "2021-08-03T21:33:35.9538097Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:38.6215767Z",
+            "id": "5acc56a1-33c3-4542-9370-5f7b9b19f5ab",
+            "createdDateTimeUtc": "2021-08-25T14:15:39.7803188Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:15:43.1246356Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1327,9 +1418,9 @@
             }
           },
           {
-            "id": "ff9490ff-1a22-4905-b300-f832c622fcd3",
-            "createdDateTimeUtc": "2021-08-03T21:14:52.4456431Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:55.1385001Z",
+            "id": "2597203e-1311-41c4-886f-f465cd164759",
+            "createdDateTimeUtc": "2021-08-25T14:15:19.2437991Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:15:23.9402734Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1342,9 +1433,9 @@
             }
           },
           {
-            "id": "a291a37f-00ff-462c-90f7-af30487cfee0",
-            "createdDateTimeUtc": "2021-08-03T21:14:47.8001603Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:52.8849738Z",
+            "id": "f4b9df36-266a-40d0-ba29-fc0e67dd4887",
+            "createdDateTimeUtc": "2021-08-25T14:14:35.4257961Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:14:41.4038969Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1357,9 +1448,9 @@
             }
           },
           {
-            "id": "35491096-d4b6-4f64-a475-3a8f425bda13",
-            "createdDateTimeUtc": "2021-08-02T16:24:08.8499137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:13.2168149Z",
+            "id": "a5c6c285-da24-494d-a971-919266469088",
+            "createdDateTimeUtc": "2021-08-25T14:14:14.5070628Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:14:19.0578249Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1372,9 +1463,9 @@
             }
           },
           {
-            "id": "d6516cd6-00bc-4dd4-81e0-ac3531a9ef9a",
-            "createdDateTimeUtc": "2021-08-02T16:24:04.9124096Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:09.2033129Z",
+            "id": "533c3361-dfbe-4bd2-a517-9491e071775a",
+            "createdDateTimeUtc": "2021-08-25T14:13:34.7214701Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:13:39.5494326Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1387,9 +1478,9 @@
             }
           },
           {
-            "id": "ec3e1c4c-3509-4f5a-86ee-3be559f978cf",
-            "createdDateTimeUtc": "2021-08-02T16:17:43.4479159Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:46.1484498Z",
+            "id": "a23b53f3-ed01-458b-947e-867a553eb591",
+            "createdDateTimeUtc": "2021-08-25T14:13:13.8939951Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:13:19.2252019Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1402,9 +1493,9 @@
             }
           },
           {
-            "id": "cd18395a-adb6-4566-a35d-4b7394ce7e7c",
-            "createdDateTimeUtc": "2021-08-02T16:17:39.2236317Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:42.3718498Z",
+            "id": "0d4b8b20-a460-469a-b3aa-588300fef2e0",
+            "createdDateTimeUtc": "2021-08-25T14:08:25.2665312Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:08:32.3285477Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1417,9 +1508,9 @@
             }
           },
           {
-            "id": "3e9a5d00-90d9-4256-9d62-f1dfa1577da0",
-            "createdDateTimeUtc": "2021-08-01T16:20:07.4673305Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:13.4203616Z",
+            "id": "2aecc1c5-d3da-45b9-93c5-d2a260d6aedf",
+            "createdDateTimeUtc": "2021-08-25T14:08:02.4909754Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:08:06.9807983Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1432,9 +1523,9 @@
             }
           },
           {
-            "id": "fc266ece-821c-4ad7-9448-1813652fd6ec",
-            "createdDateTimeUtc": "2021-08-01T16:20:03.3145089Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:12.698585Z",
+            "id": "b0607637-8b27-4120-8b39-6194b5755e92",
+            "createdDateTimeUtc": "2021-08-25T14:06:09.5993734Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:06:14.8816421Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1447,9 +1538,9 @@
             }
           },
           {
-            "id": "9d74505c-4ec7-4849-a25e-347c9ca83531",
-            "createdDateTimeUtc": "2021-08-01T16:19:14.3845766Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:19.1001524Z",
+            "id": "b7f3c08a-c2c0-4228-9f8a-c92be3b7737d",
+            "createdDateTimeUtc": "2021-08-25T14:05:44.5683358Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:05:49.4108643Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1462,9 +1553,1917 @@
             }
           },
           {
-            "id": "5263795e-4551-4f48-94da-32a53c735650",
-            "createdDateTimeUtc": "2021-08-01T16:19:10.3372901Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:18.7374885Z",
+            "id": "0d5c55f5-91e2-4d2f-88f8-9c7ae1de5505",
+            "createdDateTimeUtc": "2021-08-25T14:05:07.8586943Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:05:11.277379Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b4f56a1c-3b5d-42a2-a94e-1c949dfe776f",
+            "createdDateTimeUtc": "2021-08-25T14:04:41.9246386Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:04:48.5055613Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ff62a2bd-4c6f-47e8-b557-f429dd7e6f3a",
+            "createdDateTimeUtc": "2021-08-25T14:03:49.5697452Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:03:53.7964747Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "9eb1fcae-bc60-4b93-90eb-64a52c473672",
+            "createdDateTimeUtc": "2021-08-25T14:03:24.5425451Z",
+            "lastActionDateTimeUtc": "2021-08-25T14:03:31.821667Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "eb67646e-c215-4fa3-8eb3-da0770064e5f",
+            "createdDateTimeUtc": "2021-08-25T13:57:19.6278599Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:57:30.2946248Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "727d5bf9-f9fb-4ddf-9a38-828f22910b12",
+            "createdDateTimeUtc": "2021-08-25T13:53:59.4231523Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:54:05.5775816Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "4809cfc7-d5ae-4225-868e-05544f489358",
+            "createdDateTimeUtc": "2021-08-25T13:53:29.8911657Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:53:33.6911548Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d493956c-db6d-4a17-a5f0-028becb4ccfa",
+            "createdDateTimeUtc": "2021-08-25T13:52:31.0854759Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:52:34.9946496Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b6a8fa53-920e-4932-8c81-f3c73c0b2988",
+            "createdDateTimeUtc": "2021-08-25T13:51:53.8772741Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:52:00.7948926Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c2301f1f-c87f-4772-9f9c-5a9d7548b349",
+            "createdDateTimeUtc": "2021-08-25T13:45:19.087893Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:45:23.5227282Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d8ecc615-eeeb-4787-a601-851daef7b268",
+            "createdDateTimeUtc": "2021-08-25T13:44:54.582286Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:44:58.230487Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "14f3ad4c-7135-415e-859d-9b5f431ae6da",
+            "createdDateTimeUtc": "2021-08-25T13:44:08.2452291Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:44:16.8544217Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "9bb35643-eeb4-475b-8344-c3ae46655123",
+            "createdDateTimeUtc": "2021-08-25T13:43:37.812651Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:43:45.7364219Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ea604b93-8058-4d72-af48-81ad3ed99057",
+            "createdDateTimeUtc": "2021-08-25T13:41:46.5703013Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:41:50.3292734Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "501bfb81-87b7-4a4e-8f2a-67df97de6546",
+            "createdDateTimeUtc": "2021-08-25T13:41:24.0184265Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:41:27.7675607Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "42029254-a247-4c0b-ba14-52b9856051a4",
+            "createdDateTimeUtc": "2021-08-25T13:40:13.0836214Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:40:17.2772553Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d0ed4aa1-8314-4eff-8794-7d71942ebb55",
+            "createdDateTimeUtc": "2021-08-25T13:39:50.5251217Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:39:54.8052147Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "92252ab6-aeee-429c-8eca-f02e13be2348",
+            "createdDateTimeUtc": "2021-08-25T13:36:06.2711907Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:36:11.6241286Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "0e476571-3f2d-4999-bab6-7d3487603d22",
+            "createdDateTimeUtc": "2021-08-25T13:29:53.0363818Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:29:58.8829377Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "9feff3a9-0b8c-4c47-b780-664c7d90d549",
+            "createdDateTimeUtc": "2021-08-25T13:26:04.1635563Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:26:08.1645944Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c2f031b9-55db-42a9-9ecc-afdd741985bf",
+            "createdDateTimeUtc": "2021-08-25T13:25:45.2888951Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:25:49.1040561Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "500ffbb8-db58-417a-9bbc-98fd0d5e0f6e",
+            "createdDateTimeUtc": "2021-08-25T13:24:28.73101Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:24:32.7396137Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6385a3f7-9a39-4389-a9e3-0b533e19561d",
+            "createdDateTimeUtc": "2021-08-25T13:24:08.1547203Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:24:11.935914Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "040d09c1-a792-48a1-8b09-368ad940703c",
+            "createdDateTimeUtc": "2021-08-25T13:23:09.2673068Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:23:17.3461036Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a4720b7c-5aff-451d-9168-4aaeb46810ec",
+            "createdDateTimeUtc": "2021-08-25T13:22:47.9668002Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:22:51.8319732Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "53665f6e-2451-47ad-872e-0b60048296bc",
+            "createdDateTimeUtc": "2021-08-25T13:21:59.6468367Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:22:04.1049272Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "4d02dc0e-82d0-4106-9601-2b67d4895887",
+            "createdDateTimeUtc": "2021-08-25T13:21:41.2699303Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:21:45.685377Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "2f83a75e-3690-478a-b2c1-838a3c87780f",
+            "createdDateTimeUtc": "2021-08-25T13:20:00.4021268Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:20:04.4540659Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "79358abe-ca1d-4a34-a9dc-251d35f38d88",
+            "createdDateTimeUtc": "2021-08-25T13:19:40.6697383Z",
+            "lastActionDateTimeUtc": "2021-08-25T13:19:47.1202077Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "aa883068-64e5-435b-8663-bc9573b2e917",
+            "createdDateTimeUtc": "2021-08-25T10:56:20.2363383Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:56:27.0780797Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "90c0a544-4504-4020-8396-0544b00c18c6",
+            "createdDateTimeUtc": "2021-08-25T10:55:55.9293426Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:56:05.0797274Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "614afed7-f7f1-4d74-9ad7-eff593103cd6",
+            "createdDateTimeUtc": "2021-08-25T10:29:21.1938146Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:29:24.7004537Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "f74ec5a8-15e9-4b8c-b8b6-c33ddd521c63",
+            "createdDateTimeUtc": "2021-08-25T10:29:02.5870188Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:29:05.9331656Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "fc864d53-0ddb-4fad-85ac-2d7451de0350",
+            "createdDateTimeUtc": "2021-08-25T10:28:05.7449329Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:28:15.1486564Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "30bc281b-3a6c-4a97-92c2-43de98e83aa4",
+            "createdDateTimeUtc": "2021-08-25T10:27:43.633836Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:27:50.5077585Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6f160aba-7e60-4748-a972-d0a146b3196e",
+            "createdDateTimeUtc": "2021-08-25T10:26:50.4040903Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:26:54.3204806Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          }
+        ],
+        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=87\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=87\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5c6e9b09fc65ea40aadf593f3b65f210-c97b339ed254b741-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "83722d809175b5ca1fc8bb85b8a5e76c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "02d22c70-caad-4a6d-9e5a-1290dde935bc",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:21:42 GMT",
+        "ETag": "\u0022944ECD8F6E53579CDC56C10D10EB5E4B47E3E8CE2AB380D914D9EEDD34A662BD\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "02d22c70-caad-4a6d-9e5a-1290dde935bc"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "ca6e611e-7b53-4d7f-b638-afe8d00bb725",
+            "createdDateTimeUtc": "2021-08-25T10:26:26.2866155Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:26:30.7154518Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "5d4b8b67-af0b-4c12-9c75-0869a2ba66df",
+            "createdDateTimeUtc": "2021-08-25T10:24:14.9778475Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:24:23.0381859Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "57bc3d42-2f4c-4dd1-ad51-791847d581d4",
+            "createdDateTimeUtc": "2021-08-25T10:23:51.1332076Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:23:58.0469266Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c55b120e-d8e1-48de-b0af-0e8d45c2b960",
+            "createdDateTimeUtc": "2021-08-25T10:09:55.7948842Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:10:02.821391Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8e66ffc9-0ac3-48a0-82ae-7609c6a6050a",
+            "createdDateTimeUtc": "2021-08-25T10:09:31.391233Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:09:35.8564693Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "63fb087b-4dd8-46d8-ac10-48bb79ce86d3",
+            "createdDateTimeUtc": "2021-08-25T10:07:25.2633442Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:07:31.8339883Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "cb2faa2d-95b1-46f9-bd39-4c5ffaf3d066",
+            "createdDateTimeUtc": "2021-08-25T10:07:01.8887184Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:07:06.5864174Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "73489fba-e1e8-4fb6-9f08-1eec3698f3e3",
+            "createdDateTimeUtc": "2021-08-25T10:05:29.2026751Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:05:41.024571Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d5015b23-d0d7-46f0-af5e-50e2228f4841",
+            "createdDateTimeUtc": "2021-08-25T10:05:07.1839969Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:05:15.5031116Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8f3aefad-b2fc-41cf-968d-18b0497b5fb3",
+            "createdDateTimeUtc": "2021-08-25T10:01:07.121612Z",
+            "lastActionDateTimeUtc": "2021-08-25T10:01:13.8095906Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "609f5c8f-80e1-424b-9801-5d3e804c134e",
+            "createdDateTimeUtc": "2021-08-25T09:47:51.4646326Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:47:59.0397057Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "cc873f8b-e71f-4617-a277-00b299907c0e",
+            "createdDateTimeUtc": "2021-08-25T09:47:17.2200753Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:47:25.0694763Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "92c6004e-733f-41af-8d2f-89b41bb279c6",
+            "createdDateTimeUtc": "2021-08-25T09:44:03.9368379Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:44:09.2827307Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "0699ddc0-9394-43b7-8335-99b582ac7af5",
+            "createdDateTimeUtc": "2021-08-25T09:43:07.3141327Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:43:12.1318918Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "686ae6d7-ffc1-4c0c-a4b1-49a57d03524b",
+            "createdDateTimeUtc": "2021-08-25T09:42:39.886955Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:42:45.1118961Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "77edc600-d50a-4740-ba35-9fc276ae7415",
+            "createdDateTimeUtc": "2021-08-25T09:19:31.6344382Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:19:39.3248571Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8afe0ff5-a724-4d21-acce-da44c26b3ffe",
+            "createdDateTimeUtc": "2021-08-25T09:19:10.8844738Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:19:17.2753878Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "02acf584-26b6-40d3-a958-e34734f20ef5",
+            "createdDateTimeUtc": "2021-08-25T09:18:05.5949331Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:18:10.700436Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "da3b7f1b-eaf1-4ef3-b1d7-34cb12c58f5f",
+            "createdDateTimeUtc": "2021-08-25T09:17:41.6284086Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:17:46.8467624Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "e2fdfa9b-eef5-4285-84f2-394dc3ee0cde",
+            "createdDateTimeUtc": "2021-08-25T09:16:55.2621789Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:17:00.0474197Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8107b309-29ed-4fc0-b2e1-cfeb96210550",
+            "createdDateTimeUtc": "2021-08-25T09:16:27.1861354Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:16:31.6226169Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d33cd5ae-28a9-4560-980d-3cd99decdb56",
+            "createdDateTimeUtc": "2021-08-25T09:15:20.2067568Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:15:30.5710243Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ea961c29-189c-4dbc-b375-61167cf15a17",
+            "createdDateTimeUtc": "2021-08-25T09:14:55.2312472Z",
+            "lastActionDateTimeUtc": "2021-08-25T09:15:04.6298687Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "eb8efceb-d78d-4dcf-aedb-c3edde6cbc7e",
+            "createdDateTimeUtc": "2021-08-24T19:55:47.1477025Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:55:51.5061055Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "534d90e6-5360-471e-bfd0-54d23d28aa3f",
+            "createdDateTimeUtc": "2021-08-24T19:53:32.6469602Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:53:40.4258421Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a10ef07d-101a-4e0c-9194-ab61b49cba8a",
+            "createdDateTimeUtc": "2021-08-24T19:53:07.1127838Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:53:15.4049994Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "223a9ccf-7935-4581-995a-60605ee335a5",
+            "createdDateTimeUtc": "2021-08-24T19:50:41.7797004Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:50:48.506789Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "4dbe99ed-ca2d-4dbe-8bcd-2643d5bbe7f4",
+            "createdDateTimeUtc": "2021-08-24T19:50:16.0211307Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:50:26.0420851Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "f80c73e0-e8ec-4d35-a4d4-27179f0ed4bf",
+            "createdDateTimeUtc": "2021-08-24T19:49:10.6527877Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:49:15.2215103Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "18d1d2d0-c3e1-4864-833c-8ab189be6fc1",
+            "createdDateTimeUtc": "2021-08-24T19:48:44.5805808Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:48:49.1109041Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "5a457f72-8bd8-450c-ac60-da04df2cc2ab",
+            "createdDateTimeUtc": "2021-08-24T19:46:10.1997622Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:46:17.9106435Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "60ff13d3-9f94-431f-ac62-58f42f771630",
+            "createdDateTimeUtc": "2021-08-24T19:45:44.4022212Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:45:48.9866813Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "195c51ce-0ef1-491b-9ec2-db1542402a32",
+            "createdDateTimeUtc": "2021-08-24T19:44:53.1308296Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:45:02.5998496Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6a18a4bd-f2cc-42cc-b195-cd1cdb22eaf6",
+            "createdDateTimeUtc": "2021-08-24T19:44:31.5620308Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:44:38.2064648Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c562e87c-1fb3-4e9f-8748-803d34fe7b11",
+            "createdDateTimeUtc": "2021-08-24T19:42:08.6323717Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:42:16.6949486Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "2c8d2c87-1dd9-42af-aa73-9052cb89123c",
+            "createdDateTimeUtc": "2021-08-24T19:41:44.486071Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:41:49.5437122Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a8018349-6083-4c7b-be65-a0d93cd7f9f1",
+            "createdDateTimeUtc": "2021-08-24T19:26:28.685069Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:26:35.6712921Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "93c8fbe5-2509-4e26-aa38-5b44ae36abb9",
+            "createdDateTimeUtc": "2021-08-24T19:25:53.9806028Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:25:59.7724431Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b981ecff-a052-4239-975b-2f4ed45aa2e7",
+            "createdDateTimeUtc": "2021-08-24T19:25:32.5560562Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:25:36.3150668Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "5fce870f-5805-48fe-9e55-d978c0a44a96",
+            "createdDateTimeUtc": "2021-08-24T19:24:49.8512423Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:24:54.7359674Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "58dd2537-2390-41ce-8e66-cf5d991a0ef0",
+            "createdDateTimeUtc": "2021-08-24T19:24:28.0491081Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:24:32.8824749Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "309c5ab2-ab6e-42d2-b341-3d273507090b",
+            "createdDateTimeUtc": "2021-08-24T19:19:16.359635Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:19:26.45727Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6621b15c-9956-44d8-8bd2-de6d1dd3d518",
+            "createdDateTimeUtc": "2021-08-24T19:18:15.2019519Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:18:20.6814382Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b39c5530-1a07-4898-b0cf-d1b81c31958c",
+            "createdDateTimeUtc": "2021-08-24T19:17:00.6801855Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:17:04.7751099Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ab5f7b09-0873-4d2d-942c-5a76b6296264",
+            "createdDateTimeUtc": "2021-08-24T19:16:35.6588021Z",
+            "lastActionDateTimeUtc": "2021-08-24T19:16:45.7609068Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c0c4e53a-6bc5-4d35-be29-4e9d088d6b70",
+            "createdDateTimeUtc": "2021-08-24T15:36:55.7864604Z",
+            "lastActionDateTimeUtc": "2021-08-24T15:37:01.6474825Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "161de4ac-0924-4527-8170-a4bec6eb38c8",
+            "createdDateTimeUtc": "2021-08-24T15:36:21.2461429Z",
+            "lastActionDateTimeUtc": "2021-08-24T15:36:28.9384829Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "49840bd2-de72-4b7d-9bf4-47f746ecc5bb",
+            "createdDateTimeUtc": "2021-08-23T17:47:33.9921789Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:47:40.5970502Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6e3b9367-513c-4d20-8c07-ee3568440b7c",
+            "createdDateTimeUtc": "2021-08-23T17:47:11.3828547Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:47:15.2840674Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b2d0e15f-95ef-40d4-bfb0-9a4f203a54ba",
+            "createdDateTimeUtc": "2021-08-23T17:35:20.3985579Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:35:27.6518861Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          }
+        ],
+        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=37\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=37\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8dc461b722ef0b48b3d30df08a1b7ec6-1cf01fac16b09647-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a0cae3d6d8d4dfefd357c83f923e62d6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "17e82a39-4976-473b-9fbf-cd17b124881b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 14:21:43 GMT",
+        "ETag": "\u002262F4FBD6C85DA1E3DD9FD6FFAD960CCBA679402CC665EAFB448DA82088CCF0E6\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "17e82a39-4976-473b-9fbf-cd17b124881b"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "15bb936d-c180-4255-9ba2-a07bec5806dd",
+            "createdDateTimeUtc": "2021-08-23T17:34:58.0354643Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:35:03.3355533Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "29353a68-850e-4c04-bce3-ce98e0ee567f",
+            "createdDateTimeUtc": "2021-08-23T17:33:06.4539736Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:33:14.3872677Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "40f6ee23-324d-49fd-b74b-fcdcbb410299",
+            "createdDateTimeUtc": "2021-08-23T17:32:44.9924751Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:32:51.3694131Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "1617b829-c0a3-4971-92d4-c2964babd030",
+            "createdDateTimeUtc": "2021-08-23T17:32:09.2406517Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:32:18.6614602Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "a577fd72-5713-466c-8bc7-a1c81c9ce690",
+            "createdDateTimeUtc": "2021-08-23T17:31:48.2758423Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:31:53.1076136Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "3ef3e1fd-9489-4036-a76d-adf8121073a9",
+            "createdDateTimeUtc": "2021-08-23T17:28:59.4940221Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:29:05.3839228Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "795298f9-c99d-46ad-9be8-756171a64d47",
+            "createdDateTimeUtc": "2021-08-23T17:28:37.2538866Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:28:47.3380251Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "38136150-8f48-470f-93d0-efd2167ad0df",
+            "createdDateTimeUtc": "2021-08-23T17:28:06.0935977Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:28:15.7031915Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "8f25593f-63ad-413a-9e0b-2f7b935e53f7",
+            "createdDateTimeUtc": "2021-08-23T17:27:42.2908433Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:27:51.9149141Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "032a3bb1-cdbf-4162-b3c7-7b3618379c7f",
+            "createdDateTimeUtc": "2021-08-23T17:27:09.7358524Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:27:19.680071Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ab879574-fcf3-41e3-b77e-6ea15d44b413",
+            "createdDateTimeUtc": "2021-08-23T17:26:47.3142089Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:26:56.5225722Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "98743da0-d863-41c4-bf57-56fa90b43eb4",
+            "createdDateTimeUtc": "2021-08-23T17:25:45.600667Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:25:49.2127676Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "183d6c88-fdae-4ea5-aa68-340f1ad84f77",
+            "createdDateTimeUtc": "2021-08-23T17:25:24.3498398Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:25:31.0082101Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "09960070-bdf0-46b1-99af-928e4a626f69",
+            "createdDateTimeUtc": "2021-08-23T17:24:31.4385114Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:24:35.5546122Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d8405784-fa6b-4267-b830-d8513a4f658d",
+            "createdDateTimeUtc": "2021-08-23T17:24:00.3396396Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:24:05.6562369Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "43b2701d-cae4-47b5-8287-f00ef452a7ce",
+            "createdDateTimeUtc": "2021-08-23T17:23:35.5630305Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:23:45.0431691Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "464de745-a68f-43db-b2af-61ccf62acc73",
+            "createdDateTimeUtc": "2021-08-23T17:20:31.3475187Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:20:40.1632632Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "3591ae2c-a6f1-44f4-8f8b-802ccb41fb0d",
+            "createdDateTimeUtc": "2021-08-23T17:19:56.3627557Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:20:04.8977529Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c5addf28-55a0-4cf7-a193-452c47aba219",
+            "createdDateTimeUtc": "2021-08-23T17:19:36.4200341Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:19:43.8168428Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "7570de08-6a5c-4a7d-9862-65db205744e2",
+            "createdDateTimeUtc": "2021-08-23T17:16:04.5109438Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:16:14.2207404Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "c2b12a8c-a64e-486a-8cb8-6f533fa14d9a",
+            "createdDateTimeUtc": "2021-08-23T17:12:39.1494425Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:12:48.7856928Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "d0b76907-0261-4277-884c-f0823f9ec122",
+            "createdDateTimeUtc": "2021-08-23T17:12:16.3765099Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:12:22.483808Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "b6bd137e-2a00-4427-bbda-215b9dcdbff1",
+            "createdDateTimeUtc": "2021-08-23T17:11:35.4166713Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:11:41.9836701Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "68dba74a-e802-486b-a389-28977cbd191c",
+            "createdDateTimeUtc": "2021-08-23T17:11:11.1146708Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:11:15.5935992Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "e1bc7687-0156-45f5-9428-e63c022dbafd",
+            "createdDateTimeUtc": "2021-08-23T17:09:30.3557278Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:09:38.0232919Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "4ad591be-f6a3-424a-a368-a5ac3338c68e",
+            "createdDateTimeUtc": "2021-08-23T17:09:05.6068524Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:09:14.2949945Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "fb02d26f-4b4a-44c7-8512-1dc605b4760d",
+            "createdDateTimeUtc": "2021-08-23T17:08:01.2644983Z",
+            "lastActionDateTimeUtc": "2021-08-23T17:08:07.3426569Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "3fe85a3c-4db1-4dc5-baf8-b4956f535c2f",
+            "createdDateTimeUtc": "2021-08-23T16:59:08.3574297Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:59:16.4935524Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "5afefe59-d1b7-4df4-ad58-0c7665aa1167",
+            "createdDateTimeUtc": "2021-08-23T16:58:22.7200327Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:58:30.9323045Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "da52052a-d809-46b3-a65f-4b0b4366462b",
+            "createdDateTimeUtc": "2021-08-23T16:57:50.2799217Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:57:55.6175942Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "bf798bca-7a93-47a3-a1ff-ccdf90015328",
+            "createdDateTimeUtc": "2021-08-23T16:53:14.9104004Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:53:20.0243492Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "de676d42-097d-499d-b424-63c44ff0fd85",
+            "createdDateTimeUtc": "2021-08-23T16:41:50.025133Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:41:55.021436Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "144d63b0-b972-47da-be48-e8369610d9d0",
+            "createdDateTimeUtc": "2021-08-23T16:41:24.3300611Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:41:27.9762437Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "ae29411c-ed5f-45e6-be84-e97c675599ed",
+            "createdDateTimeUtc": "2021-08-23T16:39:53.6000673Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:39:59.431849Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6924c556-8704-4b02-9148-45101d5a8791",
+            "createdDateTimeUtc": "2021-08-23T16:39:31.6451911Z",
+            "lastActionDateTimeUtc": "2021-08-23T16:39:36.1986712Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "f1ce52fa-8234-47ec-9772-934b3a24bb70",
+            "createdDateTimeUtc": "2021-08-16T09:59:08.2257882Z",
+            "lastActionDateTimeUtc": "2021-08-16T09:59:14.4683656Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "6e7b03fa-1abe-4524-82df-9efccd37df2f",
+            "createdDateTimeUtc": "2021-08-16T09:57:10.9273883Z",
+            "lastActionDateTimeUtc": "2021-08-16T09:57:17.7325207Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1482,8 +3481,8 @@
   ],
   "Variables": {
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
     "RandomSeed": "1950452491"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source317602543?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1526045109?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-09782d694aed65429d224fa0401bee25-992c11f01fbb4144-00",
+        "traceparent": "00-a1dec20b39680b4aa7c6248f7bebc44d-7a1ab80f022b034a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "ab5814afaff8957adcbde78e3c863dfa",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:16 GMT",
+        "x-ms-client-request-id": "fac168094a15877c1b5eb97611e091c5",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:27 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:21:15 GMT",
-        "ETag": "\u00220x8D967D39938B79F\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:15 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:26 GMT",
+        "ETag": "\u00220x8D967F88142445E\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:26 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ab5814afaff8957adcbde78e3c863dfa",
-        "x-ms-request-id": "df4883cb-c01e-002d-01bc-998fec000000",
+        "x-ms-client-request-id": "fac168094a15877c1b5eb97611e091c5",
+        "x-ms-request-id": "97606329-d01e-0088-80e1-99d996000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source317602543/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1526045109/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-8a3dcd2048baa540aa7e2628fb70b86a-8f6efdee3138894f-00",
+        "traceparent": "00-9746cb5c35994049b0da327f5fd3a428-e4ef714d3050a543-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "5467b7ecb173ad8566ae54bd05391a3c",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:16 GMT",
+        "x-ms-client-request-id": "c7bd2a0367c8cba29e5c8af77d806104",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:27 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:15 GMT",
-        "ETag": "\u00220x8D967D3996688AA\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:15 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:27 GMT",
+        "ETag": "\u00220x8D967F88179A712\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:27 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "5467b7ecb173ad8566ae54bd05391a3c",
+        "x-ms-client-request-id": "c7bd2a0367c8cba29e5c8af77d806104",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "df488421-c01e-002d-51bc-998fec000000",
+        "x-ms-request-id": "97606351-d01e-0088-21e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target123362359?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target838503391?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-bcee858206959141ad433a44697d5ef8-07c82f191e9cbb45-00",
+        "traceparent": "00-8e1cc866c9bcaa4787975f2d89543be8-f0bcd173c2526448-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "14a7d2ed197afecad0a3a46c7eae3890",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:16 GMT",
+        "x-ms-client-request-id": "4cb18c0967fde0798124ac0bba62e724",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:27 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,12 +76,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:21:15 GMT",
-        "ETag": "\u00220x8D967D3998006E9\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:16 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:27 GMT",
+        "ETag": "\u00220x8D967F8818FD65B\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:27 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "14a7d2ed197afecad0a3a46c7eae3890",
-        "x-ms-request-id": "df4884b4-c01e-002d-50bc-998fec000000",
+        "x-ms-client-request-id": "4cb18c0967fde0798124ac0bba62e724",
+        "x-ms-request-id": "976063a6-d01e-0088-69e1-99d996000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -94,9 +94,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-34167d261f88b94da3c3976d801f7bce-c5804cd8a0fb6e4b-00",
+        "traceparent": "00-d78e4435e4dfc14985505edf6c7014c4-4f608a49e38a9643-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3e62ed3d7be68ffdaa454a5bbc8fa2a2",
+        "x-ms-client-request-id": "69f93aa6ed09c6a2f65bb8bf850a9afd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -116,57 +116,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "74b79387-aaee-432e-a831-8fdd4ead3edd",
+        "apim-request-id": "8ea9f6ab-5cf3-4bc1-87ac-9e1946c639d1",
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:21:16 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "74b79387-aaee-432e-a831-8fdd4ead3edd"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b34e57abe5969e729c55a30ee041e700",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9c064ee9-4e11-43f9-825b-57cd0f2ce211",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:16 GMT",
-        "ETag": "\u0022613F5D9CF0AF31FA4F55056389E38480052AF016C0565F19DF9481F4688A5A98\u0022",
-        "Retry-After": "1",
+        "Date": "Wed, 25 Aug 2021 18:45:26 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "8ea9f6ab-5cf3-4bc1-87ac-9e1946c639d1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "540896b579e0c30643e74743f6c0e4fa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b01b688a-ab39-4d4b-b599-5e649b77dd1f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:27 GMT",
+        "ETag": "\u0022C2B44453444B6DE961649415F30B2F67EC9E146C803AF7CB5FC6645D5B2FF127\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9c064ee9-4e11-43f9-825b-57cd0f2ce211"
+        "X-RequestId": "b01b688a-ab39-4d4b-b599-5e649b77dd1f"
       },
       "ResponseBody": {
-        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
-        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:21:16.426564Z",
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:27.5796961Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,41 +180,41 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4cc82d1bfdb87250d4186935ce6f4141",
+        "x-ms-client-request-id": "46d6d2a39a671bd6e9ea56a1aeb95a76",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7bd09e18-476b-4a23-a279-b00ec2bbf3eb",
+        "apim-request-id": "e33b43d5-9255-4a33-b58a-e7d574756d11",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:17 GMT",
-        "ETag": "\u0022BDA5571009B9665A913B0CC9B03ACBA63B853500F6E118EEF761D891FE099FBE\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:28 GMT",
+        "ETag": "\u0022ED7E55E11E87AB9E75429FEA67FED086C1C39A69D1FEEC4B4C62546C029D2849\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7bd09e18-476b-4a23-a279-b00ec2bbf3eb"
+        "X-RequestId": "e33b43d5-9255-4a33-b58a-e7d574756d11"
       },
       "ResponseBody": {
-        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
-        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:21:17.4300021Z",
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:28.2046541Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -228,74 +228,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "26c00101845f57fa7bc4a190d8efae68",
+        "x-ms-client-request-id": "2356ae8992592d4434362621a65fd035",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ebd76be9-6b11-4444-a3b9-ac1adffdedef",
+        "apim-request-id": "4827ac5d-3aaf-4251-b7b3-6c3c046780d6",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:19 GMT",
-        "ETag": "\u0022DC72A71591EBAFEB70BDCB34EB913AFE46F2B86D355AB217C6E444EABBAA204E\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ebd76be9-6b11-4444-a3b9-ac1adffdedef"
-      },
-      "ResponseBody": {
-        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
-        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:21:19.2324216Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8f404a5d55c7adea06dcdf7d7b3ccf2d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1a0f9def-9c06-46ee-a3c8-f2e324eea132",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:20 GMT",
-        "ETag": "\u0022DC72A71591EBAFEB70BDCB34EB913AFE46F2B86D355AB217C6E444EABBAA204E\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:29 GMT",
+        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -305,12 +257,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1a0f9def-9c06-46ee-a3c8-f2e324eea132"
+        "X-RequestId": "4827ac5d-3aaf-4251-b7b3-6c3c046780d6"
       },
       "ResponseBody": {
-        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
-        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:21:19.2324216Z",
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -324,26 +276,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "de0c6113c18096a03370d1f35cbf99e4",
+        "x-ms-client-request-id": "b31cbd7754341a95c0ec6af523641489",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d2b58234-13c0-4b8c-a2b1-073e3ecc68ea",
+        "apim-request-id": "913ecb41-f46a-4312-bc7d-d1172286280c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:21 GMT",
-        "ETag": "\u00220640856F2525F6541BC6FB41DFB34E1ED1F461E7999B7FBE402EF507F2938149\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:31 GMT",
+        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -353,12 +305,348 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d2b58234-13c0-4b8c-a2b1-073e3ecc68ea"
+        "X-RequestId": "913ecb41-f46a-4312-bc7d-d1172286280c"
       },
       "ResponseBody": {
-        "id": "6ad9e5cc-e313-4626-9143-a8f39ce5a284",
-        "createdDateTimeUtc": "2021-08-25T14:21:16.4265637Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:21:19.2324216Z",
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "47b9d08cc16910a18ea8113174b47589",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "216d269f-2ec6-42cd-967c-0e8cfd3a2ea5",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:32 GMT",
+        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "216d269f-2ec6-42cd-967c-0e8cfd3a2ea5"
+      },
+      "ResponseBody": {
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f02a201aa79d3542193c636d284e0ad0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "44cc51a9-fabd-4c80-ae31-d5510fdd02ba",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:34 GMT",
+        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "44cc51a9-fabd-4c80-ae31-d5510fdd02ba"
+      },
+      "ResponseBody": {
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d5959c2188a6b6cc1c0b258b4264a50b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c6a15a1c-ab48-463a-91fb-beb45f9194af",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:35 GMT",
+        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c6a15a1c-ab48-463a-91fb-beb45f9194af"
+      },
+      "ResponseBody": {
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "03dae0762439e4eb8d842e2d5d34e840",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "142c121a-6e54-4a52-99e0-a6c3175d1edf",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:36 GMT",
+        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "142c121a-6e54-4a52-99e0-a6c3175d1edf"
+      },
+      "ResponseBody": {
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d810419e9f1e91e35374d49282b6f3b4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "899cc5a8-ecb0-4a8c-8cc1-a052b6f8e4a1",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:37 GMT",
+        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "899cc5a8-ecb0-4a8c-8cc1-a052b6f8e4a1"
+      },
+      "ResponseBody": {
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "47f657960673fc97b0b048225a9f58e8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d22a487f-cb09-4cd1-8825-d2fdac3f67bb",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:39 GMT",
+        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d22a487f-cb09-4cd1-8825-d2fdac3f67bb"
+      },
+      "ResponseBody": {
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "00ede422cd54d7edfd49afc4505962d6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d4dec219-ce18-4994-8c37-533c09fcd07d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:40 GMT",
+        "ETag": "\u0022D9198ECFC3CA7CCDDACF895601EC5FC68CFC11738FD05F20D1D139EBB8163BF0\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d4dec219-ce18-4994-8c37-533c09fcd07d"
+      },
+      "ResponseBody": {
+        "id": "88603e31-8334-44a1-910c-a4935366b247",
+        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:39.7395417Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -372,63 +660,63 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6ad9e5cc-e313-4626-9143-a8f39ce5a284/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "84d70069b22eab7a17121f83a57cdb3e",
+        "x-ms-client-request-id": "06967991a03e97ccaa13276d57c136b4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f8d6cf82-01e7-4490-be2a-4261c81259ee",
+        "apim-request-id": "c448dfc4-2c0f-415e-b63e-4bf9fe42395d",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:22 GMT",
-        "ETag": "\u0022D48AB8309D2B6AB46128CD70072BB3AC7DE22DF961856141178A393579444E31\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:40 GMT",
+        "ETag": "\u002269EFED1CA883B54B9F4230AF51CB3F54BD0A3A17A83385B60598F3DEC5C7DE48\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f8d6cf82-01e7-4490-be2a-4261c81259ee"
+        "X-RequestId": "c448dfc4-2c0f-415e-b63e-4bf9fe42395d"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target123362359/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source317602543/File_0.txt",
-            "createdDateTimeUtc": "2021-08-25T14:21:18.7566981Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:21:21.4599642Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target838503391/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1526045109/File_0.txt",
+            "createdDateTimeUtc": "2021-08-25T18:45:29.2431846Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:39.7395248Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000b44f7-0000-0000-0000-000000000000",
+            "id": "000b4644-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1b9c6264e048bd4083f9eaeccc0b2cb6-745347ad0e9fbf44-00",
+        "traceparent": "00-c7237afd955ce044a34a7391449a9203-9f1b71af666dde47-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "e3767d74e8cfa99ca95c5683f7514742",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:24 GMT",
+        "x-ms-client-request-id": "c99d6fec60f26ac81f4a2a57d2ac574e",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -436,28 +724,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:21:23 GMT",
-        "ETag": "\u00220x8D967D39E39078B\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:23 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:40 GMT",
+        "ETag": "\u00220x8D967F889B697CF\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:40 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "e3767d74e8cfa99ca95c5683f7514742",
-        "x-ms-request-id": "9964b698-501e-0000-7abc-993c9f000000",
+        "x-ms-client-request-id": "c99d6fec60f26ac81f4a2a57d2ac574e",
+        "x-ms-request-id": "9760742a-d01e-0088-73e1-99d996000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-7f666162a09d92448bf135e9ad464a05-5328a6c86630954d-00",
+        "traceparent": "00-8103860cd82c894391cc6c56d0a248d4-162ac9209a98b245-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "657a14fbfe4ae76161c76da11df1b795",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:24 GMT",
+        "x-ms-client-request-id": "08e19171a9511882565640a67f7f3b12",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:41 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -466,30 +754,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:24 GMT",
-        "ETag": "\u00220x8D967D39E70FBD2\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:24 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:41 GMT",
+        "ETag": "\u00220x8D967F889E9690A\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:41 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "657a14fbfe4ae76161c76da11df1b795",
+        "x-ms-client-request-id": "08e19171a9511882565640a67f7f3b12",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964b6e6-501e-0000-39bc-993c9f000000",
+        "x-ms-request-id": "97607450-d01e-0088-14e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-bd9951dc8694a24daacfd08990d97c80-a9764e51a8a5104d-00",
+        "traceparent": "00-7538e134e6ae2545ad377187582cb5a6-6810d3ac65344b49-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "42e8fe930123189a3bdb8556232720c1",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "x-ms-client-request-id": "e964a7fb0dc4189ece9c1f55a240d766",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -498,30 +786,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:24 GMT",
-        "ETag": "\u00220x8D967D39EA4E697\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:24 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:41 GMT",
+        "ETag": "\u00220x8D967F88A15B147\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:41 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "42e8fe930123189a3bdb8556232720c1",
+        "x-ms-client-request-id": "e964a7fb0dc4189ece9c1f55a240d766",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964b7d2-501e-0000-0fbc-993c9f000000",
+        "x-ms-request-id": "97607495-d01e-0088-50e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_2.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_2.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-16b5101d401d27488c526c91eae8a598-a8a0613e03bb7e4f-00",
+        "traceparent": "00-6f91cdc4b6de8f498a55c19f3e2e3585-3b9f131706e98347-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "67a941d8d86075aa1c8e81077afb8cb8",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "x-ms-client-request-id": "30e61fcfab5542cbed85729c1f22ea9f",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -530,30 +818,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:24 GMT",
-        "ETag": "\u00220x8D967D39EE61A49\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:41 GMT",
+        "ETag": "\u00220x8D967F88A415D35\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:41 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "67a941d8d86075aa1c8e81077afb8cb8",
+        "x-ms-client-request-id": "30e61fcfab5542cbed85729c1f22ea9f",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964b8cf-501e-0000-78bc-993c9f000000",
+        "x-ms-request-id": "976074c6-d01e-0088-7fe1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_3.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_3.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c9536e5130f6fc4e9f9b0944632795c2-4104fea2ddefcf44-00",
+        "traceparent": "00-b602f43b842ff34eb007d19db100f6ca-14d20516ae377144-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "f8f0c1a40469f91e7a622a6f790bc439",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "x-ms-client-request-id": "2b5b170f6e486389f2c93ab48a2c7516",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:42 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -562,30 +850,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:25 GMT",
-        "ETag": "\u00220x8D967D39F15E59E\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "ETag": "\u00220x8D967F88A759631\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:42 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "f8f0c1a40469f91e7a622a6f790bc439",
+        "x-ms-client-request-id": "2b5b170f6e486389f2c93ab48a2c7516",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964ba51-501e-0000-47bc-993c9f000000",
+        "x-ms-request-id": "976074fc-d01e-0088-2be1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_4.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_4.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-2bc246751fc3a94ea9465850e1d4dbcd-a142e59f9b50f04c-00",
+        "traceparent": "00-67c11e01e46f0e428c88e8341cffa628-3cf9c9be98202c4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "dcc8aca74f47ba34547225947f929e40",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:26 GMT",
+        "x-ms-client-request-id": "5fd6d97e0b994fbcdc21fc3f9a02f8ab",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -594,30 +882,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:25 GMT",
-        "ETag": "\u00220x8D967D39F442A13\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:25 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "ETag": "\u00220x8D967F88AA0A5BE\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:42 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "dcc8aca74f47ba34547225947f929e40",
+        "x-ms-client-request-id": "5fd6d97e0b994fbcdc21fc3f9a02f8ab",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964bae4-501e-0000-4bbc-993c9f000000",
+        "x-ms-request-id": "9760754d-d01e-0088-71e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_5.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_5.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-2f295d2025af034080a1e32d177d3538-5ff15179aabf834a-00",
+        "traceparent": "00-4baaf54eb18ea7458c97fdf26ee21777-d96449fcf5dbf340-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "62b1cd4e2737d35822b0edfeae3afb11",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:26 GMT",
+        "x-ms-client-request-id": "8a467fb1ace4611e95823d8c7116b7c0",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -626,30 +914,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:25 GMT",
-        "ETag": "\u00220x8D967D39F7135D4\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:26 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "ETag": "\u00220x8D967F88ACBDC71\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:42 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "62b1cd4e2737d35822b0edfeae3afb11",
+        "x-ms-client-request-id": "8a467fb1ace4611e95823d8c7116b7c0",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964bb73-501e-0000-4dbc-993c9f000000",
+        "x-ms-request-id": "97607584-d01e-0088-1ee1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_6.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_6.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-79afcbef48597144b84581a7009e93b4-d8542d3e6028d848-00",
+        "traceparent": "00-67aa8a7aea0cd348bb5631afb35b14e9-582377eec7753944-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "cd5f48caaf3255708c35a4f6df897ae7",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:26 GMT",
+        "x-ms-client-request-id": "451d5c0f8b4b03065a0c4e26714ac8f0",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -658,30 +946,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:26 GMT",
-        "ETag": "\u00220x8D967D39FB7C1A7\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:26 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "ETag": "\u00220x8D967F88AF76153\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:43 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "cd5f48caaf3255708c35a4f6df897ae7",
+        "x-ms-client-request-id": "451d5c0f8b4b03065a0c4e26714ac8f0",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964bc6d-501e-0000-19bc-993c9f000000",
+        "x-ms-request-id": "976075c2-d01e-0088-58e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_7.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_7.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-63edd678185aef4d92158e57948ed0d2-0b249c6be5365b4e-00",
+        "traceparent": "00-76da20809018444a94ec325c257bc77d-f45165cc29f60d48-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "ac20e9c36159800254f4b99761350b19",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:27 GMT",
+        "x-ms-client-request-id": "0a028ed0eae6d232bb74ca16cd30dec5",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:43 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -690,30 +978,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:26 GMT",
-        "ETag": "\u00220x8D967D39FE89EA5\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:26 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "ETag": "\u00220x8D967F88B2249D8\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:43 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ac20e9c36159800254f4b99761350b19",
+        "x-ms-client-request-id": "0a028ed0eae6d232bb74ca16cd30dec5",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964bd07-501e-0000-29bc-993c9f000000",
+        "x-ms-request-id": "9760760d-d01e-0088-1ce1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_8.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_8.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-01c9cb6f21c8c643b2951b6850ba4981-acc7a1fef863514b-00",
+        "traceparent": "00-2c53c807ca83814bb451193fb751dc7e-7c4211e0aa75274d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "37ca1476d1329e0d5c5bd5018361f498",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:27 GMT",
+        "x-ms-client-request-id": "3e2f3b6ab2e5265f79422fd75df7ef4a",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -722,30 +1010,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:27 GMT",
-        "ETag": "\u00220x8D967D3A02DA398\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:27 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "ETag": "\u00220x8D967F88B4D8090\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:43 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "37ca1476d1329e0d5c5bd5018361f498",
+        "x-ms-client-request-id": "3e2f3b6ab2e5265f79422fd75df7ef4a",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964bdfb-501e-0000-03bc-993c9f000000",
+        "x-ms-request-id": "97607666-d01e-0088-6ce1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_9.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_9.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-029559ab77e9fa408b1b71a2f60d0a2c-d77718a4de2fab42-00",
+        "traceparent": "00-67e8abd1df4b534ca453a5725f71dcba-b695f1cd33f3d04c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "c43b06354f1a68b746df793ef6d9f357",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "x-ms-client-request-id": "e2bc4dbaac1425d92a4a8ad7c0ef362a",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -754,30 +1042,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:27 GMT",
-        "ETag": "\u00220x8D967D3A063D8C0\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:27 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "ETag": "\u00220x8D967F88B7D4BEE\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:43 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "c43b06354f1a68b746df793ef6d9f357",
+        "x-ms-client-request-id": "e2bc4dbaac1425d92a4a8ad7c0ef362a",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964be90-501e-0000-07bc-993c9f000000",
+        "x-ms-request-id": "976076d6-d01e-0088-4de1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_10.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_10.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-c75ad6e99bbdbf45bc02cc34885fd52f-ccebf6103570874e-00",
+        "traceparent": "00-2ba9135f89e3564cb011bbff59960ffd-a30e30304fd6ab48-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "ca7f8a2a43bff2b4dc8150fe8b00fcf2",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "x-ms-client-request-id": "36bc892e8a1b1d0a2fdb91a4ba5a74c4",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:44 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -786,30 +1074,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:27 GMT",
-        "ETag": "\u00220x8D967D3A08F84AD\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:27 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "ETag": "\u00220x8D967F88BA96D1B\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "ca7f8a2a43bff2b4dc8150fe8b00fcf2",
+        "x-ms-client-request-id": "36bc892e8a1b1d0a2fdb91a4ba5a74c4",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964bf1b-501e-0000-7abc-993c9f000000",
+        "x-ms-request-id": "9760772c-d01e-0088-1be1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_11.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_11.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-ff1727c95c3e9848a606e71d5c014f1e-6e7761c79600044b-00",
+        "traceparent": "00-32fb61e113c52b47bdfa4366d2ace770-a5abc889a24e5344-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "5b6121ff46fa27ff5c61f05357cfa882",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "x-ms-client-request-id": "7f5c7f85fb74bdb1620a139a2888668a",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -818,30 +1106,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:28 GMT",
-        "ETag": "\u00220x8D967D3A0C03A96\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "ETag": "\u00220x8D967F88BD47CA7\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "5b6121ff46fa27ff5c61f05357cfa882",
+        "x-ms-client-request-id": "7f5c7f85fb74bdb1620a139a2888668a",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964bf9d-501e-0000-68bc-993c9f000000",
+        "x-ms-request-id": "97607789-d01e-0088-69e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_12.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_12.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-9194f9e7278abb4181abab737a452bd8-f61a3c10f9485c44-00",
+        "traceparent": "00-311bca756755274397f4ed3b1d862def-71aee6de93fbec40-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "f9d67e672ae2f2d85148e898ffb9dc45",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "x-ms-client-request-id": "d4a9050cb93a2f2f429eb3381b356acf",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -850,30 +1138,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:28 GMT",
-        "ETag": "\u00220x8D967D3A0EE09C0\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "ETag": "\u00220x8D967F88BFFDA59\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:44 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "f9d67e672ae2f2d85148e898ffb9dc45",
+        "x-ms-client-request-id": "d4a9050cb93a2f2f429eb3381b356acf",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964c028-501e-0000-55bc-993c9f000000",
+        "x-ms-request-id": "976077bd-d01e-0088-18e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_13.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_13.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-9e745318253cc34d8c058834c388dde9-17787cc488f8c14c-00",
+        "traceparent": "00-196a2d66a7bcb94da4785afb1da0c49e-5b012b5a5de9c94b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d43e86e29877e35c8a576e5d52619a0c",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "x-ms-client-request-id": "4051c5d5b69332b5d7ffd3117670f4a6",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -882,30 +1170,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:28 GMT",
-        "ETag": "\u00220x8D967D3A11F0DDC\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:28 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "ETag": "\u00220x8D967F88C2AE9EA\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:45 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d43e86e29877e35c8a576e5d52619a0c",
+        "x-ms-client-request-id": "4051c5d5b69332b5d7ffd3117670f4a6",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964c0d8-501e-0000-6bbc-993c9f000000",
+        "x-ms-request-id": "976077f3-d01e-0088-3de1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_14.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_14.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-cdb0ea9c2567ec48b92cc4c7f11f4512-e3397a0650ae5f4a-00",
+        "traceparent": "00-190125ef86d8d543936660c895622d25-bd8514f922cbd845-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "0d96cdd80329d510486f0ab15e6728a3",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "x-ms-client-request-id": "b5980675a0b1cb8a502c3dd64879a12d",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -914,30 +1202,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:29 GMT",
-        "ETag": "\u00220x8D967D3A14F0057\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "ETag": "\u00220x8D967F88C55D262\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:45 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "0d96cdd80329d510486f0ab15e6728a3",
+        "x-ms-client-request-id": "b5980675a0b1cb8a502c3dd64879a12d",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964c1ad-501e-0000-32bc-993c9f000000",
+        "x-ms-request-id": "97607833-d01e-0088-73e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_15.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_15.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-10b799dc27c11046a6d743f71274a5d7-5f34ecffdcdec142-00",
+        "traceparent": "00-77c1bf098c1edf4cac1a11f505cbaa6c-0a8bd19a64835944-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d170ab84d491cf0a21f36e8abc7b9fef",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:30 GMT",
+        "x-ms-client-request-id": "63c5439f253655f65076fd3be51eb8d2",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -946,30 +1234,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:29 GMT",
-        "ETag": "\u00220x8D967D3A18200A5\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "ETag": "\u00220x8D967F88C813018\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:45 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d170ab84d491cf0a21f36e8abc7b9fef",
+        "x-ms-client-request-id": "63c5439f253655f65076fd3be51eb8d2",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964c2af-501e-0000-17bc-993c9f000000",
+        "x-ms-request-id": "97607858-d01e-0088-11e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_16.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_16.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-9f97ae90ec66124ea082b27b1f553ad2-d09a35722f89704b-00",
+        "traceparent": "00-bc111f9773286e49b06a181cd5dd3556-5448d696152b7d4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "31bfdbaecf22df1b75688c088eab8523",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:30 GMT",
+        "x-ms-client-request-id": "14c20caab59d351e3b86f06679dfea5d",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -978,30 +1266,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:29 GMT",
-        "ETag": "\u00220x8D967D3A1BF8A3F\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:29 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "ETag": "\u00220x8D967F88CAC8DD3\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:45 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "31bfdbaecf22df1b75688c088eab8523",
+        "x-ms-client-request-id": "14c20caab59d351e3b86f06679dfea5d",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964c38d-501e-0000-5fbc-993c9f000000",
+        "x-ms-request-id": "97607898-d01e-0088-4ae1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_17.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_17.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-e3bcb98f4d56244d8caa19a5a9978415-61ea1700af44e947-00",
+        "traceparent": "00-fb850b15710e274a8a956522174fbac6-967a5e771db89c45-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "a7d8ca2fc9f1047bc2c6eb36958619cd",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:30 GMT",
+        "x-ms-client-request-id": "3371a65d91ab506f1042643ba34ee531",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1010,30 +1298,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:30 GMT",
-        "ETag": "\u00220x8D967D3A1F486BF\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:30 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "ETag": "\u00220x8D967F88CD79D64\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "a7d8ca2fc9f1047bc2c6eb36958619cd",
+        "x-ms-client-request-id": "3371a65d91ab506f1042643ba34ee531",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964c4bb-501e-0000-76bc-993c9f000000",
+        "x-ms-request-id": "976078e3-d01e-0088-0ce1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_18.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_18.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-9ecf06323978024fbf654cc05b24fa2f-70df5a79bea6dd4e-00",
+        "traceparent": "00-1fae8ab895c0754fb670cb899d08e61d-b801b6b25f20234b-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "82031acff7a7b5808f905b2847024176",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:31 GMT",
+        "x-ms-client-request-id": "3b2c6a738cb7ea8f258f28b0348fdc70",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1042,30 +1330,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:30 GMT",
-        "ETag": "\u00220x8D967D3A232D3BA\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:30 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "ETag": "\u00220x8D967F88D032230\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "82031acff7a7b5808f905b2847024176",
+        "x-ms-client-request-id": "3b2c6a738cb7ea8f258f28b0348fdc70",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964c5b2-501e-0000-4ebc-993c9f000000",
+        "x-ms-request-id": "97607939-d01e-0088-57e1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source123007989/File_19.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_19.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-9fb174b476769245a5b02eae995284b3-dabdd9b645b1e04e-00",
+        "traceparent": "00-3903fa494e5e0d40bc21555a07efacda-875a552b78a63341-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "f15a4a6df8a2e5fd5fba6e5be3e54aee",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:31 GMT",
+        "x-ms-client-request-id": "3fdd9f8c85ad19279c71045a50e391ec",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1074,28 +1362,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 14:21:30 GMT",
-        "ETag": "\u00220x8D967D3A270D27E\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:31 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "ETag": "\u00220x8D967F88D2ECE1E\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "f15a4a6df8a2e5fd5fba6e5be3e54aee",
+        "x-ms-client-request-id": "3fdd9f8c85ad19279c71045a50e391ec",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9964c6c1-501e-0000-3dbc-993c9f000000",
+        "x-ms-request-id": "97607970-d01e-0088-0ce1-99d996000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target847432015?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1074018720?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-85a44c236c737f45a2455384c4634463-c3ff4da7e2ee6545-00",
+        "traceparent": "00-1c375396c8f00040934812bbe608e7e1-83c3e5208f2cfe41-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "a87339bf7b034a382318606d53bcc085",
-        "x-ms-date": "Wed, 25 Aug 2021 14:21:31 GMT",
+        "x-ms-client-request-id": "b30ef2bfa6ae16d0870e1b68bf1c8065",
+        "x-ms-date": "Wed, 25 Aug 2021 18:45:47 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1103,12 +1391,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:21:31 GMT",
-        "ETag": "\u00220x8D967D3A289539A\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 14:21:31 GMT",
+        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "ETag": "\u00220x8D967F88D4546D0\u0022",
+        "Last-Modified": "Wed, 25 Aug 2021 18:45:46 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "a87339bf7b034a382318606d53bcc085",
-        "x-ms-request-id": "9964c72f-501e-0000-1cbc-993c9f000000",
+        "x-ms-client-request-id": "b30ef2bfa6ae16d0870e1b68bf1c8065",
+        "x-ms-request-id": "976079ad-d01e-0088-3fe1-99d996000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -1121,9 +1409,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cc643edccdc1c54eb60444caaee6564a-350d03c22870c844-00",
+        "traceparent": "00-b091956c205c6c48b244228535e83d26-eb1db2254709c246-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2c4ac9742a281cd61d22ec8824d1aa46",
+        "x-ms-client-request-id": "7104aff384a643ee139f4588359941fd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1143,52 +1431,52 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "69b4500b-51a4-47a2-8c42-52218bb19f5b",
+        "apim-request-id": "aac1430b-d477-4c18-beb5-bb932e5dcae2",
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 14:21:31 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/decfe908-d309-4d44-838b-7b12aa38d315",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "69b4500b-51a4-47a2-8c42-52218bb19f5b"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/decfe908-d309-4d44-838b-7b12aa38d315",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c888d86ccececf6922a67ee09d770cfe",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "2fbdeae9-a461-45ef-aa4f-39eab1f53e68",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:31 GMT",
-        "Retry-After": "1",
+        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4419c955-e50f-4782-ade4-74e798ca1b7b",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "aac1430b-d477-4c18-beb5-bb932e5dcae2"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4419c955-e50f-4782-ade4-74e798ca1b7b",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9d75103bbdcef8dd0c2826770bb0dd55",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d23b5130-db00-4e4a-a0ba-173e73809c43",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:47 GMT",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2fbdeae9-a461-45ef-aa4f-39eab1f53e68"
+        "X-RequestId": "d23b5130-db00-4e4a-a0ba-173e73809c43"
       },
       "ResponseBody": {
-        "id": "decfe908-d309-4d44-838b-7b12aa38d315",
-        "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
-        "lastActionDateTimeUtc": "2021-08-25T14:21:31.8375024Z",
+        "id": "4419c955-e50f-4782-ade4-74e798ca1b7b",
+        "createdDateTimeUtc": "2021-08-25T18:45:47.205312Z",
+        "lastActionDateTimeUtc": "2021-08-25T18:45:47.4485515Z",
         "status": "Cancelling",
         "summary": {
           "total": 0,
@@ -1202,44 +1490,44 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=decfe908-d309-4d44-838b-7b12aa38d315\u0026statuses=\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=4419c955-e50f-4782-ade4-74e798ca1b7b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-156f36a6eec3c642bc6280254a810a3c-5ad62e431d6e104a-00",
+        "traceparent": "00-4ada14d178292a4987ab0b450761cd85-4431fb0b137ef043-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1b6fd6adc200942762568ae08eaf2651",
+        "x-ms-client-request-id": "345cf4847a8d3afa04caa00f6048e1ed",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "655b59d2-ef3a-4b11-bac8-2bb480e69fd4",
+        "apim-request-id": "983e3912-bc10-4fd8-8306-fc6eef2b9e68",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:36 GMT",
-        "ETag": "\u002275227BBA0DD34B849BD7797011B75C20D3E5DD80B07364161D2B515B13A7D5F4\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:52 GMT",
+        "ETag": "\u0022B691493928B7E5D183B22D888E02C7224BE4DAADF9F583025BF623B7765436EC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "655b59d2-ef3a-4b11-bac8-2bb480e69fd4"
+        "X-RequestId": "983e3912-bc10-4fd8-8306-fc6eef2b9e68"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "decfe908-d309-4d44-838b-7b12aa38d315",
-            "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:21:34.8683111Z",
+            "id": "4419c955-e50f-4782-ade4-74e798ca1b7b",
+            "createdDateTimeUtc": "2021-08-25T18:45:47.205312Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:50.4057284Z",
             "status": "Cancelling",
             "summary": {
               "total": 20,
@@ -1255,44 +1543,44 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=decfe908-d309-4d44-838b-7b12aa38d315\u0026statuses=\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=4419c955-e50f-4782-ade4-74e798ca1b7b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dc7f063f6a7cfb40b4af7fd06ac2a3ef-abda0f47f1c3594e-00",
+        "traceparent": "00-6b2ec69fa775b641bbd4b689cfc06a33-cbec53ddb9d9ca40-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7a01196df833a6b75f7a0a81acf67fa6",
+        "x-ms-client-request-id": "ae2c1dcce3a63697d10b647d5e773762",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b37a17c0-771d-4cd4-bb49-c8b471ddb3d9",
+        "apim-request-id": "9a8d9503-ddd6-47d5-8357-aa1374474c3a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:41 GMT",
-        "ETag": "\u0022732ABB2837401B3F6A0F90133FF4B1711A1C3C5FBF94817E57237224A3EEF835\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:57 GMT",
+        "ETag": "\u0022A938AA954586BAA1750FDAA95E22C3E3E1ED19F849EF51E6EFF29B1CE3723E6B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b37a17c0-771d-4cd4-bb49-c8b471ddb3d9"
+        "X-RequestId": "9a8d9503-ddd6-47d5-8357-aa1374474c3a"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "decfe908-d309-4d44-838b-7b12aa38d315",
-            "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:21:38.0583554Z",
+            "id": "4419c955-e50f-4782-ade4-74e798ca1b7b",
+            "createdDateTimeUtc": "2021-08-25T18:45:47.205312Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:54.1761712Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1308,40 +1596,70 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=Cancelled%2CCancelling\u0026$orderBy=",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?statuses=Cancelled%2CCancelling",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9fce7c44b6565d4cb6e9463de4d3cc7f-5407679a156e5d41-00",
+        "traceparent": "00-d2aed38780c9464ab5f23490e19f6a41-5d3c490cb40be445-00",
         "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4ddbee168e62a946b1f4667844894072",
+        "x-ms-client-request-id": "4003f0c10d3dc170153a98031dce97c3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bc2c9c69-8d2a-4c9a-9982-e9c4bf9b88e4",
+        "apim-request-id": "2b4b8f00-ed45-4b1a-b279-1515df9a97c9",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:42 GMT",
-        "ETag": "\u0022AE2803377D32EB9E222C539470DF2BDE4BA768D0E8EC6A3FE3E9641D136F77E1\u0022",
+        "Date": "Wed, 25 Aug 2021 18:45:57 GMT",
+        "ETag": "\u00228BA81BFA5C020A365B5B5E380F6FACD1D2F050EF0AF4D6FD782DBD59AA78F43D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "bc2c9c69-8d2a-4c9a-9982-e9c4bf9b88e4"
+        "X-RequestId": "2b4b8f00-ed45-4b1a-b279-1515df9a97c9"
       },
       "ResponseBody": {
         "value": [
+          {
+            "id": "4419c955-e50f-4782-ade4-74e798ca1b7b",
+            "createdDateTimeUtc": "2021-08-25T18:45:47.205312Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:54.1761712Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
+          {
+            "id": "69c933d1-698c-42ed-967d-40253aee437f",
+            "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
+            "lastActionDateTimeUtc": "2021-08-25T18:45:21.5359358Z",
+            "status": "Cancelled",
+            "summary": {
+              "total": 20,
+              "failed": 0,
+              "success": 0,
+              "inProgress": 0,
+              "notYetStarted": 0,
+              "cancelled": 20,
+              "totalCharacterCharged": 0
+            }
+          },
           {
             "id": "decfe908-d309-4d44-838b-7b12aa38d315",
             "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
@@ -2061,7 +2379,46 @@
               "cancelled": 20,
               "totalCharacterCharged": 0
             }
-          },
+          }
+        ],
+        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=89\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=89\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-404c0f62bd1e1345ae3f8d8cb703f472-2aac6cb968b98241-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "eeaa38472e83a1ae5d266381167cdc8c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "65ca6265-c0c5-4255-98de-1fe83d36091f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:58 GMT",
+        "ETag": "\u00220E268367A44951B59C64C1534C495086BE9520454641676C84DBE46489067D5B\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "65ca6265-c0c5-4255-98de-1fe83d36091f"
+      },
+      "ResponseBody": {
+        "value": [
           {
             "id": "30bc281b-3a6c-4a97-92c2-43de98e83aa4",
             "createdDateTimeUtc": "2021-08-25T10:27:43.633836Z",
@@ -2091,46 +2448,7 @@
               "cancelled": 20,
               "totalCharacterCharged": 0
             }
-          }
-        ],
-        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=87\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=87\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5c6e9b09fc65ea40aadf593f3b65f210-c97b339ed254b741-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "83722d809175b5ca1fc8bb85b8a5e76c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "02d22c70-caad-4a6d-9e5a-1290dde935bc",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:42 GMT",
-        "ETag": "\u0022944ECD8F6E53579CDC56C10D10EB5E4B47E3E8CE2AB380D914D9EEDD34A662BD\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "02d22c70-caad-4a6d-9e5a-1290dde935bc"
-      },
-      "ResponseBody": {
-        "value": [
+          },
           {
             "id": "ca6e611e-7b53-4d7f-b638-afe8d00bb725",
             "createdDateTimeUtc": "2021-08-25T10:26:26.2866155Z",
@@ -2850,7 +3168,46 @@
               "cancelled": 20,
               "totalCharacterCharged": 0
             }
-          },
+          }
+        ],
+        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=39\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=39\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-deb2120755e73445b90b86d23cf7b0a7-eb845d7e815dc74e-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "704d3d93a144bfb0ad6b986c4a941802",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6da52098-28fb-4694-8d19-d972af835855",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 25 Aug 2021 18:45:59 GMT",
+        "ETag": "\u0022D44C804CFCA1E28F2F68B63B3FF2BE3675D447F6A80C1DE9FAE7C86D50649FB3\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "6da52098-28fb-4694-8d19-d972af835855"
+      },
+      "ResponseBody": {
+        "value": [
           {
             "id": "6e3b9367-513c-4d20-8c07-ee3568440b7c",
             "createdDateTimeUtc": "2021-08-23T17:47:11.3828547Z",
@@ -2880,46 +3237,7 @@
               "cancelled": 20,
               "totalCharacterCharged": 0
             }
-          }
-        ],
-        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=37\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=37\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8dc461b722ef0b48b3d30df08a1b7ec6-1cf01fac16b09647-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a0cae3d6d8d4dfefd357c83f923e62d6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "17e82a39-4976-473b-9fbf-cd17b124881b",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 14:21:43 GMT",
-        "ETag": "\u002262F4FBD6C85DA1E3DD9FD6FFAD960CCBA679402CC665EAFB448DA82088CCF0E6\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "17e82a39-4976-473b-9fbf-cd17b124881b"
-      },
-      "ResponseBody": {
-        "value": [
+          },
           {
             "id": "15bb936d-c180-4255-9ba2-a07bec5806dd",
             "createdDateTimeUtc": "2021-08-23T17:34:58.0354643Z",
@@ -3483,6 +3801,6 @@
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "1950452491"
+    "RandomSeed": "611649423"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByStatusTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1526045109?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source462077597?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-a1dec20b39680b4aa7c6248f7bebc44d-7a1ab80f022b034a-00",
+        "traceparent": "00-aa28d5a9dfe49849a0a93e0533f45dd9-f8f32036d45f5149-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "fac168094a15877c1b5eb97611e091c5",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:27 GMT",
+        "x-ms-client-request-id": "6b7435528510a5535d04f896ad3b37e9",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:26 GMT",
-        "ETag": "\u00220x8D967F88142445E\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:26 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:56 GMT",
+        "ETag": "\u00220x8D9689AC3F96A66\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:57 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "fac168094a15877c1b5eb97611e091c5",
-        "x-ms-request-id": "97606329-d01e-0088-80e1-99d996000000",
+        "x-ms-client-request-id": "6b7435528510a5535d04f896ad3b37e9",
+        "x-ms-request-id": "3ddf19e2-201e-0057-3e83-9a92ac000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1526045109/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source462077597/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-9746cb5c35994049b0da327f5fd3a428-e4ef714d3050a543-00",
+        "traceparent": "00-8c88f311cff91c4b9c2f7c21d89d685c-9c212d8b21c42745-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "c7bd2a0367c8cba29e5c8af77d806104",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:27 GMT",
+        "x-ms-client-request-id": "bde7fcc6cc9fec1e47b936405d1abeb2",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:27 GMT",
-        "ETag": "\u00220x8D967F88179A712\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:27 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:57 GMT",
+        "ETag": "\u00220x8D9689AC4316BE1\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:57 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "c7bd2a0367c8cba29e5c8af77d806104",
+        "x-ms-client-request-id": "bde7fcc6cc9fec1e47b936405d1abeb2",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97606351-d01e-0088-21e1-99d996000000",
+        "x-ms-request-id": "3ddf1a55-201e-0057-1c83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target838503391?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1257220293?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-8e1cc866c9bcaa4787975f2d89543be8-f0bcd173c2526448-00",
+        "traceparent": "00-69ca4c2ef3eb6c45b0831dc1866b4ef6-35e16edd5126ea47-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "4cb18c0967fde0798124ac0bba62e724",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:27 GMT",
+        "x-ms-client-request-id": "ef4f5d8f68f6b4c7df71720a983114f9",
+        "x-ms-date": "Thu, 26 Aug 2021 14:06:57 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,12 +76,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:27 GMT",
-        "ETag": "\u00220x8D967F8818FD65B\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:27 GMT",
+        "Date": "Thu, 26 Aug 2021 14:06:57 GMT",
+        "ETag": "\u00220x8D9689AC449E2FF\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:06:57 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "4cb18c0967fde0798124ac0bba62e724",
-        "x-ms-request-id": "976063a6-d01e-0088-69e1-99d996000000",
+        "x-ms-client-request-id": "ef4f5d8f68f6b4c7df71720a983114f9",
+        "x-ms-request-id": "3ddf1ace-201e-0057-0d83-9a92ac000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -94,9 +94,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d78e4435e4dfc14985505edf6c7014c4-4f608a49e38a9643-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "69f93aa6ed09c6a2f65bb8bf850a9afd",
+        "traceparent": "00-11bff006b5c3bc45a963aacad0c581bd-55cf6c949266e549-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9e4ea60bfd4b16868724564e13484245",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -116,57 +116,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8ea9f6ab-5cf3-4bc1-87ac-9e1946c639d1",
+        "apim-request-id": "07575b2b-a7f5-4abf-be52-7f410f906235",
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:26 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8ea9f6ab-5cf3-4bc1-87ac-9e1946c639d1"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "540896b579e0c30643e74743f6c0e4fa",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b01b688a-ab39-4d4b-b599-5e649b77dd1f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:27 GMT",
-        "ETag": "\u0022C2B44453444B6DE961649415F30B2F67EC9E146C803AF7CB5FC6645D5B2FF127\u0022",
-        "Retry-After": "1",
+        "Date": "Thu, 26 Aug 2021 14:06:57 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "07575b2b-a7f5-4abf-be52-7f410f906235"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "dd1dd046f9e893d02009c05aace2af88",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a85e104a-29ab-400b-a1e5-4660bf42ed43",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 14:06:58 GMT",
+        "ETag": "\u0022A39F02F9BE66C2CE34983029F3F334DDD6B1D8F0FBC6EA24FAC50C89014432CD\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b01b688a-ab39-4d4b-b599-5e649b77dd1f"
+        "X-RequestId": "a85e104a-29ab-400b-a1e5-4660bf42ed43"
       },
       "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:27.5796961Z",
+        "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+        "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:57.9773909Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,74 +180,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "46d6d2a39a671bd6e9ea56a1aeb95a76",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "73524622136f927ad73868d21178a097",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e33b43d5-9255-4a33-b58a-e7d574756d11",
+        "apim-request-id": "2feace7e-5ba5-4c38-a3cf-1a315529ff07",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:28 GMT",
-        "ETag": "\u0022ED7E55E11E87AB9E75429FEA67FED086C1C39A69D1FEEC4B4C62546C029D2849\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e33b43d5-9255-4a33-b58a-e7d574756d11"
-      },
-      "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:28.2046541Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2356ae8992592d4434362621a65fd035",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4827ac5d-3aaf-4251-b7b3-6c3c046780d6",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:29 GMT",
-        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:06:59 GMT",
+        "ETag": "\u0022EA6EA70A4FD406C8667537F16EF659AC3B105BBFA414371B752EEB9CED376024\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -257,12 +209,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4827ac5d-3aaf-4251-b7b3-6c3c046780d6"
+        "X-RequestId": "2feace7e-5ba5-4c38-a3cf-1a315529ff07"
       },
       "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+        "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:59.1981254Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -276,26 +228,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b31cbd7754341a95c0ec6af523641489",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c7c42c2f36131211d6ba7d413d2b69a5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "913ecb41-f46a-4312-bc7d-d1172286280c",
+        "apim-request-id": "4032bc2d-0965-41a4-bd30-c00b1fcd71d8",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:31 GMT",
-        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:00 GMT",
+        "ETag": "\u0022F25A09D9D2AD0379BFCA03EF1B7C6F677862C81181D89FED99D9156C03595D5B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -305,12 +257,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "913ecb41-f46a-4312-bc7d-d1172286280c"
+        "X-RequestId": "4032bc2d-0965-41a4-bd30-c00b1fcd71d8"
       },
       "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+        "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:59.7150188Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -324,26 +276,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "47b9d08cc16910a18ea8113174b47589",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "cc2bcd74cef632d5568a06af91fd82a7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "216d269f-2ec6-42cd-967c-0e8cfd3a2ea5",
+        "apim-request-id": "2c293c0e-3eb2-4d84-9b5d-69852737f7f8",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:32 GMT",
-        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:01 GMT",
+        "ETag": "\u0022F25A09D9D2AD0379BFCA03EF1B7C6F677862C81181D89FED99D9156C03595D5B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -353,12 +305,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "216d269f-2ec6-42cd-967c-0e8cfd3a2ea5"
+        "X-RequestId": "2c293c0e-3eb2-4d84-9b5d-69852737f7f8"
       },
       "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+        "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:59.7150188Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -372,26 +324,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f02a201aa79d3542193c636d284e0ad0",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "802b2868e71dec74353f9db5963855ab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "44cc51a9-fabd-4c80-ae31-d5510fdd02ba",
+        "apim-request-id": "c1d0d1a9-d534-4922-bfad-9a803066231c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:34 GMT",
-        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:03 GMT",
+        "ETag": "\u0022F25A09D9D2AD0379BFCA03EF1B7C6F677862C81181D89FED99D9156C03595D5B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -401,12 +353,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "44cc51a9-fabd-4c80-ae31-d5510fdd02ba"
+        "X-RequestId": "c1d0d1a9-d534-4922-bfad-9a803066231c"
       },
       "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+        "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:59.7150188Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -420,26 +372,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d5959c2188a6b6cc1c0b258b4264a50b",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "445dc2ced44d61a1569171892f6181d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c6a15a1c-ab48-463a-91fb-beb45f9194af",
+        "apim-request-id": "6d98340b-27c1-4e27-9b41-b157137ac08a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:35 GMT",
-        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:04 GMT",
+        "ETag": "\u0022F25A09D9D2AD0379BFCA03EF1B7C6F677862C81181D89FED99D9156C03595D5B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -449,12 +401,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c6a15a1c-ab48-463a-91fb-beb45f9194af"
+        "X-RequestId": "6d98340b-27c1-4e27-9b41-b157137ac08a"
       },
       "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+        "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:59.7150188Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -468,26 +420,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "03dae0762439e4eb8d842e2d5d34e840",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "15d9d638e9008d87583f96b631209c1d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "142c121a-6e54-4a52-99e0-a6c3175d1edf",
+        "apim-request-id": "d4b5a2df-88e3-4851-aacb-e6fd2bc96ec9",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:36 GMT",
-        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:05 GMT",
+        "ETag": "\u0022F25A09D9D2AD0379BFCA03EF1B7C6F677862C81181D89FED99D9156C03595D5B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -497,12 +449,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "142c121a-6e54-4a52-99e0-a6c3175d1edf"
+        "X-RequestId": "d4b5a2df-88e3-4851-aacb-e6fd2bc96ec9"
       },
       "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
+        "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+        "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:06:59.7150188Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -516,26 +468,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d810419e9f1e91e35374d49282b6f3b4",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "cee05b353e9f935a86ca298c76ebbcd4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "899cc5a8-ecb0-4a8c-8cc1-a052b6f8e4a1",
+        "apim-request-id": "a37c0364-b282-42f2-b2f6-bcbd5ebc6aee",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:37 GMT",
-        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:06 GMT",
+        "ETag": "\u00226D946BC3F45EA55DB032C30C7B8EF346EBFDF7D6F3FE4BC7EFF2AC366FA42015\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -545,108 +497,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "899cc5a8-ecb0-4a8c-8cc1-a052b6f8e4a1"
+        "X-RequestId": "a37c0364-b282-42f2-b2f6-bcbd5ebc6aee"
       },
       "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "47f657960673fc97b0b048225a9f58e8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d22a487f-cb09-4cd1-8825-d2fdac3f67bb",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:39 GMT",
-        "ETag": "\u0022600E75ADA39599D303CF4A55CB7DD50555517DC4335C5E20EA0F9872FAB0387F\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d22a487f-cb09-4cd1-8825-d2fdac3f67bb"
-      },
-      "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:29.7313452Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "00ede422cd54d7edfd49afc4505962d6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d4dec219-ce18-4994-8c37-533c09fcd07d",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:40 GMT",
-        "ETag": "\u0022D9198ECFC3CA7CCDDACF895601EC5FC68CFC11738FD05F20D1D139EBB8163BF0\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d4dec219-ce18-4994-8c37-533c09fcd07d"
-      },
-      "ResponseBody": {
-        "id": "88603e31-8334-44a1-910c-a4935366b247",
-        "createdDateTimeUtc": "2021-08-25T18:45:27.5796926Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:39.7395417Z",
+        "id": "80731233-0000-4e9e-ae85-2ad4c0624110",
+        "createdDateTimeUtc": "2021-08-26T14:06:57.9773906Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:07:06.928173Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -660,26 +516,26 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/88603e31-8334-44a1-910c-a4935366b247/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/80731233-0000-4e9e-ae85-2ad4c0624110/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "06967991a03e97ccaa13276d57c136b4",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c07cc3be405fe5ab3ad0eb0d3deb2f35",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c448dfc4-2c0f-415e-b63e-4bf9fe42395d",
+        "apim-request-id": "c8de4375-9589-4302-9010-76602117aff4",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:40 GMT",
-        "ETag": "\u002269EFED1CA883B54B9F4230AF51CB3F54BD0A3A17A83385B60598F3DEC5C7DE48\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:07 GMT",
+        "ETag": "\u0022189D15B39459AE76BC09D4C81FC3445D86C0F2CC3F1A9A4C662F7104228C8C6F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -689,34 +545,34 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c448dfc4-2c0f-415e-b63e-4bf9fe42395d"
+        "X-RequestId": "c8de4375-9589-4302-9010-76602117aff4"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target838503391/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1526045109/File_0.txt",
-            "createdDateTimeUtc": "2021-08-25T18:45:29.2431846Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:39.7395248Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1257220293/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source462077597/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T14:06:59.2091595Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:07:06.9281669Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000b4644-0000-0000-0000-000000000000",
+            "id": "000b50f8-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-c7237afd955ce044a34a7391449a9203-9f1b71af666dde47-00",
+        "traceparent": "00-ad9fa02070e0144480591b0cd01569ff-54e731e19d8ef34c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "c99d6fec60f26ac81f4a2a57d2ac574e",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:41 GMT",
+        "x-ms-client-request-id": "80d4535339b27bfa458e35c0fb176c82",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -724,28 +580,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:40 GMT",
-        "ETag": "\u00220x8D967F889B697CF\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:40 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:07 GMT",
+        "ETag": "\u00220x8D9689ACA1C8260\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:07 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "c99d6fec60f26ac81f4a2a57d2ac574e",
-        "x-ms-request-id": "9760742a-d01e-0088-73e1-99d996000000",
+        "x-ms-client-request-id": "80d4535339b27bfa458e35c0fb176c82",
+        "x-ms-request-id": "3ddf28ae-201e-0057-6383-9a92ac000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-8103860cd82c894391cc6c56d0a248d4-162ac9209a98b245-00",
+        "traceparent": "00-2375ea406fcf8542b522be68a5ec33f2-58dbc65adb5b9947-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "08e19171a9511882565640a67f7f3b12",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:41 GMT",
+        "x-ms-client-request-id": "a46df8c2bedbaff5fb93ce524c559b9a",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -754,30 +610,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:41 GMT",
-        "ETag": "\u00220x8D967F889E9690A\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:41 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:07 GMT",
+        "ETag": "\u00220x8D9689ACA49B01E\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:07 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "08e19171a9511882565640a67f7f3b12",
+        "x-ms-client-request-id": "a46df8c2bedbaff5fb93ce524c559b9a",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607450-d01e-0088-14e1-99d996000000",
+        "x-ms-request-id": "3ddf28f8-201e-0057-2283-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_1.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_1.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-7538e134e6ae2545ad377187582cb5a6-6810d3ac65344b49-00",
+        "traceparent": "00-a464b88dd9be2148ac750750a0da5aad-b7b788161180cd4f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "e964a7fb0dc4189ece9c1f55a240d766",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "x-ms-client-request-id": "982296f353e8890b81441ab175243fb9",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:07 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -786,30 +642,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:41 GMT",
-        "ETag": "\u00220x8D967F88A15B147\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:41 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:07 GMT",
+        "ETag": "\u00220x8D9689ACA7C3B14\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "e964a7fb0dc4189ece9c1f55a240d766",
+        "x-ms-client-request-id": "982296f353e8890b81441ab175243fb9",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607495-d01e-0088-50e1-99d996000000",
+        "x-ms-request-id": "3ddf2994-201e-0057-2d83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_2.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_2.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-6f91cdc4b6de8f498a55c19f3e2e3585-3b9f131706e98347-00",
+        "traceparent": "00-3446f99f3ef29546ac6aa4f5dc705fb1-fdaa823492bb054d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "30e61fcfab5542cbed85729c1f22ea9f",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "x-ms-client-request-id": "f37b8b7e91c295195e24851f6ba72fef",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -818,30 +674,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:41 GMT",
-        "ETag": "\u00220x8D967F88A415D35\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:41 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:08 GMT",
+        "ETag": "\u00220x8D9689ACAA96DFF\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "30e61fcfab5542cbed85729c1f22ea9f",
+        "x-ms-client-request-id": "f37b8b7e91c295195e24851f6ba72fef",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976074c6-d01e-0088-7fe1-99d996000000",
+        "x-ms-request-id": "3ddf29fa-201e-0057-0883-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_3.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_3.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-b602f43b842ff34eb007d19db100f6ca-14d20516ae377144-00",
+        "traceparent": "00-2b088bee4cb73340afec1dd700917975-05cbedd91b811946-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "2b5b170f6e486389f2c93ab48a2c7516",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "x-ms-client-request-id": "64cd9bf2d4f46e99ece32297a44339d7",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -850,30 +706,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:42 GMT",
-        "ETag": "\u00220x8D967F88A759631\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:08 GMT",
+        "ETag": "\u00220x8D9689ACAD8EB38\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:08 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "2b5b170f6e486389f2c93ab48a2c7516",
+        "x-ms-client-request-id": "64cd9bf2d4f46e99ece32297a44339d7",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976074fc-d01e-0088-2be1-99d996000000",
+        "x-ms-request-id": "3ddf2a44-201e-0057-4a83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_4.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_4.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-67c11e01e46f0e428c88e8341cffa628-3cf9c9be98202c4e-00",
+        "traceparent": "00-e00cb58bdbfc3746927b4e79c098a02c-1b24f8f5e6117140-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "5fd6d97e0b994fbcdc21fc3f9a02f8ab",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "x-ms-client-request-id": "c0d41554a8da61d77d8c3ac3ceec1eda",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -882,30 +738,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:42 GMT",
-        "ETag": "\u00220x8D967F88AA0A5BE\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:08 GMT",
+        "ETag": "\u00220x8D9689ACB05F707\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "5fd6d97e0b994fbcdc21fc3f9a02f8ab",
+        "x-ms-client-request-id": "c0d41554a8da61d77d8c3ac3ceec1eda",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9760754d-d01e-0088-71e1-99d996000000",
+        "x-ms-request-id": "3ddf2a8d-201e-0057-0783-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_5.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_5.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-4baaf54eb18ea7458c97fdf26ee21777-d96449fcf5dbf340-00",
+        "traceparent": "00-f238a4678474944ca18e11c1b531e6a3-00375046b9fc8c4a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "8a467fb1ace4611e95823d8c7116b7c0",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "x-ms-client-request-id": "dabf2a15da57a9c4f20c06df6f82f11a",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -914,30 +770,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:42 GMT",
-        "ETag": "\u00220x8D967F88ACBDC71\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:42 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:09 GMT",
+        "ETag": "\u00220x8D9689ACB343B81\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "8a467fb1ace4611e95823d8c7116b7c0",
+        "x-ms-client-request-id": "dabf2a15da57a9c4f20c06df6f82f11a",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607584-d01e-0088-1ee1-99d996000000",
+        "x-ms-request-id": "3ddf2ae7-201e-0057-5483-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_6.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_6.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-67aa8a7aea0cd348bb5631afb35b14e9-582377eec7753944-00",
+        "traceparent": "00-011e969cf67de54ab3781eb4f18447ff-2d1f2a5bf3221949-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "451d5c0f8b4b03065a0c4e26714ac8f0",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "x-ms-client-request-id": "55caadeb6ed24915c36be7689ad5a0ff",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -946,30 +802,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:42 GMT",
-        "ETag": "\u00220x8D967F88AF76153\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:09 GMT",
+        "ETag": "\u00220x8D9689ACB667852\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "451d5c0f8b4b03065a0c4e26714ac8f0",
+        "x-ms-client-request-id": "55caadeb6ed24915c36be7689ad5a0ff",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976075c2-d01e-0088-58e1-99d996000000",
+        "x-ms-request-id": "3ddf2b45-201e-0057-2283-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_7.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_7.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-76da20809018444a94ec325c257bc77d-f45165cc29f60d48-00",
+        "traceparent": "00-1ee217e0bfa9924380dd6a38a31b475a-323e8d73454d4d42-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "0a028ed0eae6d232bb74ca16cd30dec5",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "x-ms-client-request-id": "798147c45f83797f512bcecda1f8f2fa",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -978,30 +834,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:43 GMT",
-        "ETag": "\u00220x8D967F88B2249D8\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:09 GMT",
+        "ETag": "\u00220x8D9689ACB953222\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "0a028ed0eae6d232bb74ca16cd30dec5",
+        "x-ms-client-request-id": "798147c45f83797f512bcecda1f8f2fa",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9760760d-d01e-0088-1ce1-99d996000000",
+        "x-ms-request-id": "3ddf2bb3-201e-0057-0283-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_8.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_8.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-2c53c807ca83814bb451193fb751dc7e-7c4211e0aa75274d-00",
+        "traceparent": "00-37bf500dc9593d4c8096bf1dabdca2f6-99abd6e28a0a5c4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3e2f3b6ab2e5265f79422fd75df7ef4a",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "x-ms-client-request-id": "20d81f9bc921a707157516ebf35c0f1c",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:10 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1010,30 +866,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:43 GMT",
-        "ETag": "\u00220x8D967F88B4D8090\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:10 GMT",
+        "ETag": "\u00220x8D9689ACBC1C884\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:10 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3e2f3b6ab2e5265f79422fd75df7ef4a",
+        "x-ms-client-request-id": "20d81f9bc921a707157516ebf35c0f1c",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607666-d01e-0088-6ce1-99d996000000",
+        "x-ms-request-id": "3ddf2c2a-201e-0057-6983-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_9.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_9.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-67e8abd1df4b534ca453a5725f71dcba-b695f1cd33f3d04c-00",
+        "traceparent": "00-3455c35081addb43a4ac17e864d5f49b-4f806e1781862047-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "e2bc4dbaac1425d92a4a8ad7c0ef362a",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "x-ms-client-request-id": "271a076c77008b972e5104a79f47a8cb",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:10 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1042,30 +898,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:43 GMT",
-        "ETag": "\u00220x8D967F88B7D4BEE\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:43 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:10 GMT",
+        "ETag": "\u00220x8D9689ACBF516F5\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:10 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "e2bc4dbaac1425d92a4a8ad7c0ef362a",
+        "x-ms-client-request-id": "271a076c77008b972e5104a79f47a8cb",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976076d6-d01e-0088-4de1-99d996000000",
+        "x-ms-request-id": "3ddf2c90-201e-0057-3e83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_10.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_10.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-2ba9135f89e3564cb011bbff59960ffd-a30e30304fd6ab48-00",
+        "traceparent": "00-bf86f53a96b2d04fbd66b2fc27fd6c6e-970008d3ca1a2345-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "36bc892e8a1b1d0a2fdb91a4ba5a74c4",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "x-ms-client-request-id": "7bcced797ffcfbdd40da640e499486f4",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:10 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1074,30 +930,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:44 GMT",
-        "ETag": "\u00220x8D967F88BA96D1B\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:10 GMT",
+        "ETag": "\u00220x8D9689ACC24E258\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:10 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "36bc892e8a1b1d0a2fdb91a4ba5a74c4",
+        "x-ms-client-request-id": "7bcced797ffcfbdd40da640e499486f4",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "9760772c-d01e-0088-1be1-99d996000000",
+        "x-ms-request-id": "3ddf2cea-201e-0057-0a83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_11.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_11.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-32fb61e113c52b47bdfa4366d2ace770-a5abc889a24e5344-00",
+        "traceparent": "00-7b2b72a8bcff9f409d76d6883ce48d59-88526e6a03299849-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "7f5c7f85fb74bdb1620a139a2888668a",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "x-ms-client-request-id": "9a61b21ccbdd23f9884df2d0c56007ce",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:10 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1106,30 +962,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:44 GMT",
-        "ETag": "\u00220x8D967F88BD47CA7\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:10 GMT",
+        "ETag": "\u00220x8D9689ACC54FBD7\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:11 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "7f5c7f85fb74bdb1620a139a2888668a",
+        "x-ms-client-request-id": "9a61b21ccbdd23f9884df2d0c56007ce",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607789-d01e-0088-69e1-99d996000000",
+        "x-ms-request-id": "3ddf2d47-201e-0057-5a83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_12.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_12.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-311bca756755274397f4ed3b1d862def-71aee6de93fbec40-00",
+        "traceparent": "00-ba0bf175322025478e7ad00fa9b0dd03-5031ff290afdce41-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "d4a9050cb93a2f2f429eb3381b356acf",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "x-ms-client-request-id": "06724acd938fec1f291fe72613884299",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:11 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1138,30 +994,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:44 GMT",
-        "ETag": "\u00220x8D967F88BFFDA59\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:44 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:11 GMT",
+        "ETag": "\u00220x8D9689ACC81924B\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:11 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d4a9050cb93a2f2f429eb3381b356acf",
+        "x-ms-client-request-id": "06724acd938fec1f291fe72613884299",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976077bd-d01e-0088-18e1-99d996000000",
+        "x-ms-request-id": "3ddf2da8-201e-0057-2c83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_13.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_13.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-196a2d66a7bcb94da4785afb1da0c49e-5b012b5a5de9c94b-00",
+        "traceparent": "00-680a69d1e5a51042b49c019bb654c75e-f5763d76a6ed824d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "4051c5d5b69332b5d7ffd3117670f4a6",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "x-ms-client-request-id": "ed8b0fca0de5aeeef3a8f3af8d0c35e0",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:11 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1170,30 +1026,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:44 GMT",
-        "ETag": "\u00220x8D967F88C2AE9EA\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:11 GMT",
+        "ETag": "\u00220x8D9689ACCAE4FD9\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:11 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "4051c5d5b69332b5d7ffd3117670f4a6",
+        "x-ms-client-request-id": "ed8b0fca0de5aeeef3a8f3af8d0c35e0",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976077f3-d01e-0088-3de1-99d996000000",
+        "x-ms-request-id": "3ddf2e00-201e-0057-7883-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_14.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_14.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-190125ef86d8d543936660c895622d25-bd8514f922cbd845-00",
+        "traceparent": "00-b6d9c0c85434d24081d0b10f3ccb7784-4ae66abb5441314f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b5980675a0b1cb8a502c3dd64879a12d",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "x-ms-client-request-id": "fe4095d380218865927571bde3d30fff",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:11 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1202,30 +1058,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:45 GMT",
-        "ETag": "\u00220x8D967F88C55D262\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:11 GMT",
+        "ETag": "\u00220x8D9689ACCDD57BC\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:12 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b5980675a0b1cb8a502c3dd64879a12d",
+        "x-ms-client-request-id": "fe4095d380218865927571bde3d30fff",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607833-d01e-0088-73e1-99d996000000",
+        "x-ms-request-id": "3ddf2e40-201e-0057-3083-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_15.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_15.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-77c1bf098c1edf4cac1a11f505cbaa6c-0a8bd19a64835944-00",
+        "traceparent": "00-87687e865b76cd47bfb8d8a3cc4edc63-246e9a04a0ff4a4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "63c5439f253655f65076fd3be51eb8d2",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "x-ms-client-request-id": "b606580a19d4c0e85cc412e6a0705e1c",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:12 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1234,30 +1090,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:45 GMT",
-        "ETag": "\u00220x8D967F88C813018\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:12 GMT",
+        "ETag": "\u00220x8D9689ACD0A1559\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:12 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "63c5439f253655f65076fd3be51eb8d2",
+        "x-ms-client-request-id": "b606580a19d4c0e85cc412e6a0705e1c",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607858-d01e-0088-11e1-99d996000000",
+        "x-ms-request-id": "3ddf2e84-201e-0057-6e83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_16.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_16.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-bc111f9773286e49b06a181cd5dd3556-5448d696152b7d4e-00",
+        "traceparent": "00-7c6666d13913844582c6c02dfdc98f9d-b2f43436c980c848-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "14c20caab59d351e3b86f06679dfea5d",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "x-ms-client-request-id": "7d5207e944474a78a9035b709b30ca1f",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:12 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1266,30 +1122,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:45 GMT",
-        "ETag": "\u00220x8D967F88CAC8DD3\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:45 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:12 GMT",
+        "ETag": "\u00220x8D9689ACD376F4E\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:12 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "14c20caab59d351e3b86f06679dfea5d",
+        "x-ms-client-request-id": "7d5207e944474a78a9035b709b30ca1f",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607898-d01e-0088-4ae1-99d996000000",
+        "x-ms-request-id": "3ddf2ee9-201e-0057-4383-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_17.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_17.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-fb850b15710e274a8a956522174fbac6-967a5e771db89c45-00",
+        "traceparent": "00-a042799543769d4991c0683f15f88c22-907900b4c1eb9546-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3371a65d91ab506f1042643ba34ee531",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "x-ms-client-request-id": "35a5f4997f06b90bad80a25d6d7ee722",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:12 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1298,30 +1154,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
-        "ETag": "\u00220x8D967F88CD79D64\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:12 GMT",
+        "ETag": "\u00220x8D9689ACD64A23A\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:12 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3371a65d91ab506f1042643ba34ee531",
+        "x-ms-client-request-id": "35a5f4997f06b90bad80a25d6d7ee722",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "976078e3-d01e-0088-0ce1-99d996000000",
+        "x-ms-request-id": "3ddf2f4e-201e-0057-1783-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_18.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_18.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-1fae8ab895c0754fb670cb899d08e61d-b801b6b25f20234b-00",
+        "traceparent": "00-c8870f3239fbbe468230725339890224-eaf5df6d387c3442-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3b2c6a738cb7ea8f258f28b0348fdc70",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:47 GMT",
+        "x-ms-client-request-id": "dcd455169280c6b7e0bc0cd1be78242c",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1330,30 +1186,30 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
-        "ETag": "\u00220x8D967F88D032230\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:13 GMT",
+        "ETag": "\u00220x8D9689ACD91D512\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:13 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3b2c6a738cb7ea8f258f28b0348fdc70",
+        "x-ms-client-request-id": "dcd455169280c6b7e0bc0cd1be78242c",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607939-d01e-0088-57e1-99d996000000",
+        "x-ms-request-id": "3ddf2f9e-201e-0057-5e83-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1415864092/File_19.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1147422197/File_19.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-3903fa494e5e0d40bc21555a07efacda-875a552b78a63341-00",
+        "traceparent": "00-c5a40361e5d2a94e9e50654aa4f069af-8d4a6ff5aa620b40-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "3fdd9f8c85ad19279c71045a50e391ec",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:47 GMT",
+        "x-ms-client-request-id": "ac4df3fa29ca6a15fb99d0c6a11adc2b",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1362,28 +1218,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
-        "ETag": "\u00220x8D967F88D2ECE1E\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:13 GMT",
+        "ETag": "\u00220x8D9689ACDC4872A\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:13 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3fdd9f8c85ad19279c71045a50e391ec",
+        "x-ms-client-request-id": "ac4df3fa29ca6a15fb99d0c6a11adc2b",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "97607970-d01e-0088-0ce1-99d996000000",
+        "x-ms-request-id": "3ddf2ff8-201e-0057-2883-9a92ac000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1074018720?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target789919003?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-1c375396c8f00040934812bbe608e7e1-83c3e5208f2cfe41-00",
+        "traceparent": "00-209c93b5ef02174a869af5aa9e19c865-5608c905fe78984a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "b30ef2bfa6ae16d0870e1b68bf1c8065",
-        "x-ms-date": "Wed, 25 Aug 2021 18:45:47 GMT",
+        "x-ms-client-request-id": "5c4659399eed3c06de544a733afb355c",
+        "x-ms-date": "Thu, 26 Aug 2021 14:07:13 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1391,12 +1247,12 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
-        "ETag": "\u00220x8D967F88D4546D0\u0022",
-        "Last-Modified": "Wed, 25 Aug 2021 18:45:46 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:13 GMT",
+        "ETag": "\u00220x8D9689ACDDDBC12\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 14:07:13 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b30ef2bfa6ae16d0870e1b68bf1c8065",
-        "x-ms-request-id": "976079ad-d01e-0088-3fe1-99d996000000",
+        "x-ms-client-request-id": "5c4659399eed3c06de544a733afb355c",
+        "x-ms-request-id": "3ddf3057-201e-0057-7b83-9a92ac000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
@@ -1409,9 +1265,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b091956c205c6c48b244228535e83d26-eb1db2254709c246-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7104aff384a643ee139f4588359941fd",
+        "traceparent": "00-8667b5f09f9db44e8742d4c46a62a92d-7a1032cb33eb714b-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "307a6376573b3fed6ae1e7c1f024c5df",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1431,10 +1287,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "aac1430b-d477-4c18-beb5-bb932e5dcae2",
+        "apim-request-id": "fa79f6d7-8461-4ea9-b28f-41891a4f8221",
         "Content-Length": "0",
-        "Date": "Wed, 25 Aug 2021 18:45:46 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4419c955-e50f-4782-ade4-74e798ca1b7b",
+        "Date": "Thu, 26 Aug 2021 14:07:13 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3c773c25-3b05-48cb-92b3-fe321b99ca9d",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -1442,26 +1298,26 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "aac1430b-d477-4c18-beb5-bb932e5dcae2"
+        "X-RequestId": "fa79f6d7-8461-4ea9-b28f-41891a4f8221"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4419c955-e50f-4782-ade4-74e798ca1b7b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/3c773c25-3b05-48cb-92b3-fe321b99ca9d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9d75103bbdcef8dd0c2826770bb0dd55",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1e84b5e0cfdd540c466fecd4cbf6c19d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d23b5130-db00-4e4a-a0ba-173e73809c43",
+        "apim-request-id": "420826c1-b315-4e6e-8133-d7d3f09ce4ed",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:47 GMT",
+        "Date": "Thu, 26 Aug 2021 14:07:13 GMT",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1471,12 +1327,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d23b5130-db00-4e4a-a0ba-173e73809c43"
+        "X-RequestId": "420826c1-b315-4e6e-8133-d7d3f09ce4ed"
       },
       "ResponseBody": {
-        "id": "4419c955-e50f-4782-ade4-74e798ca1b7b",
-        "createdDateTimeUtc": "2021-08-25T18:45:47.205312Z",
-        "lastActionDateTimeUtc": "2021-08-25T18:45:47.4485515Z",
+        "id": "3c773c25-3b05-48cb-92b3-fe321b99ca9d",
+        "createdDateTimeUtc": "2021-08-26T14:07:14.0385355Z",
+        "lastActionDateTimeUtc": "2021-08-26T14:07:14.2819236Z",
         "status": "Cancelling",
         "summary": {
           "total": 0,
@@ -1490,27 +1346,27 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=4419c955-e50f-4782-ade4-74e798ca1b7b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=3c773c25-3b05-48cb-92b3-fe321b99ca9d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4ada14d178292a4987ab0b450761cd85-4431fb0b137ef043-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "345cf4847a8d3afa04caa00f6048e1ed",
+        "traceparent": "00-14e5c32a8f86cf4ea6269e038b099fab-b706126b841f4d4b-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b72b6a9afa61e2df6b06f20cb7444bb9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "983e3912-bc10-4fd8-8306-fc6eef2b9e68",
+        "apim-request-id": "f78ec287-2e53-41e4-9088-fbf833b99d8b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:52 GMT",
-        "ETag": "\u0022B691493928B7E5D183B22D888E02C7224BE4DAADF9F583025BF623B7765436EC\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:19 GMT",
+        "ETag": "\u00225A37383F19542CEB2609CDD5F283EB4B9B2F8AB8454C416D63C9A5E15872885D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1520,14 +1376,14 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "983e3912-bc10-4fd8-8306-fc6eef2b9e68"
+        "X-RequestId": "f78ec287-2e53-41e4-9088-fbf833b99d8b"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "4419c955-e50f-4782-ade4-74e798ca1b7b",
-            "createdDateTimeUtc": "2021-08-25T18:45:47.205312Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:50.4057284Z",
+            "id": "3c773c25-3b05-48cb-92b3-fe321b99ca9d",
+            "createdDateTimeUtc": "2021-08-26T14:07:14.0385355Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:07:17.7495091Z",
             "status": "Cancelling",
             "summary": {
               "total": 20,
@@ -1543,27 +1399,27 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=4419c955-e50f-4782-ade4-74e798ca1b7b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=3c773c25-3b05-48cb-92b3-fe321b99ca9d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b2ec69fa775b641bbd4b689cfc06a33-cbec53ddb9d9ca40-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ae2c1dcce3a63697d10b647d5e773762",
+        "traceparent": "00-93a2554c3b7c74419a90604c06d53d46-3620452833339049-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "84926a8f1676a67e5625e9cb6a187473",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9a8d9503-ddd6-47d5-8357-aa1374474c3a",
+        "apim-request-id": "79687ae0-3faf-4312-9261-305506c7cf47",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:57 GMT",
-        "ETag": "\u0022A938AA954586BAA1750FDAA95E22C3E3E1ED19F849EF51E6EFF29B1CE3723E6B\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:24 GMT",
+        "ETag": "\u00227A25ADB7D8608255A29A6182A3309ECC97EF3D4382C4B44E3DA5775D25DF8D88\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1573,14 +1429,14 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9a8d9503-ddd6-47d5-8357-aa1374474c3a"
+        "X-RequestId": "79687ae0-3faf-4312-9261-305506c7cf47"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "4419c955-e50f-4782-ade4-74e798ca1b7b",
-            "createdDateTimeUtc": "2021-08-25T18:45:47.205312Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:54.1761712Z",
+            "id": "3c773c25-3b05-48cb-92b3-fe321b99ca9d",
+            "createdDateTimeUtc": "2021-08-26T14:07:14.0385355Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:07:21.6924944Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1596,27 +1452,27 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?statuses=Cancelled%2CCancelling",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?statuses=Cancelled%2CCancelling\u0026createdDateTimeUtcStart=2021-08-26T08%3A07%3A24.9347283Z",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d2aed38780c9464ab5f23490e19f6a41-5d3c490cb40be445-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4003f0c10d3dc170153a98031dce97c3",
+        "traceparent": "00-0683f4a49ba5c144be32a1e65bbcaf07-f27b4b469f385243-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "86274a200df8e57dd5a2b3d7dd009d02",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2b4b8f00-ed45-4b1a-b279-1515df9a97c9",
+        "apim-request-id": "5df994d6-bca0-486d-ab03-25b10dce74af",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:57 GMT",
-        "ETag": "\u00228BA81BFA5C020A365B5B5E380F6FACD1D2F050EF0AF4D6FD782DBD59AA78F43D\u0022",
+        "Date": "Thu, 26 Aug 2021 14:07:24 GMT",
+        "ETag": "\u00224BEF2B0413F72467A86050E2DA574621C37460DE56596C28FD55DDAB935B7D04\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1626,14 +1482,14 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2b4b8f00-ed45-4b1a-b279-1515df9a97c9"
+        "X-RequestId": "5df994d6-bca0-486d-ab03-25b10dce74af"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "4419c955-e50f-4782-ade4-74e798ca1b7b",
-            "createdDateTimeUtc": "2021-08-25T18:45:47.205312Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:54.1761712Z",
+            "id": "3c773c25-3b05-48cb-92b3-fe321b99ca9d",
+            "createdDateTimeUtc": "2021-08-26T14:07:14.0385355Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:07:21.6924944Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1646,9 +1502,9 @@
             }
           },
           {
-            "id": "69c933d1-698c-42ed-967d-40253aee437f",
-            "createdDateTimeUtc": "2021-08-25T18:45:12.8086284Z",
-            "lastActionDateTimeUtc": "2021-08-25T18:45:21.5359358Z",
+            "id": "f81d5c81-f7db-41da-baa7-dff063bd88c4",
+            "createdDateTimeUtc": "2021-08-26T14:06:50.6689792Z",
+            "lastActionDateTimeUtc": "2021-08-26T14:06:55.7249243Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1661,9 +1517,9 @@
             }
           },
           {
-            "id": "decfe908-d309-4d44-838b-7b12aa38d315",
-            "createdDateTimeUtc": "2021-08-25T14:21:31.5637982Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:21:38.0583554Z",
+            "id": "cbd0280d-ed6b-4ad0-818d-eee8d0d19808",
+            "createdDateTimeUtc": "2021-08-26T13:23:52.7354145Z",
+            "lastActionDateTimeUtc": "2021-08-26T13:23:57.8859353Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1676,9 +1532,9 @@
             }
           },
           {
-            "id": "c8b61454-5adf-4d70-b81b-5573dcbd5f58",
-            "createdDateTimeUtc": "2021-08-25T14:20:52.7421831Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:20:58.7274706Z",
+            "id": "2bd0dab9-918e-48f8-9919-94dcff13c8d4",
+            "createdDateTimeUtc": "2021-08-26T13:23:21.2191695Z",
+            "lastActionDateTimeUtc": "2021-08-26T13:23:25.3549473Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1691,9 +1547,9 @@
             }
           },
           {
-            "id": "253d9f25-18d2-4cc7-8669-4d8407b22a9c",
-            "createdDateTimeUtc": "2021-08-25T14:19:05.8329604Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:19:10.6795351Z",
+            "id": "7c03da23-0463-456b-bdd7-c37865f5aa61",
+            "createdDateTimeUtc": "2021-08-26T13:06:16.8917739Z",
+            "lastActionDateTimeUtc": "2021-08-26T13:06:20.2226075Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -1706,2082 +1562,9 @@
             }
           },
           {
-            "id": "60db663e-f771-4adb-b08f-6854b85696e1",
-            "createdDateTimeUtc": "2021-08-25T14:18:43.8946636Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:18:51.4148389Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5acc56a1-33c3-4542-9370-5f7b9b19f5ab",
-            "createdDateTimeUtc": "2021-08-25T14:15:39.7803188Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:15:43.1246356Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2597203e-1311-41c4-886f-f465cd164759",
-            "createdDateTimeUtc": "2021-08-25T14:15:19.2437991Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:15:23.9402734Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f4b9df36-266a-40d0-ba29-fc0e67dd4887",
-            "createdDateTimeUtc": "2021-08-25T14:14:35.4257961Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:14:41.4038969Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a5c6c285-da24-494d-a971-919266469088",
-            "createdDateTimeUtc": "2021-08-25T14:14:14.5070628Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:14:19.0578249Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "533c3361-dfbe-4bd2-a517-9491e071775a",
-            "createdDateTimeUtc": "2021-08-25T14:13:34.7214701Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:13:39.5494326Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a23b53f3-ed01-458b-947e-867a553eb591",
-            "createdDateTimeUtc": "2021-08-25T14:13:13.8939951Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:13:19.2252019Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "0d4b8b20-a460-469a-b3aa-588300fef2e0",
-            "createdDateTimeUtc": "2021-08-25T14:08:25.2665312Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:08:32.3285477Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2aecc1c5-d3da-45b9-93c5-d2a260d6aedf",
-            "createdDateTimeUtc": "2021-08-25T14:08:02.4909754Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:08:06.9807983Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b0607637-8b27-4120-8b39-6194b5755e92",
-            "createdDateTimeUtc": "2021-08-25T14:06:09.5993734Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:06:14.8816421Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b7f3c08a-c2c0-4228-9f8a-c92be3b7737d",
-            "createdDateTimeUtc": "2021-08-25T14:05:44.5683358Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:05:49.4108643Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "0d5c55f5-91e2-4d2f-88f8-9c7ae1de5505",
-            "createdDateTimeUtc": "2021-08-25T14:05:07.8586943Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:05:11.277379Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b4f56a1c-3b5d-42a2-a94e-1c949dfe776f",
-            "createdDateTimeUtc": "2021-08-25T14:04:41.9246386Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:04:48.5055613Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ff62a2bd-4c6f-47e8-b557-f429dd7e6f3a",
-            "createdDateTimeUtc": "2021-08-25T14:03:49.5697452Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:03:53.7964747Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "9eb1fcae-bc60-4b93-90eb-64a52c473672",
-            "createdDateTimeUtc": "2021-08-25T14:03:24.5425451Z",
-            "lastActionDateTimeUtc": "2021-08-25T14:03:31.821667Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "eb67646e-c215-4fa3-8eb3-da0770064e5f",
-            "createdDateTimeUtc": "2021-08-25T13:57:19.6278599Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:57:30.2946248Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "727d5bf9-f9fb-4ddf-9a38-828f22910b12",
-            "createdDateTimeUtc": "2021-08-25T13:53:59.4231523Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:54:05.5775816Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4809cfc7-d5ae-4225-868e-05544f489358",
-            "createdDateTimeUtc": "2021-08-25T13:53:29.8911657Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:53:33.6911548Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d493956c-db6d-4a17-a5f0-028becb4ccfa",
-            "createdDateTimeUtc": "2021-08-25T13:52:31.0854759Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:52:34.9946496Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b6a8fa53-920e-4932-8c81-f3c73c0b2988",
-            "createdDateTimeUtc": "2021-08-25T13:51:53.8772741Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:52:00.7948926Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c2301f1f-c87f-4772-9f9c-5a9d7548b349",
-            "createdDateTimeUtc": "2021-08-25T13:45:19.087893Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:45:23.5227282Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d8ecc615-eeeb-4787-a601-851daef7b268",
-            "createdDateTimeUtc": "2021-08-25T13:44:54.582286Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:44:58.230487Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "14f3ad4c-7135-415e-859d-9b5f431ae6da",
-            "createdDateTimeUtc": "2021-08-25T13:44:08.2452291Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:44:16.8544217Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "9bb35643-eeb4-475b-8344-c3ae46655123",
-            "createdDateTimeUtc": "2021-08-25T13:43:37.812651Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:43:45.7364219Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ea604b93-8058-4d72-af48-81ad3ed99057",
-            "createdDateTimeUtc": "2021-08-25T13:41:46.5703013Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:41:50.3292734Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "501bfb81-87b7-4a4e-8f2a-67df97de6546",
-            "createdDateTimeUtc": "2021-08-25T13:41:24.0184265Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:41:27.7675607Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "42029254-a247-4c0b-ba14-52b9856051a4",
-            "createdDateTimeUtc": "2021-08-25T13:40:13.0836214Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:40:17.2772553Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d0ed4aa1-8314-4eff-8794-7d71942ebb55",
-            "createdDateTimeUtc": "2021-08-25T13:39:50.5251217Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:39:54.8052147Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "92252ab6-aeee-429c-8eca-f02e13be2348",
-            "createdDateTimeUtc": "2021-08-25T13:36:06.2711907Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:36:11.6241286Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "0e476571-3f2d-4999-bab6-7d3487603d22",
-            "createdDateTimeUtc": "2021-08-25T13:29:53.0363818Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:29:58.8829377Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "9feff3a9-0b8c-4c47-b780-664c7d90d549",
-            "createdDateTimeUtc": "2021-08-25T13:26:04.1635563Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:26:08.1645944Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c2f031b9-55db-42a9-9ecc-afdd741985bf",
-            "createdDateTimeUtc": "2021-08-25T13:25:45.2888951Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:25:49.1040561Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "500ffbb8-db58-417a-9bbc-98fd0d5e0f6e",
-            "createdDateTimeUtc": "2021-08-25T13:24:28.73101Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:24:32.7396137Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6385a3f7-9a39-4389-a9e3-0b533e19561d",
-            "createdDateTimeUtc": "2021-08-25T13:24:08.1547203Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:24:11.935914Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "040d09c1-a792-48a1-8b09-368ad940703c",
-            "createdDateTimeUtc": "2021-08-25T13:23:09.2673068Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:23:17.3461036Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a4720b7c-5aff-451d-9168-4aaeb46810ec",
-            "createdDateTimeUtc": "2021-08-25T13:22:47.9668002Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:22:51.8319732Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "53665f6e-2451-47ad-872e-0b60048296bc",
-            "createdDateTimeUtc": "2021-08-25T13:21:59.6468367Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:22:04.1049272Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4d02dc0e-82d0-4106-9601-2b67d4895887",
-            "createdDateTimeUtc": "2021-08-25T13:21:41.2699303Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:21:45.685377Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2f83a75e-3690-478a-b2c1-838a3c87780f",
-            "createdDateTimeUtc": "2021-08-25T13:20:00.4021268Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:20:04.4540659Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "79358abe-ca1d-4a34-a9dc-251d35f38d88",
-            "createdDateTimeUtc": "2021-08-25T13:19:40.6697383Z",
-            "lastActionDateTimeUtc": "2021-08-25T13:19:47.1202077Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "aa883068-64e5-435b-8663-bc9573b2e917",
-            "createdDateTimeUtc": "2021-08-25T10:56:20.2363383Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:56:27.0780797Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "90c0a544-4504-4020-8396-0544b00c18c6",
-            "createdDateTimeUtc": "2021-08-25T10:55:55.9293426Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:56:05.0797274Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "614afed7-f7f1-4d74-9ad7-eff593103cd6",
-            "createdDateTimeUtc": "2021-08-25T10:29:21.1938146Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:29:24.7004537Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f74ec5a8-15e9-4b8c-b8b6-c33ddd521c63",
-            "createdDateTimeUtc": "2021-08-25T10:29:02.5870188Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:29:05.9331656Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "fc864d53-0ddb-4fad-85ac-2d7451de0350",
-            "createdDateTimeUtc": "2021-08-25T10:28:05.7449329Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:28:15.1486564Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          }
-        ],
-        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=89\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=89\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-404c0f62bd1e1345ae3f8d8cb703f472-2aac6cb968b98241-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eeaa38472e83a1ae5d266381167cdc8c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "65ca6265-c0c5-4255-98de-1fe83d36091f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:58 GMT",
-        "ETag": "\u00220E268367A44951B59C64C1534C495086BE9520454641676C84DBE46489067D5B\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "65ca6265-c0c5-4255-98de-1fe83d36091f"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "30bc281b-3a6c-4a97-92c2-43de98e83aa4",
-            "createdDateTimeUtc": "2021-08-25T10:27:43.633836Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:27:50.5077585Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6f160aba-7e60-4748-a972-d0a146b3196e",
-            "createdDateTimeUtc": "2021-08-25T10:26:50.4040903Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:26:54.3204806Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ca6e611e-7b53-4d7f-b638-afe8d00bb725",
-            "createdDateTimeUtc": "2021-08-25T10:26:26.2866155Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:26:30.7154518Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5d4b8b67-af0b-4c12-9c75-0869a2ba66df",
-            "createdDateTimeUtc": "2021-08-25T10:24:14.9778475Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:24:23.0381859Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "57bc3d42-2f4c-4dd1-ad51-791847d581d4",
-            "createdDateTimeUtc": "2021-08-25T10:23:51.1332076Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:23:58.0469266Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c55b120e-d8e1-48de-b0af-0e8d45c2b960",
-            "createdDateTimeUtc": "2021-08-25T10:09:55.7948842Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:10:02.821391Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8e66ffc9-0ac3-48a0-82ae-7609c6a6050a",
-            "createdDateTimeUtc": "2021-08-25T10:09:31.391233Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:09:35.8564693Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "63fb087b-4dd8-46d8-ac10-48bb79ce86d3",
-            "createdDateTimeUtc": "2021-08-25T10:07:25.2633442Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:07:31.8339883Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "cb2faa2d-95b1-46f9-bd39-4c5ffaf3d066",
-            "createdDateTimeUtc": "2021-08-25T10:07:01.8887184Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:07:06.5864174Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "73489fba-e1e8-4fb6-9f08-1eec3698f3e3",
-            "createdDateTimeUtc": "2021-08-25T10:05:29.2026751Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:05:41.024571Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d5015b23-d0d7-46f0-af5e-50e2228f4841",
-            "createdDateTimeUtc": "2021-08-25T10:05:07.1839969Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:05:15.5031116Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8f3aefad-b2fc-41cf-968d-18b0497b5fb3",
-            "createdDateTimeUtc": "2021-08-25T10:01:07.121612Z",
-            "lastActionDateTimeUtc": "2021-08-25T10:01:13.8095906Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "609f5c8f-80e1-424b-9801-5d3e804c134e",
-            "createdDateTimeUtc": "2021-08-25T09:47:51.4646326Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:47:59.0397057Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "cc873f8b-e71f-4617-a277-00b299907c0e",
-            "createdDateTimeUtc": "2021-08-25T09:47:17.2200753Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:47:25.0694763Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "92c6004e-733f-41af-8d2f-89b41bb279c6",
-            "createdDateTimeUtc": "2021-08-25T09:44:03.9368379Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:44:09.2827307Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "0699ddc0-9394-43b7-8335-99b582ac7af5",
-            "createdDateTimeUtc": "2021-08-25T09:43:07.3141327Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:43:12.1318918Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "686ae6d7-ffc1-4c0c-a4b1-49a57d03524b",
-            "createdDateTimeUtc": "2021-08-25T09:42:39.886955Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:42:45.1118961Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "77edc600-d50a-4740-ba35-9fc276ae7415",
-            "createdDateTimeUtc": "2021-08-25T09:19:31.6344382Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:19:39.3248571Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8afe0ff5-a724-4d21-acce-da44c26b3ffe",
-            "createdDateTimeUtc": "2021-08-25T09:19:10.8844738Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:19:17.2753878Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "02acf584-26b6-40d3-a958-e34734f20ef5",
-            "createdDateTimeUtc": "2021-08-25T09:18:05.5949331Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:18:10.700436Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "da3b7f1b-eaf1-4ef3-b1d7-34cb12c58f5f",
-            "createdDateTimeUtc": "2021-08-25T09:17:41.6284086Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:17:46.8467624Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "e2fdfa9b-eef5-4285-84f2-394dc3ee0cde",
-            "createdDateTimeUtc": "2021-08-25T09:16:55.2621789Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:17:00.0474197Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8107b309-29ed-4fc0-b2e1-cfeb96210550",
-            "createdDateTimeUtc": "2021-08-25T09:16:27.1861354Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:16:31.6226169Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d33cd5ae-28a9-4560-980d-3cd99decdb56",
-            "createdDateTimeUtc": "2021-08-25T09:15:20.2067568Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:15:30.5710243Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ea961c29-189c-4dbc-b375-61167cf15a17",
-            "createdDateTimeUtc": "2021-08-25T09:14:55.2312472Z",
-            "lastActionDateTimeUtc": "2021-08-25T09:15:04.6298687Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "eb8efceb-d78d-4dcf-aedb-c3edde6cbc7e",
-            "createdDateTimeUtc": "2021-08-24T19:55:47.1477025Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:55:51.5061055Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "534d90e6-5360-471e-bfd0-54d23d28aa3f",
-            "createdDateTimeUtc": "2021-08-24T19:53:32.6469602Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:53:40.4258421Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a10ef07d-101a-4e0c-9194-ab61b49cba8a",
-            "createdDateTimeUtc": "2021-08-24T19:53:07.1127838Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:53:15.4049994Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "223a9ccf-7935-4581-995a-60605ee335a5",
-            "createdDateTimeUtc": "2021-08-24T19:50:41.7797004Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:50:48.506789Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4dbe99ed-ca2d-4dbe-8bcd-2643d5bbe7f4",
-            "createdDateTimeUtc": "2021-08-24T19:50:16.0211307Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:50:26.0420851Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f80c73e0-e8ec-4d35-a4d4-27179f0ed4bf",
-            "createdDateTimeUtc": "2021-08-24T19:49:10.6527877Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:49:15.2215103Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "18d1d2d0-c3e1-4864-833c-8ab189be6fc1",
-            "createdDateTimeUtc": "2021-08-24T19:48:44.5805808Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:48:49.1109041Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5a457f72-8bd8-450c-ac60-da04df2cc2ab",
-            "createdDateTimeUtc": "2021-08-24T19:46:10.1997622Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:46:17.9106435Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "60ff13d3-9f94-431f-ac62-58f42f771630",
-            "createdDateTimeUtc": "2021-08-24T19:45:44.4022212Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:45:48.9866813Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "195c51ce-0ef1-491b-9ec2-db1542402a32",
-            "createdDateTimeUtc": "2021-08-24T19:44:53.1308296Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:45:02.5998496Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6a18a4bd-f2cc-42cc-b195-cd1cdb22eaf6",
-            "createdDateTimeUtc": "2021-08-24T19:44:31.5620308Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:44:38.2064648Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c562e87c-1fb3-4e9f-8748-803d34fe7b11",
-            "createdDateTimeUtc": "2021-08-24T19:42:08.6323717Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:42:16.6949486Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2c8d2c87-1dd9-42af-aa73-9052cb89123c",
-            "createdDateTimeUtc": "2021-08-24T19:41:44.486071Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:41:49.5437122Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a8018349-6083-4c7b-be65-a0d93cd7f9f1",
-            "createdDateTimeUtc": "2021-08-24T19:26:28.685069Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:26:35.6712921Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "93c8fbe5-2509-4e26-aa38-5b44ae36abb9",
-            "createdDateTimeUtc": "2021-08-24T19:25:53.9806028Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:25:59.7724431Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b981ecff-a052-4239-975b-2f4ed45aa2e7",
-            "createdDateTimeUtc": "2021-08-24T19:25:32.5560562Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:25:36.3150668Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5fce870f-5805-48fe-9e55-d978c0a44a96",
-            "createdDateTimeUtc": "2021-08-24T19:24:49.8512423Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:24:54.7359674Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "58dd2537-2390-41ce-8e66-cf5d991a0ef0",
-            "createdDateTimeUtc": "2021-08-24T19:24:28.0491081Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:24:32.8824749Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "309c5ab2-ab6e-42d2-b341-3d273507090b",
-            "createdDateTimeUtc": "2021-08-24T19:19:16.359635Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:19:26.45727Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6621b15c-9956-44d8-8bd2-de6d1dd3d518",
-            "createdDateTimeUtc": "2021-08-24T19:18:15.2019519Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:18:20.6814382Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b39c5530-1a07-4898-b0cf-d1b81c31958c",
-            "createdDateTimeUtc": "2021-08-24T19:17:00.6801855Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:17:04.7751099Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ab5f7b09-0873-4d2d-942c-5a76b6296264",
-            "createdDateTimeUtc": "2021-08-24T19:16:35.6588021Z",
-            "lastActionDateTimeUtc": "2021-08-24T19:16:45.7609068Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c0c4e53a-6bc5-4d35-be29-4e9d088d6b70",
-            "createdDateTimeUtc": "2021-08-24T15:36:55.7864604Z",
-            "lastActionDateTimeUtc": "2021-08-24T15:37:01.6474825Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "161de4ac-0924-4527-8170-a4bec6eb38c8",
-            "createdDateTimeUtc": "2021-08-24T15:36:21.2461429Z",
-            "lastActionDateTimeUtc": "2021-08-24T15:36:28.9384829Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "49840bd2-de72-4b7d-9bf4-47f746ecc5bb",
-            "createdDateTimeUtc": "2021-08-23T17:47:33.9921789Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:47:40.5970502Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          }
-        ],
-        "@nextLink": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=39\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling"
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=39\u0026$maxpagesize=50\u0026statuses=Cancelled,Cancelling",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-deb2120755e73445b90b86d23cf7b0a7-eb845d7e815dc74e-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210825.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "704d3d93a144bfb0ad6b986c4a941802",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6da52098-28fb-4694-8d19-d972af835855",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 25 Aug 2021 18:45:59 GMT",
-        "ETag": "\u0022D44C804CFCA1E28F2F68B63B3FF2BE3675D447F6A80C1DE9FAE7C86D50649FB3\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6da52098-28fb-4694-8d19-d972af835855"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "6e3b9367-513c-4d20-8c07-ee3568440b7c",
-            "createdDateTimeUtc": "2021-08-23T17:47:11.3828547Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:47:15.2840674Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b2d0e15f-95ef-40d4-bfb0-9a4f203a54ba",
-            "createdDateTimeUtc": "2021-08-23T17:35:20.3985579Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:35:27.6518861Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "15bb936d-c180-4255-9ba2-a07bec5806dd",
-            "createdDateTimeUtc": "2021-08-23T17:34:58.0354643Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:35:03.3355533Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "29353a68-850e-4c04-bce3-ce98e0ee567f",
-            "createdDateTimeUtc": "2021-08-23T17:33:06.4539736Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:33:14.3872677Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "40f6ee23-324d-49fd-b74b-fcdcbb410299",
-            "createdDateTimeUtc": "2021-08-23T17:32:44.9924751Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:32:51.3694131Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "1617b829-c0a3-4971-92d4-c2964babd030",
-            "createdDateTimeUtc": "2021-08-23T17:32:09.2406517Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:32:18.6614602Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a577fd72-5713-466c-8bc7-a1c81c9ce690",
-            "createdDateTimeUtc": "2021-08-23T17:31:48.2758423Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:31:53.1076136Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "3ef3e1fd-9489-4036-a76d-adf8121073a9",
-            "createdDateTimeUtc": "2021-08-23T17:28:59.4940221Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:29:05.3839228Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "795298f9-c99d-46ad-9be8-756171a64d47",
-            "createdDateTimeUtc": "2021-08-23T17:28:37.2538866Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:28:47.3380251Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "38136150-8f48-470f-93d0-efd2167ad0df",
-            "createdDateTimeUtc": "2021-08-23T17:28:06.0935977Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:28:15.7031915Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8f25593f-63ad-413a-9e0b-2f7b935e53f7",
-            "createdDateTimeUtc": "2021-08-23T17:27:42.2908433Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:27:51.9149141Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "032a3bb1-cdbf-4162-b3c7-7b3618379c7f",
-            "createdDateTimeUtc": "2021-08-23T17:27:09.7358524Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:27:19.680071Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ab879574-fcf3-41e3-b77e-6ea15d44b413",
-            "createdDateTimeUtc": "2021-08-23T17:26:47.3142089Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:26:56.5225722Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "98743da0-d863-41c4-bf57-56fa90b43eb4",
-            "createdDateTimeUtc": "2021-08-23T17:25:45.600667Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:25:49.2127676Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "183d6c88-fdae-4ea5-aa68-340f1ad84f77",
-            "createdDateTimeUtc": "2021-08-23T17:25:24.3498398Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:25:31.0082101Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "09960070-bdf0-46b1-99af-928e4a626f69",
-            "createdDateTimeUtc": "2021-08-23T17:24:31.4385114Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:24:35.5546122Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d8405784-fa6b-4267-b830-d8513a4f658d",
-            "createdDateTimeUtc": "2021-08-23T17:24:00.3396396Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:24:05.6562369Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "43b2701d-cae4-47b5-8287-f00ef452a7ce",
-            "createdDateTimeUtc": "2021-08-23T17:23:35.5630305Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:23:45.0431691Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "464de745-a68f-43db-b2af-61ccf62acc73",
-            "createdDateTimeUtc": "2021-08-23T17:20:31.3475187Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:20:40.1632632Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "3591ae2c-a6f1-44f4-8f8b-802ccb41fb0d",
-            "createdDateTimeUtc": "2021-08-23T17:19:56.3627557Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:20:04.8977529Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c5addf28-55a0-4cf7-a193-452c47aba219",
-            "createdDateTimeUtc": "2021-08-23T17:19:36.4200341Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:19:43.8168428Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "7570de08-6a5c-4a7d-9862-65db205744e2",
-            "createdDateTimeUtc": "2021-08-23T17:16:04.5109438Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:16:14.2207404Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "c2b12a8c-a64e-486a-8cb8-6f533fa14d9a",
-            "createdDateTimeUtc": "2021-08-23T17:12:39.1494425Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:12:48.7856928Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d0b76907-0261-4277-884c-f0823f9ec122",
-            "createdDateTimeUtc": "2021-08-23T17:12:16.3765099Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:12:22.483808Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b6bd137e-2a00-4427-bbda-215b9dcdbff1",
-            "createdDateTimeUtc": "2021-08-23T17:11:35.4166713Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:11:41.9836701Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "68dba74a-e802-486b-a389-28977cbd191c",
-            "createdDateTimeUtc": "2021-08-23T17:11:11.1146708Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:11:15.5935992Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "e1bc7687-0156-45f5-9428-e63c022dbafd",
-            "createdDateTimeUtc": "2021-08-23T17:09:30.3557278Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:09:38.0232919Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4ad591be-f6a3-424a-a368-a5ac3338c68e",
-            "createdDateTimeUtc": "2021-08-23T17:09:05.6068524Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:09:14.2949945Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "fb02d26f-4b4a-44c7-8512-1dc605b4760d",
-            "createdDateTimeUtc": "2021-08-23T17:08:01.2644983Z",
-            "lastActionDateTimeUtc": "2021-08-23T17:08:07.3426569Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "3fe85a3c-4db1-4dc5-baf8-b4956f535c2f",
-            "createdDateTimeUtc": "2021-08-23T16:59:08.3574297Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:59:16.4935524Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5afefe59-d1b7-4df4-ad58-0c7665aa1167",
-            "createdDateTimeUtc": "2021-08-23T16:58:22.7200327Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:58:30.9323045Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "da52052a-d809-46b3-a65f-4b0b4366462b",
-            "createdDateTimeUtc": "2021-08-23T16:57:50.2799217Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:57:55.6175942Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "bf798bca-7a93-47a3-a1ff-ccdf90015328",
-            "createdDateTimeUtc": "2021-08-23T16:53:14.9104004Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:53:20.0243492Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "de676d42-097d-499d-b424-63c44ff0fd85",
-            "createdDateTimeUtc": "2021-08-23T16:41:50.025133Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:41:55.021436Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "144d63b0-b972-47da-be48-e8369610d9d0",
-            "createdDateTimeUtc": "2021-08-23T16:41:24.3300611Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:41:27.9762437Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "ae29411c-ed5f-45e6-be84-e97c675599ed",
-            "createdDateTimeUtc": "2021-08-23T16:39:53.6000673Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:39:59.431849Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6924c556-8704-4b02-9148-45101d5a8791",
-            "createdDateTimeUtc": "2021-08-23T16:39:31.6451911Z",
-            "lastActionDateTimeUtc": "2021-08-23T16:39:36.1986712Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f1ce52fa-8234-47ec-9772-934b3a24bb70",
-            "createdDateTimeUtc": "2021-08-16T09:59:08.2257882Z",
-            "lastActionDateTimeUtc": "2021-08-16T09:59:14.4683656Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6e7b03fa-1abe-4524-82df-9efccd37df2f",
-            "createdDateTimeUtc": "2021-08-16T09:57:10.9273883Z",
-            "lastActionDateTimeUtc": "2021-08-16T09:57:17.7325207Z",
+            "id": "e31993ab-f254-49ec-afdd-3f0ba829dbbb",
+            "createdDateTimeUtc": "2021-08-26T13:05:57.8600906Z",
+            "lastActionDateTimeUtc": "2021-08-26T13:06:02.713723Z",
             "status": "Cancelled",
             "summary": {
               "total": 20,
@@ -3798,9 +1581,10 @@
     }
   ],
   "Variables": {
+    "DateTimeOffsetNow": "2021-08-26T16:07:24.9347283\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "611649423"
+    "RandomSeed": "72514056"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesOrderByCreatedOnTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesOrderByCreatedOnTest.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1360467463?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1360467463?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-6e1d4b84406b60449e9ea21b62f62887-37d3e2dffd740d4d-00",
+        "traceparent": "00-3b7ea608d616324a8a0f0c8b663c454e-e68f3114e332c84e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "2e7d3caadf736a8dabed3828bd007126",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:10 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:07:08 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:10 GMT",
-        "ETag": "\u00220x8D95786A8733CF8\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:11 GMT",
+        "Date": "Thu, 26 Aug 2021 12:07:08 GMT",
+        "ETag": "\u00220x8D9688A078ADF71\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:07:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "2e7d3caadf736a8dabed3828bd007126",
-        "x-ms-request-id": "05278379-a01e-003b-5d6f-896135000000",
+        "x-ms-request-id": "7724239d-401e-0033-6772-9a6334000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1360467463/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1360467463/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-105725458006354db99c9685477cb7a1-b4cccde416253d44-00",
+        "traceparent": "00-8bee3e874c48ac47b986ae74a36cde3b-283ecda0ad0f514a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "7cd987f8e9446ec120f024cf7edcb1fb",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:10 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:07:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:30:10 GMT",
-        "ETag": "\u00220x8D95786A8BC9CF2\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:11 GMT",
+        "Date": "Thu, 26 Aug 2021 12:07:08 GMT",
+        "ETag": "\u00220x8D9688A07C3D67A\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:07:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "7cd987f8e9446ec120f024cf7edcb1fb",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "052783d0-a01e-003b-2c6f-896135000000",
+        "x-ms-request-id": "77242405-401e-0033-4272-9a6334000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1399922601?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1399922601?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-0b06dbac32d97749b4334ac060133132-eda508d940b9df4b-00",
+        "traceparent": "00-780bcdd550f6644895af0a5935b02e68-4bf60ef82dcc7d4e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "e9b8490d51b9145bff5a190b8d490e6c",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:11 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:07:09 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:11 GMT",
-        "ETag": "\u00220x8D95786A8E28D9D\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:12 GMT",
+        "Date": "Thu, 26 Aug 2021 12:07:08 GMT",
+        "ETag": "\u00220x8D9688A07DC90BF\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:07:09 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "e9b8490d51b9145bff5a190b8d490e6c",
-        "x-ms-request-id": "05278482-a01e-003b-4a6f-896135000000",
+        "x-ms-request-id": "77242489-401e-0033-3c72-9a6334000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e8971129fb1fe24fa565ef3a43122097-312c61903ffce840-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2e5fe4774482fb45982af781e82f1b44-30dc876a9f589d46-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "675592aac2627ac00f0e83babdecce3b",
         "x-ms-return-client-request-id": "true"
       },
@@ -116,57 +116,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "49ce4ab2-11d1-43a4-81ef-f71f26a93855",
+        "apim-request-id": "70ee9e0e-ae7f-49de-b886-7ff8c090e9a6",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:12 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401",
+        "Date": "Thu, 26 Aug 2021 12:07:10 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "49ce4ab2-11d1-43a4-81ef-f71f26a93855"
+        "X-RequestId": "70ee9e0e-ae7f-49de-b886-7ff8c090e9a6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "b6b07f3c3cb8363f7d67458fa86292a7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8c1d1c83-090f-42cb-b5a7-a9ca9eeabca3",
+        "apim-request-id": "96fd33cd-0bb0-4b7b-add2-9187b5c47891",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:12 GMT",
-        "ETag": "\u002213A376C05093FB01CFAABA0BABDA36FB93AA116C2180EE5D84E97A9C894BF77D\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:10 GMT",
+        "ETag": "\u002258AAB5C8A5856D364500CDECBEDB4D282DB8E76B03F6D48B8EE41A3495255394\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8c1d1c83-090f-42cb-b5a7-a9ca9eeabca3"
+        "X-RequestId": "96fd33cd-0bb0-4b7b-add2-9187b5c47891"
       },
       "ResponseBody": {
-        "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-        "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:12.573746Z",
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:11.1220514Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,137 +180,137 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "4ad36315935c4a47893ed9abcea05613",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "619cd49e-ed68-4a35-910f-e45024aad3c8",
+        "apim-request-id": "bdf5469d-3394-4f8a-8cc1-72cb51b4b9f3",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:14 GMT",
-        "ETag": "\u00226F26221B78943667180B1B8A1EEE0B9A2AC65549C62625AC8BDAE52557B0CAB0\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:11 GMT",
+        "ETag": "\u0022BFD136C7F973D7E2BDAAE62F98BAFA82E88ED78966FA475B7F7A479333772789\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "619cd49e-ed68-4a35-910f-e45024aad3c8"
+        "X-RequestId": "bdf5469d-3394-4f8a-8cc1-72cb51b4b9f3"
       },
       "ResponseBody": {
-        "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-        "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:14.1123055Z",
-        "status": "Running",
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:11.9445044Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "0ecede8b58986db3531fe9fb7d31d1ac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b762f892-9b88-4f8c-ba13-bf3ca9022378",
+        "apim-request-id": "db9fe401-7e5c-4e2f-b58e-51eb8b2fb451",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:15 GMT",
-        "ETag": "\u0022506F6823F96939A1033F3DBB9F0DD23530E5E27FC02B1B9F44DCF1C0B265967F\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:14 GMT",
+        "ETag": "\u0022BFD136C7F973D7E2BDAAE62F98BAFA82E88ED78966FA475B7F7A479333772789\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b762f892-9b88-4f8c-ba13-bf3ca9022378"
+        "X-RequestId": "db9fe401-7e5c-4e2f-b58e-51eb8b2fb451"
       },
       "ResponseBody": {
-        "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-        "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:14.4305144Z",
-        "status": "Running",
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:11.9445044Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "5aa5db7c8418a9df37652d7a629367dc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "10ec8d9c-801b-4a08-92f8-1bfd43b68b71",
+        "apim-request-id": "76ab5a82-2558-4238-a473-2943e290ccaf",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:16 GMT",
-        "ETag": "\u0022506F6823F96939A1033F3DBB9F0DD23530E5E27FC02B1B9F44DCF1C0B265967F\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:15 GMT",
+        "ETag": "\u00226D587DAA8D0E13E54E609494E0DDC64F5F12F3EBD60BDADA3BDAA5172B54983C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "10ec8d9c-801b-4a08-92f8-1bfd43b68b71"
+        "X-RequestId": "76ab5a82-2558-4238-a473-2943e290ccaf"
       },
       "ResponseBody": {
-        "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-        "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:14.4305144Z",
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:14.7086982Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -324,41 +324,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "ca0332108393bd0eb066f73ca94ccd57",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4e82015-6c31-4404-8fd7-ce917ec400b5",
+        "apim-request-id": "b12cfe4e-6ff8-4ea8-abd0-5bc9ba90b7ab",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
-        "Content-Length": "289",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:18 GMT",
-        "ETag": "\u0022506F6823F96939A1033F3DBB9F0DD23530E5E27FC02B1B9F44DCF1C0B265967F\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:16 GMT",
+        "ETag": "\u00229093EB0840EEE1EA16495A59EBF97D6312AB9C717D66B2D9CB4AF0389106B64D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e4e82015-6c31-4404-8fd7-ce917ec400b5"
+        "X-RequestId": "b12cfe4e-6ff8-4ea8-abd0-5bc9ba90b7ab"
       },
       "ResponseBody": {
-        "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-        "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:14.4305144Z",
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:15.6824002Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -372,26 +372,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "f22f2d6cfcfb07fbfe25d6332a380bbf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "86cb2983-5dd3-45d8-9692-8607b96052bd",
+        "apim-request-id": "cc7dc227-5071-4f43-8f22-b9e83e3f883b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:19 GMT",
-        "ETag": "\u0022506F6823F96939A1033F3DBB9F0DD23530E5E27FC02B1B9F44DCF1C0B265967F\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:17 GMT",
+        "ETag": "\u00229093EB0840EEE1EA16495A59EBF97D6312AB9C717D66B2D9CB4AF0389106B64D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -401,12 +401,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "86cb2983-5dd3-45d8-9692-8607b96052bd"
+        "X-RequestId": "cc7dc227-5071-4f43-8f22-b9e83e3f883b"
       },
       "ResponseBody": {
-        "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-        "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:14.4305144Z",
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:15.6824002Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -420,74 +420,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "4bea0db7072ef818cce7aab18da2ffeb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2d874265-6348-4fd6-ac2c-821d90fbb767",
+        "apim-request-id": "33c26dbe-f465-4a59-8d99-2f5b26abc228",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:20 GMT",
-        "ETag": "\u0022404DB5389F592677ABB72EE74B9AB7FA2DDA39B838A76B2FA40C899DE3C0358C\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:18 GMT",
+        "ETag": "\u00229093EB0840EEE1EA16495A59EBF97D6312AB9C717D66B2D9CB4AF0389106B64D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2d874265-6348-4fd6-ac2c-821d90fbb767"
+        "X-RequestId": "33c26dbe-f465-4a59-8d99-2f5b26abc228"
       },
       "ResponseBody": {
-        "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-        "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:14.4305144Z",
-        "status": "Succeeded",
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:15.6824002Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
-          "success": 1,
-          "inProgress": 0,
+          "success": 0,
+          "inProgress": 1,
           "notYetStarted": 0,
           "cancelled": 0,
-          "totalCharacterCharged": 16
+          "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1375b0c8-28f6-4118-b970-72b8c417c401/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "350ed598756414e136fbcb6eacdb9277",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c1556cf2-adc4-485b-8ff1-bf494749f067",
+        "apim-request-id": "6dc90578-05d4-4469-981e-d7fdf2d936ec",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:20 GMT",
-        "ETag": "\u00228EC49941848C6A1BF24EAED234FBE76EF3F3424D3E3A5E67359FA106DB6209B0\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:20 GMT",
+        "ETag": "\u00229093EB0840EEE1EA16495A59EBF97D6312AB9C717D66B2D9CB4AF0389106B64D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -497,34 +497,130 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c1556cf2-adc4-485b-8ff1-bf494749f067"
+        "X-RequestId": "6dc90578-05d4-4469-981e-d7fdf2d936ec"
+      },
+      "ResponseBody": {
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:15.6824002Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9c85375a816164291436261451497a5c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bae6dcd7-11d8-465f-8df5-f538a8075228",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:21 GMT",
+        "ETag": "\u002206874C6729C41DDEC19DAEC5DCCA64AFAC3F0DAA0CD2105E9C44C414D8107C33\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "bae6dcd7-11d8-465f-8df5-f538a8075228"
+      },
+      "ResponseBody": {
+        "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+        "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:20.8963603Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 1,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 16
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5217e9b3-97de-49d6-865a-c1d4ccf8e01e/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "559aea25d529425a2cd614323baa4bf1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "53f645e5-3c4d-47f0-9fbd-3c761f52a3ab",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:21 GMT",
+        "ETag": "\u0022BAEAB1055FDF042F12CD2C9ABCE3D81368074EFBA2A6DE16FF11A28D6BA11DD7\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "53f645e5-3c4d-47f0-9fbd-3c761f52a3ab"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target1399922601/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1360467463/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:30:14.1219687Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:20.089058Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1399922601/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1360467463/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:07:14.7163514Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:20.8963534Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53e5-0000-0000-0000-000000000000",
+            "id": "000b4681-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target2054038618?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target143864149?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-216c8236a707f149a4cd07c0b2df8808-14101756d6b16849-00",
+        "traceparent": "00-24879e45dd4f964f9b299f4ae053b24c-f81e5bea3b0c984e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "619c85372981146436261451497a5c25",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:20 GMT",
+        "x-ms-client-request-id": "1d5557328a63ab16a9202e4fcdc2ed81",
+        "x-ms-date": "Thu, 26 Aug 2021 12:07:21 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -532,27 +628,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:20 GMT",
-        "ETag": "\u00220x8D95786AE6D666D\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:21 GMT",
+        "Date": "Thu, 26 Aug 2021 12:07:21 GMT",
+        "ETag": "\u00220x8D9688A0F30BF16\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:07:21 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "619c85372981146436261451497a5c25",
-        "x-ms-request-id": "05279d67-a01e-003b-596f-896135000000",
+        "x-ms-client-request-id": "1d5557328a63ab16a9202e4fcdc2ed81",
+        "x-ms-request-id": "77243794-401e-0033-3572-9a6334000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-91cdf015efc05c4fb9cf802be8cdc105-6bf32b9749574e4f-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "29559aea5ad52c42d614323baa4bf155",
+        "traceparent": "00-2b21baf56665fc42968ce0a68996404e-8094de2a2c3c134b-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "40c1486f4e3ddc8542708a6df7286aea",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -572,138 +668,42 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "106f55fa-f6c1-4347-a58e-07ffbf23fdf8",
+        "apim-request-id": "ba74e817-ba44-4530-ba24-365eec029284",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:21 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+        "Date": "Thu, 26 Aug 2021 12:07:22 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "106f55fa-f6c1-4347-a58e-07ffbf23fdf8"
+        "X-RequestId": "ba74e817-ba44-4530-ba24-365eec029284"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1d5557328a63ab16a9202e4fcdc2ed81",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c4e0de09-7130-4a6f-8f95-2c00f3bb45d9",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:21 GMT",
-        "ETag": "\u00224859E6E295AA244B77394F6B605BF0AE63EE36155467308A7EAFB7AD3D8F7F6D\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c4e0de09-7130-4a6f-8f95-2c00f3bb45d9"
-      },
-      "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:21.8202601Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 0,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "40c1486f4e3ddc8542708a6df7286aea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3014d571-b1e8-4934-8ba0-f8a5c42b312b",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:23 GMT",
-        "ETag": "\u002216A33E3A2C72DD3D88EB124196F7713A25DA5A622CF923EF0A9D8766D46C0FE2\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3014d571-b1e8-4934-8ba0-f8a5c42b312b"
-      },
-      "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:22.1951002Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "f21ebe343e2460c284a97fb52cf35e13",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ec2cf7db-78ce-4b96-b558-e2b34d75bdee",
+        "apim-request-id": "9d7a4c91-6352-4c5f-a606-c521fa1a2704",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:24 GMT",
-        "ETag": "\u002216A33E3A2C72DD3D88EB124196F7713A25DA5A622CF923EF0A9D8766D46C0FE2\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:22 GMT",
+        "ETag": "\u002266DA941E22E2A63D60A8E61DB4AF0F17E44F419FD9668FC06721B7685D14C249\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -713,60 +713,60 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ec2cf7db-78ce-4b96-b558-e2b34d75bdee"
+        "X-RequestId": "9d7a4c91-6352-4c5f-a606-c521fa1a2704"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:22.1951002Z",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:22.2020288Z",
         "status": "NotStarted",
         "summary": {
-          "total": 1,
+          "total": 0,
           "failed": 0,
           "success": 0,
           "inProgress": 0,
-          "notYetStarted": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "61ccb027b08ae417d179daf2ffa9b481",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "86b52e4d-3111-404a-bfeb-3e8f913728b9",
+        "apim-request-id": "b0fe9dcc-3746-4e44-8831-45eb1b4cd2cc",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:25 GMT",
-        "ETag": "\u002216A33E3A2C72DD3D88EB124196F7713A25DA5A622CF923EF0A9D8766D46C0FE2\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:23 GMT",
+        "ETag": "\u00223A4E28965AC5DFDA95D3FDEC8225E1FAE08026972ECD7EC7CA78E0A55559435C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "86b52e4d-3111-404a-bfeb-3e8f913728b9"
+        "X-RequestId": "b0fe9dcc-3746-4e44-8831-45eb1b4cd2cc"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:22.1951002Z",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:22.6829336Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -780,26 +780,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "0e1a44b5fba4305d8561bc94cecfb04f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "77b1de61-15f8-4f0a-9a81-7387a320274a",
+        "apim-request-id": "c706191b-beb2-41b9-8753-c5a222e522e0",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:26 GMT",
-        "ETag": "\u0022A6C7CCA14EA0DCAB6BD5FEF2CC87759A60B553EBF3607DB710786A157A90539A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:24 GMT",
+        "ETag": "\u00223A4E28965AC5DFDA95D3FDEC8225E1FAE08026972ECD7EC7CA78E0A55559435C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -809,93 +809,93 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "77b1de61-15f8-4f0a-9a81-7387a320274a"
+        "X-RequestId": "c706191b-beb2-41b9-8753-c5a222e522e0"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
-        "status": "Running",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:22.6829336Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "46467711085b8460a73920ab63cf61da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0c738070-d4b5-4d49-8317-c9ba00c671a8",
+        "apim-request-id": "3dff3a0f-2d60-4f11-b387-9f7a12675f1e",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:27 GMT",
-        "ETag": "\u0022A6C7CCA14EA0DCAB6BD5FEF2CC87759A60B553EBF3607DB710786A157A90539A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:26 GMT",
+        "ETag": "\u00223A4E28965AC5DFDA95D3FDEC8225E1FAE08026972ECD7EC7CA78E0A55559435C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0c738070-d4b5-4d49-8317-c9ba00c671a8"
+        "X-RequestId": "3dff3a0f-2d60-4f11-b387-9f7a12675f1e"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
-        "status": "Running",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:22.6829336Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "e8fffef450d82b6f539cdc28f4821602",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2dc04cc7-8eb2-48f6-b8cf-bfa1527e2a60",
+        "apim-request-id": "d65f37cc-9579-4c53-9193-1ff7b503ce9b",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:29 GMT",
-        "ETag": "\u0022A6C7CCA14EA0DCAB6BD5FEF2CC87759A60B553EBF3607DB710786A157A90539A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:27 GMT",
+        "ETag": "\u00223A4E28965AC5DFDA95D3FDEC8225E1FAE08026972ECD7EC7CA78E0A55559435C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -905,93 +905,93 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2dc04cc7-8eb2-48f6-b8cf-bfa1527e2a60"
+        "X-RequestId": "d65f37cc-9579-4c53-9193-1ff7b503ce9b"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
-        "status": "Running",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:22.6829336Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "88e18ac86d63ad25e396666adab2ccb5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "63bcda5c-e8c4-42cc-b559-85b209629213",
+        "apim-request-id": "925aea36-b2bc-4cc1-8fe0-7449357689d9",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:30 GMT",
-        "ETag": "\u0022A6C7CCA14EA0DCAB6BD5FEF2CC87759A60B553EBF3607DB710786A157A90539A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:28 GMT",
+        "ETag": "\u00223A4E28965AC5DFDA95D3FDEC8225E1FAE08026972ECD7EC7CA78E0A55559435C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "63bcda5c-e8c4-42cc-b559-85b209629213"
+        "X-RequestId": "925aea36-b2bc-4cc1-8fe0-7449357689d9"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
-        "status": "Running",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:22.6829336Z",
+        "status": "NotStarted",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
+          "inProgress": 0,
+          "notYetStarted": 1,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "d09fe1ffc8d0c076071af3bf2c378f24",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d40cf2ac-3872-4bf3-b815-1ae145e5a0db",
+        "apim-request-id": "e4de7ad0-fb6c-4a1a-9766-bfa7ada5bf7a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:31 GMT",
-        "ETag": "\u0022A6C7CCA14EA0DCAB6BD5FEF2CC87759A60B553EBF3607DB710786A157A90539A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:32 GMT",
+        "ETag": "\u0022D70B29E8A466C0A473CE12F5A998C4AC7851843D84881818DF1B98B10C7241F7\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1001,12 +1001,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d40cf2ac-3872-4bf3-b815-1ae145e5a0db"
+        "X-RequestId": "e4de7ad0-fb6c-4a1a-9766-bfa7ada5bf7a"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:30.4288405Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -1020,41 +1020,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "d8e21e23d9ee8777d9520442ea0550a1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a58cd141-bb41-4b47-9891-09fcb45aaf7c",
+        "apim-request-id": "b25acb5e-f779-4a61-8d96-d3137d96b16a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:32 GMT",
-        "ETag": "\u0022A6C7CCA14EA0DCAB6BD5FEF2CC87759A60B553EBF3607DB710786A157A90539A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:33 GMT",
+        "ETag": "\u0022D70B29E8A466C0A473CE12F5A998C4AC7851843D84881818DF1B98B10C7241F7\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a58cd141-bb41-4b47-9891-09fcb45aaf7c"
+        "X-RequestId": "b25acb5e-f779-4a61-8d96-d3137d96b16a"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:30.4288405Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -1068,26 +1068,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "132926cf46e30031142080497a6580ac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "52398130-a878-4e51-b519-0b192c5731ba",
+        "apim-request-id": "391e9965-b97c-46dc-8606-97e70ed8b46d",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:34 GMT",
-        "ETag": "\u002258DAA0B701E3EC6AFB5216D936E6719821365DF34935E02434DF453004889BCA\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:35 GMT",
+        "ETag": "\u0022D70B29E8A466C0A473CE12F5A998C4AC7851843D84881818DF1B98B10C7241F7\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1097,12 +1097,60 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "52398130-a878-4e51-b519-0b192c5731ba"
+        "X-RequestId": "391e9965-b97c-46dc-8606-97e70ed8b46d"
       },
       "ResponseBody": {
-        "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-        "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:30.4288405Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bc464206f3cf26c76918f77ec334d601",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "35d52787-86d5-405b-89e4-482b5e28a912",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:36 GMT",
+        "ETag": "\u0022E40EB996AFC75FB589BB36519AD358D375A899BAF58DE1B1D6AD35F5AD79109D\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "35d52787-86d5-405b-89e4-482b5e28a912"
+      },
+      "ResponseBody": {
+        "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+        "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:36.031538Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -1116,63 +1164,63 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/193f7f31-4a3e-4dac-b3d5-743038b2372c/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/5e0418c0-d47b-44f7-b621-1acb709f6083/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bc464206f3cf26c76918f77ec334d601",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "05f052c97c0edd41ece2c4cd582e0c73",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9e8d94fb-52fd-47de-a0c3-430034d25d3d",
+        "apim-request-id": "9aab6c1d-0ab5-412d-8264-34b12e8a7def",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:35 GMT",
-        "ETag": "\u00220C0177DE2A182C9226EB370BFD6329B53CE2F0C1505B9AC5802F8040E3B1AA09\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:36 GMT",
+        "ETag": "\u00224DCEE34BA41CB5DED4E7ABB67574FE3BC6D4CC268DCEE78EC0A2EF7F41D72CA0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9e8d94fb-52fd-47de-a0c3-430034d25d3d"
+        "X-RequestId": "9aab6c1d-0ab5-412d-8264-34b12e8a7def"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target2054038618/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1360467463/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:30:26.6240465Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:34.1766931Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target143864149/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1360467463/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:07:29.4765685Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:36.0315316Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a53e6-0000-0000-0000-000000000000",
+            "id": "000b4682-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target596673481?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target417640913?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-bf708302d46503498408887e8b608897-aee897fef0dc2c48-00",
+        "traceparent": "00-6009f75950ec9445a11342e47141cb93-d695a454fe33584e-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "0e05f052417cecdde2c4cd582e0c73d1",
-        "x-ms-date": "Wed, 04 Aug 2021 20:30:34 GMT",
+        "x-ms-client-request-id": "bea83c58d1945edb03a9ca4fb33cdf4a",
+        "x-ms-date": "Thu, 26 Aug 2021 12:07:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -1180,27 +1228,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:34 GMT",
-        "ETag": "\u00220x8D95786B6D927DD\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:30:35 GMT",
+        "Date": "Thu, 26 Aug 2021 12:07:36 GMT",
+        "ETag": "\u00220x8D9688A185371AF\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:07:37 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "0e05f052417cecdde2c4cd582e0c73d1",
-        "x-ms-request-id": "0527b880-a01e-003b-2a6f-896135000000",
+        "x-ms-client-request-id": "bea83c58d1945edb03a9ca4fb33cdf4a",
+        "x-ms-request-id": "77244a9c-401e-0033-5872-9a6334000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0fab9a61fa8489429bd564b16edffcfb-f88619a3f1bfdd48-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bea83c58d1945edb03a9ca4fb33cdf4a",
+        "traceparent": "00-8ee2681ffa7cdd40a8dc1cffb3915e13-58446e1757ad0342-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "74277f7f9e7b008969d0ed2efacd3b0b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1220,57 +1268,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cf76960e-b7f0-47c8-89cf-6d6d18610296",
+        "apim-request-id": "62f193b5-8730-4d65-998c-36e843622b2d",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:30:35 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
+        "Date": "Thu, 26 Aug 2021 12:07:37 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cf76960e-b7f0-47c8-89cf-6d6d18610296"
+        "X-RequestId": "62f193b5-8730-4d65-998c-36e843622b2d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "74277f7f9e7b008969d0ed2efacd3b0b",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f86bac83432e803514a70ad3768d38a6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "efa11fc7-0559-4e31-b05d-7517867f0ca7",
+        "apim-request-id": "84555b13-8af8-499b-bdda-a4cfd143b699",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
-        "Content-Length": "292",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:36 GMT",
-        "ETag": "\u0022E9B56DDD49466C1FD0FD471F9A14A91CF9CC16A86AF22BC05221168C03788CF3\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:37 GMT",
+        "ETag": "\u00221831E2575ACD62401DD0D0C941B97566FDEB99013F958B73EABA4B2D670631D3\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "efa11fc7-0559-4e31-b05d-7517867f0ca7"
+        "X-RequestId": "84555b13-8af8-499b-bdda-a4cfd143b699"
       },
       "ResponseBody": {
-        "id": "eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-        "createdDateTimeUtc": "2021-08-04T20:30:35.9657621Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:35.9657624Z",
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:37.530025Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -1284,41 +1332,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f86bac83432e803514a70ad3768d38a6",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "aed982e5fee4ba56b2a754c3e4ad6435",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4234a0ba-ac95-48b3-87a0-58f21768fe0d",
+        "apim-request-id": "960f1a6c-8139-45f5-a3a4-5b7966cf90d8",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:37 GMT",
-        "ETag": "\u0022DB57218EC909025EF469E10BF2A1636EB28FD0EF2717BAF8132EABED0090CEC4\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:38 GMT",
+        "ETag": "\u0022ECCB08ECC1C91885AAE8C9199B16D547367B18F11B66C2958F9FE7A50096A140\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4234a0ba-ac95-48b3-87a0-58f21768fe0d"
+        "X-RequestId": "960f1a6c-8139-45f5-a3a4-5b7966cf90d8"
       },
       "ResponseBody": {
-        "id": "eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-        "createdDateTimeUtc": "2021-08-04T20:30:35.9657621Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:36.230525Z",
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:38.0256296Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -1332,26 +1380,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "aed982e5fee4ba56b2a754c3e4ad6435",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "06cbbe6de7d03c1c4aa760d393b589db",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2816211d-9a95-4099-89a0-9cd26fa1d97a",
+        "apim-request-id": "40c53754-4f89-4f16-9376-c2d64af993bf",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:38 GMT",
-        "ETag": "\u0022DB57218EC909025EF469E10BF2A1636EB28FD0EF2717BAF8132EABED0090CEC4\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:39 GMT",
+        "ETag": "\u0022A3547566D1DB0F0103B2E2D16B9CE5801C537FD59D0E96B0434D672D5ED16C66\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1361,60 +1409,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2816211d-9a95-4099-89a0-9cd26fa1d97a"
+        "X-RequestId": "40c53754-4f89-4f16-9376-c2d64af993bf"
       },
       "ResponseBody": {
-        "id": "eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-        "createdDateTimeUtc": "2021-08-04T20:30:35.9657621Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:36.230525Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "06cbbe6de7d03c1c4aa760d393b589db",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0580cded-1f03-4810-a481-c1aa03207273",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:39 GMT",
-        "ETag": "\u0022355722F141330EABB9E2C77FB912CD88289A530339A57C4167A2D3641AF333B2\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0580cded-1f03-4810-a481-c1aa03207273"
-      },
-      "ResponseBody": {
-        "id": "eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-        "createdDateTimeUtc": "2021-08-04T20:30:35.9657621Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:39.4948082Z",
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:39.7812531Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -1428,26 +1428,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "774947988cf3842756b14586ee719c67",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ab581717-4db5-45a8-9d4a-04e765fdc233",
+        "apim-request-id": "3064b31c-4763-4ff1-a0d8-28d0f895bb59",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:40 GMT",
-        "ETag": "\u00229DF66192A69E48C2D878BCB9391CC73728F7FEBF89A7F3BDB93ED4DE982A734A\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:41 GMT",
+        "ETag": "\u00226EA7FD57DE96C9C4DB48F9BC3CF601F520F42BC6B5ED67349A9B94CA9C9152D9\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "3064b31c-4763-4ff1-a0d8-28d0f895bb59"
+      },
+      "ResponseBody": {
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:40.3792548Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b865d44231c1fdd5669d633d9e8226fc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2eb08811-971d-4ed4-8295-e33ef4ba4bbe",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:42 GMT",
+        "ETag": "\u00226EA7FD57DE96C9C4DB48F9BC3CF601F520F42BC6B5ED67349A9B94CA9C9152D9\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1457,12 +1505,252 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ab581717-4db5-45a8-9d4a-04e765fdc233"
+        "X-RequestId": "2eb08811-971d-4ed4-8295-e33ef4ba4bbe"
       },
       "ResponseBody": {
-        "id": "eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-        "createdDateTimeUtc": "2021-08-04T20:30:35.9657621Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:30:39.4948082Z",
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:40.3792548Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9c2b791dec63e1429747b01ea2954dd8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cfd8ebf3-7d9b-43f2-a51d-c7c327369509",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:43 GMT",
+        "ETag": "\u00226EA7FD57DE96C9C4DB48F9BC3CF601F520F42BC6B5ED67349A9B94CA9C9152D9\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "cfd8ebf3-7d9b-43f2-a51d-c7c327369509"
+      },
+      "ResponseBody": {
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:40.3792548Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "be90f80ad1506619714b115628e9e5d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ea7769a4-81a6-42b1-8789-b44487ba69ec",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:44 GMT",
+        "ETag": "\u00226EA7FD57DE96C9C4DB48F9BC3CF601F520F42BC6B5ED67349A9B94CA9C9152D9\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ea7769a4-81a6-42b1-8789-b44487ba69ec"
+      },
+      "ResponseBody": {
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:40.3792548Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7469488aff4656049284207a81b75bd1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9affe095-5ee9-4c23-9367-cfe2cfc3d09d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:46 GMT",
+        "ETag": "\u00226EA7FD57DE96C9C4DB48F9BC3CF601F520F42BC6B5ED67349A9B94CA9C9152D9\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9affe095-5ee9-4c23-9367-cfe2cfc3d09d"
+      },
+      "ResponseBody": {
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:40.3792548Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a6338a4f68f14bac5fc42b17dbebb8ad",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "44f988ab-b1ea-40dd-bdb4-c0df344c39e0",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:47 GMT",
+        "ETag": "\u00226EA7FD57DE96C9C4DB48F9BC3CF601F520F42BC6B5ED67349A9B94CA9C9152D9\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "44f988ab-b1ea-40dd-bdb4-c0df344c39e0"
+      },
+      "ResponseBody": {
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:40.3792548Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5a93db61d92c0a92f43a2bcbb09fe5ba",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c13e1738-460e-4ff9-9371-5a81984fe996",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:07:48 GMT",
+        "ETag": "\u0022566BB8A23B40B1CBF978CD3EA4D08D732698BF09BD21A971EA4E78059E316A39\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c13e1738-460e-4ff9-9371-5a81984fe996"
+      },
+      "ResponseBody": {
+        "id": "de191afa-044c-4302-860f-fead9320bfef",
+        "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:07:48.768721Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -1476,4826 +1764,92 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/eb3d2d8e-cad5-49df-a85c-45ea76ee1a33/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de191afa-044c-4302-860f-fead9320bfef/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b865d44231c1fdd5669d633d9e8226fc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6cc0bb82-9dda-47d3-961f-0f1d78242740",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:41 GMT",
-        "ETag": "\u0022D4BD56E19D49E1FB46217B9A2239BC280990ED2AC30C0D0D5292F5321343ADD7\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6cc0bb82-9dda-47d3-961f-0f1d78242740"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target596673481/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1360467463/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:30:39.1047132Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:41.3983269Z",
-            "status": "Succeeded",
-            "to": "fr",
-            "progress": 1,
-            "id": "000a53e7-0000-0000-0000-000000000000",
-            "characterCharged": 16
-          }
-        ]
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-58c27e2a98129440a1402709f11e4b67-a0ae5a08438c774f-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9c2b791dec63e1429747b01ea2954dd8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ae3d47e3-ea18-4f75-b8d9-11866503c51a",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:41 GMT",
-        "ETag": "\u0022D352D4431BE1F5DCF1FDBF39ABDA3D890EAA077AFFB24DD5924A3EB8F9117546\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ae3d47e3-ea18-4f75-b8d9-11866503c51a"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-            "createdDateTimeUtc": "2021-08-04T20:30:35.9657621Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:39.4948082Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-            "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-            "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:14.4305144Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6606d70-e903-4f08-a80d-3d1b65c07303",
-            "createdDateTimeUtc": "2021-08-04T20:30:06.5979195Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:10.7837251Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-            "createdDateTimeUtc": "2021-08-04T20:29:50.3509191Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:51.8150261Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-            "createdDateTimeUtc": "2021-08-04T20:29:43.0044925Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:46.0940111Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-            "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:39.0415286Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "129932a4-ccc4-4702-ae64-ed24fa9ebe30",
-            "createdDateTimeUtc": "2021-08-04T20:29:22.21029Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:23.790485Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-            "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:16.7676912Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-            "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:09.8583078Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-            "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:28:57.0357411Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "de3ae1b9-065c-4a2b-9da3-a413d0e1d828",
-            "createdDateTimeUtc": "2021-08-04T20:13:20.3289712Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:21.8009118Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5e58ffb7-c561-4ada-908a-5fb618214b57",
-            "createdDateTimeUtc": "2021-08-04T20:13:14.1830952Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:16.2626995Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "7349a49c-f2e4-4c35-938e-976306fdf0ec",
-            "createdDateTimeUtc": "2021-08-04T20:13:07.7204022Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:09.4175921Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "dad50132-5081-4e87-9cdb-8305960adaad",
-            "createdDateTimeUtc": "2021-08-04T20:13:00.3134951Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:02.1869029Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5149a480-1a90-4483-b9fe-8c0ae356c975",
-            "createdDateTimeUtc": "2021-08-04T20:12:48.8123001Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:12:52.257366Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "95d1a6fa-cbcc-4eda-b8c5-7f9dea903155",
-            "createdDateTimeUtc": "2021-08-04T20:12:39.6819361Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:12:42.109702Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "ee205c17-3434-4372-9ec8-093d3fc2ab0e",
-            "createdDateTimeUtc": "2021-08-03T21:39:22.1215914Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:24.0088345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "034ac505-8e05-45e9-b69d-4ae5db5c3206",
-            "createdDateTimeUtc": "2021-08-03T21:39:15.57059Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:16.9287241Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1c2e403d-4f5f-4176-ac0b-d6525df7993d",
-            "createdDateTimeUtc": "2021-08-03T21:39:08.8759005Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:09.8373116Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1f96fca2-aaec-427c-92d0-fc8d43372768",
-            "createdDateTimeUtc": "2021-08-03T21:39:02.4121988Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:05.2080796Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "52fa5dc7-49d0-4490-b402-1817331f10f9",
-            "createdDateTimeUtc": "2021-08-03T21:38:57.2193344Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:58.2127609Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "98452bfa-797a-44c2-9bb2-d7fd159fab0d",
-            "createdDateTimeUtc": "2021-08-03T21:38:51.6547083Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:54.3057302Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "32aebb1f-9dd9-4bf4-a684-514bde841fd8",
-            "createdDateTimeUtc": "2021-08-03T21:38:47.6125244Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:53.9775319Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8e25b211-27f2-4793-99d0-6e47f55427a8",
-            "createdDateTimeUtc": "2021-08-03T21:38:30.9134208Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:33.1131258Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "45af44ab-ab27-4533-be94-d14fdc2f1d69",
-            "createdDateTimeUtc": "2021-08-03T21:38:23.1840352Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:26.0456158Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5fe83ec6-8231-4c42-8f7e-a04b75c0fa20",
-            "createdDateTimeUtc": "2021-08-03T21:38:16.5690668Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:19.2704212Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2dcc3a07-d808-4004-8cbc-f8d7047be6ea",
-            "createdDateTimeUtc": "2021-08-03T21:38:08.8344934Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:12.1744445Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d44ccbb4-7c5e-4230-8641-699df49bc974",
-            "createdDateTimeUtc": "2021-08-03T21:38:03.662895Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:05.099967Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b911d708-f339-4c49-b387-3a93b892edca",
-            "createdDateTimeUtc": "2021-08-03T21:37:55.9487829Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:58.091697Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3e1a9fd7-eefa-4140-bb3d-0cae619045c8",
-            "createdDateTimeUtc": "2021-08-03T21:37:49.2093973Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:51.1527605Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5c031e55-d105-4fcd-bddf-341af3c07de3",
-            "createdDateTimeUtc": "2021-08-03T21:37:42.4444943Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:44.066063Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f422877d-d674-4826-855b-6b918a1f8448",
-            "createdDateTimeUtc": "2021-08-03T21:37:35.5232446Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:37.1398344Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6d647efa-7b96-4bb4-b74a-76f2cf63b647",
-            "createdDateTimeUtc": "2021-08-03T21:37:28.0253539Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:30.0244215Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9530409a-3f1c-4184-a932-62f7586ca48c",
-            "createdDateTimeUtc": "2021-08-03T21:37:21.3477618Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:23.0535345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "02188384-3e1d-4fd5-b7b2-1c436155a427",
-            "createdDateTimeUtc": "2021-08-03T21:37:14.5363644Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:15.8789238Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e462cb0b-c257-4a03-8704-bafedb9a34ec",
-            "createdDateTimeUtc": "2021-08-03T21:37:06.740111Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:08.9139737Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9c2aff22-052b-4fe3-a77a-0e3d002157cb",
-            "createdDateTimeUtc": "2021-08-03T21:37:00.1515856Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:01.782922Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cbd315d5-9d09-4805-aeaf-dbf5a09b3f7f",
-            "createdDateTimeUtc": "2021-08-03T21:36:50.9777091Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:54.8378022Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f434c3d-7dd9-4305-8231-52ea7ef8822a",
-            "createdDateTimeUtc": "2021-08-03T21:36:37.1050378Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:39.7392021Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9bb6ced9-7570-404b-ae57-f0f6239284ff",
-            "createdDateTimeUtc": "2021-08-03T21:36:17.4274204Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:24.6427413Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c55e7e92-9f89-4061-b896-c719864f6227",
-            "createdDateTimeUtc": "2021-08-03T21:36:09.0638051Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:10.9653857Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e7d6e45d-7068-410e-b993-c18ad571354f",
-            "createdDateTimeUtc": "2021-08-03T21:35:56.6699145Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:03.8654828Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce58c3d3-4f45-498d-b593-6a5e7e7bd192",
-            "createdDateTimeUtc": "2021-08-03T21:35:47.9412218Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:49.5951191Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1eb03d70-54fd-4310-a4bc-de808f681a39",
-            "createdDateTimeUtc": "2021-08-03T21:35:41.0214036Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:42.5156289Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0554a9e0-53ab-49cc-8f1b-6d102523e16e",
-            "createdDateTimeUtc": "2021-08-03T21:35:34.1373856Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:35.4992558Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2219aa8b-281e-4c42-9605-10c76cc72913",
-            "createdDateTimeUtc": "2021-08-03T21:35:26.2122116Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:28.9695764Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8ed3d7d1-4161-4da8-969f-f9ecd5080ad9",
-            "createdDateTimeUtc": "2021-08-03T21:35:20.7604613Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:21.8167479Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2a132541-29db-4298-8ba7-16244a41d852",
-            "createdDateTimeUtc": "2021-08-03T21:35:07.9761301Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:14.7038749Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "72f0b845-0052-4963-b25f-5e8af00d9b14",
-            "createdDateTimeUtc": "2021-08-03T21:34:58.9227471Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:59.6529936Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=361\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=361\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cf4566e0429453499d95faa62e8cb202-087629d080290d46-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "be90f80ad1506619714b115628e9e5d4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "61da9ff0-2c7f-41c8-b4c7-22559950b10c",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:42 GMT",
-        "ETag": "\u0022B7FDC2D6854EB54FEFAE11B600F55233B8E0F2B10C19F604C2CFC1C34B125A49\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "61da9ff0-2c7f-41c8-b4c7-22559950b10c"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "134a4212-2732-497b-8390-42fdd37d21e4",
-            "createdDateTimeUtc": "2021-08-03T21:34:50.9445779Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:52.6686072Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0f9f6f1d-fbb2-4fc0-af0e-6f150e37af73",
-            "createdDateTimeUtc": "2021-08-03T21:34:44.4279088Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:45.6922406Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7ad52735-0cfc-4605-994b-a001b55239da",
-            "createdDateTimeUtc": "2021-08-03T21:34:36.6416807Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:40.3689165Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4a6f90f-809d-49a7-94bd-02b8ca21f03c",
-            "createdDateTimeUtc": "2021-08-03T21:34:23.5791957Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:25.3619831Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7fd3d1ca-a218-465c-8ff4-eb4048c38473",
-            "createdDateTimeUtc": "2021-08-03T21:34:16.1133883Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:18.3802341Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "196b19e9-ecbd-436d-877a-35b530e2c0fe",
-            "createdDateTimeUtc": "2021-08-03T21:34:09.5321065Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:11.3582876Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1fb76e64-f983-4edc-9d22-4f99e100acc3",
-            "createdDateTimeUtc": "2021-08-03T21:33:57.8667531Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:04.2518359Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c89dca35-2a09-4223-aead-e3e3c5d620f7",
-            "createdDateTimeUtc": "2021-08-03T21:33:46.1148308Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:50.7386282Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6c30daea-f0dc-45d2-a5f2-c9c9ca5c454d",
-            "createdDateTimeUtc": "2021-08-03T21:33:40.0877854Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:42.98622Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "06da1349-40ca-40a9-bcbc-bd1e846f3b88",
-            "createdDateTimeUtc": "2021-08-03T21:33:35.9538097Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:38.6215767Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8afbd2b4-c1ed-4724-9e12-85961ac830ea",
-            "createdDateTimeUtc": "2021-08-03T21:33:09.7165208Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:18.2261067Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f14238b7-28ec-48ab-b76f-24d83d6dffb1",
-            "createdDateTimeUtc": "2021-08-03T21:33:01.8426407Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:03.3408766Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "dba26cd3-c01a-41a3-aa8f-8267cf500fec",
-            "createdDateTimeUtc": "2021-08-03T21:32:55.2352866Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:56.1955205Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "658543b1-f494-4515-b258-7df811c67fc4",
-            "createdDateTimeUtc": "2021-08-03T21:32:48.2354429Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:49.1386196Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "909802b6-105c-43b8-b323-1c2a8e3312bb",
-            "createdDateTimeUtc": "2021-08-03T21:32:42.6249984Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:43.7383766Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c0eb9e4b-eb06-4d7a-a1f9-d38af1250cfd",
-            "createdDateTimeUtc": "2021-08-03T21:32:34.5973391Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:36.730268Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "76ebe7f5-60a3-4ef7-a683-49370dad24a6",
-            "createdDateTimeUtc": "2021-08-03T21:32:28.4958568Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:29.6601157Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bb59e6b0-23b7-44e5-9057-2254f90fe98f",
-            "createdDateTimeUtc": "2021-08-03T21:32:20.7234242Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:22.6496271Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "28e02b6f-0895-4f5c-9a9f-2b52422c014c",
-            "createdDateTimeUtc": "2021-08-03T21:32:14.2081813Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:15.7088003Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1dbd7a32-7f17-4aef-9d3c-9dd4cdd2efa5",
-            "createdDateTimeUtc": "2021-08-03T21:32:07.5152962Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:08.641319Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9b3a8bcf-3b59-46f1-b705-7c6baf22c1a5",
-            "createdDateTimeUtc": "2021-08-03T21:32:00.4355607Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:01.5891063Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6318a8e-c90f-4781-92d1-8ce5e24597fe",
-            "createdDateTimeUtc": "2021-08-03T21:31:52.5113337Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:54.509403Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e9b2eeb6-267b-47aa-8fa9-5967c6388d6b",
-            "createdDateTimeUtc": "2021-08-03T21:31:46.0577699Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:47.5253048Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "487aa9c1-42d1-4b50-b8fc-3f85395ad6ac",
-            "createdDateTimeUtc": "2021-08-03T21:31:39.494573Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:40.4162301Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b50424f3-68b3-4e1b-8234-a23451697697",
-            "createdDateTimeUtc": "2021-08-03T21:31:30.3843702Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:34.1919695Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2541716b-10fc-4ab7-b914-f0c77cb139be",
-            "createdDateTimeUtc": "2021-08-03T21:31:14.9137729Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:19.0230031Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fdd7087b-33d3-403d-be85-1ab00fb30319",
-            "createdDateTimeUtc": "2021-08-03T21:31:01.2624907Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:05.3693236Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "203a2eb7-45bb-4bea-a0f8-0c955469a993",
-            "createdDateTimeUtc": "2021-08-03T21:30:48.6999513Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:53.8967855Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8fd4aa26-458e-4039-bb3e-98bbcced99e0",
-            "createdDateTimeUtc": "2021-08-03T21:30:37.0230807Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:38.9030608Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7b349018-5715-4420-a7f0-c43bd66289fc",
-            "createdDateTimeUtc": "2021-08-03T21:30:28.4100426Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:30.2839253Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d26b9cd2-9b7d-4237-a26f-499dc048e311",
-            "createdDateTimeUtc": "2021-08-03T21:30:20.4404126Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:23.9070865Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "052b5b6a-f84c-4230-aa1f-26a61effcde2",
-            "createdDateTimeUtc": "2021-08-03T21:30:13.8603639Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:16.8464878Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ff2b5c18-708a-440f-bf37-efc7110c99ad",
-            "createdDateTimeUtc": "2021-08-03T21:30:06.9759347Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:09.8165024Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "73fead5d-cc86-4599-a092-9cc9d0c2c342",
-            "createdDateTimeUtc": "2021-08-03T21:30:00.4839216Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:02.7580915Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9575e40d-8d1f-448d-8b42-0eab021412d1",
-            "createdDateTimeUtc": "2021-08-03T21:29:53.8576053Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:55.676247Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "acd96228-cfd4-49fb-b646-794db3c9e15e",
-            "createdDateTimeUtc": "2021-08-03T21:29:47.0106537Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:48.6365299Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e77e2fc-38e5-4f47-9cb8-b90cc449a4d8",
-            "createdDateTimeUtc": "2021-08-03T21:29:40.1528777Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:41.6088908Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e37cc03a-bf95-42b7-8e51-518f72b5e87b",
-            "createdDateTimeUtc": "2021-08-03T21:29:32.2421265Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:35.2150657Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "741e8783-65a0-4a78-b0bb-40bb90ca2ce2",
-            "createdDateTimeUtc": "2021-08-03T21:29:22.6625965Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:28.3897554Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b4c5f90d-21f4-4776-a25d-69e2c24c61a2",
-            "createdDateTimeUtc": "2021-08-03T21:26:15.0534924Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:16.4602371Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "160fbcac-6719-48b1-a381-07c96def522c",
-            "createdDateTimeUtc": "2021-08-03T21:26:08.1805962Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:09.0728405Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "21177280-61be-420c-b6a7-99dea8ba6ffa",
-            "createdDateTimeUtc": "2021-08-03T21:26:00.6291023Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:02.0416868Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "9d566e00-1591-47d1-82c0-39a2e5d7b8cc",
-            "createdDateTimeUtc": "2021-08-03T21:25:45.4916681Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:46.9737716Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "61f64340-86f6-42f1-9c8a-d5caca0214bf",
-            "createdDateTimeUtc": "2021-08-03T21:25:30.4527461Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:31.898234Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "bebd6ab4-1fc5-4cc4-8b6e-12d70b67bb67",
-            "createdDateTimeUtc": "2021-08-03T21:25:20.9001519Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:23.1142408Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "3e44fb4d-cf68-45c5-93e1-0475502d2b40",
-            "createdDateTimeUtc": "2021-08-03T21:18:36.5471645Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:37.3185218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3cb0b34a-a92b-4e3e-9800-ee9aa656eebb",
-            "createdDateTimeUtc": "2021-08-03T21:18:32.7278914Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:34.3336582Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "da1c519e-1edf-4635-859d-1978cb2f95df",
-            "createdDateTimeUtc": "2021-08-03T21:18:26.0432979Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:27.3608779Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "450f4c8a-a15d-485c-9cc1-2451642cb05b",
-            "createdDateTimeUtc": "2021-08-03T21:18:19.0642978Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:20.5598666Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fcb39bba-503d-4772-bd60-8d48be8d1ded",
-            "createdDateTimeUtc": "2021-08-03T21:18:12.3671482Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:13.3939974Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=311\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=311\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c05211ad6cfd544595082419cc356a4e-e5ed48db58523e44-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7469488aff4656049284207a81b75bd1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ac987db6-b1f1-4553-9737-2e572517faa7",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:42 GMT",
-        "ETag": "\u00229702916A0835059D316916A34EF9A155B2E39ED0F195E879A260A546D8BBBC03\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ac987db6-b1f1-4553-9737-2e572517faa7"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "710b0db7-e99c-4736-9798-019d82bb972c",
-            "createdDateTimeUtc": "2021-08-03T21:18:04.4662377Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:06.5663381Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bcd5dbd0-4c9a-4d31-bbb2-38b1fd7a9f17",
-            "createdDateTimeUtc": "2021-08-03T21:17:57.9246063Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:59.5267689Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ea865d15-6652-456a-bc50-a82036d4b55e",
-            "createdDateTimeUtc": "2021-08-03T21:17:49.8058405Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:52.3338079Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "75cd36ab-60aa-4efb-b8ce-89bd8f2482d0",
-            "createdDateTimeUtc": "2021-08-03T21:17:36.2201985Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:37.5230684Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "05e4db62-aed0-4bc9-849c-1d1fa00e9101",
-            "createdDateTimeUtc": "2021-08-03T21:17:23.2025629Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:30.3004066Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a98bd901-115e-485e-a9c3-d6848740d430",
-            "createdDateTimeUtc": "2021-08-03T21:17:10.996439Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:15.4071683Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c0ebf31-6ec7-49ec-ba54-92b3ec4111f6",
-            "createdDateTimeUtc": "2021-08-03T21:17:05.8588787Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:08.1711768Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "565abdcf-3502-4ad2-bdf1-104fa16a21eb",
-            "createdDateTimeUtc": "2021-08-03T21:16:57.3872761Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:01.0170435Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9db34ff3-784f-4ba8-bd65-f9daea73dc84",
-            "createdDateTimeUtc": "2021-08-03T21:16:49.8079754Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:54.0100467Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "be0f4975-feb8-4a4c-99df-58a2eda64759",
-            "createdDateTimeUtc": "2021-08-03T21:16:43.5676725Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:46.9951206Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ad79180b-657e-411d-8214-6e2217f5f16f",
-            "createdDateTimeUtc": "2021-08-03T21:16:37.0494791Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:39.9664948Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a6b4d2cc-dc08-4883-93d5-4e0ce1f67b2b",
-            "createdDateTimeUtc": "2021-08-03T21:16:30.4598878Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:32.9278125Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e7348e3-fa87-4468-852d-3375d2e67dea",
-            "createdDateTimeUtc": "2021-08-03T21:16:22.0289093Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:25.9157037Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e415502b-72a2-46ae-bf89-116f60f159a2",
-            "createdDateTimeUtc": "2021-08-03T21:16:15.7930067Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:18.843387Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "12ae8466-a78d-4b54-96b3-491ff6092290",
-            "createdDateTimeUtc": "2021-08-03T21:16:08.3346723Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:11.9162731Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "972d3dd5-e5ad-435f-b1c0-19994a850368",
-            "createdDateTimeUtc": "2021-08-03T21:16:00.8089969Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:04.8935886Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c03135b1-55fc-49f8-bd8e-1aa9de944109",
-            "createdDateTimeUtc": "2021-08-03T21:15:50.7914559Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:57.8420568Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d3f42fc9-c46c-4c69-8ce8-1fa7951f0feb",
-            "createdDateTimeUtc": "2021-08-03T21:15:39.2462267Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:42.8928599Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2ee8fae6-6649-4264-8a60-005c8c2e33c3",
-            "createdDateTimeUtc": "2021-08-03T21:15:31.6638047Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:35.7812306Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64cf7af2-e9cf-42dd-be76-4c92b21200e5",
-            "createdDateTimeUtc": "2021-08-03T21:15:19.0180291Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:23.7245428Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7e3b360b-3804-4cd9-8ffc-ff8c1069f9a9",
-            "createdDateTimeUtc": "2021-08-03T21:15:07.6620949Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:10.7353955Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6f7243d-95a2-42b2-9277-db3105ffeeae",
-            "createdDateTimeUtc": "2021-08-03T21:14:57.8530134Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:58.6849403Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ff9490ff-1a22-4905-b300-f832c622fcd3",
-            "createdDateTimeUtc": "2021-08-03T21:14:52.4456431Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:55.1385001Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a291a37f-00ff-462c-90f7-af30487cfee0",
-            "createdDateTimeUtc": "2021-08-03T21:14:47.8001603Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:52.8849738Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6fe9dfde-e561-40c2-bdd6-3292556c8b44",
-            "createdDateTimeUtc": "2021-08-03T21:14:35.4879327Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:38.0663837Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "281e1d88-ad9d-4517-90b3-94e74a9c24f0",
-            "createdDateTimeUtc": "2021-08-03T21:14:28.795762Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:31.0494198Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a01a857b-9018-440a-b213-00bf32fd088e",
-            "createdDateTimeUtc": "2021-08-03T21:14:13.7887949Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:17.9704114Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8a449a7e-de6e-428f-85dc-0f5057026964",
-            "createdDateTimeUtc": "2021-08-03T21:14:02.4254824Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:05.9904305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "caf6c070-88b1-4321-8677-cad70417c272",
-            "createdDateTimeUtc": "2021-08-03T21:13:49.8557451Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:52.9922839Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e8f345d1-3424-4c4a-9d47-3008e4990352",
-            "createdDateTimeUtc": "2021-08-03T21:13:41.5900414Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:45.8133665Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5dc5da5c-8efd-4cd6-815e-4b808abb4825",
-            "createdDateTimeUtc": "2021-08-03T21:13:27.7289314Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:31.0005068Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eb91834b-fb6a-4993-9678-5858c3bb1b9b",
-            "createdDateTimeUtc": "2021-08-03T21:13:16.3384857Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:23.7963549Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "806f54be-4e77-4798-a5d5-73f6bad16868",
-            "createdDateTimeUtc": "2021-08-03T21:12:59.5334323Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:00.8743421Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ae03de4-3f6f-4c29-bf1c-1ad94a5e6b7d",
-            "createdDateTimeUtc": "2021-08-03T21:12:53.1067631Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:53.7902656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fc077fb4-83ee-4897-8b1a-5aba8c1bf0a3",
-            "createdDateTimeUtc": "2021-08-03T21:12:45.5070479Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:48.6888907Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "51fc6ec4-8eac-4cc6-ae6f-6c5f36e30f23",
-            "createdDateTimeUtc": "2021-08-03T21:12:30.4582964Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:41.6843136Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "be88aa61-1e9c-4917-a2aa-5c5cdb93a5f6",
-            "createdDateTimeUtc": "2021-08-03T21:12:24.3745624Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:26.5718318Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d0e58fcb-2b27-4914-9654-3d753fa5fc6b",
-            "createdDateTimeUtc": "2021-08-03T21:12:16.9941584Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:19.5227251Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f3a6c730-1d51-404f-8b00-45607cfae421",
-            "createdDateTimeUtc": "2021-08-03T21:12:06.8062009Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:12.5283Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "37992d98-b6d5-423c-89d1-6e54e5ec8773",
-            "createdDateTimeUtc": "2021-08-03T21:11:55.6953795Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:57.438589Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a3508cfe-30da-45d2-bc88-0047a835dd5e",
-            "createdDateTimeUtc": "2021-08-03T21:11:48.3588126Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:50.4206884Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6ab6d6e-5c85-448d-84d5-4223d3a2cd1b",
-            "createdDateTimeUtc": "2021-08-03T21:11:35.4391485Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:38.7780922Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c69177b4-9de0-4961-97f9-42b1b8d3c137",
-            "createdDateTimeUtc": "2021-08-03T21:11:21.7724833Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:23.742779Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3e1ee063-8ed9-4c9d-b237-76ec3a417bac",
-            "createdDateTimeUtc": "2021-08-03T21:11:13.556122Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:15.317426Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6042d94-2cd5-46df-85ad-52c10c998b01",
-            "createdDateTimeUtc": "2021-08-03T21:11:06.2064576Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:08.6641999Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d17081c8-ff50-4d36-8b46-e88c8deb39c5",
-            "createdDateTimeUtc": "2021-08-03T21:10:58.8540771Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:01.679116Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eeb49074-527d-4cbd-95c9-6e2a33a80fe0",
-            "createdDateTimeUtc": "2021-08-03T21:10:52.75482Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:54.5968498Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c6244025-4303-4989-a816-b905e1a30d9e",
-            "createdDateTimeUtc": "2021-08-03T21:10:46.6679174Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:47.5413043Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7515a3ad-6e5e-446b-8aea-c4cc53d12feb",
-            "createdDateTimeUtc": "2021-08-03T21:10:38.7741733Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:40.5334622Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "95aff118-ace4-4193-828d-2ae77311df6f",
-            "createdDateTimeUtc": "2021-08-03T21:10:32.6760697Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:33.4547546Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=150\u0026$top=261\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=150\u0026$top=261\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-83bd292457ed7d4887f1688bdd3cf959-a728eab37c61e342-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a6338a4f68f14bac5fc42b17dbebb8ad",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "32732bb7-164e-46a2-8328-75bfceb03283",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:43 GMT",
-        "ETag": "\u0022701AEFBDF7DC54C079FB352F3AD67B7F8AB8A0ECE8B734DAA90453663526AD09\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "32732bb7-164e-46a2-8328-75bfceb03283"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "97597b48-5a0e-4dad-8d71-2591f76bf2b6",
-            "createdDateTimeUtc": "2021-08-03T21:10:25.297809Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:26.4222067Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c21ed6b-a48d-4909-92cb-73bc8274b9d2",
-            "createdDateTimeUtc": "2021-08-03T21:10:17.9312928Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:19.3974656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9fc1780-0cbf-4e09-af18-b05ab8132e1f",
-            "createdDateTimeUtc": "2021-08-03T21:10:05.2725918Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:12.5542351Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0636e96b-8ca2-44f8-a04b-a9a1c38694c4",
-            "createdDateTimeUtc": "2021-08-03T21:04:35.2211988Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:37.0514288Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce731aed-e42d-4219-a382-133b032d5f1c",
-            "createdDateTimeUtc": "2021-08-03T21:04:28.9135303Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:29.9918727Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d86704b4-8468-4fd2-a932-fd5224d0ebed",
-            "createdDateTimeUtc": "2021-08-03T21:04:14.1901594Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:19.7321506Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9f05357-c328-48b9-a611-c3732bab678d",
-            "createdDateTimeUtc": "2021-08-03T21:04:03.8683312Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:05.0527645Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0cbb6b74-7d09-4126-992c-831741492982",
-            "createdDateTimeUtc": "2021-08-03T21:03:51.6462874Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:54.7314609Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5f03f16e-de27-42b4-b2e2-844706de4b44",
-            "createdDateTimeUtc": "2021-08-03T21:03:45.1124183Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:47.674769Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "23c77867-65e6-4ad0-be05-9bdb30d3ad5e",
-            "createdDateTimeUtc": "2021-08-03T21:03:37.8720722Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:40.5848208Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f28ba69-dc12-4f0c-a4a1-e7b60934ad43",
-            "createdDateTimeUtc": "2021-08-03T21:03:32.2879169Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:33.7858305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7d8b4c2b-bae7-45ca-b351-4e9904d6ee65",
-            "createdDateTimeUtc": "2021-08-02T16:24:41.2089693Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:43.0994742Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6eb19d5e-da21-40c2-b5ac-31638a9d5834",
-            "createdDateTimeUtc": "2021-08-02T16:24:32.9603519Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:35.3478084Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8f83e37a-9fd2-4a27-acf9-fdf90c5ca88e",
-            "createdDateTimeUtc": "2021-08-02T16:24:25.3701107Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:28.2843485Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fa2f0660-ee60-44dc-891e-1807fe027001",
-            "createdDateTimeUtc": "2021-08-02T16:24:19.0661656Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:20.9267399Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9a921d78-9a3f-4fb0-bd3e-e9e85adfb5c7",
-            "createdDateTimeUtc": "2021-08-02T16:24:14.084628Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:14.8551961Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "35491096-d4b6-4f64-a475-3a8f425bda13",
-            "createdDateTimeUtc": "2021-08-02T16:24:08.8499137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:13.2168149Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d6516cd6-00bc-4dd4-81e0-ac3531a9ef9a",
-            "createdDateTimeUtc": "2021-08-02T16:24:04.9124096Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:09.2033129Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "53f7b772-34ef-4eb8-8296-85141574c168",
-            "createdDateTimeUtc": "2021-08-02T16:23:45.9322442Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:47.766539Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ee6fbf3b-4339-4bf7-a0e4-c6c4a43e713d",
-            "createdDateTimeUtc": "2021-08-02T16:23:39.6959419Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:40.4416417Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "136046f1-61bb-4d7a-abda-5d762ed48da2",
-            "createdDateTimeUtc": "2021-08-02T16:23:32.246383Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:33.6102582Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4c808776-ef91-44b3-b985-030778694e82",
-            "createdDateTimeUtc": "2021-08-02T16:23:24.7815606Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:25.6039914Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bbcb51e9-e16a-4575-b115-000e9df2a45e",
-            "createdDateTimeUtc": "2021-08-02T16:23:14.7939144Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:18.5400236Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "420e65a3-84f2-4784-8e76-0dbc11b9767d",
-            "createdDateTimeUtc": "2021-08-02T16:23:00.0350545Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:03.9941424Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3bed775d-83fb-4252-9f8a-52dacdb26ade",
-            "createdDateTimeUtc": "2021-08-02T16:22:48.7883283Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:53.2388717Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6ef1e57a-03d3-4eee-b0c1-cabd5862da1f",
-            "createdDateTimeUtc": "2021-08-02T16:22:35.1281238Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:38.165101Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "40a5525c-6988-4e7e-a203-d01a5a19add6",
-            "createdDateTimeUtc": "2021-08-02T16:22:22.6116988Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:28.2009407Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b12700de-181b-4bfb-a9ea-ab2920d66ba8",
-            "createdDateTimeUtc": "2021-08-02T16:22:11.0963198Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:13.2382617Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "588176c1-fb41-4077-9ce2-52eaefe1e6ec",
-            "createdDateTimeUtc": "2021-08-02T16:22:00.7493371Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:02.6302967Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eeddf064-09ac-4f8d-8571-dd1bb7fa4343",
-            "createdDateTimeUtc": "2021-08-02T16:21:54.4828121Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:57.0883721Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "86f769d2-0eb0-497c-a670-4b283cfcdfdf",
-            "createdDateTimeUtc": "2021-08-02T16:21:47.7892819Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:50.5734898Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ef96694-d6c5-4f51-9c7e-250c692cb5dd",
-            "createdDateTimeUtc": "2021-08-02T16:21:41.4813356Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:42.5383836Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "adf11117-52ab-486b-985c-bfea752c8125",
-            "createdDateTimeUtc": "2021-08-02T16:21:32.7479396Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:35.3424695Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8d9ccbdb-0672-4c0a-9776-0392c918c98f",
-            "createdDateTimeUtc": "2021-08-02T16:21:15.2775709Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:19.7632985Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8791b215-1f41-41d4-bb91-98341c1dd33c",
-            "createdDateTimeUtc": "2021-08-02T16:21:05.1178323Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:07.2972934Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6aba7c68-ce53-473d-a0ec-8a507ed316c9",
-            "createdDateTimeUtc": "2021-08-02T16:20:50.7351339Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:54.4492988Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7d30db48-4d73-41d8-997d-4a617c4004c9",
-            "createdDateTimeUtc": "2021-08-02T16:20:40.6756633Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:42.4301335Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d04c84d8-3802-49e5-bfed-513a24bd9d5a",
-            "createdDateTimeUtc": "2021-08-02T16:20:24.7609666Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:29.1667159Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bc6cf0b2-7fc1-40ee-ad43-98b0b5150223",
-            "createdDateTimeUtc": "2021-08-02T16:20:12.6767136Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:16.3662875Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "478fdbe7-fffd-4d69-baa1-b359ab0bf87e",
-            "createdDateTimeUtc": "2021-08-02T16:19:59.5448266Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:03.7580865Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8ac17a7c-0ef2-44e6-815e-11ca7283f7f0",
-            "createdDateTimeUtc": "2021-08-02T16:19:47.7119701Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:52.0454421Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9299720b-5702-4fd8-9b84-07d18770d0c9",
-            "createdDateTimeUtc": "2021-08-02T16:19:33.0940413Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:36.063599Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c53f5ac-5ae0-4186-986d-59db8052bd87",
-            "createdDateTimeUtc": "2021-08-02T16:19:25.5258566Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:27.5995027Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5fabbdd0-d3df-482e-80c5-751f5c65184b",
-            "createdDateTimeUtc": "2021-08-02T16:19:17.4593598Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:19.4263901Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f116c06f-6f87-406d-b1f6-79fb90dce630",
-            "createdDateTimeUtc": "2021-08-02T16:19:10.7346Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:12.2459497Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8d24c7aa-d4f7-4c8f-8540-10499063139f",
-            "createdDateTimeUtc": "2021-08-02T16:19:02.0656904Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:03.0995071Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f9b9346c-2649-429f-a88e-3bd5fa834aea",
-            "createdDateTimeUtc": "2021-08-02T16:18:52.7109118Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:57.1201114Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4676529-3017-4ca1-b2a8-dbb9c74ca6f0",
-            "createdDateTimeUtc": "2021-08-02T16:18:36.7769716Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:41.5280761Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d59e0316-c5eb-4011-a6ea-ba35c6977966",
-            "createdDateTimeUtc": "2021-08-02T16:18:23.3012061Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:29.1989939Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "28779945-5117-434b-9137-14e9c170d450",
-            "createdDateTimeUtc": "2021-08-02T16:18:11.1236727Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:16.2904795Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=200\u0026$top=211\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=200\u0026$top=211\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a3fb0fafbed3ae408855219f65a6fd8a-ab3d0458f9faba46-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5a93db61d92c0a92f43a2bcbb09fe5ba",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ecb2d50d-8e2b-4c9c-9409-b02daead167c",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:43 GMT",
-        "ETag": "\u0022A82EDC93B49C5899E46092A1D8CD5510BCABF6328117B644EEFC606717C3CDEC\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ecb2d50d-8e2b-4c9c-9409-b02daead167c"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "3b661b7e-cdbd-461e-8540-93e2e7135084",
-            "createdDateTimeUtc": "2021-08-02T16:17:57.8044821Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:02.1356502Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "826e3203-8188-4a90-92db-b65e12b7a6e6",
-            "createdDateTimeUtc": "2021-08-02T16:17:49.6808861Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:51.33726Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ec3e1c4c-3509-4f5a-86ee-3be559f978cf",
-            "createdDateTimeUtc": "2021-08-02T16:17:43.4479159Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:46.1484498Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "cd18395a-adb6-4566-a35d-4b7394ce7e7c",
-            "createdDateTimeUtc": "2021-08-02T16:17:39.2236317Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:42.3718498Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2ab88ed2-f62f-442c-a8d4-e0fe953d60f8",
-            "createdDateTimeUtc": "2021-08-02T16:17:13.5251717Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:17.8853964Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b9deb0a-7a56-440e-b9c3-51407a716f91",
-            "createdDateTimeUtc": "2021-08-02T16:17:00.3732482Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:04.8610025Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1451731d-cb81-45b9-abb6-c0ebd8d688ff",
-            "createdDateTimeUtc": "2021-08-02T16:16:46.3333522Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:51.499965Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "139c594a-e573-42bc-ac76-79592e783b4d",
-            "createdDateTimeUtc": "2021-08-02T16:16:34.5666571Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:39.7565449Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ea6a654-e1da-4712-9ade-698b4fa08cee",
-            "createdDateTimeUtc": "2021-08-02T16:16:20.2815511Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:26.1888498Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bb4649a1-1b3a-4ffe-a85e-7c42bae169e0",
-            "createdDateTimeUtc": "2021-08-02T16:16:12.5610209Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:14.670096Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fe16f7a4-60a7-47e5-af19-ae95f1ec681e",
-            "createdDateTimeUtc": "2021-08-02T16:16:02.1273592Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:06.1364515Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4aa714c0-4bf6-4938-87a1-434a1f4a7ebb",
-            "createdDateTimeUtc": "2021-08-02T16:15:47.0562229Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:50.6173263Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "026bf666-4189-437c-83aa-64695c311c08",
-            "createdDateTimeUtc": "2021-08-02T16:15:31.2491656Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:35.1652117Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bdd91bff-b609-4b0f-a2c0-c647662d414d",
-            "createdDateTimeUtc": "2021-08-02T16:15:16.5679328Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:20.3039847Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0498cf00-abbb-40b5-adab-e7725b8570f7",
-            "createdDateTimeUtc": "2021-08-02T16:15:09.9911137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:11.9184442Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "21177c94-70c4-44e1-8cff-235b74d0b99a",
-            "createdDateTimeUtc": "2021-08-02T16:14:55.1654786Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:00.1764926Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "85670b87-e8d6-4d6d-8ea2-c25d36c5ab31",
-            "createdDateTimeUtc": "2021-08-02T16:14:43.5832687Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:46.5409074Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6120317e-0084-4d39-be37-4a22da834f5d",
-            "createdDateTimeUtc": "2021-08-02T16:14:27.9772355Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:34.8024586Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6af7eb57-f9c1-42e2-82d7-1f12e5b212fe",
-            "createdDateTimeUtc": "2021-08-02T16:14:17.0902143Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:21.24705Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cd6a2e5d-84e2-41b1-9337-a69dad3d47c1",
-            "createdDateTimeUtc": "2021-08-02T16:14:07.7724718Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:08.5411317Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c2ef1201-4b72-4500-af9d-6c46e43d9c8b",
-            "createdDateTimeUtc": "2021-08-02T16:14:00.4820687Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:02.206196Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e02cc96c-f613-4d31-b301-64b1ba8f087d",
-            "createdDateTimeUtc": "2021-08-02T16:13:52.654235Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:53.9684859Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "56985d49-4f45-4bf5-bc5a-815be0a31d77",
-            "createdDateTimeUtc": "2021-08-02T16:13:44.4222786Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:46.3632429Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f277b4e7-6107-4fce-9843-57ea37403cd0",
-            "createdDateTimeUtc": "2021-08-02T16:13:36.1118921Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:38.5818188Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cb2ae958-26f6-497c-a0d2-0f24b680a296",
-            "createdDateTimeUtc": "2021-08-02T16:13:28.2526551Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:31.4669162Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e44cb835-83cf-4568-af90-37dc0bfc591f",
-            "createdDateTimeUtc": "2021-08-02T16:13:21.6945505Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:24.3971649Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "53732eaf-861e-4cc7-ab1b-7fe8f2c59f72",
-            "createdDateTimeUtc": "2021-08-02T16:13:09.3426779Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:09.9894448Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "22467b38-820b-496e-af13-6118e55f474f",
-            "createdDateTimeUtc": "2021-08-02T16:12:54.8368437Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:02.7871782Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f2db3e76-05f6-487e-8f7a-71ff84a07c41",
-            "createdDateTimeUtc": "2021-08-02T16:12:46.1722803Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:47.8187574Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6fa6124a-382c-4cae-a8e8-bafa8771ffb4",
-            "createdDateTimeUtc": "2021-08-02T16:12:38.3102608Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:40.6814713Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "08077374-25ed-4062-8157-d2aaf376a00c",
-            "createdDateTimeUtc": "2021-08-02T16:12:26.6208936Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:33.2913497Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a94a2a28-a797-4f76-91cd-b51148e62b16",
-            "createdDateTimeUtc": "2021-08-02T16:12:13.1684199Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:18.4618218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bc4c4898-1c22-4525-a645-7ce619839b24",
-            "createdDateTimeUtc": "2021-08-02T16:11:56.0176535Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:03.7809247Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e84c225d-6eac-485e-a02c-27944ff4dbdb",
-            "createdDateTimeUtc": "2021-08-02T16:05:51.141745Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:55.0127867Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "7c879c56-18e3-404d-a749-27467f12e635",
-            "createdDateTimeUtc": "2021-08-02T16:05:45.2156446Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:46.3340871Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "a475da26-6ac8-4c57-ad1f-a95856f88516",
-            "createdDateTimeUtc": "2021-08-02T16:05:36.590968Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:39.4988016Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "54a2e7ba-61be-4704-9a1b-2e4b36baa088",
-            "createdDateTimeUtc": "2021-08-02T16:05:21.5609955Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:24.9840622Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "7afd5c7e-13d8-4691-abd0-abde4ce5474e",
-            "createdDateTimeUtc": "2021-08-02T16:05:02.9540382Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:05.7674713Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "557f2c23-bc72-40b7-a138-4561429fa9aa",
-            "createdDateTimeUtc": "2021-08-02T16:04:47.8352521Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:04:50.2573908Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "3e9a5d00-90d9-4256-9d62-f1dfa1577da0",
-            "createdDateTimeUtc": "2021-08-01T16:20:07.4673305Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:13.4203616Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "fc266ece-821c-4ad7-9448-1813652fd6ec",
-            "createdDateTimeUtc": "2021-08-01T16:20:03.3145089Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:12.698585Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "09bd712a-8979-4a10-b5cd-e9f10cd67d10",
-            "createdDateTimeUtc": "2021-08-01T16:19:46.7079557Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:49.1799156Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d7a02f06-f676-408e-b3c1-c15c6bba0b44",
-            "createdDateTimeUtc": "2021-08-01T16:19:40.2888558Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:42.0951378Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c225a85d-2f4e-4823-bed5-aafc11420317",
-            "createdDateTimeUtc": "2021-08-01T16:19:32.7591319Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:35.0214842Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8afe93e5-55f8-4b29-aad7-e52aafa852e9",
-            "createdDateTimeUtc": "2021-08-01T16:19:26.4656956Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:27.9695511Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d2d58232-7d45-4649-8eee-884989571d14",
-            "createdDateTimeUtc": "2021-08-01T16:19:20.0951281Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:20.9141679Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9d74505c-4ec7-4849-a25e-347c9ca83531",
-            "createdDateTimeUtc": "2021-08-01T16:19:14.3845766Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:19.1001524Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5263795e-4551-4f48-94da-32a53c735650",
-            "createdDateTimeUtc": "2021-08-01T16:19:10.3372901Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:18.7374885Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b51a5572-a945-4b96-a953-c59a894ef975",
-            "createdDateTimeUtc": "2021-08-01T16:18:54.1999881Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:57.9280154Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ed28552f-7298-466f-be5d-d72fc1596544",
-            "createdDateTimeUtc": "2021-08-01T16:18:47.7220195Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:50.8569952Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=250\u0026$top=161\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=250\u0026$top=161\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ef755fdd66cd8f4bbd13db0c73f9ed71-db2980a3517cf34d-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "9e0640f03fb622e29b1d1581d4ec7aa6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9553f9e9-9e76-40e9-ab9c-cb9a05c07d33",
+        "apim-request-id": "2166e038-5a85-4381-8830-d641282ed793",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:44 GMT",
-        "ETag": "\u002221C20EACC25E499F9E3690239B3A7E473C20AB3CCE05FFE394A5DC4BC5B66CDE\u0022",
+        "Date": "Thu, 26 Aug 2021 12:07:48 GMT",
+        "ETag": "\u0022EB8CA10B1518F44E758A81FB62DAA997F4A4D3357FCF7655444C8C483076A44E\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9553f9e9-9e76-40e9-ab9c-cb9a05c07d33"
+        "X-RequestId": "2166e038-5a85-4381-8830-d641282ed793"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "c0ebd77c-0245-4fa7-b3e7-83694b3734fe",
-            "createdDateTimeUtc": "2021-08-01T16:18:41.3753213Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:43.9537812Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target417640913/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1360467463/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:07:39.7954357Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:48.7687145Z",
             "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64716ad2-d3e2-4bcf-9a75-0fc0c9a5f4c8",
-            "createdDateTimeUtc": "2021-08-01T16:18:34.7356044Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:36.8659384Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "48155210-6958-4ce0-9863-e3747a64c145",
-            "createdDateTimeUtc": "2021-08-01T16:18:20.2854234Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:30.0642323Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9453ca0c-5d2e-4071-ab7f-442df231b85f",
-            "createdDateTimeUtc": "2021-08-01T16:15:01.5996298Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:15:05.5361722Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b0f1d39d-b564-4cd9-8032-6a12e1a9d05b",
-            "createdDateTimeUtc": "2021-08-01T16:14:55.2901759Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:58.5033728Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "59da2c26-8f14-4221-ab40-ac76b9501ad1",
-            "createdDateTimeUtc": "2021-08-01T16:14:47.6768806Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:51.4645762Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "497af134-1eb1-4531-96cf-2b6426d21b25",
-            "createdDateTimeUtc": "2021-08-01T16:14:43.8701994Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:44.532919Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "49417fb3-b2f3-4a94-a5bf-adf21b10f5d6",
-            "createdDateTimeUtc": "2021-08-01T16:14:36.2995057Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:37.5066305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3a12cc5a-b95b-4934-8fd5-f338b1e8ffca",
-            "createdDateTimeUtc": "2021-08-01T16:14:29.7501476Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:30.4496382Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f30dfeae-5899-4b4a-ab89-d6d04d0efe74",
-            "createdDateTimeUtc": "2021-08-01T16:14:22.1534158Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:26.376851Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e65c1cc-310e-4cc2-b8cb-94549af2f62e",
-            "createdDateTimeUtc": "2021-08-01T16:14:15.8071242Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:19.3429665Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3bb426c3-ecc1-4316-bc03-730dc1f3653b",
-            "createdDateTimeUtc": "2021-08-01T16:14:08.2125728Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:12.4635748Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ddf0085d-dbdf-4cba-990c-3ba10a7e1a66",
-            "createdDateTimeUtc": "2021-08-01T16:14:03.1671065Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:05.4704945Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "329cec92-7703-4747-ae44-5990a8726d8f",
-            "createdDateTimeUtc": "2021-08-01T16:13:54.1407053Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:58.3447181Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b8f07233-7e1c-4c08-80cf-1a15eb328e81",
-            "createdDateTimeUtc": "2021-08-01T16:13:47.8669235Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:51.5406534Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "77cdd294-733d-41f8-819f-92003e64ceb5",
-            "createdDateTimeUtc": "2021-08-01T16:13:40.2946017Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:44.3266783Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e0991fae-123b-4f43-bff0-cab0009d9523",
-            "createdDateTimeUtc": "2021-08-01T16:13:36.5057131Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:37.2374588Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5ca898b1-422a-4871-abb7-1ce16766fe75",
-            "createdDateTimeUtc": "2021-08-01T16:13:28.8893885Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:30.2057848Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "71c20eb7-04ac-4b18-8147-170d958cf215",
-            "createdDateTimeUtc": "2021-08-01T16:13:14.9186078Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:23.1567567Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0f6623cf-56f0-49c2-8b2d-92a7d173e656",
-            "createdDateTimeUtc": "2021-08-01T16:13:07.2768816Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:08.1446081Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "51452eaa-72c0-4d09-aece-3ce74ea05c2d",
-            "createdDateTimeUtc": "2021-08-01T16:12:58.3531499Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:00.9818419Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "83122575-c3e0-40cf-a740-bb3ab9fc56be",
-            "createdDateTimeUtc": "2021-08-01T16:12:43.7935713Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:12:49.3598783Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ab3adbcc-1036-4e0b-903d-681b154f1c19",
-            "createdDateTimeUtc": "2021-08-01T16:12:34.5845034Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:12:35.9467789Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "39c76fc2-bb64-4a08-a91a-023f467170c8",
-            "createdDateTimeUtc": "2021-08-01T16:10:30.7671066Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:33.9996641Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1946e12f-48c9-479d-a14d-957a52af4819",
-            "createdDateTimeUtc": "2021-08-01T16:10:24.4268864Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:26.950039Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "061184c9-b5cc-4622-9536-a088ef98ef51",
-            "createdDateTimeUtc": "2021-08-01T16:10:16.7322617Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:20.8210184Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6dab8cd8-4b45-4244-b5a3-1df6ce3e6e9e",
-            "createdDateTimeUtc": "2021-08-01T16:10:10.3791367Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:13.7755381Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ccecf223-30d9-427f-baac-d28fabd2ba91",
-            "createdDateTimeUtc": "2021-08-01T16:09:56.0857482Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:01.8186959Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "686c032b-f1f9-461c-b591-19be033130a6",
-            "createdDateTimeUtc": "2021-08-01T16:09:47.6916292Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:48.7555826Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f1fb728-a50b-4279-b98e-8f70a89cba26",
-            "createdDateTimeUtc": "2021-08-01T16:09:35.1147989Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:41.7039641Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ac064e9c-9558-4940-81b6-6591e24b22b0",
-            "createdDateTimeUtc": "2021-08-01T16:09:23.6462928Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:26.7238672Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f7dfd6e7-2149-4ed6-9118-1f50a9badde5",
-            "createdDateTimeUtc": "2021-08-01T16:09:15.6989555Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:16.6008152Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a37bd766-988f-4d35-93b4-82b678984a0b",
-            "createdDateTimeUtc": "2021-08-01T16:09:10.2798543Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:11.6248087Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "dd3207eb-c63b-4ee9-8d71-303a17f6831a",
-            "createdDateTimeUtc": "2021-08-01T16:09:02.3812973Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:04.6501124Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c2017771-02a1-4c4d-89c6-e53ddc375b6c",
-            "createdDateTimeUtc": "2021-08-01T16:08:54.6514534Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:57.5553054Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8e675672-c991-4b00-9f3b-151fff0ba025",
-            "createdDateTimeUtc": "2021-08-01T16:08:50.6903241Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:51.5542816Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "86d50aab-06b7-4674-94f1-d78f62cfcd3c",
-            "createdDateTimeUtc": "2021-08-01T16:08:42.9294372Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:44.5249817Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64eee42e-3b77-4308-b66b-6dfd687dfcb8",
-            "createdDateTimeUtc": "2021-08-01T16:08:29.0253923Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:37.4953732Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ec95d30a-ca29-44c2-a3d3-7f1e81768232",
-            "createdDateTimeUtc": "2021-08-01T16:08:20.5267131Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:22.4653843Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "baa67a70-f2c2-4798-af85-bf4039800973",
-            "createdDateTimeUtc": "2021-08-01T16:08:14.027446Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:15.5419027Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9fd64070-3063-4a1f-b6c7-a5433ce879c1",
-            "createdDateTimeUtc": "2021-08-01T16:08:07.3241133Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:08.3919937Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eca524e6-f052-4f33-9f75-849aa58968f2",
-            "createdDateTimeUtc": "2021-08-01T16:07:59.6488045Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:02.4292358Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e4553a79-86bc-4607-93ba-acd98eef29a8",
-            "createdDateTimeUtc": "2021-08-01T16:07:51.7754119Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:07:55.6059096Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3733384b-4378-49e9-9d6c-eb777dd951e7",
-            "createdDateTimeUtc": "2021-08-01T16:03:47.7295123Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:50.0428444Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5af0415d-d065-4223-8377-8c4b476b1e51",
-            "createdDateTimeUtc": "2021-08-01T16:03:41.2997619Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:43.1057319Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "19825a18-d71e-4d71-ad50-ac9efde28439",
-            "createdDateTimeUtc": "2021-08-01T16:03:33.0672128Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:36.0643347Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2126372c-82d1-4ca5-99cd-6320189e4456",
-            "createdDateTimeUtc": "2021-08-01T16:03:21.6139816Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:29.0787165Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "351567c2-21d9-44d7-80cd-ae88bcfc86c1",
-            "createdDateTimeUtc": "2021-08-01T16:03:11.2412744Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:14.0681571Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3687fbc7-cfc7-4946-abbd-d20c2c47872b",
-            "createdDateTimeUtc": "2021-08-01T16:02:54.8769861Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:59.157192Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "75b82710-29d5-4a29-b31d-b4b276547f85",
-            "createdDateTimeUtc": "2021-08-01T16:02:42.7637598Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:44.4525561Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
+            "to": "fr",
+            "progress": 1,
+            "id": "000b4683-0000-0000-0000-000000000000",
+            "characterCharged": 16
           }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=300\u0026$top=111\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
+        ]
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=300\u0026$top=111\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2021-08-26T06%3A07%3A58.3333724Z\u0026$orderBy=createdDateTimeUtc%20Desc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-41ea26a78b380a4c86cbe4024b4d79f8-66dbf08e50f78e4b-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-664bc4502910024fa1860546c543cc0f-2908781ab4e5f149-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "a51872cc012376a5f829b2b63ce09bc0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "41b8c471-759e-4e81-b4d4-a2ce740c13ee",
+        "apim-request-id": "62cc8ab3-4758-42c2-af8c-8aa9b134cf43",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:44 GMT",
-        "ETag": "\u0022800AC53E6D28FD578C8EB619EA733E3B908DBAAF58D319A2DC1862AF142BDCA3\u0022",
+        "Date": "Thu, 26 Aug 2021 12:08:02 GMT",
+        "ETag": "\u00221215BEE18A488897266350985A66FD1975EFB2C1D2D657BD6A619AB275E62D5C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "41b8c471-759e-4e81-b4d4-a2ce740c13ee"
+        "X-RequestId": "62cc8ab3-4758-42c2-af8c-8aa9b134cf43"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "45e52c50-a5d3-4185-ad9c-302fb18b86fb",
-            "createdDateTimeUtc": "2021-08-01T16:02:33.7748165Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:37.1302955Z",
+            "id": "de191afa-044c-4302-860f-fead9320bfef",
+            "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:48.768721Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -6308,9 +1862,9 @@
             }
           },
           {
-            "id": "0794e1ae-1cbb-4ce3-a359-5baea72b7f4f",
-            "createdDateTimeUtc": "2021-08-01T15:59:52.4064413Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:54.8434933Z",
+            "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+            "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:36.031538Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -6323,9 +1877,9 @@
             }
           },
           {
-            "id": "b6bf80ca-523f-424b-bb16-43b74851cd72",
-            "createdDateTimeUtc": "2021-08-01T15:59:46.146435Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:47.7975734Z",
+            "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+            "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:20.8963603Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -6338,9 +1892,9 @@
             }
           },
           {
-            "id": "f151cf31-9668-4c64-9fa3-1eab66bd54de",
-            "createdDateTimeUtc": "2021-08-01T15:59:38.6998762Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:41.734894Z",
+            "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+            "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:04:16.1141626Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -6353,9 +1907,9 @@
             }
           },
           {
-            "id": "eab2ef7c-cccd-4b8d-9c28-43fa1246a6ec",
-            "createdDateTimeUtc": "2021-08-01T15:59:33.1867669Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:34.7568857Z",
+            "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+            "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:04:05.8188604Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -6368,9 +1922,9 @@
             }
           },
           {
-            "id": "fe3b6f5b-2f4f-4ba6-87b0-b49ce11a40f1",
-            "createdDateTimeUtc": "2021-08-01T15:59:23.8646186Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:27.6910914Z",
+            "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+            "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:03:43.710026Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -6383,9 +1937,9 @@
             }
           },
           {
-            "id": "c688f16b-c48f-4d93-ae25-97e9419cf990",
-            "createdDateTimeUtc": "2021-08-01T15:59:20.0728064Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:20.6633025Z",
+            "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+            "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:03:30.7517838Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -6395,1752 +1949,6 @@
               "notYetStarted": 0,
               "cancelled": 0,
               "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "65b3ecb9-b44e-45cb-9b48-4c3dc410ea83",
-            "createdDateTimeUtc": "2021-08-01T15:59:09.2524163Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:13.6285104Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4dc36f8-1a47-4082-9e74-55b17a656aee",
-            "createdDateTimeUtc": "2021-08-01T15:58:55.2515733Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:02.9435279Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f3021ca2-9cec-4123-8750-e48d70416733",
-            "createdDateTimeUtc": "2021-08-01T15:56:37.0490386Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:38.4486071Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6b145029-9721-429c-a6a7-09c88b0985bf",
-            "createdDateTimeUtc": "2021-08-01T15:56:30.7478816Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:31.4431875Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bd39da52-dc84-4165-bd31-8b4e3386e291",
-            "createdDateTimeUtc": "2021-08-01T15:56:23.0776782Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:27.4828878Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fa4f24ae-2898-4a3f-99c4-1cb3803f90f9",
-            "createdDateTimeUtc": "2021-08-01T15:56:16.7471751Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:20.4937894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7ab33b72-ce13-4ddb-8201-c3c334eae327",
-            "createdDateTimeUtc": "2021-08-01T15:56:03.8859689Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:05.4735936Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ab288e5d-b6b4-44e3-abf9-6faa8c4be7ec",
-            "createdDateTimeUtc": "2021-08-01T15:55:55.0121462Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:56.3540986Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f93cafa9-8dd4-4b3b-8b51-1e2171088923",
-            "createdDateTimeUtc": "2021-08-01T15:55:47.3645091Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:49.3078416Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e4b8104a-b73b-4412-9053-8e5ebec49801",
-            "createdDateTimeUtc": "2021-08-01T15:55:40.55381Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:42.2818894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5d43cd87-26c7-4c64-a7c6-b594408e7335",
-            "createdDateTimeUtc": "2021-08-01T15:55:32.9887665Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:35.2182692Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2136b292-19b7-4256-8c19-5fa788b76984",
-            "createdDateTimeUtc": "2021-08-01T15:55:25.9783249Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:28.383526Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0517cacc-3271-4281-a3d5-104ef81a6787",
-            "createdDateTimeUtc": "2021-08-01T13:52:26.3146047Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:27.02053Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "13dc0dc6-55d9-4815-925b-53831ccd5b1a",
-            "createdDateTimeUtc": "2021-08-01T13:52:20.0346113Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:20.7450313Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d63c2da4-ba89-4240-8ca3-3303a99b2321",
-            "createdDateTimeUtc": "2021-08-01T13:52:11.7638283Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:14.351392Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5c4dd9bb-d4c3-4154-b014-5b999af767fc",
-            "createdDateTimeUtc": "2021-08-01T13:51:59.0858938Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:06.7430348Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fba3ac3e-5074-4ae6-b21b-77e83ddd5728",
-            "createdDateTimeUtc": "2021-08-01T13:51:50.096311Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:51.9229238Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "919b875a-ac8a-4168-9f5d-2b002e2e990b",
-            "createdDateTimeUtc": "2021-08-01T13:51:36.2700242Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:44.8851496Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b65dd502-78d8-41eb-a5c2-e38841e8a64d",
-            "createdDateTimeUtc": "2021-08-01T13:51:29.279615Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:29.8684676Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f31e8014-63fa-40b4-99c8-0bcd7b0e55c8",
-            "createdDateTimeUtc": "2021-08-01T13:51:18.8649454Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:23.0945034Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "03ff545e-1823-45a4-b776-69f0e04acc30",
-            "createdDateTimeUtc": "2021-08-01T13:47:29.3049005Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:31.3629345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ba88a76e-c3d3-4ea6-a53c-b85651fcf2e3",
-            "createdDateTimeUtc": "2021-08-01T13:47:23.0010181Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:24.2943392Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "74a8ff69-cb7a-4499-86df-c3a2d3832f35",
-            "createdDateTimeUtc": "2021-08-01T13:47:15.4214201Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:17.6049061Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d34a947d-dbfe-4629-94ca-583ba3135c38",
-            "createdDateTimeUtc": "2021-08-01T13:47:09.0574092Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:10.5667782Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "292e0fc5-31f9-4bbe-a16d-118e79c6447d",
-            "createdDateTimeUtc": "2021-08-01T13:46:55.8006784Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:03.6165324Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "46cfff21-a830-4bfe-bcf7-7845dea12314",
-            "createdDateTimeUtc": "2021-08-01T13:46:47.3054Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:49.2160598Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "992cdea9-d5e3-4518-a34f-463b467802b8",
-            "createdDateTimeUtc": "2021-08-01T13:46:39.1556709Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:42.1830707Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1b93d4c5-0c5a-4c53-9d0b-123580370ac4",
-            "createdDateTimeUtc": "2021-08-01T13:46:34.0334308Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:35.0748515Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c10423c1-70a0-4249-9b44-c4e35fa531cf",
-            "createdDateTimeUtc": "2021-08-01T13:46:27.7441155Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:28.5230851Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "762b843d-5634-4e71-8998-3c269c5aa71a",
-            "createdDateTimeUtc": "2021-08-01T13:46:14.8806312Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:21.7377245Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8c396dd4-a4d4-4fd6-b49c-9bf293bc5b22",
-            "createdDateTimeUtc": "2021-08-01T13:39:53.2223797Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:59.6350234Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "15fa9332-a622-4903-9c2d-30ec419c019f",
-            "createdDateTimeUtc": "2021-08-01T13:39:40.8849092Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:45.8189345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "4eba9692-8936-433d-8277-37297439855f",
-            "createdDateTimeUtc": "2021-08-01T13:39:25.8159637Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:34.600318Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "d7d61b86-c02c-44a7-9d94-1b3bf73ea68c",
-            "createdDateTimeUtc": "2021-08-01T13:39:18.4391794Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:19.4610126Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "501ab4fe-6bb1-4f2f-bc60-0ed6375ff114",
-            "createdDateTimeUtc": "2021-08-01T13:39:08.0207097Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:12.3862208Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "92b4bf08-9a7b-4e86-bf5f-6287b863b2f8",
-            "createdDateTimeUtc": "2021-08-01T13:38:54.8712186Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:01.0996993Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "e89ae3bd-9e8e-4035-91c8-1110271964f5",
-            "createdDateTimeUtc": "2021-07-29T18:56:30.5852007Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:32.8561054Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "80f86e77-a61c-4fb6-a924-86ed9fd9dcdb",
-            "createdDateTimeUtc": "2021-07-29T18:56:17.7021902Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:25.2356539Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bfebe6ca-0904-4142-8deb-def8890749cc",
-            "createdDateTimeUtc": "2021-07-29T18:56:08.9244466Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:10.2588454Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c627c2f9-4605-4e98-92d7-d9814db0bfff",
-            "createdDateTimeUtc": "2021-07-29T18:55:56.0217273Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:03.7770256Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7cff621d-1a6d-432e-8fa5-df00eb8e076e",
-            "createdDateTimeUtc": "2021-07-29T18:55:47.2424877Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:48.0765309Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4338311b-280f-4aa3-844a-a7fb7236879d",
-            "createdDateTimeUtc": "2021-07-29T18:55:36.922933Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:41.5171516Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8794c5c1-f497-4a83-8293-da713258faa8",
-            "createdDateTimeUtc": "2021-07-29T18:55:23.3488567Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:30.3458735Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=350\u0026$top=61\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=350\u0026$top=61\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a8cb83d3a8b3fc46b4505651f96506ba-fd3ef16738b8ca46-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9b2771df1ae522f7f971be0ec3103607",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "44f7591f-0c7a-4cdc-94e4-88405ef83848",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:45 GMT",
-        "ETag": "\u0022216357BDF2CE86C57D7173C53DF5E14B2896280DA6C14C5FC9FC322EBC0B0D2D\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "44f7591f-0c7a-4cdc-94e4-88405ef83848"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "b86b6998-282c-4594-81a4-a6cb6d123953",
-            "createdDateTimeUtc": "2021-07-29T18:55:14.0853219Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:16.7959039Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "af92572b-d7d2-4d21-9ec7-411116a78904",
-            "createdDateTimeUtc": "2021-07-29T18:27:48.249869Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:48.9487415Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a7725a19-0c98-4ffd-947f-4d574615fd1e",
-            "createdDateTimeUtc": "2021-07-29T18:27:35.1676798Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:41.9314655Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bf5cbc3b-2921-4372-bcae-ffd87391abef",
-            "createdDateTimeUtc": "2021-07-29T18:27:27.7901646Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:28.4614677Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "69b858d0-ff26-4cfd-911e-37e3f73bb4f7",
-            "createdDateTimeUtc": "2021-07-29T18:27:19.8707951Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:21.4611112Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "14721933-e03d-4f8a-8f21-83219f03b279",
-            "createdDateTimeUtc": "2021-07-29T18:27:03.2894117Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:10.3609678Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8375af4f-848a-46ff-891e-a8b844ca0856",
-            "createdDateTimeUtc": "2021-07-29T18:26:52.907266Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:56.3528141Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "23dfbdb4-cf55-45bb-ab9c-02e3167a29e1",
-            "createdDateTimeUtc": "2021-07-29T18:26:45.3554314Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:46.2619525Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d5c5dd3e-1858-468d-bf7f-33f2833f4872",
-            "createdDateTimeUtc": "2021-07-29T18:26:37.3639687Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:38.3200345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e7188ffe-9202-479a-afe1-01fecc04ad22",
-            "createdDateTimeUtc": "2021-07-29T18:25:33.3238602Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:35.2984814Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "70db07a3-07c0-4d9d-83c5-5f65da69c4f9",
-            "createdDateTimeUtc": "2021-07-29T18:25:26.783298Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:28.2271307Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6a32867d-406a-4da9-a9aa-6d869d895bfd",
-            "createdDateTimeUtc": "2021-07-29T18:25:18.055152Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:21.1616142Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "05e70da4-5e01-4a27-b706-19fcf0adcada",
-            "createdDateTimeUtc": "2021-07-29T18:25:12.7651639Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:14.1490239Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f9b7a393-c7a5-421c-ba1d-a44c02048634",
-            "createdDateTimeUtc": "2021-07-29T18:25:04.3837212Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:07.1327422Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b4902c6f-6289-477e-8f9b-2bcb70c2e924",
-            "createdDateTimeUtc": "2021-07-29T18:24:57.6574082Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:00.1100818Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6048a21b-abc8-4457-b921-b9f3602082dd",
-            "createdDateTimeUtc": "2021-07-29T18:24:51.4511113Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:53.231795Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "72139ec3-ad0b-42cc-9a6c-92c555cc1417",
-            "createdDateTimeUtc": "2021-07-29T18:24:42.1866362Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:46.1095564Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a0efbf77-53fb-4af8-8c69-61df229575cc",
-            "createdDateTimeUtc": "2021-07-29T18:24:18.6490605Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:21.0023446Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f50dd147-dd7a-4589-8f90-b40bdc22e6d9",
-            "createdDateTimeUtc": "2021-07-29T18:24:13.4076008Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:14.9595162Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1769c3a9-a912-4e02-ad76-4ad658e6bd07",
-            "createdDateTimeUtc": "2021-07-29T18:24:06.1419128Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:07.8638717Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7a8a7450-9f6e-4ee0-9c72-caa4303e9649",
-            "createdDateTimeUtc": "2021-07-29T18:23:53.1730982Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:00.9552258Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4b5fd2ee-aa2a-45e2-a64b-69d4b6aa8fef",
-            "createdDateTimeUtc": "2021-07-29T18:23:44.6321958Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:46.0263327Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6d4a7add-df54-4f67-a3dd-bc47675e5131",
-            "createdDateTimeUtc": "2021-07-29T18:23:35.607668Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:38.9203906Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "73a8b048-a34e-4bf9-9a77-9fd7a1fa0eab",
-            "createdDateTimeUtc": "2021-07-29T18:23:22.5480081Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:26.9561971Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3221547b-76a3-45d2-ad5e-28383c397f11",
-            "createdDateTimeUtc": "2021-07-29T18:23:12.8991624Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:16.2575253Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce9f5f49-3336-4ef4-996f-7086e032e208",
-            "createdDateTimeUtc": "2021-07-29T18:11:08.689952Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:11:10.9326895Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a17020af-7225-4a1c-bd1d-f9c86b8e8231",
-            "createdDateTimeUtc": "2021-07-29T18:10:59.594621Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:11:03.8658837Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bcd6fdf4-0572-475d-af9c-6df2e9882564",
-            "createdDateTimeUtc": "2021-07-29T18:10:48.318371Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:53.1219508Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7f7329d9-9d65-4aa0-a19e-c151f45fbfba",
-            "createdDateTimeUtc": "2021-07-29T18:10:36.4711697Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:39.9591092Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8a8759c6-38f8-4587-82c5-551099482e2e",
-            "createdDateTimeUtc": "2021-07-29T18:10:25.3356743Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:29.6315203Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "41696374-9114-4f8d-90f7-6c8a1c7b0607",
-            "createdDateTimeUtc": "2021-07-29T18:10:14.5091385Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:18.8819684Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c1fe9b5d-e1ec-410d-84e1-14780b307360",
-            "createdDateTimeUtc": "2021-07-29T18:10:03.0941124Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:08.0754094Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5f6d6b60-7017-4ae9-b89b-734dbc8df3a2",
-            "createdDateTimeUtc": "2021-07-29T18:09:50.6890119Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:09:54.5512218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "68c61875-9896-4531-8eec-f79a84ec0732",
-            "createdDateTimeUtc": "2021-07-29T18:07:41.3308148Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:43.0283024Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9b825b8-de7f-4ef9-8b15-67f8a05228de",
-            "createdDateTimeUtc": "2021-07-29T18:07:33.4253241Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:35.8948263Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "07266a35-6965-49a7-b488-c6aec774f353",
-            "createdDateTimeUtc": "2021-07-29T18:07:28.0747509Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:29.4732464Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "712bb162-dda9-4e0d-900d-6e32ccb84ce2",
-            "createdDateTimeUtc": "2021-07-29T18:07:21.4384466Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:22.3419567Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8f0a8627-974a-452a-b531-0a7eeba67834",
-            "createdDateTimeUtc": "2021-07-29T18:07:11.9494241Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:13.7989556Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c944ca83-770a-4981-8393-8436509a3ac5",
-            "createdDateTimeUtc": "2021-07-29T18:07:03.4708288Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:04.7948363Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "579fe594-a0ac-46c9-99bc-6337aacf022c",
-            "createdDateTimeUtc": "2021-07-29T18:06:55.3491078Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:57.7260656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b9b9b7a-0467-49b5-a230-d6c2c1c80827",
-            "createdDateTimeUtc": "2021-07-29T18:06:40.9676932Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:46.6887745Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b47abfb4-48de-49de-a4cd-147fe3742a71",
-            "createdDateTimeUtc": "2021-07-29T18:06:35.6198036Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:37.3471477Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5dc846fa-dea1-4528-b9cb-39fba11fb4da",
-            "createdDateTimeUtc": "2021-07-29T18:06:18.7068479Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:26.7025516Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2a1743af-a8b6-4ff4-aacc-709b078c56ad",
-            "createdDateTimeUtc": "2021-07-29T18:02:37.0777259Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:40.6627767Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "cd0f86ef-4325-4732-bb52-a12b6bc460df",
-            "createdDateTimeUtc": "2021-07-29T18:02:26.2775788Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:28.2284503Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "905ec32b-4d49-47e5-825a-167cee386199",
-            "createdDateTimeUtc": "2021-07-29T18:02:02.1798526Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:05.4444688Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5e5d4037-f4be-4678-85f2-6c2d10eb35b0",
-            "createdDateTimeUtc": "2021-07-29T18:01:50.005682Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:01:53.1664365Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "f8e7a8b6-428a-45c1-8046-b00f16793d40",
-            "createdDateTimeUtc": "2021-07-29T18:00:58.4154875Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:01:00.6279809Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "f5aa1906-2807-4db0-bd08-a8f9e56b4750",
-            "createdDateTimeUtc": "2021-07-29T18:00:39.80581Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:00:48.5772657Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "0498c77f-42de-46cb-91fb-529c044d9e2b",
-            "createdDateTimeUtc": "2021-07-29T16:05:46.6656342Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:05:46.8929852Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=400\u0026$top=11\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=400\u0026$top=11\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3efb01eb553ba54fba8b092efd147e62-ee97066ee491d34b-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3eff84c03f86ef969b90a58c8c2be6bb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1632eaa9-5b49-4399-9d42-66e87ce4d6a9",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:30:46 GMT",
-        "ETag": "\u002237D2A7636A41ED2E180191AEACEA7518C0D571B3BCB9767871E6B53AFA017D4F\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "1632eaa9-5b49-4399-9d42-66e87ce4d6a9"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "f97fa266-258a-43be-abf7-3a851dd3438a",
-            "createdDateTimeUtc": "2021-07-29T16:05:43.5493779Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:05:43.798646Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "bfe99a22-0966-4bb8-8f99-a60956e1bd44",
-            "createdDateTimeUtc": "2021-07-29T16:04:43.3132785Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:04:43.6688398Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "364a7f60-b5e0-40ed-8fbe-8c269e757f58",
-            "createdDateTimeUtc": "2021-07-29T16:04:38.8243421Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:04:39.7360075Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "173f4456-92b0-47d4-87f0-d3b3f6b076c8",
-            "createdDateTimeUtc": "2021-07-29T16:00:33.3385235Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:00:33.6856601Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "e2cebd98-9179-47ff-a520-d6e672f9548d",
-            "createdDateTimeUtc": "2021-07-29T15:59:51.7446608Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:59:51.9630722Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d44729c5-7422-414e-9ec8-41be82649bcd",
-            "createdDateTimeUtc": "2021-07-29T15:59:47.8488179Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:59:48.0834023Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "879d0008-1264-4273-9f94-61eaa0d53818",
-            "createdDateTimeUtc": "2021-07-29T15:57:48.4243818Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:48.6367029Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "52a46f0a-80cc-4e51-94e8-6355a5a00782",
-            "createdDateTimeUtc": "2021-07-29T15:57:45.4760932Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:45.6975927Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "1b1df384-0c32-48e3-8539-53619fe9847f",
-            "createdDateTimeUtc": "2021-07-29T15:57:06.0490196Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:06.4194196Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "49e77fae-33ee-486c-aac8-5a9e6e27d6c0",
-            "createdDateTimeUtc": "2021-07-29T15:54:13.5289776Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:54:13.9172691Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "dea162d3-b03d-466e-bd33-fae8e3279b21",
-            "createdDateTimeUtc": "2021-07-29T15:54:09.3707087Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:54:09.7229003Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
             }
           }
         ]
@@ -8148,10 +1956,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-04T22:30:46.6846171\u002B02:00",
+    "DateTimeOffsetNow": "2021-08-26T14:07:58.3333724\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
     "RandomSeed": "231125431"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesOrderByCreatedOnTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesOrderByCreatedOnTestAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1210274283?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1210274283?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-97306791aad5c4488a1da3b3944518bc-37b8f9208861274d-00",
+        "traceparent": "00-5860373fc7aa914ea0f7e26d9b92f497-cdadbc914e575e4c-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "b656b720e70da0ef32dd293cb079f76a",
-        "x-ms-date": "Wed, 04 Aug 2021 20:32:01 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:32:01 GMT",
-        "ETag": "\u00220x8D95786EA78589C\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:32:02 GMT",
+        "Date": "Thu, 26 Aug 2021 12:09:22 GMT",
+        "ETag": "\u00220x8D9688A5739F90F\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:09:22 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "b656b720e70da0ef32dd293cb079f76a",
-        "x-ms-request-id": "05285607-a01e-003b-446f-896135000000",
+        "x-ms-request-id": "2e7634bc-601e-0046-5f73-9a0818000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/source1210274283/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1210274283/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "16",
         "If-None-Match": "*",
-        "traceparent": "00-add9fe12a21a594182f661626af1a36a-72670d7d4d8ca642-00",
+        "traceparent": "00-3001294777f6c048ad557765049bd939-9308283427b3ce4d-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-client-request-id": "c7687d22dfc2b3b8db4f044e1c2481cd",
-        "x-ms-date": "Wed, 04 Aug 2021 20:32:01 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:09:22 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -47,28 +47,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Wed, 04 Aug 2021 20:32:01 GMT",
-        "ETag": "\u00220x8D95786EAC5B4D3\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:32:02 GMT",
+        "Date": "Thu, 26 Aug 2021 12:09:22 GMT",
+        "ETag": "\u00220x8D9688A576DB3DC\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:09:23 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "c7687d22dfc2b3b8db4f044e1c2481cd",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "05285653-a01e-003b-076f-896135000000",
+        "x-ms-request-id": "2e763565-601e-0046-7c73-9a0818000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target1922004621?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1922004621?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-176a9d5d2477ec49863ed856a316f700-b1755c8abf382f48-00",
+        "traceparent": "00-4610d9c8c801c144bb9475089e66fb77-aa77a02ec969284f-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
         "x-ms-client-request-id": "bccffedf32547096f580ca03503474d2",
-        "x-ms-date": "Wed, 04 Aug 2021 20:32:02 GMT",
+        "x-ms-date": "Thu, 26 Aug 2021 12:09:23 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -76,26 +76,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:32:01 GMT",
-        "ETag": "\u00220x8D95786EAEADE28\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:32:02 GMT",
+        "Date": "Thu, 26 Aug 2021 12:09:22 GMT",
+        "ETag": "\u00220x8D9688A5784562E\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:09:23 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
         "x-ms-client-request-id": "bccffedf32547096f580ca03503474d2",
-        "x-ms-request-id": "052856fe-a01e-003b-186f-896135000000",
+        "x-ms-request-id": "2e7636b2-601e-0046-3d73-9a0818000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-03583c3ed6ed0e41942f44d33a32e239-73d6c9e450595845-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ac3100451383f243a088462b7919ae54-8ffe5202ebc4e842-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "a5c5d85d299eff41a3dbbde2a1830d5b",
         "x-ms-return-client-request-id": "true"
       },
@@ -116,10 +116,10 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "47dcdb0e-b0b1-4441-8646-1833a9e9341f",
+        "apim-request-id": "8c2d8078-4d77-42ae-bc5f-51e98e499f09",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:32:02 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e",
+        "Date": "Thu, 26 Aug 2021 12:09:23 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cb1ee967-8a8e-44b2-8e02-550471203caa",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
@@ -127,46 +127,46 @@
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "47dcdb0e-b0b1-4441-8646-1833a9e9341f"
+        "X-RequestId": "8c2d8078-4d77-42ae-bc5f-51e98e499f09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cb1ee967-8a8e-44b2-8e02-550471203caa",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "7ad1ae5bad284bced256cc5fedaf8a1a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8dc0140c-6d94-4d5c-9cf5-6e865cf45404",
+        "apim-request-id": "acf1c70d-576c-4602-9858-5aa9a0d2a8f7",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:02 GMT",
-        "ETag": "\u00227B23A5D1775E6C13EDD187A86CA5F4A562A3C02A784E4718F86F4C732804EE35\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:23 GMT",
+        "ETag": "\u0022001C68226A17EF9161627BEBB564164D8D8E355F81980591A57E4EA8BC8D64D0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8dc0140c-6d94-4d5c-9cf5-6e865cf45404"
+        "X-RequestId": "acf1c70d-576c-4602-9858-5aa9a0d2a8f7"
       },
       "ResponseBody": {
-        "id": "68a574df-5601-4215-8d29-f89145a98f5e",
-        "createdDateTimeUtc": "2021-08-04T20:32:03.2996874Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:03.2996877Z",
+        "id": "cb1ee967-8a8e-44b2-8e02-550471203caa",
+        "createdDateTimeUtc": "2021-08-26T12:09:23.5552184Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:23.5552187Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -180,26 +180,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cb1ee967-8a8e-44b2-8e02-550471203caa",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "4cbe7b8f28bcb5efbcd0197974b3cf71",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ac692eb7-4127-472f-83ea-1bc8e4a62885",
+        "apim-request-id": "3f1c2754-abb7-47b3-a877-ab547e70c12d",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:04 GMT",
-        "ETag": "\u0022CAA468C75DFA043ED16E3D6A9E2016E0538D0A545E16734CD93196FA26466CC5\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:24 GMT",
+        "ETag": "\u0022EF07E6B732D7C3019FA555329AFE885759B830C06874AD60BE89AFDD82F72988\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -209,156 +209,156 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ac692eb7-4127-472f-83ea-1bc8e4a62885"
+        "X-RequestId": "3f1c2754-abb7-47b3-a877-ab547e70c12d"
       },
       "ResponseBody": {
-        "id": "68a574df-5601-4215-8d29-f89145a98f5e",
-        "createdDateTimeUtc": "2021-08-04T20:32:03.2996874Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:03.5932269Z",
-        "status": "NotStarted",
+        "id": "cb1ee967-8a8e-44b2-8e02-550471203caa",
+        "createdDateTimeUtc": "2021-08-26T12:09:23.5552184Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:25.002537Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cb1ee967-8a8e-44b2-8e02-550471203caa",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "a2a76e72fa63b0aa0a7ad3475ce211f3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d6bf9fd7-544f-4b28-bd82-4493c5d35fc5",
+        "apim-request-id": "bad2f93e-a6c2-4446-a15c-a68cf85167ee",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:05 GMT",
-        "ETag": "\u0022CAA468C75DFA043ED16E3D6A9E2016E0538D0A545E16734CD93196FA26466CC5\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:26 GMT",
+        "ETag": "\u00229E3A55E7E41DC96FD5CE7084D39A7166E0C5EB4EF27CF88D4A5AC4D26C26E556\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d6bf9fd7-544f-4b28-bd82-4493c5d35fc5"
+        "X-RequestId": "bad2f93e-a6c2-4446-a15c-a68cf85167ee"
       },
       "ResponseBody": {
-        "id": "68a574df-5601-4215-8d29-f89145a98f5e",
-        "createdDateTimeUtc": "2021-08-04T20:32:03.2996874Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:03.5932269Z",
-        "status": "NotStarted",
+        "id": "cb1ee967-8a8e-44b2-8e02-550471203caa",
+        "createdDateTimeUtc": "2021-08-26T12:09:23.5552184Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:25.8467461Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cb1ee967-8a8e-44b2-8e02-550471203caa",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "2553a250c1c4339fbe1bbe589354d61e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d41432aa-c711-4d19-93ef-3b28a5bf416c",
+        "apim-request-id": "6c61ea24-3224-4500-9d0d-b982d52d3eb3",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:06 GMT",
-        "ETag": "\u0022CAA468C75DFA043ED16E3D6A9E2016E0538D0A545E16734CD93196FA26466CC5\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:27 GMT",
+        "ETag": "\u00229E3A55E7E41DC96FD5CE7084D39A7166E0C5EB4EF27CF88D4A5AC4D26C26E556\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "d41432aa-c711-4d19-93ef-3b28a5bf416c"
+        "X-RequestId": "6c61ea24-3224-4500-9d0d-b982d52d3eb3"
       },
       "ResponseBody": {
-        "id": "68a574df-5601-4215-8d29-f89145a98f5e",
-        "createdDateTimeUtc": "2021-08-04T20:32:03.2996874Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:03.5932269Z",
-        "status": "NotStarted",
+        "id": "cb1ee967-8a8e-44b2-8e02-550471203caa",
+        "createdDateTimeUtc": "2021-08-26T12:09:23.5552184Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:25.8467461Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cb1ee967-8a8e-44b2-8e02-550471203caa",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "7fec5a87e70895b7d00e424154a859da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3a35a1a8-598d-4e7d-a14f-cc611bbd7c25",
+        "apim-request-id": "2aceda60-ed54-447b-8be0-d886f912b646",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:07 GMT",
-        "ETag": "\u00221F0F6248B275621DDEC44EBF551036C5CBCAF873494317B0EA256A8E044E9D72\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:28 GMT",
+        "ETag": "\u00229E3A55E7E41DC96FD5CE7084D39A7166E0C5EB4EF27CF88D4A5AC4D26C26E556\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3a35a1a8-598d-4e7d-a14f-cc611bbd7c25"
+        "X-RequestId": "2aceda60-ed54-447b-8be0-d886f912b646"
       },
       "ResponseBody": {
-        "id": "68a574df-5601-4215-8d29-f89145a98f5e",
-        "createdDateTimeUtc": "2021-08-04T20:32:03.2996874Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:08.2866112Z",
+        "id": "cb1ee967-8a8e-44b2-8e02-550471203caa",
+        "createdDateTimeUtc": "2021-08-26T12:09:23.5552184Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:25.8467461Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -372,74 +372,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cb1ee967-8a8e-44b2-8e02-550471203caa",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "d22826bea960b1adcf73e3473c521cb5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c1144976-242c-4a12-81e0-5c097d2e3647",
+        "apim-request-id": "d30949de-0f9d-454f-8d24-2cb28a76308c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:09 GMT",
-        "ETag": "\u00227C93D1A560DE99D1E45181B1123D9B65D8C61593447E47B56ABCB91850FB5D71\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:29 GMT",
+        "ETag": "\u0022629242F6F8926EE44EC160A9ACD11C4C8A8CC37972A1868E8324D114A23DE539\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c1144976-242c-4a12-81e0-5c097d2e3647"
+        "X-RequestId": "d30949de-0f9d-454f-8d24-2cb28a76308c"
       },
       "ResponseBody": {
-        "id": "68a574df-5601-4215-8d29-f89145a98f5e",
-        "createdDateTimeUtc": "2021-08-04T20:32:03.2996874Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:08.6609665Z",
-        "status": "Running",
+        "id": "cb1ee967-8a8e-44b2-8e02-550471203caa",
+        "createdDateTimeUtc": "2021-08-26T12:09:23.5552184Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:29.6264436Z",
+        "status": "Succeeded",
         "summary": {
           "total": 1,
           "failed": 0,
-          "success": 0,
-          "inProgress": 1,
+          "success": 1,
+          "inProgress": 0,
           "notYetStarted": 0,
           "cancelled": 0,
-          "totalCharacterCharged": 0
+          "totalCharacterCharged": 16
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/cb1ee967-8a8e-44b2-8e02-550471203caa/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "02bfb4a392f568ebebbd54b67e5ddf16",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4fe5ddc2-6bb2-458a-9ce7-f48821605aea",
+        "apim-request-id": "806d8eaa-5b43-4087-a7fe-0f35d49e192c",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:10 GMT",
-        "ETag": "\u0022E44C0F30C13165404372D6370F4D9E261C8172521278DB7C774D771B6D38C540\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:30 GMT",
+        "ETag": "\u0022B4A08B12F189DCE27C00044987F9D11684C065B0C602C1AC2D7480F6315D021F\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -449,82 +449,34 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4fe5ddc2-6bb2-458a-9ce7-f48821605aea"
-      },
-      "ResponseBody": {
-        "id": "68a574df-5601-4215-8d29-f89145a98f5e",
-        "createdDateTimeUtc": "2021-08-04T20:32:03.2996874Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:08.6609665Z",
-        "status": "Succeeded",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 1,
-          "inProgress": 0,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 16
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/68a574df-5601-4215-8d29-f89145a98f5e/documents",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6d99e3c2042cdebdad3baf940470597e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e0c141fd-6b17-40ba-b9dc-6051eb9cd384",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:10 GMT",
-        "ETag": "\u0022068B1761AB314D5D8D8DEAEC661ECAEE131AB39164BD2145461C830BE5E5468F\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "e0c141fd-6b17-40ba-b9dc-6051eb9cd384"
+        "X-RequestId": "806d8eaa-5b43-4087-a7fe-0f35d49e192c"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target1922004621/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1210274283/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:32:08.2966726Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:32:10.5502961Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1922004621/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1210274283/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:09:25.0119204Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:09:29.6264309Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a5403-0000-0000-0000-000000000000",
+            "id": "000b4684-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target344819442?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1968987842?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-d949eda519df6542a5703836cd3fc558-5af2b332341dc146-00",
+        "traceparent": "00-e3e0224462b40f4d83539143bf92ab05-ce336a93d647dc4a-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "e89f9d8de4563b2cbfe7a354f7327194",
-        "x-ms-date": "Wed, 04 Aug 2021 20:32:11 GMT",
+        "x-ms-client-request-id": "2c6d99e3bd04adde3baf940470597ef2",
+        "x-ms-date": "Thu, 26 Aug 2021 12:09:30 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -532,27 +484,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:32:10 GMT",
-        "ETag": "\u00220x8D95786F02B3312\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:32:11 GMT",
+        "Date": "Thu, 26 Aug 2021 12:09:29 GMT",
+        "ETag": "\u00220x8D9688A5BD960C7\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:09:30 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "e89f9d8de4563b2cbfe7a354f7327194",
-        "x-ms-request-id": "05286693-a01e-003b-486f-896135000000",
+        "x-ms-client-request-id": "2c6d99e3bd04adde3baf940470597ef2",
+        "x-ms-request-id": "2e765338-601e-0046-6573-9a0818000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-932a9e50357040408e10c0c298971b12-48df024b6cbceb43-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b95884cd88aff69fe154bae256647a63",
+        "traceparent": "00-6b71dedcdc5d354590f50398dc917349-6b8a6129de0f1645-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e89f9d8de4563b2cbfe7a354f7327194",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -572,63 +524,111 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "788da3aa-6882-4362-a41f-b37e5a1528d4",
+        "apim-request-id": "3004b5bb-d3a7-4ac2-897d-796804caca8e",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:32:11 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f91a6052-9469-4822-84f0-0798caa53c81",
+        "Date": "Thu, 26 Aug 2021 12:09:30 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f006866a-29e4-4b84-b741-1e7f9fed8351",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "3004b5bb-d3a7-4ac2-897d-796804caca8e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f006866a-29e4-4b84-b741-1e7f9fed8351",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b95884cd88aff69fe154bae256647a63",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "72dd3e1c-4263-491b-8850-85a794a7c253",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:09:30 GMT",
+        "ETag": "\u00220BD3E12273D882E4DA3C767A319BB2748B205D5F9457F1791AFAA8B26F58BB13\u0022",
+        "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
           "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "788da3aa-6882-4362-a41f-b37e5a1528d4"
+        "X-RequestId": "72dd3e1c-4263-491b-8850-85a794a7c253"
       },
-      "ResponseBody": []
+      "ResponseBody": {
+        "id": "f006866a-29e4-4b84-b741-1e7f9fed8351",
+        "createdDateTimeUtc": "2021-08-26T12:09:30.8113089Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:30.8113093Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f91a6052-9469-4822-84f0-0798caa53c81",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f006866a-29e4-4b84-b741-1e7f9fed8351",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "c0f1c3d62d3fff6b6c316d1d1a89b609",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50391cd6-6d20-4cf8-8ac9-47e961317995",
+        "apim-request-id": "f935c639-39d0-4eaa-88cd-1cef93f09585",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:11 GMT",
-        "ETag": "\u0022AA506FFE1EFA545F5533FEB55EBD96BD1AFB1DA9F75F82193D75C1D815FEDA64\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:31 GMT",
+        "ETag": "\u0022F3AB962A7ADA7314DE18A400C8F237A693F3E0349F1EFB6E3B6A0697907E7C0A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "50391cd6-6d20-4cf8-8ac9-47e961317995"
+        "X-RequestId": "f935c639-39d0-4eaa-88cd-1cef93f09585"
       },
       "ResponseBody": {
-        "id": "f91a6052-9469-4822-84f0-0798caa53c81",
-        "createdDateTimeUtc": "2021-08-04T20:32:12.1058827Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:12.105883Z",
-        "status": "NotStarted",
+        "id": "f006866a-29e4-4b84-b741-1e7f9fed8351",
+        "createdDateTimeUtc": "2021-08-26T12:09:30.8113089Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:32.2087831Z",
+        "status": "Running",
         "summary": {
-          "total": 0,
+          "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
+          "inProgress": 1,
           "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
@@ -636,26 +636,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f91a6052-9469-4822-84f0-0798caa53c81",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f006866a-29e4-4b84-b741-1e7f9fed8351",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "ec36ff3ec4010442fda907022a49e45a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dbe963dc-4352-4fcf-93f8-0f1d95131298",
+        "apim-request-id": "0e1d8045-612b-4f34-8b78-5307fef4bcc0",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:12 GMT",
-        "ETag": "\u0022CF9F9FF861AD455DB4F6D01E9D1CF09D03801B560402BCA27E2631EE2C0B0A19\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:33 GMT",
+        "ETag": "\u002220A29C7B58EB7FC995123D5FA2A4395DE388254DDB200D59A8A447EDA223DB8D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -665,93 +665,93 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "dbe963dc-4352-4fcf-93f8-0f1d95131298"
+        "X-RequestId": "0e1d8045-612b-4f34-8b78-5307fef4bcc0"
       },
       "ResponseBody": {
-        "id": "f91a6052-9469-4822-84f0-0798caa53c81",
-        "createdDateTimeUtc": "2021-08-04T20:32:12.1058827Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:12.4778181Z",
-        "status": "NotStarted",
+        "id": "f006866a-29e4-4b84-b741-1e7f9fed8351",
+        "createdDateTimeUtc": "2021-08-26T12:09:30.8113089Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:32.6460879Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f91a6052-9469-4822-84f0-0798caa53c81",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f006866a-29e4-4b84-b741-1e7f9fed8351",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "337e3f6cb141a05518584c7d1b82dc58",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8c5ac0e8-f1e5-4b63-b520-e0c47af31119",
+        "apim-request-id": "e3d5d056-9f49-4bd0-9f37-7dae109fb475",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:14 GMT",
-        "ETag": "\u0022CF9F9FF861AD455DB4F6D01E9D1CF09D03801B560402BCA27E2631EE2C0B0A19\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:34 GMT",
+        "ETag": "\u002220A29C7B58EB7FC995123D5FA2A4395DE388254DDB200D59A8A447EDA223DB8D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8c5ac0e8-f1e5-4b63-b520-e0c47af31119"
+        "X-RequestId": "e3d5d056-9f49-4bd0-9f37-7dae109fb475"
       },
       "ResponseBody": {
-        "id": "f91a6052-9469-4822-84f0-0798caa53c81",
-        "createdDateTimeUtc": "2021-08-04T20:32:12.1058827Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:12.4778181Z",
-        "status": "NotStarted",
+        "id": "f006866a-29e4-4b84-b741-1e7f9fed8351",
+        "createdDateTimeUtc": "2021-08-26T12:09:30.8113089Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:32.6460879Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f91a6052-9469-4822-84f0-0798caa53c81",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f006866a-29e4-4b84-b741-1e7f9fed8351",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "56a4b09e8e2e116280ecc2952669d422",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c786d4f7-bc76-4807-b85e-ec4694360448",
+        "apim-request-id": "b309b002-9307-4110-9dde-80567cf88966",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:15 GMT",
-        "ETag": "\u00222D9F0FA473048099CD2F9A5CDD44B976307057DAFB51444E4FBF4BA6625866AD\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:35 GMT",
+        "ETag": "\u002220A29C7B58EB7FC995123D5FA2A4395DE388254DDB200D59A8A447EDA223DB8D\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -761,12 +761,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c786d4f7-bc76-4807-b85e-ec4694360448"
+        "X-RequestId": "b309b002-9307-4110-9dde-80567cf88966"
       },
       "ResponseBody": {
-        "id": "f91a6052-9469-4822-84f0-0798caa53c81",
-        "createdDateTimeUtc": "2021-08-04T20:32:12.1058827Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:15.8051468Z",
+        "id": "f006866a-29e4-4b84-b741-1e7f9fed8351",
+        "createdDateTimeUtc": "2021-08-26T12:09:30.8113089Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:32.6460879Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -780,89 +780,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f91a6052-9469-4822-84f0-0798caa53c81",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f006866a-29e4-4b84-b741-1e7f9fed8351",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "dbb0124d830a8cc7aa96d3a878c5e97b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bf6c28ce-4c38-49df-bc48-cb857bf34be0",
+        "apim-request-id": "75a33e9e-f619-4bd3-a295-b06a6b0172c4",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:16 GMT",
-        "ETag": "\u00222D9F0FA473048099CD2F9A5CDD44B976307057DAFB51444E4FBF4BA6625866AD\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:36 GMT",
+        "ETag": "\u00222DD831508A96C8870AD80311DDA5CE2CAB2A0CD1E9E0D2D4A4486820659D4ABD\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "bf6c28ce-4c38-49df-bc48-cb857bf34be0"
+        "X-RequestId": "75a33e9e-f619-4bd3-a295-b06a6b0172c4"
       },
       "ResponseBody": {
-        "id": "f91a6052-9469-4822-84f0-0798caa53c81",
-        "createdDateTimeUtc": "2021-08-04T20:32:12.1058827Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:15.8051468Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f91a6052-9469-4822-84f0-0798caa53c81",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7964afcd8da5de2cdd6cb254efbf79ae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7a97c6ca-cfe8-4d50-948f-dd5568381d5f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:17 GMT",
-        "ETag": "\u00220DE4258F468C2496F5DAC8C481B274C45B00F6619BECDA8C9C046298D1007B91\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7a97c6ca-cfe8-4d50-948f-dd5568381d5f"
-      },
-      "ResponseBody": {
-        "id": "f91a6052-9469-4822-84f0-0798caa53c81",
-        "createdDateTimeUtc": "2021-08-04T20:32:12.1058827Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:15.8051468Z",
+        "id": "f006866a-29e4-4b84-b741-1e7f9fed8351",
+        "createdDateTimeUtc": "2021-08-26T12:09:30.8113089Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:36.7717739Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -876,63 +828,63 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f91a6052-9469-4822-84f0-0798caa53c81/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f006866a-29e4-4b84-b741-1e7f9fed8351/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "082f298400d11a4de917ac98bab999bb",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7964afcd8da5de2cdd6cb254efbf79ae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "464da21d-087e-4b21-87ff-0230c520dd8d",
+        "apim-request-id": "cda83363-6eb7-4d48-a38a-0d59491288e2",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:18 GMT",
-        "ETag": "\u002293F6FB92CD091916D378F3FBD9F212FED3B1E6E343E0552395440F7CD4B51E84\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:36 GMT",
+        "ETag": "\u002248835D5F40F20D8D3E34ECE53AD210F5BA8A49584D71BC4EF04FA25E050ED091\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "464da21d-087e-4b21-87ff-0230c520dd8d"
+        "X-RequestId": "cda83363-6eb7-4d48-a38a-0d59491288e2"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target344819442/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1210274283/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:32:15.3729728Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:32:17.7036533Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1968987842/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1210274283/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:09:32.2181823Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:09:36.771768Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a5404-0000-0000-0000-000000000000",
+            "id": "000b4685-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://storagedoctranslator.blob.core.windows.net/target152893187?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target441670532?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "traceparent": "00-4b64515d52f5d7439ead36d7b775f514-26796d80fc821844-00",
+        "traceparent": "00-9f1f7071d94b3c4c882a376954c154d7-c43d56a785b7f149-00",
         "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "0477c8467d5be6bfd2fd9ed0739dea1c",
-        "x-ms-date": "Wed, 04 Aug 2021 20:32:18 GMT",
+        "x-ms-client-request-id": "d1082f294d00e91a17ac98bab999bb03",
+        "x-ms-date": "Thu, 26 Aug 2021 12:09:37 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -940,27 +892,27 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:32:18 GMT",
-        "ETag": "\u00220x8D95786F4ABE5E7\u0022",
-        "Last-Modified": "Wed, 04 Aug 2021 20:32:19 GMT",
+        "Date": "Thu, 26 Aug 2021 12:09:37 GMT",
+        "ETag": "\u00220x8D9688A603B3ED3\u0022",
+        "Last-Modified": "Thu, 26 Aug 2021 12:09:37 GMT",
         "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "0477c8467d5be6bfd2fd9ed0739dea1c",
-        "x-ms-request-id": "0528747b-a01e-003b-6c6f-896135000000",
+        "x-ms-client-request-id": "d1082f294d00e91a17ac98bab999bb03",
+        "x-ms-request-id": "2e766f04-601e-0046-6473-9a0818000000",
         "x-ms-version": "2020-04-08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-32958aaa60295049a7dcad9eee2088a1-b8448a34405d4949-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "954e2424a9e062cc49908de1942323d3",
+        "traceparent": "00-43716fab1384004dbae4859eb9a547d2-5b13ac33766e4f44-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0477c8467d5be6bfd2fd9ed0739dea1c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -980,57 +932,57 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "6e45ecd8-d02c-46ef-bfe8-9a301087abaa",
+        "apim-request-id": "8d9e04e4-72c1-4304-8f21-fe611d2d31b6",
         "Content-Length": "0",
-        "Date": "Wed, 04 Aug 2021 20:32:18 GMT",
-        "Operation-Location": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
+        "Date": "Thu, 26 Aug 2021 12:09:37 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/40b95fad-705c-4adb-b6ea-bd429b49e374",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "6e45ecd8-d02c-46ef-bfe8-9a301087abaa"
+        "X-RequestId": "8d9e04e4-72c1-4304-8f21-fe611d2d31b6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/40b95fad-705c-4adb-b6ea-bd429b49e374",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f6a851f7a902ac297022ff03af4a757a",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "954e2424a9e062cc49908de1942323d3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ef091d1b-b9f8-4c51-bd15-988604fd487a",
+        "apim-request-id": "164048f8-fa2b-4cd5-bbef-adf810c0a992",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:19 GMT",
-        "ETag": "\u0022B3EA51DE13268A494086D0544AA02C502F430071E09AD476D507687CE33330A0\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:37 GMT",
+        "ETag": "\u002244313B8590609BC6FB551827746E4624C51B388AE7FC5024A7AE739AA7816ABC\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ef091d1b-b9f8-4c51-bd15-988604fd487a"
+        "X-RequestId": "164048f8-fa2b-4cd5-bbef-adf810c0a992"
       },
       "ResponseBody": {
-        "id": "f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
-        "createdDateTimeUtc": "2021-08-04T20:32:19.6854582Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:19.6854585Z",
+        "id": "40b95fad-705c-4adb-b6ea-bd429b49e374",
+        "createdDateTimeUtc": "2021-08-26T12:09:38.2523679Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:38.2523685Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -1044,26 +996,74 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/40b95fad-705c-4adb-b6ea-bd429b49e374",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f6a851f7a902ac297022ff03af4a757a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4d6d3056-757f-41b6-90a1-2265309a7ea3",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 26 Aug 2021 12:09:38 GMT",
+        "ETag": "\u0022246816E93AD2EA7A5FFC97246CD0491E2827BAD7EF7D9C360393623ED5C08083\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "4d6d3056-757f-41b6-90a1-2265309a7ea3"
+      },
+      "ResponseBody": {
+        "id": "40b95fad-705c-4adb-b6ea-bd429b49e374",
+        "createdDateTimeUtc": "2021-08-26T12:09:38.2523679Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:39.7335768Z",
+        "status": "Running",
+        "summary": {
+          "total": 1,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 1,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/40b95fad-705c-4adb-b6ea-bd429b49e374",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "95957bc1254a9d22fc14bbcaefdd52af",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9cf6beff-04e4-4096-a46b-21682f28503f",
+        "apim-request-id": "9933cca7-50e6-45b4-93c8-33de1888f492",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:20 GMT",
-        "ETag": "\u00229B9C8378082672D9A7FC806C916F289D15BB73FADE7F9D3F80375B6F8564C13C\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:40 GMT",
+        "ETag": "\u0022246816E93AD2EA7A5FFC97246CD0491E2827BAD7EF7D9C360393623ED5C08083\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1073,60 +1073,60 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9cf6beff-04e4-4096-a46b-21682f28503f"
+        "X-RequestId": "9933cca7-50e6-45b4-93c8-33de1888f492"
       },
       "ResponseBody": {
-        "id": "f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
-        "createdDateTimeUtc": "2021-08-04T20:32:19.6854582Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:20.1629317Z",
-        "status": "NotStarted",
+        "id": "40b95fad-705c-4adb-b6ea-bd429b49e374",
+        "createdDateTimeUtc": "2021-08-26T12:09:38.2523679Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:39.7335768Z",
+        "status": "Running",
         "summary": {
           "total": 1,
           "failed": 0,
           "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
+          "inProgress": 1,
+          "notYetStarted": 0,
           "cancelled": 0,
           "totalCharacterCharged": 0
         }
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/40b95fad-705c-4adb-b6ea-bd429b49e374",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "21d9cadaf4f57a19fba125beaac9b3ff",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "87a86d29-9933-434c-8a6e-343976cf4b65",
+        "apim-request-id": "9a040068-875b-4e98-bd0f-4edbb97d99db",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:21 GMT",
-        "ETag": "\u0022B31897DEB8961EB936350CDC966DBBCC82E8603A486B5EFA09F821DDA15A787E\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:41 GMT",
+        "ETag": "\u0022246816E93AD2EA7A5FFC97246CD0491E2827BAD7EF7D9C360393623ED5C08083\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "87a86d29-9933-434c-8a6e-343976cf4b65"
+        "X-RequestId": "9a040068-875b-4e98-bd0f-4edbb97d99db"
       },
       "ResponseBody": {
-        "id": "f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
-        "createdDateTimeUtc": "2021-08-04T20:32:19.6854582Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:22.4578596Z",
+        "id": "40b95fad-705c-4adb-b6ea-bd429b49e374",
+        "createdDateTimeUtc": "2021-08-26T12:09:38.2523679Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:39.7335768Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -1140,26 +1140,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/40b95fad-705c-4adb-b6ea-bd429b49e374",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "1820131a8d8dd1892f0afaedee5ebc92",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cc8c630f-a2ca-4477-9e53-6cfbe6dd210f",
+        "apim-request-id": "4b77e389-edd0-4bbd-acf8-3cb12e3960df",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:22 GMT",
-        "ETag": "\u0022CCD7A004390BBA896F03887FB6DC017C24261781669324EA29AFF7BA5420DBE5\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:43 GMT",
+        "ETag": "\u0022246816E93AD2EA7A5FFC97246CD0491E2827BAD7EF7D9C360393623ED5C08083\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1169,12 +1169,12 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cc8c630f-a2ca-4477-9e53-6cfbe6dd210f"
+        "X-RequestId": "4b77e389-edd0-4bbd-acf8-3cb12e3960df"
       },
       "ResponseBody": {
-        "id": "f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
-        "createdDateTimeUtc": "2021-08-04T20:32:19.6854582Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:22.7671897Z",
+        "id": "40b95fad-705c-4adb-b6ea-bd429b49e374",
+        "createdDateTimeUtc": "2021-08-26T12:09:38.2523679Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:39.7335768Z",
         "status": "Running",
         "summary": {
           "total": 1,
@@ -1188,41 +1188,41 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/40b95fad-705c-4adb-b6ea-bd429b49e374",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "e42850cf5470cd85611a9aa80063f333",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cf86e5ae-c016-46a0-a513-6399e4842795",
+        "apim-request-id": "530bc921-b209-4651-a9f7-41c591429774",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:24 GMT",
-        "ETag": "\u00228DCB575B3825F97BC3A2A44B4568B224F8569C6BE0C51C4C786B43114FB03A67\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:44 GMT",
+        "ETag": "\u0022008F5F2F287A1010F0A2A9CD9DE8CA1ABC01FC2682E908B46D832578B5361A9B\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cf86e5ae-c016-46a0-a513-6399e4842795"
+        "X-RequestId": "530bc921-b209-4651-a9f7-41c591429774"
       },
       "ResponseBody": {
-        "id": "f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
-        "createdDateTimeUtc": "2021-08-04T20:32:19.6854582Z",
-        "lastActionDateTimeUtc": "2021-08-04T20:32:22.7671897Z",
+        "id": "40b95fad-705c-4adb-b6ea-bd429b49e374",
+        "createdDateTimeUtc": "2021-08-26T12:09:38.2523679Z",
+        "lastActionDateTimeUtc": "2021-08-26T12:09:43.5136649Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -1236,26 +1236,26 @@
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/f88b4af0-1efd-43c5-a904-1fdc8224fa0b/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/40b95fad-705c-4adb-b6ea-bd429b49e374/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "dcb0bc6139bd4c214107f2eaf92b8c9c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dced86c9-76a3-4f36-88a0-3125f66aa490",
+        "apim-request-id": "f8f1b1e3-eaec-4db8-92db-59cc15a2feea",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:24 GMT",
-        "ETag": "\u00229422160D7EA621D6D5DFE25B86C2518EB1ABE995F13AD6DD4D9A903E49336DF9\u0022",
+        "Date": "Thu, 26 Aug 2021 12:09:45 GMT",
+        "ETag": "\u00225329762A47B816D6F6F52AC7DC840BF1648A580FD02211721884383B1973F059\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
           "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
@@ -1265,63 +1265,63 @@
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "dced86c9-76a3-4f36-88a0-3125f66aa490"
+        "X-RequestId": "f8f1b1e3-eaec-4db8-92db-59cc15a2feea"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://storagedoctranslator.blob.core.windows.net/target152893187/File_0.txt",
-            "sourcePath": "https://storagedoctranslator.blob.core.windows.net/source1210274283/File_0.txt",
-            "createdDateTimeUtc": "2021-08-04T20:32:22.4659475Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:32:24.4455321Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target441670532/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1210274283/File_0.txt",
+            "createdDateTimeUtc": "2021-08-26T12:09:39.2716647Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:09:43.513659Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000a5405-0000-0000-0000-000000000000",
+            "id": "000b4686-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?ids=\u0026statuses=\u0026$orderBy=createdDateTimeUtc%20Desc",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2021-08-26T06%3A10%3A00.6091733Z\u0026$orderBy=createdDateTimeUtc%20Desc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-724f157116177f40929b1d5ab18c0c4d-5b7b25bd7807bb48-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-fd526420853af64ba53f47363c8eb9aa-0e4044369958174a-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
         "x-ms-client-request-id": "5aee92e5cea0c68e8e53b673f3e0d1cb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9a21d85e-2574-4009-a6b2-9fc22c0c1226",
+        "apim-request-id": "deccd325-7303-4598-93df-dc5e43e9929a",
         "Cache-Control": [
           "public",
           "max-age=1"
         ],
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:24 GMT",
-        "ETag": "\u002246EBE83AC9FE7FFAAD1CEF9DEE0700F4A03D4DC876F86C97389DBBFC2EC4A0E2\u0022",
+        "Date": "Thu, 26 Aug 2021 12:10:07 GMT",
+        "ETag": "\u0022B6D7C2842A0BEE0D8B1E6FFB5B1F0CD28BD6BC144B0A0A4247AD2898C3133632\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "x-content-type-options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9a21d85e-2574-4009-a6b2-9fc22c0c1226"
+        "X-RequestId": "deccd325-7303-4598-93df-dc5e43e9929a"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "f88b4af0-1efd-43c5-a904-1fdc8224fa0b",
-            "createdDateTimeUtc": "2021-08-04T20:32:19.6854582Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:32:22.7671897Z",
+            "id": "40b95fad-705c-4adb-b6ea-bd429b49e374",
+            "createdDateTimeUtc": "2021-08-26T12:09:38.2523679Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:09:43.5136649Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -1334,9 +1334,9 @@
             }
           },
           {
-            "id": "f91a6052-9469-4822-84f0-0798caa53c81",
-            "createdDateTimeUtc": "2021-08-04T20:32:12.1058827Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:32:15.8051468Z",
+            "id": "f006866a-29e4-4b84-b741-1e7f9fed8351",
+            "createdDateTimeUtc": "2021-08-26T12:09:30.8113089Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:09:36.7717739Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -1349,9 +1349,9 @@
             }
           },
           {
-            "id": "68a574df-5601-4215-8d29-f89145a98f5e",
-            "createdDateTimeUtc": "2021-08-04T20:32:03.2996874Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:32:08.6609665Z",
+            "id": "cb1ee967-8a8e-44b2-8e02-550471203caa",
+            "createdDateTimeUtc": "2021-08-26T12:09:23.5552184Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:09:29.6264436Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -1364,6057 +1364,9 @@
             }
           },
           {
-            "id": "62e69318-c19f-4cd0-98ff-d35fd903af13",
-            "createdDateTimeUtc": "2021-08-04T20:31:57.8581636Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:32:08.0670345Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4fd4f892-ac98-445b-9e2e-6dec4bd0ee53",
-            "createdDateTimeUtc": "2021-08-04T20:31:41.3401888Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:43.2981058Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b47a1878-eba6-4fd1-bd91-28a8278dc7c9",
-            "createdDateTimeUtc": "2021-08-04T20:31:32.7483449Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:34.465173Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7577037f-17ab-4851-b00c-08c9990ab365",
-            "createdDateTimeUtc": "2021-08-04T20:31:23.886505Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:28.2809993Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c1844d4e-91e7-4d27-8306-c4ae872fb0fe",
-            "createdDateTimeUtc": "2021-08-04T20:31:11.9333165Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:13.1538284Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1ba62433-3859-4df5-af33-cd4c4073e598",
-            "createdDateTimeUtc": "2021-08-04T20:31:04.8312514Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:31:06.0766477Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f7fe9d68-111f-4a6b-a389-0119d4df3805",
-            "createdDateTimeUtc": "2021-08-04T20:30:58.2974422Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:59.07834Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "10f5f9f9-2d5c-463c-815b-4fc7e3f50be2",
-            "createdDateTimeUtc": "2021-08-04T20:30:48.5711301Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:52.0223948Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eb3d2d8e-cad5-49df-a85c-45ea76ee1a33",
-            "createdDateTimeUtc": "2021-08-04T20:30:35.9657621Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:39.4948082Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "193f7f31-4a3e-4dac-b3d5-743038b2372c",
-            "createdDateTimeUtc": "2021-08-04T20:30:21.8202596Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:26.8712492Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1375b0c8-28f6-4118-b970-72b8c417c401",
-            "createdDateTimeUtc": "2021-08-04T20:30:12.5737458Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:14.4305144Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6606d70-e903-4f08-a80d-3d1b65c07303",
-            "createdDateTimeUtc": "2021-08-04T20:30:06.5979195Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:30:10.7837251Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "4d28332b-55aa-4fe2-bc8d-221c43ab0c79",
-            "createdDateTimeUtc": "2021-08-04T20:29:50.3509191Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:51.8150261Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e75bd705-e165-4fcf-b6ad-e6da946f44bd",
-            "createdDateTimeUtc": "2021-08-04T20:29:43.0044925Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:46.0940111Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a5cb9bb3-5100-40c6-bfae-a02a9099ce01",
-            "createdDateTimeUtc": "2021-08-04T20:29:32.9101442Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:39.0415286Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "129932a4-ccc4-4702-ae64-ed24fa9ebe30",
-            "createdDateTimeUtc": "2021-08-04T20:29:22.21029Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:23.790485Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b52c3e52-8d38-4c7a-b5d0-54679bcc80b5",
-            "createdDateTimeUtc": "2021-08-04T20:29:14.841147Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:16.7676912Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3998c574-c735-49bf-b118-d33fee05dd0d",
-            "createdDateTimeUtc": "2021-08-04T20:29:03.3100139Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:29:09.8583078Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ffecb1d4-4f3c-4b37-896e-4de9fd083855",
-            "createdDateTimeUtc": "2021-08-04T20:28:54.7241777Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:28:57.0357411Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "de3ae1b9-065c-4a2b-9da3-a413d0e1d828",
-            "createdDateTimeUtc": "2021-08-04T20:13:20.3289712Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:21.8009118Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5e58ffb7-c561-4ada-908a-5fb618214b57",
-            "createdDateTimeUtc": "2021-08-04T20:13:14.1830952Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:16.2626995Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "7349a49c-f2e4-4c35-938e-976306fdf0ec",
-            "createdDateTimeUtc": "2021-08-04T20:13:07.7204022Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:09.4175921Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "dad50132-5081-4e87-9cdb-8305960adaad",
-            "createdDateTimeUtc": "2021-08-04T20:13:00.3134951Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:13:02.1869029Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5149a480-1a90-4483-b9fe-8c0ae356c975",
-            "createdDateTimeUtc": "2021-08-04T20:12:48.8123001Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:12:52.257366Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "95d1a6fa-cbcc-4eda-b8c5-7f9dea903155",
-            "createdDateTimeUtc": "2021-08-04T20:12:39.6819361Z",
-            "lastActionDateTimeUtc": "2021-08-04T20:12:42.109702Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 2,
-              "failed": 0,
-              "success": 2,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 32
-            }
-          },
-          {
-            "id": "ee205c17-3434-4372-9ec8-093d3fc2ab0e",
-            "createdDateTimeUtc": "2021-08-03T21:39:22.1215914Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:24.0088345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "034ac505-8e05-45e9-b69d-4ae5db5c3206",
-            "createdDateTimeUtc": "2021-08-03T21:39:15.57059Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:16.9287241Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1c2e403d-4f5f-4176-ac0b-d6525df7993d",
-            "createdDateTimeUtc": "2021-08-03T21:39:08.8759005Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:09.8373116Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1f96fca2-aaec-427c-92d0-fc8d43372768",
-            "createdDateTimeUtc": "2021-08-03T21:39:02.4121988Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:39:05.2080796Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "52fa5dc7-49d0-4490-b402-1817331f10f9",
-            "createdDateTimeUtc": "2021-08-03T21:38:57.2193344Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:58.2127609Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "98452bfa-797a-44c2-9bb2-d7fd159fab0d",
-            "createdDateTimeUtc": "2021-08-03T21:38:51.6547083Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:54.3057302Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "32aebb1f-9dd9-4bf4-a684-514bde841fd8",
-            "createdDateTimeUtc": "2021-08-03T21:38:47.6125244Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:53.9775319Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8e25b211-27f2-4793-99d0-6e47f55427a8",
-            "createdDateTimeUtc": "2021-08-03T21:38:30.9134208Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:33.1131258Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "45af44ab-ab27-4533-be94-d14fdc2f1d69",
-            "createdDateTimeUtc": "2021-08-03T21:38:23.1840352Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:26.0456158Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5fe83ec6-8231-4c42-8f7e-a04b75c0fa20",
-            "createdDateTimeUtc": "2021-08-03T21:38:16.5690668Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:19.2704212Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2dcc3a07-d808-4004-8cbc-f8d7047be6ea",
-            "createdDateTimeUtc": "2021-08-03T21:38:08.8344934Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:12.1744445Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d44ccbb4-7c5e-4230-8641-699df49bc974",
-            "createdDateTimeUtc": "2021-08-03T21:38:03.662895Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:38:05.099967Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b911d708-f339-4c49-b387-3a93b892edca",
-            "createdDateTimeUtc": "2021-08-03T21:37:55.9487829Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:58.091697Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3e1a9fd7-eefa-4140-bb3d-0cae619045c8",
-            "createdDateTimeUtc": "2021-08-03T21:37:49.2093973Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:51.1527605Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5c031e55-d105-4fcd-bddf-341af3c07de3",
-            "createdDateTimeUtc": "2021-08-03T21:37:42.4444943Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:44.066063Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f422877d-d674-4826-855b-6b918a1f8448",
-            "createdDateTimeUtc": "2021-08-03T21:37:35.5232446Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:37.1398344Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6d647efa-7b96-4bb4-b74a-76f2cf63b647",
-            "createdDateTimeUtc": "2021-08-03T21:37:28.0253539Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:30.0244215Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9530409a-3f1c-4184-a932-62f7586ca48c",
-            "createdDateTimeUtc": "2021-08-03T21:37:21.3477618Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:23.0535345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "02188384-3e1d-4fd5-b7b2-1c436155a427",
-            "createdDateTimeUtc": "2021-08-03T21:37:14.5363644Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:15.8789238Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e462cb0b-c257-4a03-8704-bafedb9a34ec",
-            "createdDateTimeUtc": "2021-08-03T21:37:06.740111Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:08.9139737Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9c2aff22-052b-4fe3-a77a-0e3d002157cb",
-            "createdDateTimeUtc": "2021-08-03T21:37:00.1515856Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:37:01.782922Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cbd315d5-9d09-4805-aeaf-dbf5a09b3f7f",
-            "createdDateTimeUtc": "2021-08-03T21:36:50.9777091Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:54.8378022Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=372\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=50\u0026$top=372\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0f18185a209ab84c9cf8ebdb95135aaf-faba48daa4171f44-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "328cc617e0ae95d52edba368629ad336",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3c6cd543-28a8-4de2-a971-181118d9dadc",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:25 GMT",
-        "ETag": "\u002253C0ED55CAE1CABFECD32763E33FCC9A57A1C5F7F73A0A4401AEBD1B6C68AAB6\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3c6cd543-28a8-4de2-a971-181118d9dadc"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "6f434c3d-7dd9-4305-8231-52ea7ef8822a",
-            "createdDateTimeUtc": "2021-08-03T21:36:37.1050378Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:39.7392021Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9bb6ced9-7570-404b-ae57-f0f6239284ff",
-            "createdDateTimeUtc": "2021-08-03T21:36:17.4274204Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:24.6427413Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c55e7e92-9f89-4061-b896-c719864f6227",
-            "createdDateTimeUtc": "2021-08-03T21:36:09.0638051Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:10.9653857Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e7d6e45d-7068-410e-b993-c18ad571354f",
-            "createdDateTimeUtc": "2021-08-03T21:35:56.6699145Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:36:03.8654828Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce58c3d3-4f45-498d-b593-6a5e7e7bd192",
-            "createdDateTimeUtc": "2021-08-03T21:35:47.9412218Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:49.5951191Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1eb03d70-54fd-4310-a4bc-de808f681a39",
-            "createdDateTimeUtc": "2021-08-03T21:35:41.0214036Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:42.5156289Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0554a9e0-53ab-49cc-8f1b-6d102523e16e",
-            "createdDateTimeUtc": "2021-08-03T21:35:34.1373856Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:35.4992558Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2219aa8b-281e-4c42-9605-10c76cc72913",
-            "createdDateTimeUtc": "2021-08-03T21:35:26.2122116Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:28.9695764Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8ed3d7d1-4161-4da8-969f-f9ecd5080ad9",
-            "createdDateTimeUtc": "2021-08-03T21:35:20.7604613Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:21.8167479Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2a132541-29db-4298-8ba7-16244a41d852",
-            "createdDateTimeUtc": "2021-08-03T21:35:07.9761301Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:35:14.7038749Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "72f0b845-0052-4963-b25f-5e8af00d9b14",
-            "createdDateTimeUtc": "2021-08-03T21:34:58.9227471Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:59.6529936Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "134a4212-2732-497b-8390-42fdd37d21e4",
-            "createdDateTimeUtc": "2021-08-03T21:34:50.9445779Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:52.6686072Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0f9f6f1d-fbb2-4fc0-af0e-6f150e37af73",
-            "createdDateTimeUtc": "2021-08-03T21:34:44.4279088Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:45.6922406Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7ad52735-0cfc-4605-994b-a001b55239da",
-            "createdDateTimeUtc": "2021-08-03T21:34:36.6416807Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:40.3689165Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4a6f90f-809d-49a7-94bd-02b8ca21f03c",
-            "createdDateTimeUtc": "2021-08-03T21:34:23.5791957Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:25.3619831Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7fd3d1ca-a218-465c-8ff4-eb4048c38473",
-            "createdDateTimeUtc": "2021-08-03T21:34:16.1133883Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:18.3802341Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "196b19e9-ecbd-436d-877a-35b530e2c0fe",
-            "createdDateTimeUtc": "2021-08-03T21:34:09.5321065Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:11.3582876Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1fb76e64-f983-4edc-9d22-4f99e100acc3",
-            "createdDateTimeUtc": "2021-08-03T21:33:57.8667531Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:34:04.2518359Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c89dca35-2a09-4223-aead-e3e3c5d620f7",
-            "createdDateTimeUtc": "2021-08-03T21:33:46.1148308Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:50.7386282Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6c30daea-f0dc-45d2-a5f2-c9c9ca5c454d",
-            "createdDateTimeUtc": "2021-08-03T21:33:40.0877854Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:42.98622Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "06da1349-40ca-40a9-bcbc-bd1e846f3b88",
-            "createdDateTimeUtc": "2021-08-03T21:33:35.9538097Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:38.6215767Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "8afbd2b4-c1ed-4724-9e12-85961ac830ea",
-            "createdDateTimeUtc": "2021-08-03T21:33:09.7165208Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:18.2261067Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f14238b7-28ec-48ab-b76f-24d83d6dffb1",
-            "createdDateTimeUtc": "2021-08-03T21:33:01.8426407Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:33:03.3408766Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "dba26cd3-c01a-41a3-aa8f-8267cf500fec",
-            "createdDateTimeUtc": "2021-08-03T21:32:55.2352866Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:56.1955205Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "658543b1-f494-4515-b258-7df811c67fc4",
-            "createdDateTimeUtc": "2021-08-03T21:32:48.2354429Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:49.1386196Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "909802b6-105c-43b8-b323-1c2a8e3312bb",
-            "createdDateTimeUtc": "2021-08-03T21:32:42.6249984Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:43.7383766Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c0eb9e4b-eb06-4d7a-a1f9-d38af1250cfd",
-            "createdDateTimeUtc": "2021-08-03T21:32:34.5973391Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:36.730268Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "76ebe7f5-60a3-4ef7-a683-49370dad24a6",
-            "createdDateTimeUtc": "2021-08-03T21:32:28.4958568Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:29.6601157Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bb59e6b0-23b7-44e5-9057-2254f90fe98f",
-            "createdDateTimeUtc": "2021-08-03T21:32:20.7234242Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:22.6496271Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "28e02b6f-0895-4f5c-9a9f-2b52422c014c",
-            "createdDateTimeUtc": "2021-08-03T21:32:14.2081813Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:15.7088003Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1dbd7a32-7f17-4aef-9d3c-9dd4cdd2efa5",
-            "createdDateTimeUtc": "2021-08-03T21:32:07.5152962Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:08.641319Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9b3a8bcf-3b59-46f1-b705-7c6baf22c1a5",
-            "createdDateTimeUtc": "2021-08-03T21:32:00.4355607Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:32:01.5891063Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6318a8e-c90f-4781-92d1-8ce5e24597fe",
-            "createdDateTimeUtc": "2021-08-03T21:31:52.5113337Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:54.509403Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e9b2eeb6-267b-47aa-8fa9-5967c6388d6b",
-            "createdDateTimeUtc": "2021-08-03T21:31:46.0577699Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:47.5253048Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "487aa9c1-42d1-4b50-b8fc-3f85395ad6ac",
-            "createdDateTimeUtc": "2021-08-03T21:31:39.494573Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:40.4162301Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b50424f3-68b3-4e1b-8234-a23451697697",
-            "createdDateTimeUtc": "2021-08-03T21:31:30.3843702Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:34.1919695Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2541716b-10fc-4ab7-b914-f0c77cb139be",
-            "createdDateTimeUtc": "2021-08-03T21:31:14.9137729Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:19.0230031Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fdd7087b-33d3-403d-be85-1ab00fb30319",
-            "createdDateTimeUtc": "2021-08-03T21:31:01.2624907Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:31:05.3693236Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "203a2eb7-45bb-4bea-a0f8-0c955469a993",
-            "createdDateTimeUtc": "2021-08-03T21:30:48.6999513Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:53.8967855Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8fd4aa26-458e-4039-bb3e-98bbcced99e0",
-            "createdDateTimeUtc": "2021-08-03T21:30:37.0230807Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:38.9030608Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7b349018-5715-4420-a7f0-c43bd66289fc",
-            "createdDateTimeUtc": "2021-08-03T21:30:28.4100426Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:30.2839253Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d26b9cd2-9b7d-4237-a26f-499dc048e311",
-            "createdDateTimeUtc": "2021-08-03T21:30:20.4404126Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:23.9070865Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "052b5b6a-f84c-4230-aa1f-26a61effcde2",
-            "createdDateTimeUtc": "2021-08-03T21:30:13.8603639Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:16.8464878Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ff2b5c18-708a-440f-bf37-efc7110c99ad",
-            "createdDateTimeUtc": "2021-08-03T21:30:06.9759347Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:09.8165024Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "73fead5d-cc86-4599-a092-9cc9d0c2c342",
-            "createdDateTimeUtc": "2021-08-03T21:30:00.4839216Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:30:02.7580915Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9575e40d-8d1f-448d-8b42-0eab021412d1",
-            "createdDateTimeUtc": "2021-08-03T21:29:53.8576053Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:55.676247Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "acd96228-cfd4-49fb-b646-794db3c9e15e",
-            "createdDateTimeUtc": "2021-08-03T21:29:47.0106537Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:48.6365299Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e77e2fc-38e5-4f47-9cb8-b90cc449a4d8",
-            "createdDateTimeUtc": "2021-08-03T21:29:40.1528777Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:41.6088908Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e37cc03a-bf95-42b7-8e51-518f72b5e87b",
-            "createdDateTimeUtc": "2021-08-03T21:29:32.2421265Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:35.2150657Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "741e8783-65a0-4a78-b0bb-40bb90ca2ce2",
-            "createdDateTimeUtc": "2021-08-03T21:29:22.6625965Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:29:28.3897554Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=322\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=100\u0026$top=322\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-546d49ef6b6ca2468f4976017695fd28-261d818e3eed0843-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6dc3fd8e997493922de94e6a83ae5961",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f5df7c53-10e4-4ebe-a2d3-4d639b4aaf84",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:25 GMT",
-        "ETag": "\u0022119976FED7852ABC84EB3476530459C7D0091F8DE77EE9F1F1024C4C02D631E4\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f5df7c53-10e4-4ebe-a2d3-4d639b4aaf84"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "b4c5f90d-21f4-4776-a25d-69e2c24c61a2",
-            "createdDateTimeUtc": "2021-08-03T21:26:15.0534924Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:16.4602371Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "160fbcac-6719-48b1-a381-07c96def522c",
-            "createdDateTimeUtc": "2021-08-03T21:26:08.1805962Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:09.0728405Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "21177280-61be-420c-b6a7-99dea8ba6ffa",
-            "createdDateTimeUtc": "2021-08-03T21:26:00.6291023Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:26:02.0416868Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "9d566e00-1591-47d1-82c0-39a2e5d7b8cc",
-            "createdDateTimeUtc": "2021-08-03T21:25:45.4916681Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:46.9737716Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "61f64340-86f6-42f1-9c8a-d5caca0214bf",
-            "createdDateTimeUtc": "2021-08-03T21:25:30.4527461Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:31.898234Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "bebd6ab4-1fc5-4cc4-8b6e-12d70b67bb67",
-            "createdDateTimeUtc": "2021-08-03T21:25:20.9001519Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:25:23.1142408Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "3e44fb4d-cf68-45c5-93e1-0475502d2b40",
-            "createdDateTimeUtc": "2021-08-03T21:18:36.5471645Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:37.3185218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3cb0b34a-a92b-4e3e-9800-ee9aa656eebb",
-            "createdDateTimeUtc": "2021-08-03T21:18:32.7278914Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:34.3336582Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "da1c519e-1edf-4635-859d-1978cb2f95df",
-            "createdDateTimeUtc": "2021-08-03T21:18:26.0432979Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:27.3608779Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "450f4c8a-a15d-485c-9cc1-2451642cb05b",
-            "createdDateTimeUtc": "2021-08-03T21:18:19.0642978Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:20.5598666Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fcb39bba-503d-4772-bd60-8d48be8d1ded",
-            "createdDateTimeUtc": "2021-08-03T21:18:12.3671482Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:13.3939974Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "710b0db7-e99c-4736-9798-019d82bb972c",
-            "createdDateTimeUtc": "2021-08-03T21:18:04.4662377Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:18:06.5663381Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bcd5dbd0-4c9a-4d31-bbb2-38b1fd7a9f17",
-            "createdDateTimeUtc": "2021-08-03T21:17:57.9246063Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:59.5267689Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ea865d15-6652-456a-bc50-a82036d4b55e",
-            "createdDateTimeUtc": "2021-08-03T21:17:49.8058405Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:52.3338079Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "75cd36ab-60aa-4efb-b8ce-89bd8f2482d0",
-            "createdDateTimeUtc": "2021-08-03T21:17:36.2201985Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:37.5230684Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "05e4db62-aed0-4bc9-849c-1d1fa00e9101",
-            "createdDateTimeUtc": "2021-08-03T21:17:23.2025629Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:30.3004066Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a98bd901-115e-485e-a9c3-d6848740d430",
-            "createdDateTimeUtc": "2021-08-03T21:17:10.996439Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:15.4071683Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c0ebf31-6ec7-49ec-ba54-92b3ec4111f6",
-            "createdDateTimeUtc": "2021-08-03T21:17:05.8588787Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:08.1711768Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "565abdcf-3502-4ad2-bdf1-104fa16a21eb",
-            "createdDateTimeUtc": "2021-08-03T21:16:57.3872761Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:17:01.0170435Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9db34ff3-784f-4ba8-bd65-f9daea73dc84",
-            "createdDateTimeUtc": "2021-08-03T21:16:49.8079754Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:54.0100467Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "be0f4975-feb8-4a4c-99df-58a2eda64759",
-            "createdDateTimeUtc": "2021-08-03T21:16:43.5676725Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:46.9951206Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ad79180b-657e-411d-8214-6e2217f5f16f",
-            "createdDateTimeUtc": "2021-08-03T21:16:37.0494791Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:39.9664948Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a6b4d2cc-dc08-4883-93d5-4e0ce1f67b2b",
-            "createdDateTimeUtc": "2021-08-03T21:16:30.4598878Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:32.9278125Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e7348e3-fa87-4468-852d-3375d2e67dea",
-            "createdDateTimeUtc": "2021-08-03T21:16:22.0289093Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:25.9157037Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e415502b-72a2-46ae-bf89-116f60f159a2",
-            "createdDateTimeUtc": "2021-08-03T21:16:15.7930067Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:18.843387Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "12ae8466-a78d-4b54-96b3-491ff6092290",
-            "createdDateTimeUtc": "2021-08-03T21:16:08.3346723Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:11.9162731Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "972d3dd5-e5ad-435f-b1c0-19994a850368",
-            "createdDateTimeUtc": "2021-08-03T21:16:00.8089969Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:16:04.8935886Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c03135b1-55fc-49f8-bd8e-1aa9de944109",
-            "createdDateTimeUtc": "2021-08-03T21:15:50.7914559Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:57.8420568Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d3f42fc9-c46c-4c69-8ce8-1fa7951f0feb",
-            "createdDateTimeUtc": "2021-08-03T21:15:39.2462267Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:42.8928599Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2ee8fae6-6649-4264-8a60-005c8c2e33c3",
-            "createdDateTimeUtc": "2021-08-03T21:15:31.6638047Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:35.7812306Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64cf7af2-e9cf-42dd-be76-4c92b21200e5",
-            "createdDateTimeUtc": "2021-08-03T21:15:19.0180291Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:23.7245428Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7e3b360b-3804-4cd9-8ffc-ff8c1069f9a9",
-            "createdDateTimeUtc": "2021-08-03T21:15:07.6620949Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:15:10.7353955Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6f7243d-95a2-42b2-9277-db3105ffeeae",
-            "createdDateTimeUtc": "2021-08-03T21:14:57.8530134Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:58.6849403Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ff9490ff-1a22-4905-b300-f832c622fcd3",
-            "createdDateTimeUtc": "2021-08-03T21:14:52.4456431Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:55.1385001Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "a291a37f-00ff-462c-90f7-af30487cfee0",
-            "createdDateTimeUtc": "2021-08-03T21:14:47.8001603Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:52.8849738Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "6fe9dfde-e561-40c2-bdd6-3292556c8b44",
-            "createdDateTimeUtc": "2021-08-03T21:14:35.4879327Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:38.0663837Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "281e1d88-ad9d-4517-90b3-94e74a9c24f0",
-            "createdDateTimeUtc": "2021-08-03T21:14:28.795762Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:31.0494198Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a01a857b-9018-440a-b213-00bf32fd088e",
-            "createdDateTimeUtc": "2021-08-03T21:14:13.7887949Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:17.9704114Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8a449a7e-de6e-428f-85dc-0f5057026964",
-            "createdDateTimeUtc": "2021-08-03T21:14:02.4254824Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:14:05.9904305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "caf6c070-88b1-4321-8677-cad70417c272",
-            "createdDateTimeUtc": "2021-08-03T21:13:49.8557451Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:52.9922839Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e8f345d1-3424-4c4a-9d47-3008e4990352",
-            "createdDateTimeUtc": "2021-08-03T21:13:41.5900414Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:45.8133665Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5dc5da5c-8efd-4cd6-815e-4b808abb4825",
-            "createdDateTimeUtc": "2021-08-03T21:13:27.7289314Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:31.0005068Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eb91834b-fb6a-4993-9678-5858c3bb1b9b",
-            "createdDateTimeUtc": "2021-08-03T21:13:16.3384857Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:23.7963549Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "806f54be-4e77-4798-a5d5-73f6bad16868",
-            "createdDateTimeUtc": "2021-08-03T21:12:59.5334323Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:13:00.8743421Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ae03de4-3f6f-4c29-bf1c-1ad94a5e6b7d",
-            "createdDateTimeUtc": "2021-08-03T21:12:53.1067631Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:53.7902656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fc077fb4-83ee-4897-8b1a-5aba8c1bf0a3",
-            "createdDateTimeUtc": "2021-08-03T21:12:45.5070479Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:48.6888907Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "51fc6ec4-8eac-4cc6-ae6f-6c5f36e30f23",
-            "createdDateTimeUtc": "2021-08-03T21:12:30.4582964Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:41.6843136Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "be88aa61-1e9c-4917-a2aa-5c5cdb93a5f6",
-            "createdDateTimeUtc": "2021-08-03T21:12:24.3745624Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:26.5718318Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d0e58fcb-2b27-4914-9654-3d753fa5fc6b",
-            "createdDateTimeUtc": "2021-08-03T21:12:16.9941584Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:19.5227251Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f3a6c730-1d51-404f-8b00-45607cfae421",
-            "createdDateTimeUtc": "2021-08-03T21:12:06.8062009Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:12:12.5283Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=150\u0026$top=272\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=150\u0026$top=272\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ca705ef75b7b0f4db042c3e270e4991f-92e8aea48e502148-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "33d32636599f04eebd582bc52b2663f3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "bf76d160-65f2-4c6a-bf1c-c7a843e28c37",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:26 GMT",
-        "ETag": "\u00227AE5DA898D83199503A675385BE19ED56FF936F0F7343BD5CAD2E03B01E38AF2\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "bf76d160-65f2-4c6a-bf1c-c7a843e28c37"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "37992d98-b6d5-423c-89d1-6e54e5ec8773",
-            "createdDateTimeUtc": "2021-08-03T21:11:55.6953795Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:57.438589Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a3508cfe-30da-45d2-bc88-0047a835dd5e",
-            "createdDateTimeUtc": "2021-08-03T21:11:48.3588126Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:50.4206884Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6ab6d6e-5c85-448d-84d5-4223d3a2cd1b",
-            "createdDateTimeUtc": "2021-08-03T21:11:35.4391485Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:38.7780922Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c69177b4-9de0-4961-97f9-42b1b8d3c137",
-            "createdDateTimeUtc": "2021-08-03T21:11:21.7724833Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:23.742779Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3e1ee063-8ed9-4c9d-b237-76ec3a417bac",
-            "createdDateTimeUtc": "2021-08-03T21:11:13.556122Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:15.317426Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f6042d94-2cd5-46df-85ad-52c10c998b01",
-            "createdDateTimeUtc": "2021-08-03T21:11:06.2064576Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:08.6641999Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d17081c8-ff50-4d36-8b46-e88c8deb39c5",
-            "createdDateTimeUtc": "2021-08-03T21:10:58.8540771Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:11:01.679116Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eeb49074-527d-4cbd-95c9-6e2a33a80fe0",
-            "createdDateTimeUtc": "2021-08-03T21:10:52.75482Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:54.5968498Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c6244025-4303-4989-a816-b905e1a30d9e",
-            "createdDateTimeUtc": "2021-08-03T21:10:46.6679174Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:47.5413043Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7515a3ad-6e5e-446b-8aea-c4cc53d12feb",
-            "createdDateTimeUtc": "2021-08-03T21:10:38.7741733Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:40.5334622Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "95aff118-ace4-4193-828d-2ae77311df6f",
-            "createdDateTimeUtc": "2021-08-03T21:10:32.6760697Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:33.4547546Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "97597b48-5a0e-4dad-8d71-2591f76bf2b6",
-            "createdDateTimeUtc": "2021-08-03T21:10:25.297809Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:26.4222067Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c21ed6b-a48d-4909-92cb-73bc8274b9d2",
-            "createdDateTimeUtc": "2021-08-03T21:10:17.9312928Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:19.3974656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9fc1780-0cbf-4e09-af18-b05ab8132e1f",
-            "createdDateTimeUtc": "2021-08-03T21:10:05.2725918Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:10:12.5542351Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0636e96b-8ca2-44f8-a04b-a9a1c38694c4",
-            "createdDateTimeUtc": "2021-08-03T21:04:35.2211988Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:37.0514288Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce731aed-e42d-4219-a382-133b032d5f1c",
-            "createdDateTimeUtc": "2021-08-03T21:04:28.9135303Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:29.9918727Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d86704b4-8468-4fd2-a932-fd5224d0ebed",
-            "createdDateTimeUtc": "2021-08-03T21:04:14.1901594Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:19.7321506Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9f05357-c328-48b9-a611-c3732bab678d",
-            "createdDateTimeUtc": "2021-08-03T21:04:03.8683312Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:04:05.0527645Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0cbb6b74-7d09-4126-992c-831741492982",
-            "createdDateTimeUtc": "2021-08-03T21:03:51.6462874Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:54.7314609Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5f03f16e-de27-42b4-b2e2-844706de4b44",
-            "createdDateTimeUtc": "2021-08-03T21:03:45.1124183Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:47.674769Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "23c77867-65e6-4ad0-be05-9bdb30d3ad5e",
-            "createdDateTimeUtc": "2021-08-03T21:03:37.8720722Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:40.5848208Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f28ba69-dc12-4f0c-a4a1-e7b60934ad43",
-            "createdDateTimeUtc": "2021-08-03T21:03:32.2879169Z",
-            "lastActionDateTimeUtc": "2021-08-03T21:03:33.7858305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7d8b4c2b-bae7-45ca-b351-4e9904d6ee65",
-            "createdDateTimeUtc": "2021-08-02T16:24:41.2089693Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:43.0994742Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6eb19d5e-da21-40c2-b5ac-31638a9d5834",
-            "createdDateTimeUtc": "2021-08-02T16:24:32.9603519Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:35.3478084Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8f83e37a-9fd2-4a27-acf9-fdf90c5ca88e",
-            "createdDateTimeUtc": "2021-08-02T16:24:25.3701107Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:28.2843485Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fa2f0660-ee60-44dc-891e-1807fe027001",
-            "createdDateTimeUtc": "2021-08-02T16:24:19.0661656Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:20.9267399Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9a921d78-9a3f-4fb0-bd3e-e9e85adfb5c7",
-            "createdDateTimeUtc": "2021-08-02T16:24:14.084628Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:14.8551961Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "35491096-d4b6-4f64-a475-3a8f425bda13",
-            "createdDateTimeUtc": "2021-08-02T16:24:08.8499137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:13.2168149Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d6516cd6-00bc-4dd4-81e0-ac3531a9ef9a",
-            "createdDateTimeUtc": "2021-08-02T16:24:04.9124096Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:24:09.2033129Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "53f7b772-34ef-4eb8-8296-85141574c168",
-            "createdDateTimeUtc": "2021-08-02T16:23:45.9322442Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:47.766539Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ee6fbf3b-4339-4bf7-a0e4-c6c4a43e713d",
-            "createdDateTimeUtc": "2021-08-02T16:23:39.6959419Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:40.4416417Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "136046f1-61bb-4d7a-abda-5d762ed48da2",
-            "createdDateTimeUtc": "2021-08-02T16:23:32.246383Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:33.6102582Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4c808776-ef91-44b3-b985-030778694e82",
-            "createdDateTimeUtc": "2021-08-02T16:23:24.7815606Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:25.6039914Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bbcb51e9-e16a-4575-b115-000e9df2a45e",
-            "createdDateTimeUtc": "2021-08-02T16:23:14.7939144Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:18.5400236Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "420e65a3-84f2-4784-8e76-0dbc11b9767d",
-            "createdDateTimeUtc": "2021-08-02T16:23:00.0350545Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:23:03.9941424Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3bed775d-83fb-4252-9f8a-52dacdb26ade",
-            "createdDateTimeUtc": "2021-08-02T16:22:48.7883283Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:53.2388717Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6ef1e57a-03d3-4eee-b0c1-cabd5862da1f",
-            "createdDateTimeUtc": "2021-08-02T16:22:35.1281238Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:38.165101Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "40a5525c-6988-4e7e-a203-d01a5a19add6",
-            "createdDateTimeUtc": "2021-08-02T16:22:22.6116988Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:28.2009407Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b12700de-181b-4bfb-a9ea-ab2920d66ba8",
-            "createdDateTimeUtc": "2021-08-02T16:22:11.0963198Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:13.2382617Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "588176c1-fb41-4077-9ce2-52eaefe1e6ec",
-            "createdDateTimeUtc": "2021-08-02T16:22:00.7493371Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:22:02.6302967Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eeddf064-09ac-4f8d-8571-dd1bb7fa4343",
-            "createdDateTimeUtc": "2021-08-02T16:21:54.4828121Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:57.0883721Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "86f769d2-0eb0-497c-a670-4b283cfcdfdf",
-            "createdDateTimeUtc": "2021-08-02T16:21:47.7892819Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:50.5734898Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ef96694-d6c5-4f51-9c7e-250c692cb5dd",
-            "createdDateTimeUtc": "2021-08-02T16:21:41.4813356Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:42.5383836Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "adf11117-52ab-486b-985c-bfea752c8125",
-            "createdDateTimeUtc": "2021-08-02T16:21:32.7479396Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:35.3424695Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8d9ccbdb-0672-4c0a-9776-0392c918c98f",
-            "createdDateTimeUtc": "2021-08-02T16:21:15.2775709Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:19.7632985Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8791b215-1f41-41d4-bb91-98341c1dd33c",
-            "createdDateTimeUtc": "2021-08-02T16:21:05.1178323Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:21:07.2972934Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6aba7c68-ce53-473d-a0ec-8a507ed316c9",
-            "createdDateTimeUtc": "2021-08-02T16:20:50.7351339Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:54.4492988Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7d30db48-4d73-41d8-997d-4a617c4004c9",
-            "createdDateTimeUtc": "2021-08-02T16:20:40.6756633Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:42.4301335Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d04c84d8-3802-49e5-bfed-513a24bd9d5a",
-            "createdDateTimeUtc": "2021-08-02T16:20:24.7609666Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:29.1667159Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bc6cf0b2-7fc1-40ee-ad43-98b0b5150223",
-            "createdDateTimeUtc": "2021-08-02T16:20:12.6767136Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:16.3662875Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=200\u0026$top=222\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=200\u0026$top=222\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-17255928bccaf34b8db4a93a0066c6c4-d07c0c012a3da740-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f5e4807f631c7e5634f805c4926a1280",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "cfe068b1-2f11-4c09-85b8-1ea91654c1e0",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:26 GMT",
-        "ETag": "\u00222E45D0A4F853A9D0D018A10BE8C321083F8A2BCCC6F53EB7947907EB9CC7138E\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cfe068b1-2f11-4c09-85b8-1ea91654c1e0"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "478fdbe7-fffd-4d69-baa1-b359ab0bf87e",
-            "createdDateTimeUtc": "2021-08-02T16:19:59.5448266Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:20:03.7580865Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8ac17a7c-0ef2-44e6-815e-11ca7283f7f0",
-            "createdDateTimeUtc": "2021-08-02T16:19:47.7119701Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:52.0454421Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9299720b-5702-4fd8-9b84-07d18770d0c9",
-            "createdDateTimeUtc": "2021-08-02T16:19:33.0940413Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:36.063599Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0c53f5ac-5ae0-4186-986d-59db8052bd87",
-            "createdDateTimeUtc": "2021-08-02T16:19:25.5258566Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:27.5995027Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5fabbdd0-d3df-482e-80c5-751f5c65184b",
-            "createdDateTimeUtc": "2021-08-02T16:19:17.4593598Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:19.4263901Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f116c06f-6f87-406d-b1f6-79fb90dce630",
-            "createdDateTimeUtc": "2021-08-02T16:19:10.7346Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:12.2459497Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8d24c7aa-d4f7-4c8f-8540-10499063139f",
-            "createdDateTimeUtc": "2021-08-02T16:19:02.0656904Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:19:03.0995071Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f9b9346c-2649-429f-a88e-3bd5fa834aea",
-            "createdDateTimeUtc": "2021-08-02T16:18:52.7109118Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:57.1201114Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4676529-3017-4ca1-b2a8-dbb9c74ca6f0",
-            "createdDateTimeUtc": "2021-08-02T16:18:36.7769716Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:41.5280761Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d59e0316-c5eb-4011-a6ea-ba35c6977966",
-            "createdDateTimeUtc": "2021-08-02T16:18:23.3012061Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:29.1989939Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "28779945-5117-434b-9137-14e9c170d450",
-            "createdDateTimeUtc": "2021-08-02T16:18:11.1236727Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:16.2904795Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b661b7e-cdbd-461e-8540-93e2e7135084",
-            "createdDateTimeUtc": "2021-08-02T16:17:57.8044821Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:18:02.1356502Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "826e3203-8188-4a90-92db-b65e12b7a6e6",
-            "createdDateTimeUtc": "2021-08-02T16:17:49.6808861Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:51.33726Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ec3e1c4c-3509-4f5a-86ee-3be559f978cf",
-            "createdDateTimeUtc": "2021-08-02T16:17:43.4479159Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:46.1484498Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "cd18395a-adb6-4566-a35d-4b7394ce7e7c",
-            "createdDateTimeUtc": "2021-08-02T16:17:39.2236317Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:42.3718498Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "2ab88ed2-f62f-442c-a8d4-e0fe953d60f8",
-            "createdDateTimeUtc": "2021-08-02T16:17:13.5251717Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:17.8853964Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b9deb0a-7a56-440e-b9c3-51407a716f91",
-            "createdDateTimeUtc": "2021-08-02T16:17:00.3732482Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:17:04.8610025Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1451731d-cb81-45b9-abb6-c0ebd8d688ff",
-            "createdDateTimeUtc": "2021-08-02T16:16:46.3333522Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:51.499965Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "139c594a-e573-42bc-ac76-79592e783b4d",
-            "createdDateTimeUtc": "2021-08-02T16:16:34.5666571Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:39.7565449Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3ea6a654-e1da-4712-9ade-698b4fa08cee",
-            "createdDateTimeUtc": "2021-08-02T16:16:20.2815511Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:26.1888498Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bb4649a1-1b3a-4ffe-a85e-7c42bae169e0",
-            "createdDateTimeUtc": "2021-08-02T16:16:12.5610209Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:14.670096Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fe16f7a4-60a7-47e5-af19-ae95f1ec681e",
-            "createdDateTimeUtc": "2021-08-02T16:16:02.1273592Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:16:06.1364515Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4aa714c0-4bf6-4938-87a1-434a1f4a7ebb",
-            "createdDateTimeUtc": "2021-08-02T16:15:47.0562229Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:50.6173263Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "026bf666-4189-437c-83aa-64695c311c08",
-            "createdDateTimeUtc": "2021-08-02T16:15:31.2491656Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:35.1652117Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bdd91bff-b609-4b0f-a2c0-c647662d414d",
-            "createdDateTimeUtc": "2021-08-02T16:15:16.5679328Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:20.3039847Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0498cf00-abbb-40b5-adab-e7725b8570f7",
-            "createdDateTimeUtc": "2021-08-02T16:15:09.9911137Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:11.9184442Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "21177c94-70c4-44e1-8cff-235b74d0b99a",
-            "createdDateTimeUtc": "2021-08-02T16:14:55.1654786Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:15:00.1764926Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "85670b87-e8d6-4d6d-8ea2-c25d36c5ab31",
-            "createdDateTimeUtc": "2021-08-02T16:14:43.5832687Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:46.5409074Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6120317e-0084-4d39-be37-4a22da834f5d",
-            "createdDateTimeUtc": "2021-08-02T16:14:27.9772355Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:34.8024586Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6af7eb57-f9c1-42e2-82d7-1f12e5b212fe",
-            "createdDateTimeUtc": "2021-08-02T16:14:17.0902143Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:21.24705Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cd6a2e5d-84e2-41b1-9337-a69dad3d47c1",
-            "createdDateTimeUtc": "2021-08-02T16:14:07.7724718Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:08.5411317Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c2ef1201-4b72-4500-af9d-6c46e43d9c8b",
-            "createdDateTimeUtc": "2021-08-02T16:14:00.4820687Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:14:02.206196Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e02cc96c-f613-4d31-b301-64b1ba8f087d",
-            "createdDateTimeUtc": "2021-08-02T16:13:52.654235Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:53.9684859Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "56985d49-4f45-4bf5-bc5a-815be0a31d77",
-            "createdDateTimeUtc": "2021-08-02T16:13:44.4222786Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:46.3632429Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f277b4e7-6107-4fce-9843-57ea37403cd0",
-            "createdDateTimeUtc": "2021-08-02T16:13:36.1118921Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:38.5818188Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "cb2ae958-26f6-497c-a0d2-0f24b680a296",
-            "createdDateTimeUtc": "2021-08-02T16:13:28.2526551Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:31.4669162Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e44cb835-83cf-4568-af90-37dc0bfc591f",
-            "createdDateTimeUtc": "2021-08-02T16:13:21.6945505Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:24.3971649Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "53732eaf-861e-4cc7-ab1b-7fe8f2c59f72",
-            "createdDateTimeUtc": "2021-08-02T16:13:09.3426779Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:09.9894448Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "22467b38-820b-496e-af13-6118e55f474f",
-            "createdDateTimeUtc": "2021-08-02T16:12:54.8368437Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:13:02.7871782Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f2db3e76-05f6-487e-8f7a-71ff84a07c41",
-            "createdDateTimeUtc": "2021-08-02T16:12:46.1722803Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:47.8187574Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6fa6124a-382c-4cae-a8e8-bafa8771ffb4",
-            "createdDateTimeUtc": "2021-08-02T16:12:38.3102608Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:40.6814713Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "08077374-25ed-4062-8157-d2aaf376a00c",
-            "createdDateTimeUtc": "2021-08-02T16:12:26.6208936Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:33.2913497Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a94a2a28-a797-4f76-91cd-b51148e62b16",
-            "createdDateTimeUtc": "2021-08-02T16:12:13.1684199Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:18.4618218Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bc4c4898-1c22-4525-a645-7ce619839b24",
-            "createdDateTimeUtc": "2021-08-02T16:11:56.0176535Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:12:03.7809247Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e84c225d-6eac-485e-a02c-27944ff4dbdb",
-            "createdDateTimeUtc": "2021-08-02T16:05:51.141745Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:55.0127867Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "7c879c56-18e3-404d-a749-27467f12e635",
-            "createdDateTimeUtc": "2021-08-02T16:05:45.2156446Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:46.3340871Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "a475da26-6ac8-4c57-ad1f-a95856f88516",
-            "createdDateTimeUtc": "2021-08-02T16:05:36.590968Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:39.4988016Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "54a2e7ba-61be-4704-9a1b-2e4b36baa088",
-            "createdDateTimeUtc": "2021-08-02T16:05:21.5609955Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:24.9840622Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "7afd5c7e-13d8-4691-abd0-abde4ce5474e",
-            "createdDateTimeUtc": "2021-08-02T16:05:02.9540382Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:05:05.7674713Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "557f2c23-bc72-40b7-a138-4561429fa9aa",
-            "createdDateTimeUtc": "2021-08-02T16:04:47.8352521Z",
-            "lastActionDateTimeUtc": "2021-08-02T16:04:50.2573908Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=250\u0026$top=172\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=250\u0026$top=172\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e757a3b15f25044690550f2365b03558-a8366a26b657794e-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3b324281a0c734960fbfb01c6dcd6807",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "14a4a10c-3595-4ae0-8af1-7b74b68174c0",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:27 GMT",
-        "ETag": "\u002271D2D20E5BF676DC697F5B8AF36EADBF196980190A063E0A6ED3C56796E71281\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "14a4a10c-3595-4ae0-8af1-7b74b68174c0"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "3e9a5d00-90d9-4256-9d62-f1dfa1577da0",
-            "createdDateTimeUtc": "2021-08-01T16:20:07.4673305Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:13.4203616Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "fc266ece-821c-4ad7-9448-1813652fd6ec",
-            "createdDateTimeUtc": "2021-08-01T16:20:03.3145089Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:20:12.698585Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "09bd712a-8979-4a10-b5cd-e9f10cd67d10",
-            "createdDateTimeUtc": "2021-08-01T16:19:46.7079557Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:49.1799156Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d7a02f06-f676-408e-b3c1-c15c6bba0b44",
-            "createdDateTimeUtc": "2021-08-01T16:19:40.2888558Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:42.0951378Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c225a85d-2f4e-4823-bed5-aafc11420317",
-            "createdDateTimeUtc": "2021-08-01T16:19:32.7591319Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:35.0214842Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8afe93e5-55f8-4b29-aad7-e52aafa852e9",
-            "createdDateTimeUtc": "2021-08-01T16:19:26.4656956Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:27.9695511Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d2d58232-7d45-4649-8eee-884989571d14",
-            "createdDateTimeUtc": "2021-08-01T16:19:20.0951281Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:20.9141679Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9d74505c-4ec7-4849-a25e-347c9ca83531",
-            "createdDateTimeUtc": "2021-08-01T16:19:14.3845766Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:19.1001524Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "5263795e-4551-4f48-94da-32a53c735650",
-            "createdDateTimeUtc": "2021-08-01T16:19:10.3372901Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:19:18.7374885Z",
-            "status": "Cancelled",
-            "summary": {
-              "total": 20,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 20,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "b51a5572-a945-4b96-a953-c59a894ef975",
-            "createdDateTimeUtc": "2021-08-01T16:18:54.1999881Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:57.9280154Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ed28552f-7298-466f-be5d-d72fc1596544",
-            "createdDateTimeUtc": "2021-08-01T16:18:47.7220195Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:50.8569952Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c0ebd77c-0245-4fa7-b3e7-83694b3734fe",
-            "createdDateTimeUtc": "2021-08-01T16:18:41.3753213Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:43.9537812Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64716ad2-d3e2-4bcf-9a75-0fc0c9a5f4c8",
-            "createdDateTimeUtc": "2021-08-01T16:18:34.7356044Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:36.8659384Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "48155210-6958-4ce0-9863-e3747a64c145",
-            "createdDateTimeUtc": "2021-08-01T16:18:20.2854234Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:18:30.0642323Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9453ca0c-5d2e-4071-ab7f-442df231b85f",
-            "createdDateTimeUtc": "2021-08-01T16:15:01.5996298Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:15:05.5361722Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b0f1d39d-b564-4cd9-8032-6a12e1a9d05b",
-            "createdDateTimeUtc": "2021-08-01T16:14:55.2901759Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:58.5033728Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "59da2c26-8f14-4221-ab40-ac76b9501ad1",
-            "createdDateTimeUtc": "2021-08-01T16:14:47.6768806Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:51.4645762Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "497af134-1eb1-4531-96cf-2b6426d21b25",
-            "createdDateTimeUtc": "2021-08-01T16:14:43.8701994Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:44.532919Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "49417fb3-b2f3-4a94-a5bf-adf21b10f5d6",
-            "createdDateTimeUtc": "2021-08-01T16:14:36.2995057Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:37.5066305Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3a12cc5a-b95b-4934-8fd5-f338b1e8ffca",
-            "createdDateTimeUtc": "2021-08-01T16:14:29.7501476Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:30.4496382Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f30dfeae-5899-4b4a-ab89-d6d04d0efe74",
-            "createdDateTimeUtc": "2021-08-01T16:14:22.1534158Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:26.376851Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9e65c1cc-310e-4cc2-b8cb-94549af2f62e",
-            "createdDateTimeUtc": "2021-08-01T16:14:15.8071242Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:19.3429665Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3bb426c3-ecc1-4316-bc03-730dc1f3653b",
-            "createdDateTimeUtc": "2021-08-01T16:14:08.2125728Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:12.4635748Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ddf0085d-dbdf-4cba-990c-3ba10a7e1a66",
-            "createdDateTimeUtc": "2021-08-01T16:14:03.1671065Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:14:05.4704945Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "329cec92-7703-4747-ae44-5990a8726d8f",
-            "createdDateTimeUtc": "2021-08-01T16:13:54.1407053Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:58.3447181Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b8f07233-7e1c-4c08-80cf-1a15eb328e81",
-            "createdDateTimeUtc": "2021-08-01T16:13:47.8669235Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:51.5406534Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "77cdd294-733d-41f8-819f-92003e64ceb5",
-            "createdDateTimeUtc": "2021-08-01T16:13:40.2946017Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:44.3266783Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e0991fae-123b-4f43-bff0-cab0009d9523",
-            "createdDateTimeUtc": "2021-08-01T16:13:36.5057131Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:37.2374588Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5ca898b1-422a-4871-abb7-1ce16766fe75",
-            "createdDateTimeUtc": "2021-08-01T16:13:28.8893885Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:30.2057848Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "71c20eb7-04ac-4b18-8147-170d958cf215",
-            "createdDateTimeUtc": "2021-08-01T16:13:14.9186078Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:23.1567567Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0f6623cf-56f0-49c2-8b2d-92a7d173e656",
-            "createdDateTimeUtc": "2021-08-01T16:13:07.2768816Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:08.1446081Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "51452eaa-72c0-4d09-aece-3ce74ea05c2d",
-            "createdDateTimeUtc": "2021-08-01T16:12:58.3531499Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:13:00.9818419Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "83122575-c3e0-40cf-a740-bb3ab9fc56be",
-            "createdDateTimeUtc": "2021-08-01T16:12:43.7935713Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:12:49.3598783Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ab3adbcc-1036-4e0b-903d-681b154f1c19",
-            "createdDateTimeUtc": "2021-08-01T16:12:34.5845034Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:12:35.9467789Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "39c76fc2-bb64-4a08-a91a-023f467170c8",
-            "createdDateTimeUtc": "2021-08-01T16:10:30.7671066Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:33.9996641Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1946e12f-48c9-479d-a14d-957a52af4819",
-            "createdDateTimeUtc": "2021-08-01T16:10:24.4268864Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:26.950039Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "061184c9-b5cc-4622-9536-a088ef98ef51",
-            "createdDateTimeUtc": "2021-08-01T16:10:16.7322617Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:20.8210184Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6dab8cd8-4b45-4244-b5a3-1df6ce3e6e9e",
-            "createdDateTimeUtc": "2021-08-01T16:10:10.3791367Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:13.7755381Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ccecf223-30d9-427f-baac-d28fabd2ba91",
-            "createdDateTimeUtc": "2021-08-01T16:09:56.0857482Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:10:01.8186959Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "686c032b-f1f9-461c-b591-19be033130a6",
-            "createdDateTimeUtc": "2021-08-01T16:09:47.6916292Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:48.7555826Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6f1fb728-a50b-4279-b98e-8f70a89cba26",
-            "createdDateTimeUtc": "2021-08-01T16:09:35.1147989Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:41.7039641Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ac064e9c-9558-4940-81b6-6591e24b22b0",
-            "createdDateTimeUtc": "2021-08-01T16:09:23.6462928Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:26.7238672Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f7dfd6e7-2149-4ed6-9118-1f50a9badde5",
-            "createdDateTimeUtc": "2021-08-01T16:09:15.6989555Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:16.6008152Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a37bd766-988f-4d35-93b4-82b678984a0b",
-            "createdDateTimeUtc": "2021-08-01T16:09:10.2798543Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:11.6248087Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "dd3207eb-c63b-4ee9-8d71-303a17f6831a",
-            "createdDateTimeUtc": "2021-08-01T16:09:02.3812973Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:09:04.6501124Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c2017771-02a1-4c4d-89c6-e53ddc375b6c",
-            "createdDateTimeUtc": "2021-08-01T16:08:54.6514534Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:57.5553054Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8e675672-c991-4b00-9f3b-151fff0ba025",
-            "createdDateTimeUtc": "2021-08-01T16:08:50.6903241Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:51.5542816Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "86d50aab-06b7-4674-94f1-d78f62cfcd3c",
-            "createdDateTimeUtc": "2021-08-01T16:08:42.9294372Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:44.5249817Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "64eee42e-3b77-4308-b66b-6dfd687dfcb8",
-            "createdDateTimeUtc": "2021-08-01T16:08:29.0253923Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:37.4953732Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ec95d30a-ca29-44c2-a3d3-7f1e81768232",
-            "createdDateTimeUtc": "2021-08-01T16:08:20.5267131Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:22.4653843Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=300\u0026$top=122\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=300\u0026$top=122\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8083ae583f22454395639751ca5a3e6e-e3087f8c6d7cd046-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "02ea5a8564c9d244cf55fea7542a7252",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b9cbf71f-ea25-4780-8ebd-785766a8d64b",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:28 GMT",
-        "ETag": "\u00220D424101ED19CD8F328C35ACB051BD9B960C5E6B20B15640135D0D524A6AA718\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b9cbf71f-ea25-4780-8ebd-785766a8d64b"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "baa67a70-f2c2-4798-af85-bf4039800973",
-            "createdDateTimeUtc": "2021-08-01T16:08:14.027446Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:15.5419027Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "9fd64070-3063-4a1f-b6c7-a5433ce879c1",
-            "createdDateTimeUtc": "2021-08-01T16:08:07.3241133Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:08.3919937Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eca524e6-f052-4f33-9f75-849aa58968f2",
-            "createdDateTimeUtc": "2021-08-01T16:07:59.6488045Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:08:02.4292358Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e4553a79-86bc-4607-93ba-acd98eef29a8",
-            "createdDateTimeUtc": "2021-08-01T16:07:51.7754119Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:07:55.6059096Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3733384b-4378-49e9-9d6c-eb777dd951e7",
-            "createdDateTimeUtc": "2021-08-01T16:03:47.7295123Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:50.0428444Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5af0415d-d065-4223-8377-8c4b476b1e51",
-            "createdDateTimeUtc": "2021-08-01T16:03:41.2997619Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:43.1057319Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "19825a18-d71e-4d71-ad50-ac9efde28439",
-            "createdDateTimeUtc": "2021-08-01T16:03:33.0672128Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:36.0643347Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2126372c-82d1-4ca5-99cd-6320189e4456",
-            "createdDateTimeUtc": "2021-08-01T16:03:21.6139816Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:29.0787165Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "351567c2-21d9-44d7-80cd-ae88bcfc86c1",
-            "createdDateTimeUtc": "2021-08-01T16:03:11.2412744Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:03:14.0681571Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3687fbc7-cfc7-4946-abbd-d20c2c47872b",
-            "createdDateTimeUtc": "2021-08-01T16:02:54.8769861Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:59.157192Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "75b82710-29d5-4a29-b31d-b4b276547f85",
-            "createdDateTimeUtc": "2021-08-01T16:02:42.7637598Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:44.4525561Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "45e52c50-a5d3-4185-ad9c-302fb18b86fb",
-            "createdDateTimeUtc": "2021-08-01T16:02:33.7748165Z",
-            "lastActionDateTimeUtc": "2021-08-01T16:02:37.1302955Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0794e1ae-1cbb-4ce3-a359-5baea72b7f4f",
-            "createdDateTimeUtc": "2021-08-01T15:59:52.4064413Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:54.8434933Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b6bf80ca-523f-424b-bb16-43b74851cd72",
-            "createdDateTimeUtc": "2021-08-01T15:59:46.146435Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:47.7975734Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f151cf31-9668-4c64-9fa3-1eab66bd54de",
-            "createdDateTimeUtc": "2021-08-01T15:59:38.6998762Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:41.734894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "eab2ef7c-cccd-4b8d-9c28-43fa1246a6ec",
-            "createdDateTimeUtc": "2021-08-01T15:59:33.1867669Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:34.7568857Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fe3b6f5b-2f4f-4ba6-87b0-b49ce11a40f1",
-            "createdDateTimeUtc": "2021-08-01T15:59:23.8646186Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:27.6910914Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c688f16b-c48f-4d93-ae25-97e9419cf990",
-            "createdDateTimeUtc": "2021-08-01T15:59:20.0728064Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:20.6633025Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "65b3ecb9-b44e-45cb-9b48-4c3dc410ea83",
-            "createdDateTimeUtc": "2021-08-01T15:59:09.2524163Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:13.6285104Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c4dc36f8-1a47-4082-9e74-55b17a656aee",
-            "createdDateTimeUtc": "2021-08-01T15:58:55.2515733Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:59:02.9435279Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f3021ca2-9cec-4123-8750-e48d70416733",
-            "createdDateTimeUtc": "2021-08-01T15:56:37.0490386Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:38.4486071Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6b145029-9721-429c-a6a7-09c88b0985bf",
-            "createdDateTimeUtc": "2021-08-01T15:56:30.7478816Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:31.4431875Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bd39da52-dc84-4165-bd31-8b4e3386e291",
-            "createdDateTimeUtc": "2021-08-01T15:56:23.0776782Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:27.4828878Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fa4f24ae-2898-4a3f-99c4-1cb3803f90f9",
-            "createdDateTimeUtc": "2021-08-01T15:56:16.7471751Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:20.4937894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7ab33b72-ce13-4ddb-8201-c3c334eae327",
-            "createdDateTimeUtc": "2021-08-01T15:56:03.8859689Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:56:05.4735936Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ab288e5d-b6b4-44e3-abf9-6faa8c4be7ec",
-            "createdDateTimeUtc": "2021-08-01T15:55:55.0121462Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:56.3540986Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f93cafa9-8dd4-4b3b-8b51-1e2171088923",
-            "createdDateTimeUtc": "2021-08-01T15:55:47.3645091Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:49.3078416Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e4b8104a-b73b-4412-9053-8e5ebec49801",
-            "createdDateTimeUtc": "2021-08-01T15:55:40.55381Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:42.2818894Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5d43cd87-26c7-4c64-a7c6-b594408e7335",
-            "createdDateTimeUtc": "2021-08-01T15:55:32.9887665Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:35.2182692Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2136b292-19b7-4256-8c19-5fa788b76984",
-            "createdDateTimeUtc": "2021-08-01T15:55:25.9783249Z",
-            "lastActionDateTimeUtc": "2021-08-01T15:55:28.383526Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "0517cacc-3271-4281-a3d5-104ef81a6787",
-            "createdDateTimeUtc": "2021-08-01T13:52:26.3146047Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:27.02053Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "13dc0dc6-55d9-4815-925b-53831ccd5b1a",
-            "createdDateTimeUtc": "2021-08-01T13:52:20.0346113Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:20.7450313Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d63c2da4-ba89-4240-8ca3-3303a99b2321",
-            "createdDateTimeUtc": "2021-08-01T13:52:11.7638283Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:14.351392Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5c4dd9bb-d4c3-4154-b014-5b999af767fc",
-            "createdDateTimeUtc": "2021-08-01T13:51:59.0858938Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:52:06.7430348Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "fba3ac3e-5074-4ae6-b21b-77e83ddd5728",
-            "createdDateTimeUtc": "2021-08-01T13:51:50.096311Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:51.9229238Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "919b875a-ac8a-4168-9f5d-2b002e2e990b",
-            "createdDateTimeUtc": "2021-08-01T13:51:36.2700242Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:44.8851496Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b65dd502-78d8-41eb-a5c2-e38841e8a64d",
-            "createdDateTimeUtc": "2021-08-01T13:51:29.279615Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:29.8684676Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f31e8014-63fa-40b4-99c8-0bcd7b0e55c8",
-            "createdDateTimeUtc": "2021-08-01T13:51:18.8649454Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:51:23.0945034Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "03ff545e-1823-45a4-b776-69f0e04acc30",
-            "createdDateTimeUtc": "2021-08-01T13:47:29.3049005Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:31.3629345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ba88a76e-c3d3-4ea6-a53c-b85651fcf2e3",
-            "createdDateTimeUtc": "2021-08-01T13:47:23.0010181Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:24.2943392Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "74a8ff69-cb7a-4499-86df-c3a2d3832f35",
-            "createdDateTimeUtc": "2021-08-01T13:47:15.4214201Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:17.6049061Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d34a947d-dbfe-4629-94ca-583ba3135c38",
-            "createdDateTimeUtc": "2021-08-01T13:47:09.0574092Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:10.5667782Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "292e0fc5-31f9-4bbe-a16d-118e79c6447d",
-            "createdDateTimeUtc": "2021-08-01T13:46:55.8006784Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:47:03.6165324Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "46cfff21-a830-4bfe-bcf7-7845dea12314",
-            "createdDateTimeUtc": "2021-08-01T13:46:47.3054Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:49.2160598Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "992cdea9-d5e3-4518-a34f-463b467802b8",
-            "createdDateTimeUtc": "2021-08-01T13:46:39.1556709Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:42.1830707Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1b93d4c5-0c5a-4c53-9d0b-123580370ac4",
-            "createdDateTimeUtc": "2021-08-01T13:46:34.0334308Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:35.0748515Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c10423c1-70a0-4249-9b44-c4e35fa531cf",
-            "createdDateTimeUtc": "2021-08-01T13:46:27.7441155Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:28.5230851Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "762b843d-5634-4e71-8998-3c269c5aa71a",
-            "createdDateTimeUtc": "2021-08-01T13:46:14.8806312Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:46:21.7377245Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8c396dd4-a4d4-4fd6-b49c-9bf293bc5b22",
-            "createdDateTimeUtc": "2021-08-01T13:39:53.2223797Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:59.6350234Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "15fa9332-a622-4903-9c2d-30ec419c019f",
-            "createdDateTimeUtc": "2021-08-01T13:39:40.8849092Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:45.8189345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=350\u0026$top=72\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=350\u0026$top=72\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-67ba7f37dec8c144bd9fefe5099363df-9383edd7446eaf44-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e843ab4628f3df2ceab0e65db33a1066",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c5aec01c-2505-4d77-90e4-867d5296f412",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:28 GMT",
-        "ETag": "\u00225D720C9C9D49E11F253F91585405268A956A01EE91EFA0FBCD1FF02378B581A3\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c5aec01c-2505-4d77-90e4-867d5296f412"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "4eba9692-8936-433d-8277-37297439855f",
-            "createdDateTimeUtc": "2021-08-01T13:39:25.8159637Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:34.600318Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "d7d61b86-c02c-44a7-9d94-1b3bf73ea68c",
-            "createdDateTimeUtc": "2021-08-01T13:39:18.4391794Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:19.4610126Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "501ab4fe-6bb1-4f2f-bc60-0ed6375ff114",
-            "createdDateTimeUtc": "2021-08-01T13:39:08.0207097Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:12.3862208Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "92b4bf08-9a7b-4e86-bf5f-6287b863b2f8",
-            "createdDateTimeUtc": "2021-08-01T13:38:54.8712186Z",
-            "lastActionDateTimeUtc": "2021-08-01T13:39:01.0996993Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "e89ae3bd-9e8e-4035-91c8-1110271964f5",
-            "createdDateTimeUtc": "2021-07-29T18:56:30.5852007Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:32.8561054Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "80f86e77-a61c-4fb6-a924-86ed9fd9dcdb",
-            "createdDateTimeUtc": "2021-07-29T18:56:17.7021902Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:25.2356539Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bfebe6ca-0904-4142-8deb-def8890749cc",
-            "createdDateTimeUtc": "2021-07-29T18:56:08.9244466Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:10.2588454Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c627c2f9-4605-4e98-92d7-d9814db0bfff",
-            "createdDateTimeUtc": "2021-07-29T18:55:56.0217273Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:56:03.7770256Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7cff621d-1a6d-432e-8fa5-df00eb8e076e",
-            "createdDateTimeUtc": "2021-07-29T18:55:47.2424877Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:48.0765309Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4338311b-280f-4aa3-844a-a7fb7236879d",
-            "createdDateTimeUtc": "2021-07-29T18:55:36.922933Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:41.5171516Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8794c5c1-f497-4a83-8293-da713258faa8",
-            "createdDateTimeUtc": "2021-07-29T18:55:23.3488567Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:30.3458735Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b86b6998-282c-4594-81a4-a6cb6d123953",
-            "createdDateTimeUtc": "2021-07-29T18:55:14.0853219Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:55:16.7959039Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "af92572b-d7d2-4d21-9ec7-411116a78904",
-            "createdDateTimeUtc": "2021-07-29T18:27:48.249869Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:48.9487415Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a7725a19-0c98-4ffd-947f-4d574615fd1e",
-            "createdDateTimeUtc": "2021-07-29T18:27:35.1676798Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:41.9314655Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bf5cbc3b-2921-4372-bcae-ffd87391abef",
-            "createdDateTimeUtc": "2021-07-29T18:27:27.7901646Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:28.4614677Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "69b858d0-ff26-4cfd-911e-37e3f73bb4f7",
-            "createdDateTimeUtc": "2021-07-29T18:27:19.8707951Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:21.4611112Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "14721933-e03d-4f8a-8f21-83219f03b279",
-            "createdDateTimeUtc": "2021-07-29T18:27:03.2894117Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:27:10.3609678Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8375af4f-848a-46ff-891e-a8b844ca0856",
-            "createdDateTimeUtc": "2021-07-29T18:26:52.907266Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:56.3528141Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "23dfbdb4-cf55-45bb-ab9c-02e3167a29e1",
-            "createdDateTimeUtc": "2021-07-29T18:26:45.3554314Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:46.2619525Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "d5c5dd3e-1858-468d-bf7f-33f2833f4872",
-            "createdDateTimeUtc": "2021-07-29T18:26:37.3639687Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:26:38.3200345Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "e7188ffe-9202-479a-afe1-01fecc04ad22",
-            "createdDateTimeUtc": "2021-07-29T18:25:33.3238602Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:35.2984814Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "70db07a3-07c0-4d9d-83c5-5f65da69c4f9",
-            "createdDateTimeUtc": "2021-07-29T18:25:26.783298Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:28.2271307Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6a32867d-406a-4da9-a9aa-6d869d895bfd",
-            "createdDateTimeUtc": "2021-07-29T18:25:18.055152Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:21.1616142Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "05e70da4-5e01-4a27-b706-19fcf0adcada",
-            "createdDateTimeUtc": "2021-07-29T18:25:12.7651639Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:14.1490239Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f9b7a393-c7a5-421c-ba1d-a44c02048634",
-            "createdDateTimeUtc": "2021-07-29T18:25:04.3837212Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:07.1327422Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b4902c6f-6289-477e-8f9b-2bcb70c2e924",
-            "createdDateTimeUtc": "2021-07-29T18:24:57.6574082Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:25:00.1100818Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6048a21b-abc8-4457-b921-b9f3602082dd",
-            "createdDateTimeUtc": "2021-07-29T18:24:51.4511113Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:53.231795Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "72139ec3-ad0b-42cc-9a6c-92c555cc1417",
-            "createdDateTimeUtc": "2021-07-29T18:24:42.1866362Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:46.1095564Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a0efbf77-53fb-4af8-8c69-61df229575cc",
-            "createdDateTimeUtc": "2021-07-29T18:24:18.6490605Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:21.0023446Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "f50dd147-dd7a-4589-8f90-b40bdc22e6d9",
-            "createdDateTimeUtc": "2021-07-29T18:24:13.4076008Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:14.9595162Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "1769c3a9-a912-4e02-ad76-4ad658e6bd07",
-            "createdDateTimeUtc": "2021-07-29T18:24:06.1419128Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:07.8638717Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "7a8a7450-9f6e-4ee0-9c72-caa4303e9649",
-            "createdDateTimeUtc": "2021-07-29T18:23:53.1730982Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:24:00.9552258Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "4b5fd2ee-aa2a-45e2-a64b-69d4b6aa8fef",
-            "createdDateTimeUtc": "2021-07-29T18:23:44.6321958Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:46.0263327Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "6d4a7add-df54-4f67-a3dd-bc47675e5131",
-            "createdDateTimeUtc": "2021-07-29T18:23:35.607668Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:38.9203906Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "73a8b048-a34e-4bf9-9a77-9fd7a1fa0eab",
-            "createdDateTimeUtc": "2021-07-29T18:23:22.5480081Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:26.9561971Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3221547b-76a3-45d2-ad5e-28383c397f11",
-            "createdDateTimeUtc": "2021-07-29T18:23:12.8991624Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:23:16.2575253Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "ce9f5f49-3336-4ef4-996f-7086e032e208",
-            "createdDateTimeUtc": "2021-07-29T18:11:08.689952Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:11:10.9326895Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a17020af-7225-4a1c-bd1d-f9c86b8e8231",
-            "createdDateTimeUtc": "2021-07-29T18:10:59.594621Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:11:03.8658837Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "bcd6fdf4-0572-475d-af9c-6df2e9882564",
-            "createdDateTimeUtc": "2021-07-29T18:10:48.318371Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:53.1219508Z",
+            "id": "de191afa-044c-4302-860f-fead9320bfef",
+            "createdDateTimeUtc": "2021-08-26T12:07:37.5300245Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:48.768721Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -7427,9 +1379,9 @@
             }
           },
           {
-            "id": "7f7329d9-9d65-4aa0-a19e-c151f45fbfba",
-            "createdDateTimeUtc": "2021-07-29T18:10:36.4711697Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:39.9591092Z",
+            "id": "5e0418c0-d47b-44f7-b621-1acb709f6083",
+            "createdDateTimeUtc": "2021-08-26T12:07:22.2020284Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:36.031538Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -7442,9 +1394,9 @@
             }
           },
           {
-            "id": "8a8759c6-38f8-4587-82c5-551099482e2e",
-            "createdDateTimeUtc": "2021-07-29T18:10:25.3356743Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:29.6315203Z",
+            "id": "5217e9b3-97de-49d6-865a-c1d4ccf8e01e",
+            "createdDateTimeUtc": "2021-08-26T12:07:11.1220511Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:07:20.8963603Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -7457,9 +1409,9 @@
             }
           },
           {
-            "id": "41696374-9114-4f8d-90f7-6c8a1c7b0607",
-            "createdDateTimeUtc": "2021-07-29T18:10:14.5091385Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:18.8819684Z",
+            "id": "c191cac1-5192-40a3-ad33-3e2362486994",
+            "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:04:16.1141626Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -7472,9 +1424,9 @@
             }
           },
           {
-            "id": "c1fe9b5d-e1ec-410d-84e1-14780b307360",
-            "createdDateTimeUtc": "2021-07-29T18:10:03.0941124Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:10:08.0754094Z",
+            "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
+            "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:04:05.8188604Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -7487,9 +1439,9 @@
             }
           },
           {
-            "id": "5f6d6b60-7017-4ae9-b89b-734dbc8df3a2",
-            "createdDateTimeUtc": "2021-07-29T18:09:50.6890119Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:09:54.5512218Z",
+            "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
+            "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:03:43.710026Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -7502,9 +1454,9 @@
             }
           },
           {
-            "id": "68c61875-9896-4531-8eec-f79a84ec0732",
-            "createdDateTimeUtc": "2021-07-29T18:07:41.3308148Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:43.0283024Z",
+            "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+            "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
+            "lastActionDateTimeUtc": "2021-08-26T12:03:30.7517838Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -7514,558 +1466,6 @@
               "notYetStarted": 0,
               "cancelled": 0,
               "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "a9b825b8-de7f-4ef9-8b15-67f8a05228de",
-            "createdDateTimeUtc": "2021-07-29T18:07:33.4253241Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:35.8948263Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "07266a35-6965-49a7-b488-c6aec774f353",
-            "createdDateTimeUtc": "2021-07-29T18:07:28.0747509Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:29.4732464Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "712bb162-dda9-4e0d-900d-6e32ccb84ce2",
-            "createdDateTimeUtc": "2021-07-29T18:07:21.4384466Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:22.3419567Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "8f0a8627-974a-452a-b531-0a7eeba67834",
-            "createdDateTimeUtc": "2021-07-29T18:07:11.9494241Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:13.7989556Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "c944ca83-770a-4981-8393-8436509a3ac5",
-            "createdDateTimeUtc": "2021-07-29T18:07:03.4708288Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:07:04.7948363Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          }
-        ],
-        "@nextLink": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=400\u0026$top=22\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc Desc"
-      }
-    },
-    {
-      "RequestUri": "https://r-doctranslator.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?$skip=400\u0026$top=22\u0026$maxpagesize=50\u0026$orderBy=createdDateTimeUtc%20Desc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-852a4b4b810ecc4da6f04378c478143a-4a34a7401abdf348-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210804.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "373efd900f801db6fd5f6b72a1efdfe4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8212386e-4d91-427e-ab3c-9c3838443f98",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 04 Aug 2021 20:32:29 GMT",
-        "ETag": "\u00229CAAA156E76D2C692706E6D2D0ABA045429F8C3C6673804A6F02F5B6FA6AE16C\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=d5311be9a7eee70fefb806f1e2337cdd19ccc651d9ba4b6954f0949b8feead5f;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8212386e-4d91-427e-ab3c-9c3838443f98"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "579fe594-a0ac-46c9-99bc-6337aacf022c",
-            "createdDateTimeUtc": "2021-07-29T18:06:55.3491078Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:57.7260656Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "3b9b9b7a-0467-49b5-a230-d6c2c1c80827",
-            "createdDateTimeUtc": "2021-07-29T18:06:40.9676932Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:46.6887745Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "b47abfb4-48de-49de-a4cd-147fe3742a71",
-            "createdDateTimeUtc": "2021-07-29T18:06:35.6198036Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:37.3471477Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "5dc846fa-dea1-4528-b9cb-39fba11fb4da",
-            "createdDateTimeUtc": "2021-07-29T18:06:18.7068479Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:06:26.7025516Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 1,
-              "failed": 0,
-              "success": 1,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 16
-            }
-          },
-          {
-            "id": "2a1743af-a8b6-4ff4-aacc-709b078c56ad",
-            "createdDateTimeUtc": "2021-07-29T18:02:37.0777259Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:40.6627767Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "cd0f86ef-4325-4732-bb52-a12b6bc460df",
-            "createdDateTimeUtc": "2021-07-29T18:02:26.2775788Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:28.2284503Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "905ec32b-4d49-47e5-825a-167cee386199",
-            "createdDateTimeUtc": "2021-07-29T18:02:02.1798526Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:02:05.4444688Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "5e5d4037-f4be-4678-85f2-6c2d10eb35b0",
-            "createdDateTimeUtc": "2021-07-29T18:01:50.005682Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:01:53.1664365Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "f8e7a8b6-428a-45c1-8046-b00f16793d40",
-            "createdDateTimeUtc": "2021-07-29T18:00:58.4154875Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:01:00.6279809Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "f5aa1906-2807-4db0-bd08-a8f9e56b4750",
-            "createdDateTimeUtc": "2021-07-29T18:00:39.80581Z",
-            "lastActionDateTimeUtc": "2021-07-29T18:00:48.5772657Z",
-            "status": "Succeeded",
-            "summary": {
-              "total": 3,
-              "failed": 0,
-              "success": 3,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 48
-            }
-          },
-          {
-            "id": "0498c77f-42de-46cb-91fb-529c044d9e2b",
-            "createdDateTimeUtc": "2021-07-29T16:05:46.6656342Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:05:46.8929852Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "f97fa266-258a-43be-abf7-3a851dd3438a",
-            "createdDateTimeUtc": "2021-07-29T16:05:43.5493779Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:05:43.798646Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "bfe99a22-0966-4bb8-8f99-a60956e1bd44",
-            "createdDateTimeUtc": "2021-07-29T16:04:43.3132785Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:04:43.6688398Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "364a7f60-b5e0-40ed-8fbe-8c269e757f58",
-            "createdDateTimeUtc": "2021-07-29T16:04:38.8243421Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:04:39.7360075Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "173f4456-92b0-47d4-87f0-d3b3f6b076c8",
-            "createdDateTimeUtc": "2021-07-29T16:00:33.3385235Z",
-            "lastActionDateTimeUtc": "2021-07-29T16:00:33.6856601Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "e2cebd98-9179-47ff-a520-d6e672f9548d",
-            "createdDateTimeUtc": "2021-07-29T15:59:51.7446608Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:59:51.9630722Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "d44729c5-7422-414e-9ec8-41be82649bcd",
-            "createdDateTimeUtc": "2021-07-29T15:59:47.8488179Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:59:48.0834023Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "879d0008-1264-4273-9f94-61eaa0d53818",
-            "createdDateTimeUtc": "2021-07-29T15:57:48.4243818Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:48.6367029Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "52a46f0a-80cc-4e51-94e8-6355a5a00782",
-            "createdDateTimeUtc": "2021-07-29T15:57:45.4760932Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:45.6975927Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "1b1df384-0c32-48e3-8539-53619fe9847f",
-            "createdDateTimeUtc": "2021-07-29T15:57:06.0490196Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:57:06.4194196Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "49e77fae-33ee-486c-aac8-5a9e6e27d6c0",
-            "createdDateTimeUtc": "2021-07-29T15:54:13.5289776Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:54:13.9172691Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
-            }
-          },
-          {
-            "id": "dea162d3-b03d-466e-bd33-fae8e3279b21",
-            "createdDateTimeUtc": "2021-07-29T15:54:09.3707087Z",
-            "lastActionDateTimeUtc": "2021-07-29T15:54:09.7229003Z",
-            "status": "ValidationFailed",
-            "error": {
-              "code": "InvalidRequest",
-              "message": "Cannot access target document location with the current permissions.",
-              "target": "Operation",
-              "innerError": {
-                "code": "InvalidTargetDocumentAccessLevel",
-                "message": "Cannot access target document location with the current permissions."
-              }
-            },
-            "summary": {
-              "total": 0,
-              "failed": 0,
-              "success": 0,
-              "inProgress": 0,
-              "notYetStarted": 0,
-              "cancelled": 0,
-              "totalCharacterCharged": 0
             }
           }
         ]
@@ -8073,10 +1473,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-04T22:32:30.1036876\u002B02:00",
+    "DateTimeOffsetNow": "2021-08-26T14:10:00.6091733\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
-    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=storagedoctranslator;AccountKey=Kg==;EndpointSuffix=core.windows.net",
-    "DOCUMENT_TRANSLATION_ENDPOINT": "https://r-doctranslator.cognitiveservices.azure.com/",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
     "RandomSeed": "150275836"
   }
 }


### PR DESCRIPTION
This is in response to this tests failing in the pipeline a couple of days ago.

I've implemented a polling while loop to ensure that the cancellation operation has propagated before returning from the `CreateTranslationJobsAsync` function. I've also added a simple counter to ensure that we do not poll more than a 100 times in case of long term service failure (a max total of around 8 minutes of waiting for the cancellation to propagate). 