### PR TITLE
[MetricsAdvisor] Improve validation in ValidateDataFeedWithOptionalMembersSet and ValidateUpdatedDataFeedWithOptionalMembersSet

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -1061,6 +1061,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.AccessMode, Is.EqualTo(DataFeedAccessMode.Public));
             Assert.That(dataFeed.ActionLinkTemplate, Is.EqualTo("https://fakeurl.com/%metric/%datafeed"));
             Assert.That(dataFeed.Creator, Is.Not.Null.And.Not.Empty);
+            Assert.That(dataFeed.Creator, Is.EqualTo("foo@contoso.com"));
 
             Assert.That(dataFeed.Administrators, Is.Not.Null);
             Assert.That(dataFeed.Administrators.Count, Is.EqualTo(2));
@@ -1131,6 +1132,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.AccessMode, Is.EqualTo(DataFeedAccessMode.Public));
             Assert.That(dataFeed.ActionLinkTemplate, Is.EqualTo("https://fakeurl.com/%datafeed/%metric"));
             Assert.That(dataFeed.Creator, Is.Not.Null.And.Not.Empty);
+            Assert.That(dataFeed.Creator, Is.EqualTo("foo@contoso.com"));
 
             // In the SetOptionalMembers method, we may or may not add a new admin (fake@admin.com) depending on whether
             // the data feed instance used for the Update call was created from scratch or from a GetDataFeed operation:

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -1062,6 +1062,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.ActionLinkTemplate, Is.EqualTo("https://fakeurl.com/%metric/%datafeed"));
             Assert.That(dataFeed.Creator, Is.Not.Null.And.Not.Empty);
             Assert.That(dataFeed.Creator, Is.EqualTo("foo@contoso.com"));
+            Assert.That(dataFeed.DataSource, Is.Not.Null);
 
             Assert.That(dataFeed.Administrators, Is.Not.Null);
             Assert.That(dataFeed.Administrators.Count, Is.EqualTo(2));
@@ -1133,6 +1134,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.ActionLinkTemplate, Is.EqualTo("https://fakeurl.com/%datafeed/%metric"));
             Assert.That(dataFeed.Creator, Is.Not.Null.And.Not.Empty);
             Assert.That(dataFeed.Creator, Is.EqualTo("foo@contoso.com"));
+            Assert.That(dataFeed.DataSource, Is.Not.Null);
 
             // In the SetOptionalMembers method, we may or may not add a new admin (fake@admin.com) depending on whether
             // the data feed instance used for the Update call was created from scratch or from a GetDataFeed operation:

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -1126,6 +1126,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(80)));
             Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromMinutes(10)));
             Assert.That(dataFeed.IngestionSettings.DataSourceRequestConcurrency, Is.EqualTo(5));
+
+            Assert.That(dataFeed.RollupSettings, Is.Not.Null);
+            Assert.That(dataFeed.RollupSettings.RollupType, Is.EqualTo(DataFeedRollupType.NoRollupNeeded));
+            Assert.That(dataFeed.RollupSettings.RollupIdentificationValue, Is.Null);
+            Assert.That(dataFeed.RollupSettings.AutoRollupMethod, Is.EqualTo(DataFeedAutoRollupMethod.None));
+            Assert.That(dataFeed.RollupSettings.AutoRollupGroupByColumnNames, Is.Not.Null);
+            Assert.That(dataFeed.RollupSettings.AutoRollupGroupByColumnNames.Count, Is.EqualTo(0));
         }
 
         private void ValidateUpdatedDataFeedWithOptionalMembersSet(DataFeed dataFeed, string expectedId, string expectedName)
@@ -1196,6 +1203,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(90)));
             Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromMinutes(20)));
             Assert.That(dataFeed.IngestionSettings.DataSourceRequestConcurrency, Is.EqualTo(6));
+
+            Assert.That(dataFeed.RollupSettings, Is.Not.Null);
+            Assert.That(dataFeed.RollupSettings.RollupType, Is.EqualTo(DataFeedRollupType.NoRollupNeeded));
+            Assert.That(dataFeed.RollupSettings.RollupIdentificationValue, Is.Null);
+            Assert.That(dataFeed.RollupSettings.AutoRollupMethod, Is.EqualTo(DataFeedAutoRollupMethod.None));
+            Assert.That(dataFeed.RollupSettings.AutoRollupGroupByColumnNames, Is.Not.Null);
+            Assert.That(dataFeed.RollupSettings.AutoRollupGroupByColumnNames.Count, Is.EqualTo(0));
         }
 
         private void ValidateGenericDataSource(DataFeedSource dataSource, bool isAdmin)

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -1084,6 +1084,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.Granularity.GranularityType, Is.EqualTo(DataFeedGranularityType.Custom));
             Assert.That(dataFeed.Granularity.CustomGranularityValue, Is.EqualTo(3000));
 
+            Assert.That(dataFeed.MetricIds, Is.Not.Null);
+            Assert.That(dataFeed.MetricIds.Count, Is.EqualTo(2));
+            Assert.That(dataFeed.MetricIds.Count, Is.EqualTo(dataFeed.Schema.MetricColumns.Count));
+            Assert.That(dataFeed.MetricIds.Keys, Contains.Item("cost"));
+            Assert.That(dataFeed.MetricIds.Keys, Contains.Item("revenue"));
+
             Assert.That(dataFeed.Schema, Is.Not.Null);
             Assert.That(dataFeed.Schema.MetricColumns, Is.Not.Null);
             Assert.That(dataFeed.Schema.MetricColumns.Count, Is.EqualTo(2));
@@ -1164,6 +1170,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.Granularity, Is.Not.Null);
             Assert.That(dataFeed.Granularity.GranularityType, Is.EqualTo(DataFeedGranularityType.Daily));
             Assert.That(dataFeed.Granularity.CustomGranularityValue, Is.Null);
+
+            Assert.That(dataFeed.MetricIds, Is.Not.Null);
+            Assert.That(dataFeed.MetricIds.Count, Is.EqualTo(1));
+            Assert.That(dataFeed.MetricIds.Count, Is.EqualTo(dataFeed.Schema.MetricColumns.Count));
+            Assert.That(dataFeed.MetricIds.Keys, Contains.Item("cost"));
 
             Assert.That(dataFeed.Schema, Is.Not.Null);
             Assert.That(dataFeed.Schema.MetricColumns, Is.Not.Null);


### PR DESCRIPTION
Changes:

 * Validate DataFeed.Creator
 * Validate DataFeed.DataSource
 * Validate DataFeed.MetricsIds
 * Validate DataFeed.RollupSettings

in the DataFeedLiveTests.ValidateDataFeedWithOptionalMembersSet and ValidateUpdatedDataFeedWithOptionalMembersSet method.

Part of #17766 