### PR TITLE
Route test failure notifications to the right teams (SB & EH)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -663,3 +663,5 @@ sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsupp
 
 # Add owners for notifications for specific pipelines
 /eng/pipelines/aggregate-reports.yml            @AlexGhiondea @maririos
+/sdk/eventhub/tests.data.yml  @serkantkaraca @sjkwak
+/sdk/servicebus/tests.data.yml @shankarsama @DorothySun216 


### PR DESCRIPTION
Based on https://github.com/Azure/azure-sdk-for-net/pull/23654#discussion_r698857837 by @weshaggard, the changes in #23654 are not enough to ensure the test failure notifications reach the right teams.

Adding code owners to the yml file directly as suggested

cc @AlexGhiondea 

Sigh