### PR TITLE
[EngSys] Updating Tables tests to use suppressed secrets

### DIFF
--- a/sdk/tables/Azure.Data.Tables/tests/TableUriBuilderTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableUriBuilderTests.cs
@@ -232,7 +232,7 @@ namespace Azure.Data.Tables.Tests
         public void TableBuilder_SasStartExpiryTimeFormats(string startTime, string expiryTime)
         {
             // Arrange
-            Uri initialUri = new Uri($"https://account.table.core.windows.net/table?tn=tablename&sv=2020-04-08&st={WebUtility.UrlEncode(startTime)}&se={WebUtility.UrlEncode(expiryTime)}&sr=b&sp=racwd&sig=jQetX8odiJoZ7Yo0X8vWgh%2FMqRv9WE3GU%2Fr%2BLNMK3GU%3D");
+            Uri initialUri = new Uri($"https://account.table.core.windows.net/table?tn=tablename&sv=2020-04-08&st={WebUtility.UrlEncode(startTime)}&se={WebUtility.UrlEncode(expiryTime)}&sr=b&sp=racwd&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D");
             TableUriBuilder tableuribuilder = new TableUriBuilder(initialUri);
 
             // Act
@@ -250,7 +250,7 @@ namespace Azure.Data.Tables.Tests
             // Arrange
             string startTime = "2020-10-27T12Z";
             string expiryTime = "2020-10-28T13Z";
-            Uri initialUri = new Uri($"https://account.table.core.windows.net/table?sv=2020-04-08&st={WebUtility.UrlEncode(startTime)}&se={WebUtility.UrlEncode(expiryTime)}&sr=b&sp=racwd&sig=jQetX8odiJoZ7Yo0X8vWgh%2FMqRv9WE3GU%2Fr%2BLNMK3GU%3D");
+            Uri initialUri = new Uri($"https://account.table.core.windows.net/table?sv=2020-04-08&st={WebUtility.UrlEncode(startTime)}&se={WebUtility.UrlEncode(expiryTime)}&sr=b&sp=racwd&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D");
 
             // Act
             try


### PR DESCRIPTION
The shared access signature used in Tables tests, `jQetX8odiJoZ7Yo0X8vWgh%2FMqRv9WE3GU%2Fr%2BLNMK3GU%3D`, is being flagged by CredScan as a leak, even though it's a fake secret. We could add it to our [suppression file](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/CredScanSuppression.json), but we already have a base64 encoded placeholder there we can use: `%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D`.

In this PR, we're opting for using the existing placeholder instead of extending the suppression file.