### PR TITLE
Default RoleInstance to HostName

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -157,9 +157,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 RoleName = serviceName;
             }
 
-            // This will happen in two cases
+            // This will happen when
             // 1) AddService() is not called on resource.
             // 2) AddService is called with autoGenerateServiceInstanceId set to false and serviceInstanceId is not passed.
+            // 3) service.instance.id attribute is not set.
             if (RoleInstance == null)
             {
                 try

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -157,10 +157,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 RoleName = serviceName;
             }
 
-            // This will happen when
-            // 1) AddService() is not called on resource.
-            // 2) AddService is called with autoGenerateServiceInstanceId set to false and serviceInstanceId is not passed.
-            // 3) service.instance.id attribute is not set.
             if (RoleInstance == null)
             {
                 try

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-
+using System.Net;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 using OpenTelemetry.Logs;
@@ -154,6 +155,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             else
             {
                 RoleName = serviceName;
+            }
+
+            // This will happen in two cases
+            // 1) AddService() is not called on resource.
+            // 2) AddService is called with autoGenerateServiceInstanceId set to false and serviceInstanceId is not passed.
+            if (RoleInstance == null)
+            {
+                try
+                {
+                    RoleInstance = Dns.GetHostName();
+                }
+                catch (Exception e)
+                {
+                    AzureMonitorExporterEventSource.Log.Write($"ErrorInitializingRoleInstanceToHostName{EventLevelSuffix.Error}", $"{e.ToInvariantString()}");
+                }
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -167,9 +167,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 {
                     RoleInstance = Dns.GetHostName();
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    AzureMonitorExporterEventSource.Log.Write($"ErrorInitializingRoleInstanceToHostName{EventLevelSuffix.Error}", $"{e.ToInvariantString()}");
+                    AzureMonitorExporterEventSource.Log.Write($"ErrorInitializingRoleInstanceToHostName{EventLevelSuffix.Error}", $"{ex.ToInvariantString()}");
                 }
             }
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
@@ -5,13 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net;
 using Xunit;
 
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using OpenTelemetry.Resources;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
-using System.Net;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
@@ -57,7 +57,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             TelemetryPartA.InitRoleInfo(resource);
 
             Assert.StartsWith("unknown_service", TelemetryPartA.RoleName);
-            Assert.Null(TelemetryPartA.RoleInstance);
+            Assert.Equal(Dns.GetHostName(), TelemetryPartA.RoleInstance);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             TelemetryPartA.InitRoleInfo(resource);
 
             Assert.Equal("my-service", TelemetryPartA.RoleName);
-            Assert.Null(TelemetryPartA.RoleInstance);
+            Assert.Equal(Dns.GetHostName(), TelemetryPartA.RoleInstance);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             TelemetryPartA.InitRoleInfo(resource);
 
             Assert.StartsWith("my-namespace.unknown_service", TelemetryPartA.RoleName);
-            Assert.Null(TelemetryPartA.RoleInstance);
+            Assert.Equal(Dns.GetHostName(), TelemetryPartA.RoleInstance);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryPartA.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
             Assert.StartsWith("unknown_service", telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()]);
-            Assert.Null(telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
+            Assert.Equal(Dns.GetHostName(), telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
             Assert.NotNull(telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()]);
             Assert.NotNull(telemetryItem.Tags[ContextTagKeys.AiInternalSdkVersion.ToString()]);
             Assert.Throws<KeyNotFoundException>(() => telemetryItem.Tags[ContextTagKeys.AiOperationParentId.ToString()]);
@@ -178,7 +178,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             Assert.Equal("RemoteDependency", telemetryItem.Name);
             Assert.Equal(TelemetryPartA.FormatUtcTimestamp(activity.StartTimeUtc), telemetryItem.Time);
             Assert.StartsWith("unknown_service", telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()]);
-            Assert.Null(telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
+            Assert.Equal(Dns.GetHostName(), telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
             Assert.NotNull(telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()]);
             Assert.NotNull(telemetryItem.Tags[ContextTagKeys.AiInternalSdkVersion.ToString()]);
             Assert.Equal(activity.ParentSpanId.ToHexString(), telemetryItem.Tags[ContextTagKeys.AiOperationParentId.ToString()]);


### PR DESCRIPTION
Mapping for cloud.roleInstance
1) service.instance.id
2) If service.instance.id is not set then default to the host name where the exporter is running. The host name may be obtained by calling hostname or by other means.