### PR TITLE
Make "Setup Versioning Properties" cancellable

### DIFF
--- a/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+++ b/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
@@ -21,4 +21,4 @@ steps:
     }
     echo "##vso[task.setvariable variable=SetDevVersion]$setDailyDevBuild"
   displayName: "Setup Versioning Properties"
-  condition: eq(variables['SetDevVersion'], '')
+  condition: and(succeeded(), eq(variables['SetDevVersion'], ''))


### PR DESCRIPTION
- Condition is missing either `succeeded()` or `succeededOrFailed()` which is required to respect pipeline cancellation