### PR TITLE
Update to ManagementClient.cs - Microsoft.Azure.ServiceBus

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/ManagementClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/ManagementClient.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Azure.ServiceBus.Management
         private readonly string clientId;
 
         /// <summary>
+        /// Can be used for mocking.
+        /// </summary>
+        public ManagementClient()
+        {
+        }
+        
+        /// <summary>
         /// Initializes a new <see cref="ManagementClient"/> which can be used to perform management opertions on ServiceBus entities.
         /// </summary>
         /// <param name="connectionString">Namespace connection string.</param>


### PR DESCRIPTION
### Added constructor for mocking to ManagementClient 🎨

Hello Azure Development team

I have come accross an issue when trying to test some of my code that uses a ManagementClient underlying, to create and delete subscriptions. To create unit tests for this i need either a mocking constructor, or an interface to implement a Stub or Mock. It seems like the ServiceBusClient already implements a mocking constructor that has 0 parameters so therefore i don't see the issue of having a ManagementClient that also implements this.

I tried extending the class and giving the base connection string an empty connectionstring, but it seems to be creating the connection within the constructor of the class, and therefore it crashes upon trying to connect to ABS. Is this really the way to play it out?
