### PR TITLE
[Core] Added 'x-ms-encryption-key' as a sanitized header

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestSanitizer.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestSanitizer.cs
@@ -40,7 +40,7 @@ namespace Azure.Core.TestFramework
             DateParseHandling = DateParseHandling.None
         };
 
-        public List<string> SanitizedHeaders { get; } = new List<string> { "Authorization" };
+        public List<string> SanitizedHeaders { get; } = new List<string> { "Authorization", "x-ms-encryption-key" };
 
         public void AddJsonPathSanitizer(string jsonPath, Func<JToken, JToken> sanitizer = null)
         {


### PR DESCRIPTION
The `x-ms-encryption-key` header is used by the Storage service as an authentication method. [More information here](https://azure.microsoft.com/blog/customer-provided-keys-with-azure-storage-service-encryption/).

This PR adds `x-ms-encryption-key` to the list of headers to be sanitized by default in our Test Framework.