### PR TITLE
Fix connection string ctor issue

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 - Properly handle `GenerateSasUri` when the client is constructed with a connection string ([#23404](https://github.com/Azure/azure-sdk-for-net/issues/23404))
+- Fixed an exception when constructing the `TableClient` with a connection string where the table name is the same as the account name.
 
 ### Other Changes
 

--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -1606,8 +1606,12 @@ namespace Azure.Data.Tables
 
         private static Uri GetEndpointWithoutTableName(Uri endpoint, string tableName)
         {
+            if (!endpoint.AbsolutePath.Contains(tableName))
+            {
+                return endpoint;
+            }
             var endpointString = endpoint.AbsoluteUri;
-            var indexOfTableName = endpointString.IndexOf("/" + tableName, StringComparison.OrdinalIgnoreCase);
+            var indexOfTableName = endpointString.LastIndexOf("/" + tableName, StringComparison.OrdinalIgnoreCase);
             if (indexOfTableName <= 0)
             {
                 return endpoint;

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientTests.cs
@@ -104,26 +104,27 @@ namespace Azure.Data.Tables.Tests
 
         public static IEnumerable<object[]> ValidConnStrings()
         {
-            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.com:443/;" };
-            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/;" };
-            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/{TableName};" };
-            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.com:443/;" };
-            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/;" };
-            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/{TableName};" };
-            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};EndpointSuffix=core.windows.net" };
-            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};EndpointSuffix=core.windows.net" };
-            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret}" };
-            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret}" };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.com:443/;", TableName };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/;", TableName };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/{TableName};", TableName };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.com:443/;", TableName };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/;", TableName };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/;", AccountName };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/{AccountName};", AccountName };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};EndpointSuffix=core.windows.net", TableName };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};EndpointSuffix=core.windows.net", TableName };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret}", TableName };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret}", TableName };
         }
 
         [Test]
         [TestCaseSource(nameof(ValidConnStrings))]
-        public void AccountNameAndNameForConnStringCtor(string connString)
+        public void AccountNameAndNameForConnStringCtor(string connString, string tableName)
         {
-            var client = new TableClient(connString, TableName, new TableClientOptions());
+            var client = new TableClient(connString, tableName, new TableClientOptions());
 
             Assert.AreEqual(AccountName, client.AccountName);
-            Assert.AreEqual(TableName, client.Name);
+            Assert.AreEqual(tableName, client.Name);
         }
 
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientTests.cs
@@ -105,7 +105,11 @@ namespace Azure.Data.Tables.Tests
         public static IEnumerable<object[]> ValidConnStrings()
         {
             yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.com:443/;" };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/;" };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/{TableName};" };
             yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.com:443/;" };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/;" };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.microsoft.scloud:443/{TableName};" };
             yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};EndpointSuffix=core.windows.net" };
             yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};EndpointSuffix=core.windows.net" };
             yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret}" };

--- a/sdk/tables/Azure.Data.Tables/tests/TableConnectionStringTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableConnectionStringTests.cs
@@ -233,6 +233,11 @@ namespace Azure.Data.Tables.Tests
             yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/{TableName}"), AccountName, TableName };
             yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/{TableName}/"), AccountName, TableName };
             yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/Tables('{TableName}')/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://localhost:10002/{AccountName}/{AccountName}"), AccountName, AccountName };
+            yield return new object[] { new Uri($"https://localhost:10002/{AccountName}/{AccountName}/"), AccountName, AccountName };
+            yield return new object[] { new Uri($"https://localhost:10002/{AccountName}/{TableName}"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://localhost:10002/{AccountName}/{TableName}/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://localhost:10002/{AccountName}/Tables('{TableName}')/"), AccountName, TableName };
         }
 
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/TableConnectionStringTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableConnectionStringTests.cs
@@ -219,36 +219,38 @@ namespace Azure.Data.Tables.Tests
 
         public static IEnumerable<object[]> UriInputs()
         {
-            yield return new object[] { new Uri($"https://{AccountName}.table.cosmos.azure.com:443/{TableName}") };
-            yield return new object[] { new Uri($"https://{AccountName}.table.cosmos.azure.com:443/{TableName}/") };
-            yield return new object[] { new Uri($"https://{AccountName}.table.cosmos.azure.com:443/Tables('{TableName}')/") };
-            yield return new object[] { new Uri($"https://{AccountName}.table.core.windows.net/{TableName}") };
-            yield return new object[] { new Uri($"https://{AccountName}.table.core.windows.net/{TableName}/") };
-            yield return new object[] { new Uri($"https://{AccountName}.table.core.windows.net/Tables('{TableName}')/") };
-            yield return new object[] { new Uri($"https://127.0.0.1:10002/{AccountName}/{TableName}") };
-            yield return new object[] { new Uri($"https://127.0.0.1:10002/{AccountName}/{TableName}/") };
-            yield return new object[] { new Uri($"https://127.0.0.1:10002/{AccountName}/Tables('{TableName}')/") };
-            yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/{TableName}") };
-            yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/{TableName}/") };
-            yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/Tables('{TableName}')/") };
+            yield return new object[] { new Uri($"https://{AccountName}.table.cosmos.azure.com:443/{TableName}"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://{AccountName}.table.cosmos.azure.com:443/{TableName}/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://{AccountName}.table.cosmos.azure.com:443/Tables('{TableName}')/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://{AccountName}.table.core.windows.net/{TableName}"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://{AccountName}.table.core.windows.net/{TableName}/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://{AccountName}.table.core.windows.net/Tables('{TableName}')/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://127.0.0.1:10002/{AccountName}/{AccountName}"), AccountName, AccountName };
+            yield return new object[] { new Uri($"https://127.0.0.1:10002/{AccountName}/{AccountName}/"), AccountName, AccountName };
+            yield return new object[] { new Uri($"https://127.0.0.1:10002/{AccountName}/{TableName}"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://127.0.0.1:10002/{AccountName}/{TableName}/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://127.0.0.1:10002/{AccountName}/Tables('{TableName}')/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/{TableName}"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/{TableName}/"), AccountName, TableName };
+            yield return new object[] { new Uri($"https://10.0.0.1:10002/{AccountName}/Tables('{TableName}')/"), AccountName, TableName };
         }
 
         [Test]
         [TestCaseSource(nameof(UriInputs))]
-        public void GetAccountNameFromUri(Uri uri)
+        public void GetAccountNameFromUri(Uri uri, string expectedAccountName, string expectedTableName)
         {
-            string expectedAccountName = TableConnectionString.GetAccountNameFromUri(uri);
+            string actualAccountName = TableConnectionString.GetAccountNameFromUri(uri);
 
-            Assert.That(expectedAccountName, Is.EqualTo(AccountName));
+            Assert.That(actualAccountName, Is.EqualTo(expectedAccountName));
         }
 
         [Test]
         [TestCaseSource(nameof(UriInputs))]
-        public void GetTableNameFromUri(Uri uri)
+        public void GetTableNameFromUri(Uri uri, string expectedAccountName, string expectedTableName)
         {
-            string expectedTableName = TableConnectionString.GetTableNameFromUri(uri);
+            string actualTableName = TableConnectionString.GetTableNameFromUri(uri);
 
-            Assert.That(expectedTableName, Is.EqualTo(TableName));
+            Assert.That(actualTableName, Is.EqualTo(expectedTableName));
         }
 
         private string GetExpectedHash(TableSharedKeyCredential cred) => cred.ComputeHMACSHA256("message");

--- a/sdk/tables/Azure.Data.Tables/tests/TableConnectionStringTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableConnectionStringTests.cs
@@ -16,6 +16,8 @@ namespace Azure.Data.Tables.Tests
         private const string Secret = "Kg==";
         private readonly TableSharedKeyCredential _expectedCred = new TableSharedKeyCredential(AccountName, Secret);
         private readonly TableSharedKeyCredential _expectedDevStoraageCred = new TableSharedKeyCredential(TableConstants.ConnectionStrings.DevStoreAccountName, TableConstants.ConnectionStrings.DevStoreAccountKey);
+        private const string cosmosPubDomain = "table.cosmos.azure.com";
+        private const string cosmosUsSecDomain = "table.cosmos.azure.microsoft.scloud";
 
         /// <summary>
         /// Validates the functionality of the TableConnectionString.
@@ -97,8 +99,12 @@ namespace Azure.Data.Tables.Tests
 
         public static IEnumerable<object[]> ValidCosmosConnStrings()
         {
-            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.com:443/;" };
-            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.table.cosmos.azure.com:443/;" };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.{cosmosPubDomain}:443/;", cosmosPubDomain };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.{cosmosPubDomain}:443/;", cosmosPubDomain };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.{cosmosPubDomain}:443/;", cosmosPubDomain };
+            yield return new object[] { $"DefaultEndpointsProtocol=https;AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.{cosmosUsSecDomain}:443/;", cosmosUsSecDomain };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.{cosmosUsSecDomain}:443/;", cosmosUsSecDomain };
+            yield return new object[] { $"AccountName={AccountName};AccountKey={Secret};TableEndpoint=https://{AccountName}.{cosmosUsSecDomain}:443/;", cosmosUsSecDomain };
         }
 
         /// <summary>
@@ -106,13 +112,13 @@ namespace Azure.Data.Tables.Tests
         /// </summary>
         [Test]
         [TestCaseSource(nameof(ValidCosmosConnStrings))]
-        public void ParsesCosmos(string connString)
+        public void ParsesCosmos(string connString, string domain)
         {
             Assert.That(TableConnectionString.TryParse(connString, out TableConnectionString tcs), "Parsing should have been successful");
             Assert.That(tcs.Credentials, Is.Not.Null);
             Assert.That(GetCredString(tcs.Credentials), Is.EqualTo(GetExpectedHash(_expectedCred)), "The Credentials should have matched.");
-            Assert.That(tcs.TableStorageUri.PrimaryUri, Is.EqualTo(new Uri($"https://{AccountName}.table.cosmos.azure.com:443/")), "The PrimaryUri should have matched.");
-            Assert.That(tcs.TableStorageUri.SecondaryUri, Is.EqualTo(new Uri($"https://{AccountName}{TableConstants.ConnectionStrings.SecondaryLocationAccountSuffix}.table.cosmos.azure.com:443/")), "The SecondaryUri should have matched.");
+            Assert.That(tcs.TableStorageUri.PrimaryUri, Is.EqualTo(new Uri($"https://{AccountName}.{domain}:443/")), "The PrimaryUri should have matched.");
+            Assert.That(tcs.TableStorageUri.SecondaryUri, Is.EqualTo(new Uri($"https://{AccountName}{TableConstants.ConnectionStrings.SecondaryLocationAccountSuffix}.{domain}:443/")), "The SecondaryUri should have matched.");
         }
 
         public static IEnumerable<object[]> ValidSasStorageConnStrings()


### PR DESCRIPTION
Fixed an exception when constructing the `TableClient` with a connection string where the table name is the same as the account name.