### PR TITLE
[Service Bus] AMQP Transport Tweaks

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -8,19 +8,13 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Andrey Shihov _([GitHub](https://github.com/andreyshihov))_
 
-### Changes
-
-#### Features Added
-
-#### Breaking Changes
-
-#### Bugs Fixed
+### Bugs Fixed
 
 - Fixed an issue with refreshing authorization where redundant requests were made to acquire AAD tokens that were due to expire.  Refreshes will now coordinate to ensure a single AAD token acquisition.
 
 - Fixed an issue with authorization refresh where attempts may have been made to authorize a faulted link.  Links that fail to open are no longer be considered valid for authorization.
 
-#### Other Changes
+### Other Changes
 
 - Documentation has been enhanced to provide additional context for client library types, notably detailing non-obvious validations applied to parameters and options members.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -7,22 +7,19 @@
 Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
 
 - Andrey Shihov _([GitHub](https://github.com/andreyshihov))_
+- John Call _([GitHub](https://github.com/johnthcall))_
 
-### Changes
-
-#### Features Added
-
-#### Breaking Changes
-
-#### Bugs Fixed
+### Bugs Fixed
 
 - Fixed an issue with refreshing authorization where redundant requests were made to acquire AAD tokens that were due to expire.  Refreshes will now coordinate to ensure a single AAD token acquisition.
 
 - Fixed an issue with authorization refresh where attempts may have been made to authorize a faulted link.  Links that fail to open are no longer be considered valid for authorization.
 
-### Other Changes
+## Other Changes
 
 - A sample demonstrating the use of the `AzureEventSourceListener` from `Azure.Core` for common scenarios with the Event Hubs client library has been created.   _(A community contribution, courtesy of [andreyshihov](https://github.com/andreyshihov))_
+
+- Serialization of event data from Event Hubs has been tweaked for greater efficiency.  _(A community contribution, courtesy of [johnthcall](https://github.com/johnthcall))_
 
 - Documentation has been enhanced to provide additional context for client library types, notably detailing non-obvious validations applied to parameters and options members.
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 7.3.0-beta.2 (Unreleased)
 
+### Acknowledgments
+
+Thank you to our developer community members who helped to make the Service Bus client library better with their contributions to this release:
+
+- John Call _([GitHub](https://github.com/johnthcall))_
+
 ### Features Added
 
 ### Breaking Changes
@@ -10,7 +16,11 @@
 
 - Fixed an issue with refreshing authorization where redundant requests were made to acquire AAD tokens that were due to expire.  Refreshes will now coordinate to ensure a single AAD token acquisition.
 
+- Fixed an issue with authorization refresh where attempts may have been made to authorize a faulted link.  Links that fail to open are no longer be considered valid for authorization.
+
 ### Other Changes
+
+- Serialization of messages read from Service Bus has been tweaked for greater efficiency.  _(A community contribution, courtesy of [johnthcall](https://github.com/johnthcall))_
 
 ## 7.3.0-beta.1 (2021-08-10)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -513,6 +513,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             var session = default(AmqpSession);
+            var refreshTimer = default(Timer);
             var stopWatch = ValueStopwatch.StartNew();
             RequestResponseAmqpLink link = null;
 
@@ -557,7 +558,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 linkSettings.LinkName = $"{connection.Settings.ContainerId};{connection.Identifier}:{session.Identifier}:{link.Identifier}";
 
                 // Track the link before returning it, so that it can be managed with the scope.
-                var refreshTimer = default(Timer);
 
                 TimerCallback refreshHandler = CreateAuthorizationRefreshHandler
                 (
@@ -581,7 +581,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception exception)
             {
-                StopTrackingLinkAsActive(link);
+                StopTrackingLinkAsActive(link, refreshTimer);
 
                 // Aborting the session will perform any necessary cleanup of
                 // the associated link as well.
@@ -628,6 +628,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             var session = default(AmqpSession);
+            var refreshTimer = default(Timer);
             var stopWatch = ValueStopwatch.StartNew();
             ReceivingAmqpLink link = null;
 
@@ -679,8 +680,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 // Configure refresh for authorization of the link.
 
-                var refreshTimer = default(Timer);
-
                 TimerCallback refreshHandler = CreateAuthorizationRefreshHandler
                 (
                     entityPath: entityPath,
@@ -703,7 +702,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception exception)
             {
-                StopTrackingLinkAsActive(link);
+                StopTrackingLinkAsActive(link, refreshTimer);
                 // Aborting the session will perform any necessary cleanup of
                 // the associated link as well.
                 session?.Abort();
@@ -767,6 +766,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             var session = default(AmqpSession);
+            var refreshTimer = default(Timer);
             var stopWatch = ValueStopwatch.StartNew();
             SendingAmqpLink link = null;
 
@@ -820,8 +820,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 // Configure refresh for authorization of the link.
 
-                var refreshTimer = default(Timer);
-
                 TimerCallback refreshHandler = CreateAuthorizationRefreshHandler
                 (
                     entityPath: entityPath,
@@ -845,7 +843,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception exception)
             {
-                StopTrackingLinkAsActive(link);
+                StopTrackingLinkAsActive(link, refreshTimer);
 
                 // Aborting the session will perform any necessary cleanup of
                 // the associated link as well.
@@ -945,14 +943,40 @@ namespace Azure.Messaging.ServiceBus.Amqp
             link.Closed += closeHandler;
         }
 
-        private void StopTrackingLinkAsActive(AmqpObject link)
+        private void StopTrackingLinkAsActive(AmqpObject link, Timer authorizationRefreshTimer = null)
         {
+            var activeTimer = default(Timer);
+
             if (link != null)
             {
-                ActiveLinks.TryRemove(link, out var timer);
+                ActiveLinks.TryRemove(link, out activeTimer);
 
-                timer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-                timer?.Dispose();
+                if (activeTimer != null)
+                {
+                    try
+                    {
+                        activeTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                        activeTimer.Dispose();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
+                }
+            }
+
+            // If the refresh timer was created but not associated with the link, then it will need
+            // to be cleaned up.
+
+            if ((authorizationRefreshTimer != null) && (!ReferenceEquals(authorizationRefreshTimer, activeTimer)))
+            {
+                try
+                {
+                    authorizationRefreshTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                    authorizationRefreshTimer.Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -144,12 +144,20 @@ namespace Azure.Messaging.ServiceBus.Amqp
             {
                 case BufferListStream bufferListStream:
                     return bufferListStream.ReadBytes((int)stream.Length);
+
+                case MemoryStream memStreamSource:
+                {
+                    using var memStreamCopy = new MemoryStream((int)(memStreamSource.Length - memStreamSource.Position));
+                    memStreamSource.CopyTo(memStreamCopy, StreamBufferSizeInBytes);
+                    return new ArraySegment<byte>(memStreamCopy.ToArray());
+                }
+
                 default:
-                    {
-                        using var memStream = new MemoryStream(StreamBufferSizeInBytes);
-                        stream.CopyTo(memStream, StreamBufferSizeInBytes);
-                        return new ArraySegment<byte>(memStream.ToArray());
-                    }
+                {
+                    using var memStream = new MemoryStream(StreamBufferSizeInBytes);
+                    stream.CopyTo(memStream, StreamBufferSizeInBytes);
+                    return new ArraySegment<byte>(memStream.ToArray());
+                }
             }
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to catch a potential corner case during link creation and ensure that the authorization refresh timer is disposed when an error occurs while marking the link as active.  Also included is a minor tweak for more efficient memory stream use during AMQP message conversion.

# References and Related

- [[Event Hubs Client] ReadStreamToArraySegment right size memory stream (#23695)](https://github.com/Azure/azure-sdk-for-net/pull/23695)