### PR TITLE
Fix check in EventDataBatch.TryAdd, which could result in a batch exceeding its max size

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventDataBatch.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventDataBatch.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.EventHubs
 
         long currentSize;
         bool disposed;
+        bool skipFirstMessageCheck = false;
 
         /// <summary>
         /// Creates a new <see cref="EventDataBatch"/>.
@@ -44,6 +45,11 @@ namespace Microsoft.Azure.EventHubs
                 AmqpMessageConverter.UpdateAmqpMessagePartitionKey(batchMessage, partitionKey);
                 this.currentSize = batchMessage.SerializedMessageSize;
             }
+        }
+
+        internal EventDataBatch(long maxSizeInBytes, bool skipFirstMessageCheck, string partitionKey = null) : this(maxSizeInBytes, partitionKey)
+        {
+            this.skipFirstMessageCheck = skipFirstMessageCheck;
         }
 
         /// <summary>Gets the current event count in the batch.</summary>
@@ -81,7 +87,7 @@ namespace Microsoft.Azure.EventHubs
 
             this.ThrowIfDisposed();
             long size = GetEventSizeForBatch(eventData);
-            if (this.eventDataList.Count > 0 && this.currentSize + size > this.maxSize)
+            if (!(this.skipFirstMessageCheck && this.eventDataList.Count == 0) && this.currentSize + size > this.maxSize)
             {
                 return false;
             }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventHubClient.cs
@@ -457,8 +457,9 @@ namespace Microsoft.Azure.EventHubs
         /// <returns>Returns <see cref="EventDataBatch" />.</returns>
         public EventDataBatch CreateBatch(BatchOptions options)
         {
-            return new EventDataBatch(options.MaxMessageSize > 0 ?
-                options.MaxMessageSize : this.InnerSender.MaxMessageSize, options.PartitionKey);
+            var isMaxSizeSet = options.MaxMessageSize > 0;
+            return new EventDataBatch(isMaxSizeSet ?
+                options.MaxMessageSize : this.InnerSender.MaxMessageSize, !isMaxSizeSet, options.PartitionKey);
         }
 
         /// <summary> Gets or sets a value indicating whether the runtime metric of a receiver is enabled. </summary>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/EventDataBatch.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/EventDataBatch.cs
@@ -1,0 +1,42 @@
+using Xunit;
+using Microsoft.Azure.EventHubs;
+
+namespace Microsoft.Azure.EventHubs.Tests
+{
+    public class TestEventDataBatch
+    {
+        [Fact]
+        [LiveTest]
+        [DisplayTestMethodName]
+        public void TryAdd()
+        {
+            var eventBatch = new EventDataBatch(2_000);
+            Assert.True(eventBatch.TryAdd(new EventData(new byte[1_000])));
+            Assert.True(eventBatch.TryAdd(new EventData(new byte[900]))); // There is some overhead.
+            Assert.False(eventBatch.TryAdd(new EventData(new byte[1_00])));
+        }
+
+        [Fact]
+        [LiveTest]
+        [DisplayTestMethodName]
+        public void TryAddExceedingMaxSize()
+        {
+            var eventBatch = new EventDataBatch(1_000);
+            Assert.False(eventBatch.TryAdd(new EventData(new byte[2_000])));
+        }
+
+        [Fact]
+        [LiveTest]
+        [DisplayTestMethodName]
+        public void TryAddNoExplicitMaxSize()
+        {
+            var connStr = "Endpoint=sb://mynamespace.servicebus.windows.net/;SharedAccessKeyName=keyname;SharedAccessKey=key;EntityPath=test";
+            var client = EventHubClient.CreateFromConnectionString(connStr);
+            var batch = client.CreateBatch();
+            // First event is always accepted when no explicit max size is given.
+            Assert.True(batch.TryAdd(new EventData(new byte[1024 * 1024])));
+            Assert.False(batch.TryAdd(new EventData(new byte[0])));
+        }
+
+    }
+}


### PR DESCRIPTION
It was possible to add a single `EventData` that exceeded the max size of the batch, due to the `this.eventDataList.Count > 0` condition, which I removed.