### PR TITLE
Update Microsoft.Internal.NetSdkBuild.Mgmt.Tools Version

### DIFF
--- a/eng/mgmt/Directory.Build.Mgmt.props
+++ b/eng/mgmt/Directory.Build.Mgmt.props
@@ -1,6 +1,6 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PkgVersion>0.12.0-dev.20210610.1</PkgVersion>
+    <PkgVersion>0.12.0-dev.20210827.1</PkgVersion>
     <PkgLocalDir>$(NuGetPackageRoot)\microsoft.internal.netsdkbuild.mgmt.tools\$(PkgVersion)\Sdk</PkgLocalDir>
     <SymbolPackageFormat>symbols.nupkg</SymbolPackageFormat>
   </PropertyGroup>


### PR DESCRIPTION
Update Microsoft.Internal.NetSdkBuild.Mgmt.Tools from 0.12.0-dev.2020610.1 to 0.12.0-dev.20210827.1

This is required to pull in the changes in https://github.com/Azure/azure-sdk-tools/pull/1928