### PR TITLE
Add InProc dependency type and update db target mapping.

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/HttpHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/HttpHelper.cs
@@ -225,15 +225,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
             string target = tagObjects.GetDependencyTarget(PartBType.Db);
             string dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
-            if (!string.IsNullOrEmpty(target) && !string.IsNullOrEmpty(dbName))
+            bool isTargetEmpty = string.IsNullOrEmpty(target);
+            bool isDbNameEmpty = string.IsNullOrEmpty(dbName);
+            if (!isTargetEmpty && !isDbNameEmpty)
             {
                 target = $"{target}/{dbName}";
             }
-            else if (string.IsNullOrEmpty(target) && !string.IsNullOrEmpty(dbName))
+            else if (isTargetEmpty && !isDbNameEmpty)
             {
                 target = dbName;
             }
-            else if (string.IsNullOrEmpty(target) && string.IsNullOrEmpty(dbName))
+            else if (isTargetEmpty && isDbNameEmpty)
             {
                 target = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString();
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/HttpHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/HttpHelper.cs
@@ -219,7 +219,30 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         }
 
         ///<summary>
-        /// Gets http dependency target from activity tag objects.
+        /// Gets Database dependency target from activity tag objects.
+        ///</summary>
+        internal static string GetDbDependencyTarget(this AzMonList tagObjects)
+        {
+            string target = tagObjects.GetDependencyTarget(PartBType.Db);
+            string dbName = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbName)?.ToString();
+            if (!string.IsNullOrEmpty(target) && !string.IsNullOrEmpty(dbName))
+            {
+                target = $"{target}/{dbName}";
+            }
+            else if (string.IsNullOrEmpty(target) && !string.IsNullOrEmpty(dbName))
+            {
+                target = dbName;
+            }
+            else if (string.IsNullOrEmpty(target) && string.IsNullOrEmpty(dbName))
+            {
+                target = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeDbSystem)?.ToString();
+            }
+
+            return target;
+        }
+
+        ///<summary>
+        /// Gets Http dependency target from activity tag objects.
         ///</summary>
         internal static string GetDependencyTarget(this AzMonList tagObjects, PartBType type)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TagEnumerationState.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TagEnumerationState.cs
@@ -14,6 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
             [SemanticConventions.AttributeDbStatement] = PartBType.Db,
             [SemanticConventions.AttributeDbSystem] = PartBType.Db,
+            [SemanticConventions.AttributeDbName] = PartBType.Db,
 
             [SemanticConventions.AttributeHttpMethod] = PartBType.Http,
             [SemanticConventions.AttributeHttpUrl] = PartBType.Http,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
@@ -78,7 +78,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 case PartBType.Db:
                     var depDataAndType = AzMonList.GetTagValues(ref monitorTags.PartBTags, SemanticConventions.AttributeDbStatement, SemanticConventions.AttributeDbSystem);
                     dependency.Data = depDataAndType[0]?.ToString();
-                    dependency.Target = monitorTags.PartBTags.GetDependencyTarget(PartBType.Db);
+                    dependency.Target = monitorTags.PartBTags.GetDbDependencyTarget();
                     dependency.Type = SqlDbs.Contains(depDataAndType[1]?.ToString()) ? "SQL" : depDataAndType[1]?.ToString();
                     break;
                 case PartBType.Rpc:
@@ -92,6 +92,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     dependency.Data = depDataAndType[0]?.ToString();
                     dependency.Type = depDataAndType[1]?.ToString();
                     break;
+            }
+
+            if (activity.Kind == ActivityKind.Internal && activity.Parent != null)
+            {
+                dependency.Type = "InProc";
             }
 
             AddPropertiesToTelemetry(dependency.Properties, ref monitorTags.PartCTags);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/HttpHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/HttpHelperTests.cs
@@ -431,7 +431,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         [InlineData("https", "8888", PartBType.Http)]
         [InlineData("https", "1433", PartBType.Db)]
         [InlineData("https", "8888", PartBType.Db)]
-        internal void HttpDependencyTargetIsSetUsingNetPeerIp(string httpScheme, string port, PartBType type)
+        internal void DependencyTargetIsSetUsingNetPeerIp(string httpScheme, string port, PartBType type)
         {
             var PartBTags = AzMonList.Initialize();
             AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, httpScheme));
@@ -542,6 +542,65 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
             var PartBTags = AzMonList.Initialize();
             string target = PartBTags.GetDependencyTarget(type);
+            Assert.Null(target);
+        }
+
+        [Theory]
+        [InlineData("peerservice", null, null, null)]
+        [InlineData(null, "servicename.com", null, "8888")]
+        [InlineData(null, null, "127.0.0.1", "8888")]
+        public void DbNameIsAppendedToTargetDerivedFromNetAttributesforDBDependencyTarget(string peerService, string netPeerName, string netPeerIp, string netPeerPort)
+        {
+            var PartBTags = AzMonList.Initialize();
+            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributePeerService, peerService));
+            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, netPeerName));
+            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerIp, netPeerIp));
+            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, netPeerPort));
+            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbName, "DbName"));
+            string hostName = null;
+            if (peerService != null)
+            {
+                hostName = peerService;
+            }
+            if (netPeerName != null)
+            {
+                hostName = $"{netPeerName}:{netPeerPort}";
+            }
+            if (netPeerIp != null)
+            {
+                hostName = $"{netPeerIp}:{netPeerPort}";
+            }
+            string expectedTarget = $"{hostName}/DbName";
+            string target = PartBTags.GetDbDependencyTarget();
+            Assert.Equal(expectedTarget, target);
+        }
+
+        [Fact]
+        public void DbDependencyTargetIsSetToDbNameWhenNetAttributesAreNotPresent()
+        {
+            var PartBTags = AzMonList.Initialize();
+            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributePeerService, "servicename"));
+            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbName, "DbName"));
+            string expectedTarget = "servicename/DbName";
+            string target = PartBTags.GetDbDependencyTarget();
+            Assert.Equal(expectedTarget, target);
+        }
+
+        [Fact]
+        public void DbDependencyTargetIsSetToDbSystemWhenNetAndDbNameAttributesAreNotPresent()
+        {
+            var PartBTags = AzMonList.Initialize();
+            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "DbSystem"));
+            string expectedTarget = "DbSystem";
+            string target = PartBTags.GetDbDependencyTarget();
+            Assert.Equal(expectedTarget, target);
+        }
+
+        [Fact]
+        public void DbDependencyTargetIsSetToNullByDefault()
+        {
+            var PartBTags = AzMonList.Initialize();
+            string target = PartBTags.GetDbDependencyTarget();
             Assert.Null(target);
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/HttpHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/HttpHelperTests.cs
@@ -579,11 +579,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public void DbDependencyTargetIsSetToDbNameWhenNetAttributesAreNotPresent()
         {
             var PartBTags = AzMonList.Initialize();
-            AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributePeerService, "servicename"));
             AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbName, "DbName"));
-            string expectedTarget = "servicename/DbName";
             string target = PartBTags.GetDbDependencyTarget();
-            Assert.Equal(expectedTarget, target);
+            Assert.Equal("DbName", target);
         }
 
         [Fact]
@@ -591,9 +589,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         {
             var PartBTags = AzMonList.Initialize();
             AzMonList.Add(ref PartBTags, new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "DbSystem"));
-            string expectedTarget = "DbSystem";
             string target = PartBTags.GetDbDependencyTarget();
-            Assert.Equal(expectedTarget, target);
+            Assert.Equal("DbSystem", target);
         }
 
         [Fact]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -141,5 +141,25 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             Assert.Equal(expectedType, remoteDependencyDataType);
         }
+
+        [Fact]
+        public void DependencyTypeisSetToInProcForInternalSpanWithParent()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var parentActivity = activitySource.StartActivity("ParentActivity", ActivityKind.Internal);
+            using var childActivity = activitySource.StartActivity("ChildActivity", ActivityKind.Internal);
+
+            var monitorTagsParent = AzureMonitorConverter.EnumerateActivityTags(parentActivity);
+
+            var remoteDependencyDataTypeForParent = TelemetryPartB.GetRemoteDependencyData(parentActivity, ref monitorTagsParent).Type;
+
+            Assert.Null(remoteDependencyDataTypeForParent);
+
+            var monitorTagsChild = AzureMonitorConverter.EnumerateActivityTags(childActivity);
+
+            var remoteDependencyDataTypeForChild = TelemetryPartB.GetRemoteDependencyData(childActivity, ref monitorTagsChild).Type;
+
+            Assert.Equal("InProc", remoteDependencyDataTypeForChild);
+        }
     }
 }


### PR DESCRIPTION
1) InProc type should be used for all the in-process spans (Part B Span.kind == SpanKind.INTERNAL) with parent
2) For db target:
* If target derived from peerService or net* attributes is not null, then append Span.dbName (if present) using / delimiter.
* If target derived from peerService or net* attributes is null, then assign Span.dbName (if present) to target.
* Default: If none of the above are available, assign Span.dbSystem to target.