### PR TITLE
Update codeowners for Microsoft.Azure.ServiceBus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -543,7 +543,7 @@ sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsupp
 /sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/ @pakrym @JoshLove-msft @jsquire
 
 # ServiceLabel: %Service Bus %Service Attention
-/sdk/servicebus/Microsoft.Azure.ServiceBus/                    @axisc
+/sdk/servicebus/Microsoft.Azure.ServiceBus/                    @shankarsama @DorothySun216 
 
 # ServiceLabel: %Service Fabric %Service Attention
 /sdk/servicefabric/Microsoft.Azure.Management.ServiceFabric/           @QingChenmsft @vaishnavk @juhacket


### PR DESCRIPTION
Adding @shankarsama and @DorothySun216 as code owners for the Microsoft.Azure.ServiceBus package.
This will result in 2 things
- All PRs to this package will add the above two folks as code reviewers automatically
- Test failure notifications for this package will go to the emails of the above two folks (currently confirming this with @weshaggard as I am not sure if multiple owners at the service folder level works out for test failure notifications)

