### PR TITLE
[DT] Added tests for GetDocumentStatusesFilterByCreatedAfter/Before

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/GetAllDocumentsFilterTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/GetAllDocumentsFilterTests.cs
@@ -68,16 +68,80 @@ namespace Azure.AI.Translation.Document.Tests
             Assert.That(result.All(d => testIds.Contains(d.Id)));
         }
 
-        [Ignore("no way to test this filter")]
         [RecordedTest]
-        public void GetDocumentStatusesFilterByCreatedAfter()
+        public async Task GetDocumentStatusesFilterByCreatedAfter()
         {
+            // create client
+            var client = GetClient();
+
+            // create translation job
+            var operation = await CreateSingleTranslationJobAsync(client, docsCount: 5);
+            await operation.WaitForCompletionAsync();
+
+            // option to sort in order of Created On
+            var optionsOrdering = new GetDocumentStatusesOptions
+            {
+                OrderBy = { new DocumentFilterOrder(property: DocumentFilterProperty.CreatedOn, ascending: true) }
+            };
+
+            var testCreatedOnDateTimes = operation.GetDocumentStatuses(options: optionsOrdering).Select(d => d.CreatedOn).ToList();
+
+            var optionsCreatedAfterLastDate = new GetDocumentStatusesOptions
+            {
+                CreatedAfter = testCreatedOnDateTimes[4]
+            };
+
+            var optionsCreatedAfterIndex2 = new GetDocumentStatusesOptions
+            {
+                CreatedAfter = testCreatedOnDateTimes[2]
+            };
+
+            var docsAfterLastDate = operation.GetDocumentStatuses(options: optionsCreatedAfterLastDate).ToList();
+            var docsAfterIndex2Date = operation.GetDocumentStatuses(options: optionsCreatedAfterIndex2).ToList();
+
+            // Asserting that only the last document is returned
+            Assert.AreEqual(1, docsAfterLastDate.Count());
+
+            // Asserting that the last 3/5 docs are returned
+             Assert.AreEqual(3, docsAfterIndex2Date.Count());
         }
 
-        [Ignore("no way to test this filter")]
         [RecordedTest]
-        public void GetDocumentStatusesFilterByCreatedBefore()
+        public async Task GetDocumentStatusesFilterByCreatedBefore()
         {
+            // create client
+            var client = GetClient();
+
+            // create translation job
+            var operation = await CreateSingleTranslationJobAsync(client, docsCount: 5);
+            await operation.WaitForCompletionAsync();
+
+            // option to sort in order of Created On
+            var optionsOrdering = new GetDocumentStatusesOptions
+            {
+                OrderBy = { new DocumentFilterOrder(property: DocumentFilterProperty.CreatedOn, ascending: true) }
+            };
+
+            var testCreatedOnDateTimes = operation.GetDocumentStatuses(options: optionsOrdering).Select(d => d.CreatedOn).ToList();
+
+            var optionsCreatedBeforeFirstDate = new GetDocumentStatusesOptions
+            {
+                CreatedBefore = testCreatedOnDateTimes[0]
+            };
+
+            var optionsCreatedBeforeIndex3 = new GetDocumentStatusesOptions
+            {
+                CreatedBefore = testCreatedOnDateTimes[3]
+            };
+
+            var docsBeforeFirstDate = operation.GetDocumentStatuses(options: optionsCreatedBeforeFirstDate).ToList();
+            var docsBeforeIndex3Date = operation.GetDocumentStatuses(options: optionsCreatedBeforeIndex3).ToList();
+
+            // Asserting that only the first document is returned
+            Assert.AreEqual(1, docsBeforeFirstDate.Count());
+
+            // Asserting that the first 4/5 docs are returned
+            Assert.AreEqual(4, docsBeforeIndex3Date.Count());
         }
 
         [RecordedTest]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByCreatedAfter.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByCreatedAfter.json
@@ -1,0 +1,955 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1259501965?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ddd814627042c347a9c9f79c3da64490-2b842db396c69b44-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3b4a2a2e12c559a8293162005b1c6a8e",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:05 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:02:05 GMT",
+        "ETag": "\u00220x8D96BBEBFF538E8\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:05 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "3b4a2a2e12c559a8293162005b1c6a8e",
+        "x-ms-request-id": "d2794d2c-701e-0028-72a7-9d5d37000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_0.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-318b752980ad1044b9297469a05ae5e2-cd0aeb67bd06ec45-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a54f80d9cc3ffa1e881f9ae2087c85ad",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:06 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:05 GMT",
+        "ETag": "\u00220x8D96BBEC0404056\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:06 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "a54f80d9cc3ffa1e881f9ae2087c85ad",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2794da2-701e-0028-50a7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-8de822cc22112643a5c6be8167b29afa-f1d0e0e5d181f442-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "03983e08f7bdfd7f7ee67061241cfe4e",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:06 GMT",
+        "ETag": "\u00220x8D96BBEC06E36A2\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:06 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "03983e08f7bdfd7f7ee67061241cfe4e",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2794e0c-701e-0028-2ba7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_2.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-29ee04d22f5e1c4a9cb2d4892c91dd02-20eb338a2deaab42-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e4319f74f6b2624d0c50b2a577c550ad",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:06 GMT",
+        "ETag": "\u00220x8D96BBEC09F61C5\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:06 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "e4319f74f6b2624d0c50b2a577c550ad",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2794ea4-701e-0028-28a7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_3.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-5393c7030747ba43b5f31a48a8401482-72b6c7c6bb1fe541-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "1df7b5ac6684e1d1005226595bbcd56b",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:06 GMT",
+        "ETag": "\u00220x8D96BBEC0CC1F4A\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:07 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "1df7b5ac6684e1d1005226595bbcd56b",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2794f40-701e-0028-2ba7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_4.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-2fb11d104a890a4b9573858ba28b4d89-d71caa798fc6e84e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "696e4b21a14a12fbf035f76d45da85b9",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:06 GMT",
+        "ETag": "\u00220x8D96BBEC0F95225\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:07 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "696e4b21a14a12fbf035f76d45da85b9",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2794fb2-701e-0028-0aa7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target2144097173?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1c2072353e01e544a7074f9ff92ed5a6-39feedddb679784b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "256fb5c3cae0cd0e50e360d0f4074f7a",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:08 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:02:07 GMT",
+        "ETag": "\u00220x8D96BBEC11AB400\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:07 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "256fb5c3cae0cd0e50e360d0f4074f7a",
+        "x-ms-request-id": "d2795058-701e-0028-1ea7-9d5d37000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a22ea5959d136347b18721779b26d0e5-7cefc94d4e6bce4e-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "572b844663e7ba0ae42d4e6f649c26cc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "468e5c6d-c98f-48ae-9872-52503f82d395",
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:02:09 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "468e5c6d-c98f-48ae-9872-52503f82d395"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0797c36c466681405f9cfabd9b42fc2e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7810983b-6781-48dc-81f2-75bee930ebb6",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:09 GMT",
+        "ETag": "\u0022BB8D4C2821A3B10D57E6AD2A5F4B5B536FBA4C17CEE166A35E57925D52E615AA\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7810983b-6781-48dc-81f2-75bee930ebb6"
+      },
+      "ResponseBody": {
+        "id": "7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "createdDateTimeUtc": "2021-08-30T14:02:09.2924097Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:09.2924099Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "56fef2a8625a60aeaab540b37c9f69b4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "02c0446d-6ee4-49b2-a2ac-fb0138bbebea",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:11 GMT",
+        "ETag": "\u0022224D31799FC72BBA5886015950435322C94F357288073088A39D211C82064D41\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "02c0446d-6ee4-49b2-a2ac-fb0138bbebea"
+      },
+      "ResponseBody": {
+        "id": "7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "createdDateTimeUtc": "2021-08-30T14:02:09.2924097Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:10.7692501Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 4,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "316394bd476f001443aaf74b694c1fa2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cf5d8ae5-91ef-4f99-b5ee-f4979c291d9b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:12 GMT",
+        "ETag": "\u00221E653637C16AA2283DC86A27584AA52E5E529DDC3FEED1C11E93E38ED258644E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "cf5d8ae5-91ef-4f99-b5ee-f4979c291d9b"
+      },
+      "ResponseBody": {
+        "id": "7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "createdDateTimeUtc": "2021-08-30T14:02:09.2924097Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:11.9574425Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "71c71f30d09d0a7214375cb0058d05c0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9726c9be-cf49-46a1-a128-321d64c4225b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:13 GMT",
+        "ETag": "\u00221E653637C16AA2283DC86A27584AA52E5E529DDC3FEED1C11E93E38ED258644E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9726c9be-cf49-46a1-a128-321d64c4225b"
+      },
+      "ResponseBody": {
+        "id": "7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "createdDateTimeUtc": "2021-08-30T14:02:09.2924097Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:11.9574425Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "06004532cade60bfdefe12af6b63f75e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "23ef8883-27eb-4bb8-aa10-9da237179a21",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:14 GMT",
+        "ETag": "\u00221E653637C16AA2283DC86A27584AA52E5E529DDC3FEED1C11E93E38ED258644E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "23ef8883-27eb-4bb8-aa10-9da237179a21"
+      },
+      "ResponseBody": {
+        "id": "7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "createdDateTimeUtc": "2021-08-30T14:02:09.2924097Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:11.9574425Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5c829d95f7d7ed1621591d37ea63fab5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a343e556-4777-48e5-a3ed-77435cff5cec",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:15 GMT",
+        "ETag": "\u00221E653637C16AA2283DC86A27584AA52E5E529DDC3FEED1C11E93E38ED258644E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "a343e556-4777-48e5-a3ed-77435cff5cec"
+      },
+      "ResponseBody": {
+        "id": "7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "createdDateTimeUtc": "2021-08-30T14:02:09.2924097Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:11.9574425Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "231836a5184c66c45f66929fbdc29eb0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f532ead3-1086-45ad-926b-f2368449e27b",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:17 GMT",
+        "ETag": "\u00221E653637C16AA2283DC86A27584AA52E5E529DDC3FEED1C11E93E38ED258644E\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f532ead3-1086-45ad-926b-f2368449e27b"
+      },
+      "ResponseBody": {
+        "id": "7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "createdDateTimeUtc": "2021-08-30T14:02:09.2924097Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:11.9574425Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "671bfe40a80b3ae82f13e585ad87757a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d4cdfb62-3dad-420e-ad26-aad335d24ea9",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:18 GMT",
+        "ETag": "\u0022A1B7F99D8C6DB85514A725564921A56C82F462D439B7D84A7574E8054A125529\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d4cdfb62-3dad-420e-ad26-aad335d24ea9"
+      },
+      "ResponseBody": {
+        "id": "7150fada-c0e0-4982-a8bb-d0ec54e87f85",
+        "createdDateTimeUtc": "2021-08-30T14:02:09.2924097Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:18.1085252Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 5,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 80
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "340a5c03d44b7d12d91cfd7164762f5f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cfb4f5e2-5d1c-45b0-bbe8-407f24c5d2ec",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:18 GMT",
+        "ETag": "\u002250E30C7892BEBC297467587CFF088496A4A76F3FA1A2A309BB0E82E1DEB800FA\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "cfb4f5e2-5d1c-45b0-bbe8-407f24c5d2ec"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:11.4997815Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:17.9114419Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711b-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7763747Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.108256Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7119-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7359907Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.108517Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7117-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7300025Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.1002692Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711a-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7180161Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.0573856Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7118-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85/documents?$orderBy=createdDateTimeUtc%20Asc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ecf76cba9348fcaa4dddf338333eb8d7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1076096c-64b6-4aea-b8cb-2f84be424fdf",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:18 GMT",
+        "ETag": "\u0022DA7215205ADF722A7CC1C724930A394ADB21D8549D38324A761B67E66B2C119D\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "1076096c-64b6-4aea-b8cb-2f84be424fdf"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7180161Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.0573856Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7118-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7300025Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.1002692Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711a-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7359907Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.108517Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7117-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7763747Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.108256Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7119-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:11.4997815Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:17.9114419Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711b-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85/documents?createdDateTimeUtcStart=2021-08-30T14%3A02%3A11.4997815Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "609c18f16ab76c64ec9d8eeeab77d5b8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "75bb0ad6-bfc3-4d8f-a517-4c870f86e6e5",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:19 GMT",
+        "ETag": "\u0022AD40AD09A1A766C05E9D286855D620C9826625461F4C62ED4CBD11A8AB51743D\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "75bb0ad6-bfc3-4d8f-a517-4c870f86e6e5"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:11.4997815Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:17.9114419Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711b-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/7150fada-c0e0-4982-a8bb-d0ec54e87f85/documents?createdDateTimeUtcStart=2021-08-30T14%3A02%3A10.7359907Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "40ca85e389907032b10ee66ee0d94a9b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "73843dcb-d037-434a-b3f2-17fa678e5a02",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:19 GMT",
+        "ETag": "\u00221B0E45D52941C7070FDB6761667F1FF7BAD8CD1B9C1E78B1DABE19808ECDF9A8\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "73843dcb-d037-434a-b3f2-17fa678e5a02"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:11.4997815Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:17.9114419Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711b-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7763747Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.108256Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7119-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target2144097173/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1259501965/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:10.7359907Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:18.108517Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7117-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
+    "RandomSeed": "1987140603"
+  }
+}

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByCreatedAfterAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByCreatedAfterAsync.json
@@ -1,0 +1,1003 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source144448566?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e99c0e3469a6524db7da26b2db31da40-a628a9ac553db148-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "df38b7b953f61a0e438c120035b7cccb",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:02:19 GMT",
+        "ETag": "\u00220x8D96BBEC8B0D670\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:20 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "df38b7b953f61a0e438c120035b7cccb",
+        "x-ms-request-id": "d279697a-701e-0028-0fa7-9d5d37000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_0.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-bc9c4a500c047b43aad13e10421615af-b7beddd3e37f2645-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "bca63b4288f2498bb3628b8a07c18f97",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:20 GMT",
+        "ETag": "\u00220x8D96BBEC90CD956\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "bca63b4288f2498bb3628b8a07c18f97",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d27969e0-701e-0028-66a7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-1a20e81ad46ea54781c94c053cd28472-0d7a3ca0a32ef14a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "19abf3e6eaef8861ca5e50b908763c56",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:20 GMT",
+        "ETag": "\u00220x8D96BBEC93A8174\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "19abf3e6eaef8861ca5e50b908763c56",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2796add-701e-0028-45a7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_2.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-1f64df42f6f2034db55b101676feae7a-7f6ce77172028941-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c041b53ff5cb30432bee2c94c8841382",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "ETag": "\u00220x8D96BBEC967DB5F\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "c041b53ff5cb30432bee2c94c8841382",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2796b94-701e-0028-69a7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_3.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-cd9cb41733d930459d2b0deb034a4a3e-3c10250b841d964c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "42197afcb30c57dcd91ef29438d2403d",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "ETag": "\u00220x8D96BBEC99D7425\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:22 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "42197afcb30c57dcd91ef29438d2403d",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2796c84-701e-0028-3ba7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_4.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-cc7383a14a5a3844a882dcba8c5e9d80-d58bb548b4030347-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "514a3425cf7ff1ccb07aee00becdbf46",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "ETag": "\u00220x8D96BBEC9CACE1E\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:22 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "514a3425cf7ff1ccb07aee00becdbf46",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "d2796d4f-701e-0028-6fa7-9d5d37000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target998993738?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-486ebb1af7eff44c8b5b3b3b50b472d7-d169fa5d8c5de94c-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5c8dbcce4afad98ce9e6ad03aef859ae",
+        "x-ms-date": "Mon, 30 Aug 2021 14:02:23 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:02:21 GMT",
+        "ETag": "\u00220x8D96BBEC9E3251D\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:02:22 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "5c8dbcce4afad98ce9e6ad03aef859ae",
+        "x-ms-request-id": "d2796e13-701e-0028-23a7-9d5d37000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0a9e48dbc7a5b54e9432dd750e751109-5dd28aab834e824f-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "39936eef02c2ae2d289292c4dc990b5e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "7a0a4e32-8fa7-4e56-826f-879a4db16882",
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:02:22 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7a0a4e32-8fa7-4e56-826f-879a4db16882"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "156a4aace0b3ea2bbd7895e81eee0181",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e33247f0-4a71-4a19-b3cc-a83313db66cd",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:22 GMT",
+        "ETag": "\u0022E9C37517807313F1661B36D38487446DCCF02C665836F451A14F1DDA54DCD475\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e33247f0-4a71-4a19-b3cc-a83313db66cd"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:22.7617379Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5fcf52950c2bcb888fde3468b8c7fd50",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e4c38b96-5790-462a-ae6a-683cc91bce94",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:23 GMT",
+        "ETag": "\u0022596D59668513E016E4D475257358D847721BF36884A810DCE241C8736B5B830D\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e4c38b96-5790-462a-ae6a-683cc91bce94"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:24.163678Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "64564eda438e0efa42a97b4a6d458f3a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2c2daf21-c920-48e4-91ab-6ad0fa94589d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:25 GMT",
+        "ETag": "\u0022596D59668513E016E4D475257358D847721BF36884A810DCE241C8736B5B830D\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2c2daf21-c920-48e4-91ab-6ad0fa94589d"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:24.163678Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8a2f1090acca9f33c19e85d5acc332f5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c590c865-60e9-468b-bec1-ee0af99570e9",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:26 GMT",
+        "ETag": "\u002291388141E313E73DA38F9FE991CF1383719DF4A472BD045D28DFA4B436E8ECF0\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c590c865-60e9-468b-bec1-ee0af99570e9"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:26.6226324Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 4,
+          "notYetStarted": 1,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "d00d457a9d9751f357c01c81903e5e4a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cfee8ded-10e5-4467-bdc4-9d9f6e025346",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:27 GMT",
+        "ETag": "\u0022F8F4BED57F54FDD3639D2E91C8AD740C633D4F0C311A4618D727110F3795925A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "cfee8ded-10e5-4467-bdc4-9d9f6e025346"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:27.6793905Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a7d7fa4e73982e851ab7a2efbe25627f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "43ddd23a-8911-4f5c-810e-c988e07ef7c8",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:28 GMT",
+        "ETag": "\u002216F4774F0DAEC985A1870E06A235BE90EE50DE93F0E923DBF85392349CA7210F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "43ddd23a-8911-4f5c-810e-c988e07ef7c8"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:28.5079991Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "27cf8577bf37f3a21cdd320a8fb10e83",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "09a19bd5-d758-48fc-b008-6a76be7b6142",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:29 GMT",
+        "ETag": "\u002216F4774F0DAEC985A1870E06A235BE90EE50DE93F0E923DBF85392349CA7210F\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "09a19bd5-d758-48fc-b008-6a76be7b6142"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:28.5079991Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b2863b408aeb075dbfdfb5e0fb039331",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7552960d-1c05-4cef-bbe4-530ecfb5ee99",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:31 GMT",
+        "ETag": "\u0022F2E825559EE956F22BFD533A057350F4ABEF558269E779201C299083797AD30A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7552960d-1c05-4cef-bbe4-530ecfb5ee99"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:31.790058Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 3,
+          "inProgress": 2,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 48
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0b0a9d5d366f8f1257e48bba407b9f69",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "04c1b226-282c-488b-bf61-6f085808a9fc",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:32 GMT",
+        "ETag": "\u0022197A53345B9754F25B7EDDFBE0AAC26BA3D0DE6805075128AEE9D4F8277212A6\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "04c1b226-282c-488b-bf61-6f085808a9fc"
+      },
+      "ResponseBody": {
+        "id": "6dc0b0ae-309f-4869-945c-e56dd97b86e3",
+        "createdDateTimeUtc": "2021-08-30T14:02:22.7617376Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:02:31.980689Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 5,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 80
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "82ae1ea8b09fed9328c7675809c2f718",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c717f65f-31e0-4676-b79f-dbe7932c1af2",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:32 GMT",
+        "ETag": "\u002245CA8DDFA46C0C56813C46183292889CECF38FFA87514B3E8C2952D773919875\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "c717f65f-31e0-4676-b79f-dbe7932c1af2"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:27.1060657Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.8905257Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7120-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6291368Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.5951667Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711f-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6227884Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.7616025Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711c-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6194891Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.9806844Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711e-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6143694Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.790054Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711d-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3/documents?$orderBy=createdDateTimeUtc%20Asc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f1ac014a03a7091428f75a07ffa2c744",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "845da33a-2728-44b1-b518-c46941234860",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:32 GMT",
+        "ETag": "\u00220ED6341BC1D70A446DB356089B8EDC4C1B41D8F081C9DB2B5DD873DB56F024ED\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "845da33a-2728-44b1-b518-c46941234860"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6143694Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.790054Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711d-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6194891Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.9806844Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711e-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6227884Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.7616025Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711c-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6291368Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.5951667Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711f-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:27.1060657Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.8905257Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7120-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3/documents?createdDateTimeUtcStart=2021-08-30T14%3A02%3A27.1060657Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "dc374c3f1054ac920a1ce2a7cfba8695",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9eee2316-eac6-4384-b42b-e5ea4bd947fc",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:33 GMT",
+        "ETag": "\u0022E37534968E71BC8E10C918B48E7F22BF494D704AFB76BF20061188261CA7B7B4\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "9eee2316-eac6-4384-b42b-e5ea4bd947fc"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:27.1060657Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.8905257Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7120-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/6dc0b0ae-309f-4869-945c-e56dd97b86e3/documents?createdDateTimeUtcStart=2021-08-30T14%3A02%3A26.6227884Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3f7072ecadcea4c20aa55aa7568cee85",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3221251c-0ee2-4e52-a2e4-8a45d900544a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:02:33 GMT",
+        "ETag": "\u002219B0950EE5136FB0F9B03F228CF8C58F35B62800AC1A3A3D0C3F493A99BE5AE6\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "3221251c-0ee2-4e52-a2e4-8a45d900544a"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:27.1060657Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.8905257Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7120-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6291368Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.5951667Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711f-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target998993738/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source144448566/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:02:26.6227884Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:02:31.7616025Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b711c-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
+    "RandomSeed": "1605960926"
+  }
+}

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByCreatedBefore.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByCreatedBefore.json
@@ -1,0 +1,1158 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1644041781?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b0bcd036480eff4aa2841a4ce2f02588-8392cc050858be4a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5aafdb769e46d8b8786442eba2ffae14",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:03:00 GMT",
+        "ETag": "\u00220x8D96BBEE0DF1873\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:01 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "5aafdb769e46d8b8786442eba2ffae14",
+        "x-ms-request-id": "fd5b1ce9-401e-000c-44a7-9dab97000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_0.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-2bdb26fa5107b34d9eeefe270e55dbd6-6632f3d55a82b842-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c8330172d917490b3b38c7d31a983081",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:00 GMT",
+        "ETag": "\u00220x8D96BBEE1295A60\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:01 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "c8330172d917490b3b38c7d31a983081",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b1d90-401e-000c-5ca7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-16e34852916ef046bad6b03b1fefd9e9-7ad591a41152e24d-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9afc616597d7778d6c9c10764443a611",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:00 GMT",
+        "ETag": "\u00220x8D96BBEE154B820\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:01 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "9afc616597d7778d6c9c10764443a611",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b1e09-401e-000c-48a7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_2.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-97de316d00ae6e46a011de658514fa4d-5bd9f07e991e6f44-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a07f57a402fd9d1ed0651f0ed6e4bde0",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:02 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:01 GMT",
+        "ETag": "\u00220x8D96BBEE18015D9\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:02 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "a07f57a402fd9d1ed0651f0ed6e4bde0",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b1ea6-401e-000c-5da7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_3.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-f42e9d656b11f641bb63ec0b3fee8b96-a53a4bd273d9444a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "4185c1331303db3d74bb5c7ac89405f7",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:01 GMT",
+        "ETag": "\u00220x8D96BBEE1AC3713\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:02 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "4185c1331303db3d74bb5c7ac89405f7",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b1f47-401e-000c-6ea7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_4.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-98a861498ffb2e42b5634c63b57aa7ff-b2e544f6e77ce14b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c32fb69190196283425fca71777fa187",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:01 GMT",
+        "ETag": "\u00220x8D96BBEE1DD3B48\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:02 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "c32fb69190196283425fca71777fa187",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b1fb9-401e-000c-5ba7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target27256543?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0dd350cd709d2048b65d80afdff99161-b11d8b11acc98447-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "bd8342300e651990a42b42a6a3d43b60",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:03 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:03:02 GMT",
+        "ETag": "\u00220x8D96BBEE1F7C14E\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:02 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "bd8342300e651990a42b42a6a3d43b60",
+        "x-ms-request-id": "fd5b201d-401e-000c-35a7-9dab97000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d81e32b076e8644b836ab1ace22bb9df-d350fc2af65de541-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b5207c27c6f93da322fea448cc63f51a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "ce9fa6b9-4000-403e-b3e7-a0e329044459",
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:03:03 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ce9fa6b9-4000-403e-b3e7-a0e329044459"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "51989bd43981a72c9eaa746441bb9f8a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "48ced4b0-d794-49ef-8de8-40bf0b218e75",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:03 GMT",
+        "ETag": "\u002244E7E4610E3D279BD80219901BD12EF666BFCF79F84AD98C5E9136C4CD8213B3\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "48ced4b0-d794-49ef-8de8-40bf0b218e75"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:04.3592362Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0250108fd28169e59f469a676a484c41",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d2f6fbd8-d658-4b2c-a6f2-a388a1a90791",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:05 GMT",
+        "ETag": "\u0022371802CE4FE8EBE193E5B9DAA3BBA83575AD9977DF97C2DF6840809893A0B0D1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d2f6fbd8-d658-4b2c-a6f2-a388a1a90791"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:05.5890633Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "07d22736e93ceddf5078164e513efb67",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "af67f98b-0f72-4b2f-93aa-d492687befa6",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:06 GMT",
+        "ETag": "\u0022371802CE4FE8EBE193E5B9DAA3BBA83575AD9977DF97C2DF6840809893A0B0D1\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "af67f98b-0f72-4b2f-93aa-d492687befa6"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:05.5890633Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bcb9195ef2120199b62eb23a9ec53d56",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4841cfbd-a9eb-4585-972a-8375d4a52555",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:07 GMT",
+        "ETag": "\u0022BF9F117EE2DE8D6EFBB2F8E7226C97DFA6CD9356131B926936CF7E7057F31476\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "4841cfbd-a9eb-4585-972a-8375d4a52555"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:08.4443602Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1a2d335e97e9a54e3162b208bb961760",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f8f88e8e-4a09-4ada-9247-e7c46711dc32",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:08 GMT",
+        "ETag": "\u00224B3835333F65FF1E1325F4EA8740ED906474F565A50A3E8D1CC06CEE19A9D617\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f8f88e8e-4a09-4ada-9247-e7c46711dc32"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:08.9627452Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5108334a908e432e8ed0510d36a44e8b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d5268204-50d4-438c-a2ec-b2d90aded70a",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:11 GMT",
+        "ETag": "\u00224B3835333F65FF1E1325F4EA8740ED906474F565A50A3E8D1CC06CEE19A9D617\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d5268204-50d4-438c-a2ec-b2d90aded70a"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:08.9627452Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1ef0c03be111c67eca138ab04090461f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "db7e749e-3ef7-4465-9dca-fd71e3327c4e",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:12 GMT",
+        "ETag": "\u00224B3835333F65FF1E1325F4EA8740ED906474F565A50A3E8D1CC06CEE19A9D617\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "db7e749e-3ef7-4465-9dca-fd71e3327c4e"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:08.9627452Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6bef5216ecbccdc705ea8b1846406f8c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "89b6c122-760e-45a9-90f4-2645d17f7591",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:13 GMT",
+        "ETag": "\u00224B3835333F65FF1E1325F4EA8740ED906474F565A50A3E8D1CC06CEE19A9D617\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "89b6c122-760e-45a9-90f4-2645d17f7591"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:08.9627452Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "fbcd2613f9a6694fb541867b057e03fe",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "570cf171-8c10-44ab-82ae-a925d67cc7ed",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:14 GMT",
+        "ETag": "\u00224B3835333F65FF1E1325F4EA8740ED906474F565A50A3E8D1CC06CEE19A9D617\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "570cf171-8c10-44ab-82ae-a925d67cc7ed"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:08.9627452Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "e4f6318ae3b44ecef92319265566808a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "113bf3fd-1165-4b69-b4a6-a417dfc580e3",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:16 GMT",
+        "ETag": "\u00224B3835333F65FF1E1325F4EA8740ED906474F565A50A3E8D1CC06CEE19A9D617\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "113bf3fd-1165-4b69-b4a6-a417dfc580e3"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:08.9627452Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "199cfea44ac21d790386b67b664bc786",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "86b77811-d13d-49bd-a8c3-7c6c08dc4d5d",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:17 GMT",
+        "ETag": "\u00224B3835333F65FF1E1325F4EA8740ED906474F565A50A3E8D1CC06CEE19A9D617\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "86b77811-d13d-49bd-a8c3-7c6c08dc4d5d"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:08.9627452Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "148d8de78b4930d7587f0182e028134f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "748a4a3c-fac5-443f-b090-fdfd5467c7b5",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:18 GMT",
+        "ETag": "\u0022D7D80519C1315F3DD4C425AE3ACFCA012FC14B171763909D9C972F4EFB995FF6\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "748a4a3c-fac5-443f-b090-fdfd5467c7b5"
+      },
+      "ResponseBody": {
+        "id": "911acf0f-22a4-4d3f-ac8c-365fdaf1f546",
+        "createdDateTimeUtc": "2021-08-30T14:03:04.3592358Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:17.9405217Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 5,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 80
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "07d7fbc1e9e13f3bb8d9e02e2d52e8ad",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cc3cccc5-6398-4d3c-954c-57c7f641755f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:18 GMT",
+        "ETag": "\u0022B4EC431EBAD554B179C578684049F3CF99D4C81F94EE765201646824FE539134\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "cc3cccc5-6398-4d3c-954c-57c7f641755f"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:08.452265Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5944512Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7125-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.9145444Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.9405161Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7124-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8987307Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5616848Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7121-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8950087Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.528475Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7122-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8578139Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5989572Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7123-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546/documents?$orderBy=createdDateTimeUtc%20Asc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c73f925b6bd81940266bc14349f63ddb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8bf53ba1-8483-4d5d-94c2-c6d721752b78",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:19 GMT",
+        "ETag": "\u00225D235970B8EA574624BD43617CD36724374D726FAC7364BE812C9209DA4CEDEE\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "8bf53ba1-8483-4d5d-94c2-c6d721752b78"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8578139Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5989572Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7123-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8950087Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.528475Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7122-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8987307Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5616848Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7121-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.9145444Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.9405161Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7124-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:08.452265Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5944512Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7125-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546/documents?createdDateTimeUtcEnd=2021-08-30T14%3A03%3A07.8578139Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6aba6772c074fda5514d5c70aaa90305",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "56ab7d8c-9b8f-4af2-8e09-c7fe82895230",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:19 GMT",
+        "ETag": "\u00221A6375FC56041B8CE04ABF4AE13B7811429D4E4198CCA80B90DE3C3547B9A967\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "56ab7d8c-9b8f-4af2-8e09-c7fe82895230"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8578139Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5989572Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7123-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/911acf0f-22a4-4d3f-ac8c-365fdaf1f546/documents?createdDateTimeUtcEnd=2021-08-30T14%3A03%3A07.9145444Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4d2754964be85676bbbee07528f8f6c2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b4b5eeaa-bbfa-4e2c-bae5-40039dad9cfc",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:19 GMT",
+        "ETag": "\u002232B6EAAA6869586B74FA737C0DC57C8B16C3FBD7E55E8309239101BDF8B5AFC2\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "b4b5eeaa-bbfa-4e2c-bae5-40039dad9cfc"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.9145444Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.9405161Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7124-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8987307Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5616848Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7121-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8950087Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.528475Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7122-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target27256543/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1644041781/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:07.8578139Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:17.5989572Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7123-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
+    "RandomSeed": "831990976"
+  }
+}

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByCreatedBeforeAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetDocumentStatusesFilterByCreatedBeforeAsync.json
@@ -1,0 +1,1446 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source364019479?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-79016097c3c68f439e8f99604e2c15ce-0131930218fad340-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "30b5d7a63a0fe7b814722e4398e1fd97",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:03:19 GMT",
+        "ETag": "\u00220x8D96BBEEC638C08\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:20 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "30b5d7a63a0fe7b814722e4398e1fd97",
+        "x-ms-request-id": "fd5b3d99-401e-000c-71a7-9dab97000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_0.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-46596aa7540df440b760c9322256febb-d25bc528f72fa448-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "193b7c6bee1ea2f37597b2e889a4ac87",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:19 GMT",
+        "ETag": "\u00220x8D96BBEEC9695F3\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:20 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "193b7c6bee1ea2f37597b2e889a4ac87",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b3e18-401e-000c-63a7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_1.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-a3752fde9a79c04798c7f9b3af00dab0-e634574c1fc7a340-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9bcec36dbbfaa161480bb4951665def9",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:20 GMT",
+        "ETag": "\u00220x8D96BBEECC5289C\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:20 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "9bcec36dbbfaa161480bb4951665def9",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b3f0a-401e-000c-44a7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_2.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-fb4be9550e63d744ba6a2ce375c78c23-e22e4739951c7e4e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "8efd8b1fa942b8f8e313bb7788d05d70",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:20 GMT",
+        "ETag": "\u00220x8D96BBEECF1BF10\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "8efd8b1fa942b8f8e313bb7788d05d70",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b3fd8-401e-000c-7fa7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_3.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-b48f015ccd42ac4a832252cee067ff47-3d4a03d202364147-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d4d5a6c66113af9c1b99d013395e8b0f",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:20 GMT",
+        "ETag": "\u00220x8D96BBEED1EA3B3\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "d4d5a6c66113af9c1b99d013395e8b0f",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b4089-401e-000c-1fa7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_4.txt",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "16",
+        "If-None-Match": "*",
+        "traceparent": "00-7804f5ecce686644ad697b07e1fd50c4-bc54649efcd7464a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "fec9b8b91ea7c445cb15b8e600e91978",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": "c29tZSByYW5kb20gdGV4dA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
+        "Date": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "ETag": "\u00220x8D96BBEED4BFD95\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "fec9b8b91ea7c445cb15b8e600e91978",
+        "x-ms-content-crc64": "fxwoBBSnywc=",
+        "x-ms-request-id": "fd5b418f-401e-000c-16a7-9dab97000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1412065197?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-87decb128a90764b962339f93c3d297b-bb358e559406a349-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "906fce44e60aeebd4d72a8d8e57f8587",
+        "x-ms-date": "Mon, 30 Aug 2021 14:03:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:03:21 GMT",
+        "ETag": "\u00220x8D96BBEED654D4A\u0022",
+        "Last-Modified": "Mon, 30 Aug 2021 14:03:22 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "906fce44e60aeebd4d72a8d8e57f8587",
+        "x-ms-request-id": "fd5b4290-401e-000c-0ba7-9dab97000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "103",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dafdc6a1a466944e8e7a1a896598785b-2dc03c5f9f0a5542-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "07d0beabc95f61a81008fda9b6af317f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "inputs": [
+          {
+            "source": {
+              "sourceUrl": "Sanitized"
+            },
+            "targets": [
+              {
+                "targetUrl": "Sanitized",
+                "language": "fr"
+              }
+            ]
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "e139d05b-04ee-4c86-a127-5fb00f7a65fa",
+        "Content-Length": "0",
+        "Date": "Mon, 30 Aug 2021 14:03:22 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e139d05b-04ee-4c86-a127-5fb00f7a65fa"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8ff465587f1cd1af0b0f59ab9cebe596",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a531b223-4df2-4117-8048-2f58f827f188",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:22 GMT",
+        "ETag": "\u00227109DC6DBD2CECBE153CD75A81DC518DFB2C5D1D27A84FC29517F3B745534E6A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "a531b223-4df2-4117-8048-2f58f827f188"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:22.3685011Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2b555f3270497b4e260d7f01e913389e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1f66797c-97bb-4573-bd86-0ac794492b0f",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:23 GMT",
+        "ETag": "\u00227109DC6DBD2CECBE153CD75A81DC518DFB2C5D1D27A84FC29517F3B745534E6A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "1f66797c-97bb-4573-bd86-0ac794492b0f"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:22.3685011Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 0,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7f7f2841f58a2b6b0efefb4f6ffdc425",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f1f02f1c-f2a2-4ccb-8c7c-2e6755787c94",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:24 GMT",
+        "ETag": "\u0022295C0CE0C6186BD2CDC2602334C2504B1D2AA186D97F6060B7B1884D6D146816\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "f1f02f1c-f2a2-4ccb-8c7c-2e6755787c94"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:23.8743555Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "56776623055ae7361779690e00aee8f8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "341ecbbf-1ee8-471a-a639-9a2d5c3b97d1",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:26 GMT",
+        "ETag": "\u0022295C0CE0C6186BD2CDC2602334C2504B1D2AA186D97F6060B7B1884D6D146816\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "341ecbbf-1ee8-471a-a639-9a2d5c3b97d1"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:23.8743555Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7369bbd6666b3d0cf4291c4b74fe0b28",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2a47a012-7905-4ffd-b76d-cf9d6fc7e2da",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:27 GMT",
+        "ETag": "\u0022295C0CE0C6186BD2CDC2602334C2504B1D2AA186D97F6060B7B1884D6D146816\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2a47a012-7905-4ffd-b76d-cf9d6fc7e2da"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:23.8743555Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "82de5a49e19c3b44f29868118c5c2b60",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1bb16394-843a-4cd4-92ff-c93050b8c4ec",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:28 GMT",
+        "ETag": "\u0022295C0CE0C6186BD2CDC2602334C2504B1D2AA186D97F6060B7B1884D6D146816\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "1bb16394-843a-4cd4-92ff-c93050b8c4ec"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:23.8743555Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b47803155093bcb95a396230e8eb7318",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6c7f5be8-d915-4879-81a1-06a7dc4abc02",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:29 GMT",
+        "ETag": "\u0022295C0CE0C6186BD2CDC2602334C2504B1D2AA186D97F6060B7B1884D6D146816\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "6c7f5be8-d915-4879-81a1-06a7dc4abc02"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:23.8743555Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "a6c5406d66cff45b772e81d3fdfbb097",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b8592c8e-398e-46ab-be99-c52293f3bb94",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:31 GMT",
+        "ETag": "\u0022295C0CE0C6186BD2CDC2602334C2504B1D2AA186D97F6060B7B1884D6D146816\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "b8592c8e-398e-46ab-be99-c52293f3bb94"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:23.8743555Z",
+        "status": "NotStarted",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 0,
+          "notYetStarted": 5,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "7135bcfd5785f895a02128627f135307",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6a225d90-a149-407c-aef8-ff6b2b3aca59",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:32 GMT",
+        "ETag": "\u0022B6E33502FE83324CE391AB600C37B2D74070BACF7599112B7F1719B6B18273F0\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "6a225d90-a149-407c-aef8-ff6b2b3aca59"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:32.7441739Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "4ca34f248597af91a8843d65cfe5be5f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ccc50f2b-ce15-4fb4-922e-313e44fcf017",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:33 GMT",
+        "ETag": "\u0022BFDB19F9B24AC2B9AA1E2083EE1425F4178EAFC52A1E72994943752413837D80\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "ccc50f2b-ce15-4fb4-922e-313e44fcf017"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:33.3250683Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2c32cb8901b51592aacd05ae3ef97563",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e1348424-9634-4376-b49b-5822ed5d21bb",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:34 GMT",
+        "ETag": "\u0022BFDB19F9B24AC2B9AA1E2083EE1425F4178EAFC52A1E72994943752413837D80\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "e1348424-9634-4376-b49b-5822ed5d21bb"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:33.3250683Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "adae7adb645778002a85c9011a3028bb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "283c3e89-9b91-4165-8d64-7d7662901c60",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:36 GMT",
+        "ETag": "\u0022BFDB19F9B24AC2B9AA1E2083EE1425F4178EAFC52A1E72994943752413837D80\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "283c3e89-9b91-4165-8d64-7d7662901c60"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:33.3250683Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "b4d9c96226e02351bd8ea1ca80e271af",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "963d2dbe-56c4-4247-bfdd-48abb23c2f93",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:37 GMT",
+        "ETag": "\u0022BFDB19F9B24AC2B9AA1E2083EE1425F4178EAFC52A1E72994943752413837D80\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "963d2dbe-56c4-4247-bfdd-48abb23c2f93"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:33.3250683Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "558ad90e11362407caba012f3890fa7a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "de77f71e-9204-4ed9-a380-4ccff37ce94e",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:38 GMT",
+        "ETag": "\u0022BFDB19F9B24AC2B9AA1E2083EE1425F4178EAFC52A1E72994943752413837D80\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "de77f71e-9204-4ed9-a380-4ccff37ce94e"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:33.3250683Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "754b49a4c11fb483288bf0c9c336f848",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "39da1416-94d4-4f0b-8382-7bf133c08a8e",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:39 GMT",
+        "ETag": "\u0022BFDB19F9B24AC2B9AA1E2083EE1425F4178EAFC52A1E72994943752413837D80\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "39da1416-94d4-4f0b-8382-7bf133c08a8e"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:33.3250683Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "41f31a14d3a65184c1b4e9252421ea2c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "87772044-7f99-42d9-9e72-91a4744b1a39",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:41 GMT",
+        "ETag": "\u0022BFDB19F9B24AC2B9AA1E2083EE1425F4178EAFC52A1E72994943752413837D80\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "87772044-7f99-42d9-9e72-91a4744b1a39"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:33.3250683Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 0,
+          "inProgress": 5,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 0
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "36252693fc964d8f55d52caa203e6194",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a7696657-b385-4c57-ac95-eed1fde1ecce",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:42 GMT",
+        "ETag": "\u00228A1A7A6396DBE1DDCA8B933188E797B69A0D8D3421F81BA200F850658086E715\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "a7696657-b385-4c57-ac95-eed1fde1ecce"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:42.835647Z",
+        "status": "Running",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 1,
+          "inProgress": 4,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 16
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "1e1bb9c2b99dd0d4c4fab36bd75d9006",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d581cb2a-4b08-4bc5-b4f1-d2a5f9fe49ab",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:43 GMT",
+        "ETag": "\u0022443DB932BCB66576E121355154567421F9C2B303895E55DBEE571A839E6504EF\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "d581cb2a-4b08-4bc5-b4f1-d2a5f9fe49ab"
+      },
+      "ResponseBody": {
+        "id": "4c6b3e1c-2b24-4ba8-aa65-250592e6126f",
+        "createdDateTimeUtc": "2021-08-30T14:03:22.3685008Z",
+        "lastActionDateTimeUtc": "2021-08-30T14:03:43.5667248Z",
+        "status": "Succeeded",
+        "summary": {
+          "total": 5,
+          "failed": 0,
+          "success": 5,
+          "inProgress": 0,
+          "notYetStarted": 0,
+          "cancelled": 0,
+          "totalCharacterCharged": 80
+        }
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f/documents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9d35c4a1c11018b18ba5ecd0a6d93083",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5618821f-aadb-4cfd-b3b6-148a49c184e5",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:43 GMT",
+        "ETag": "\u0022A2850580C8C81593D8964F1C40B9C50DEF5E363A731ADF76E204BA7B7BCC6CD5\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "5618821f-aadb-4cfd-b3b6-148a49c184e5"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.7549822Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:42.8356416Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b712a-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.4297743Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5615703Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7129-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3762981Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.4989906Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7127-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3670744Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5479303Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7126-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3561159Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5667214Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7128-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f/documents?$orderBy=createdDateTimeUtc%20Asc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6b635452cc06da8e5154719c482375f7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7329fe3c-1719-472f-9706-0f2a4e942e7c",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:43 GMT",
+        "ETag": "\u0022A59EC7DFAEC9D84C035FCB9D6E087185DCA6E3617A7BC18F241FDB7E02DE526A\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "7329fe3c-1719-472f-9706-0f2a4e942e7c"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3561159Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5667214Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7128-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3670744Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5479303Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7126-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3762981Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.4989906Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7127-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.4297743Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5615703Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7129-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_4.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_4.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.7549822Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:42.8356416Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b712a-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f/documents?createdDateTimeUtcEnd=2021-08-30T14%3A03%3A32.3561159Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "5c092645c4080184070393f7cd032aea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "96e5cef6-68fb-466f-94ac-77dca4cc1c62",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:44 GMT",
+        "ETag": "\u0022D52A1BC6891B4B898655DE32C7D757843CAC95ABE941EC58C6312C5005185A48\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=09a10d9e036c982a6acf1ed7f4e9558b44845127dddc55af67b87cd656dd4d77;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "96e5cef6-68fb-466f-94ac-77dca4cc1c62"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3561159Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5667214Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7128-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/4c6b3e1c-2b24-4ba8-aa65-250592e6126f/documents?createdDateTimeUtcEnd=2021-08-30T14%3A03%3A32.4297743Z",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210830.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "821930c924fad4ff355b4bbb4f15cf67",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2099d874-2fa1-4026-86b0-42e30641ef50",
+        "Cache-Control": [
+          "public",
+          "max-age=1"
+        ],
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 30 Aug 2021 14:03:44 GMT",
+        "ETag": "\u0022066900C9772B9A20C5E7C32263F3219E9E7FD00745017B686EFD1884AE319DA6\u0022",
+        "Retry-After": "1",
+        "Set-Cookie": [
+          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+        ],
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "X-Powered-By": "ASP.NET",
+        "X-RequestId": "2099d874-2fa1-4026-86b0-42e30641ef50"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_3.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_3.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.4297743Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5615703Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7129-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_1.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_1.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3762981Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.4989906Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7127-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_0.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3670744Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5479303Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7126-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          },
+          {
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1412065197/File_2.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source364019479/File_2.txt",
+            "createdDateTimeUtc": "2021-08-30T14:03:32.3561159Z",
+            "lastActionDateTimeUtc": "2021-08-30T14:03:43.5667214Z",
+            "status": "Succeeded",
+            "to": "fr",
+            "progress": 1,
+            "id": "000b7128-0000-0000-0000-000000000000",
+            "characterCharged": 16
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
+    "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
+    "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
+    "RandomSeed": "1717773500"
+  }
+}


### PR DESCRIPTION
Added the test code for the tests "GetDocumentStatusesFilterByCreatedAfter" and "GetDocumentStatusesFilterByCreatedBefore". Closes issue #23348 

The tests simply do the following:
- creates an operation involving 5 documents.
- gets their ordered creation dates using the "OrderBy" filter.
- Uses the respective filter (createdAfter or createdBefore) on two examples from the 5 documents.

It might be worth noting that these filters are inclusive. 