### PR TITLE
Refactor IMDS discovery to remove socket probing and caching of failures

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvVar.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvVar.cs
@@ -26,7 +26,7 @@ namespace Azure.Core.TestFramework
         {
             foreach (var kvp in values)
             {
-                _originalValues[kvp.Key] = kvp.Value;
+                _originalValues[kvp.Key] = Environment.GetEnvironmentVariable(kvp.Key);
             }
 
             CleanExistingEnvironmentVariables();

--- a/sdk/identity/Azure.Identity/src/ImdsManagedIdentitySource.cs
+++ b/sdk/identity/Azure.Identity/src/ImdsManagedIdentitySource.cs
@@ -21,8 +21,8 @@ namespace Azure.Identity
         private const string ImdsApiVersion = "2018-02-01";
 
         internal const string IdentityUnavailableError = "ManagedIdentityCredential authentication unavailable. The requested identity has not been assigned to this resource.";
-        internal const string CannotConnectError = "ManagedIdentityCredential authentication unavailable. Failed to connect to the managed identity endpoint.";
-        internal const string TimoutError = "ManagedIdentityCredential authentication unavailable. The request to the managed identity endpoint timed out.";
+        internal const string NoResponseError = "ManagedIdentityCredential authentication unavailable. No response received from the managed identity endpoint.";
+        internal const string TimeoutError = "ManagedIdentityCredential authentication unavailable. The request to the managed identity endpoint timed out.";
         internal const string GatewayError = "ManagedIdentityCredential authentication unavailable. The request failed due to a gateway error.";
         internal const string AggregateError = "ManagedIdentityCredential authentication unavailable. Multiple attempts failed to obtain a token from the managed identity endpoint.";
 
@@ -76,10 +76,14 @@ namespace Azure.Identity
             {
                 if (e.Status == 0)
                 {
-                    throw new CredentialUnavailableException(CannotConnectError, e);
+                    throw new CredentialUnavailableException(NoResponseError, e);
                 }
 
                 throw;
+            }
+            catch (TaskCanceledException e)
+            {
+                throw new CredentialUnavailableException(NoResponseError, e);
             }
             catch (AggregateException e)
             {

--- a/sdk/identity/Azure.Identity/src/ImdsManagedIdentitySource.cs
+++ b/sdk/identity/Azure.Identity/src/ImdsManagedIdentitySource.cs
@@ -33,7 +33,7 @@ namespace Azure.Identity
         {
             _clientId = clientId;
 
-			if (!string.IsNullOrEmpty(EnvironmentVariables.PodIdentityEndpoint))
+            if (!string.IsNullOrEmpty(EnvironmentVariables.PodIdentityEndpoint))
 			{
 				var builder = new UriBuilder(EnvironmentVariables.PodIdentityEndpoint);
             	builder.Path = imddsTokenPath;
@@ -72,14 +72,9 @@ namespace Azure.Identity
             {
                 return await base.AuthenticateAsync(async, context, cancellationToken).ConfigureAwait(false);
             }
-            catch (RequestFailedException e)
+            catch (RequestFailedException e) when (e.Status == 0)
             {
-                if (e.Status == 0)
-                {
-                    throw new CredentialUnavailableException(NoResponseError, e);
-                }
-
-                throw;
+                throw new CredentialUnavailableException(NoResponseError, e);
             }
             catch (TaskCanceledException e)
             {

--- a/sdk/identity/Azure.Identity/src/ImdsManagedIdentitySource.cs
+++ b/sdk/identity/Azure.Identity/src/ImdsManagedIdentitySource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,84 +17,36 @@ namespace Azure.Identity
         // IMDS constants. Docs for IMDS are available here https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
         private static readonly Uri s_imdsEndpoint = new Uri("http://169.254.169.254/metadata/identity/oauth2/token");
         internal const string imddsTokenPath = "/metadata/identity/oauth2/token";
-        private static readonly IPAddress s_imdsHostIp = IPAddress.Parse("169.254.169.254");
-        private const int s_imdsPort = 80;
-        private const int ImdsAvailableTimeoutMs = 1000;
+
         private const string ImdsApiVersion = "2018-02-01";
 
         internal const string IdentityUnavailableError = "ManagedIdentityCredential authentication unavailable. The requested identity has not been assigned to this resource.";
+        internal const string CannotConnectError = "ManagedIdentityCredential authentication unavailable. Failed to connect to the managed identity endpoint.";
+        internal const string TimoutError = "ManagedIdentityCredential authentication unavailable. The request to the managed identity endpoint timed out.";
+        internal const string GatewayError = "ManagedIdentityCredential authentication unavailable. The request failed due to a gateway error.";
+        internal const string AggregateError = "ManagedIdentityCredential authentication unavailable. Multiple attempts failed to obtain a token from the managed identity endpoint.";
 
         private readonly string _clientId;
         private readonly Uri _imdsEndpoint;
 
-        private string _identityUnavailableErrorMessage;
-
-        public static async ValueTask<ManagedIdentitySource> TryCreateAsync(ManagedIdentityClientOptions options, bool async, CancellationToken cancellationToken)
-        {
-            // if the PodIdenityEndpoint environment variable was set no need to probe the endpoint, it can be assumed to exist
-            if (!string.IsNullOrEmpty(EnvironmentVariables.PodIdentityEndpoint))
-            {
-                var builder = new UriBuilder(EnvironmentVariables.PodIdentityEndpoint);
-                builder.Path = imddsTokenPath;
-                return new ImdsManagedIdentitySource(options.Pipeline, options.ClientId, builder.Uri);
-            }
-
-            AzureIdentityEventSource.Singleton.ProbeImdsEndpoint(s_imdsEndpoint);
-
-            bool available;
-            // try to create a TCP connection to the IMDS IP address. If the connection can be established
-            // we assume that IMDS is available. If connecting times out or fails to connect assume that
-            // IMDS is not available in this environment.
-            try
-            {
-                using var client = new TcpClient();
-                Task connectTask = client.ConnectAsync(s_imdsHostIp, s_imdsPort);
-
-                if (async)
-                {
-                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-                    cts.CancelAfter(ImdsAvailableTimeoutMs);
-                    await connectTask.AwaitWithCancellation(cts.Token);
-                    available = client.Connected;
-                }
-                else
-                {
-                    available = connectTask.Wait(ImdsAvailableTimeoutMs, cancellationToken) && client.Connected;
-                }
-
-                if (available)
-                {
-                    AzureIdentityEventSource.Singleton.ImdsEndpointFound(s_imdsEndpoint);
-                }
-                else
-                {
-                    AzureIdentityEventSource.Singleton.ImdsEndpointUnavailable(s_imdsEndpoint, "Establishing a connection timed out or failed without exception." );
-                }
-            }
-            catch (Exception e)
-            {
-                AzureIdentityEventSource.Singleton.ImdsEndpointUnavailable(s_imdsEndpoint, e);
-
-                available = false;
-            }
-
-            return available ? new ImdsManagedIdentitySource(options.Pipeline, options.ClientId) : default;
-        }
-
-        internal ImdsManagedIdentitySource(CredentialPipeline pipeline, string clientId, Uri imdsEndpoint = default) : base(pipeline)
+        internal ImdsManagedIdentitySource(CredentialPipeline pipeline, string clientId) : base(pipeline)
         {
             _clientId = clientId;
-            _imdsEndpoint = imdsEndpoint ?? s_imdsEndpoint;
+
+			if (!string.IsNullOrEmpty(EnvironmentVariables.PodIdentityEndpoint))
+			{
+				var builder = new UriBuilder(EnvironmentVariables.PodIdentityEndpoint);
+            	builder.Path = imddsTokenPath;
+                _imdsEndpoint = builder.Uri;
+			}
+			else
+			{
+            	_imdsEndpoint = s_imdsEndpoint;
+			}
         }
 
         protected override Request CreateRequest(string[] scopes)
         {
-            if (_identityUnavailableErrorMessage != default)
-            {
-                throw new CredentialUnavailableException(_identityUnavailableErrorMessage);
-            }
-
             // covert the scopes to a resource string
             string resource = ScopeUtilities.ScopesToResource(scopes);
 
@@ -113,21 +66,49 @@ namespace Azure.Identity
             return request;
         }
 
+        public async override ValueTask<AccessToken> AuthenticateAsync(bool async, TokenRequestContext context, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await base.AuthenticateAsync(async, context, cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException e)
+            {
+                if (e.Status == 0)
+                {
+                    throw new CredentialUnavailableException(CannotConnectError, e);
+                }
+
+                throw;
+            }
+            catch (AggregateException e)
+            {
+                throw new CredentialUnavailableException(AggregateError, e);
+            }
+        }
+
         protected override async ValueTask<AccessToken> HandleResponseAsync(bool async, TokenRequestContext context, Response response, CancellationToken cancellationToken)
         {
-            // 502 is typically due to the client dealing with a proxy configuration, which is not supported.
-            if (response.Status == 400 || response.Status == 502)
+            // handle error status codes indicating managed identity is not available
+            var baseMessage = response.Status switch
             {
-                string message = _identityUnavailableErrorMessage ?? await Pipeline.Diagnostics
-                    .CreateRequestFailedMessageAsync(response, IdentityUnavailableError, null, null, async)
-                    .ConfigureAwait(false);
+                400 => IdentityUnavailableError,
+                502 => GatewayError,
+                504 => GatewayError,
+                _ => default(string)
+            };
+
+            if (baseMessage != null)
+            {
+                string message = await Pipeline.Diagnostics.CreateRequestFailedMessageAsync(response, baseMessage, null, null, async).ConfigureAwait(false);
 
                 var errorContentMessage = await GetMessageFromResponse(response, async, cancellationToken).ConfigureAwait(false);
+
                 if (errorContentMessage != null)
                 {
                     message = message + Environment.NewLine + errorContentMessage;
                 }
-                Interlocked.CompareExchange(ref _identityUnavailableErrorMessage, message, null);
+
                 throw new CredentialUnavailableException(message);
             }
 

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -12,8 +12,7 @@ namespace Azure.Identity
     {
         internal const string MsiUnavailableError = "ManagedIdentityCredential authentication unavailable. No Managed Identity endpoint found.";
 
-        private readonly AsyncLockWithValue<ManagedIdentitySource> _identitySourceAsyncLock = new AsyncLockWithValue<ManagedIdentitySource>();
-        private readonly ManagedIdentityClientOptions _options;
+        private readonly ManagedIdentitySource _identitySource;
 
         protected ManagedIdentityClient()
         {
@@ -26,9 +25,14 @@ namespace Azure.Identity
 
         public ManagedIdentityClient(ManagedIdentityClientOptions options)
         {
-            _options = options;
             ClientId = options.ClientId;
             Pipeline = options.Pipeline;
+
+            _identitySource = AppServiceV2017ManagedIdentitySource.TryCreate(options) ??
+                                                    CloudShellManagedIdentitySource.TryCreate(options) ??
+                                                    AzureArcManagedIdentitySource.TryCreate(options) ??
+                                                    ServiceFabricManagedIdentitySource.TryCreate(options) ??
+                                                    new ImdsManagedIdentitySource(Pipeline, ClientId);
         }
 
         internal CredentialPipeline Pipeline { get; }
@@ -37,33 +41,7 @@ namespace Azure.Identity
 
         public virtual async ValueTask<AccessToken> AuthenticateAsync(bool async, TokenRequestContext context, CancellationToken cancellationToken)
         {
-            ManagedIdentitySource identitySource = await GetManagedIdentitySourceAsync(async, cancellationToken).ConfigureAwait(false);
-
-            // if msi is unavailable or we were unable to determine the type return CredentialUnavailable exception that no endpoint was found
-            if (identitySource == default)
-            {
-                throw new CredentialUnavailableException(MsiUnavailableError);
-            }
-
-            return await identitySource.AuthenticateAsync(async, context, cancellationToken).ConfigureAwait(false);
-        }
-
-        private protected virtual async ValueTask<ManagedIdentitySource> GetManagedIdentitySourceAsync(bool async, CancellationToken cancellationToken)
-        {
-            using var asyncLock = await _identitySourceAsyncLock.GetLockOrValueAsync(async, cancellationToken).ConfigureAwait(false);
-            if (asyncLock.HasValue)
-            {
-                return asyncLock.Value;
-            }
-
-            ManagedIdentitySource identitySource = AppServiceV2017ManagedIdentitySource.TryCreate(_options) ??
-                                                    CloudShellManagedIdentitySource.TryCreate(_options) ??
-                                                    AzureArcManagedIdentitySource.TryCreate(_options) ??
-                                                    ServiceFabricManagedIdentitySource.TryCreate(_options) ??
-                                                    await ImdsManagedIdentitySource.TryCreateAsync(_options, async, cancellationToken).ConfigureAwait(false);
-
-            asyncLock.SetValue(identitySource);
-            return identitySource;
+            return await _identitySource.AuthenticateAsync(async, context, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -142,7 +142,6 @@ namespace Azure.Identity.Tests
 
             var client = PublicClientApplicationBuilder.Create(clientId)
                 .WithAuthority(authorityUri)
-                .WithTenantId(testEnvironment.TestTenantId)
                 .Build();
 
             var retriever = new RefreshTokenRetriever(client.UserTokenCache);

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
@@ -29,6 +29,7 @@ namespace Azure.Identity.Tests
             var options = InstrumentClientOptions(new DefaultAzureCredentialOptions
             {
                 ExcludeEnvironmentCredential = true,
+                ExcludeManagedIdentityCredential = true,
                 ExcludeInteractiveBrowserCredential = true,
                 ExcludeSharedTokenCacheCredential = true,
             });
@@ -37,7 +38,7 @@ namespace Azure.Identity.Tests
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForVisualStudio();
             var testProcess = new TestProcess { Output = processOutput };
 
-            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, new TestProcessService(testProcess), default) { ManagedIdentitySourceFactory = () => default };
+            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, new TestProcessService(testProcess), default);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             AccessToken token;
@@ -75,7 +76,7 @@ namespace Azure.Identity.Tests
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment, cloudName);
             var process = new TestProcess { Error = "Error" };
 
-            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, new TestProcessService(process), default) { ManagedIdentitySourceFactory = () => default };
+            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, new TestProcessService(process), default);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             AccessToken token;
@@ -112,7 +113,7 @@ namespace Azure.Identity.Tests
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment, cloudName);
             var processService = new TestProcessService { CreateHandler = psi => new TestProcess { Error = "Error" }};
 
-            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, processService, default) { ManagedIdentitySourceFactory = () => default };
+            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, processService, default);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             var tasks = new List<Task<AccessToken>>();
@@ -140,6 +141,7 @@ namespace Azure.Identity.Tests
                 ExcludeEnvironmentCredential = true,
                 ExcludeInteractiveBrowserCredential = true,
                 ExcludeSharedTokenCacheCredential = true,
+                ExcludeManagedIdentityCredential = true,
                 VisualStudioCodeTenantId = TestEnvironment.TestTenantId
             });
 
@@ -148,7 +150,7 @@ namespace Azure.Identity.Tests
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
 
-            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, new TestProcessService(testProcess), vscAdapter) { ManagedIdentitySourceFactory = () => default };
+            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, new TestProcessService(testProcess), vscAdapter);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             AccessToken token;
@@ -176,6 +178,7 @@ namespace Azure.Identity.Tests
                 ExcludeEnvironmentCredential = true,
                 ExcludeInteractiveBrowserCredential = true,
                 ExcludeSharedTokenCacheCredential = true,
+                ExcludeManagedIdentityCredential = true,
                 VisualStudioCodeTenantId = TestEnvironment.TestTenantId
             });
 
@@ -184,7 +187,7 @@ namespace Azure.Identity.Tests
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
 
-            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, processService, vscAdapter) { ManagedIdentitySourceFactory = () => default };
+            var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, processService, vscAdapter);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             var tasks = new List<Task<AccessToken>>();
@@ -214,7 +217,7 @@ namespace Azure.Identity.Tests
             });
 
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", "{}");
-            var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "'az' is not recognized" }, new TestProcess{Error = "'PowerShell' is not recognized"}), vscAdapter) { ManagedIdentitySourceFactory = () => default };
+            var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "'az' is not recognized" }, new TestProcess{Error = "'PowerShell' is not recognized"}), vscAdapter);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;
@@ -241,10 +244,11 @@ namespace Azure.Identity.Tests
                 ExcludeEnvironmentCredential = true,
                 ExcludeInteractiveBrowserCredential = true,
                 ExcludeSharedTokenCacheCredential = true,
+                ExcludeManagedIdentityCredential = true,
             });
 
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
-            var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "Error" }), vscAdapter) { ManagedIdentitySourceFactory = () => throw new InvalidOperationException() };
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
+            var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "Error" }), vscAdapter);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;
@@ -255,9 +259,8 @@ namespace Azure.Identity.Tests
                 scopes = diagnosticListener.Scopes;
             }
 
-            Assert.AreEqual(2, scopes.Count);
+            Assert.AreEqual(4, scopes.Count);
             Assert.AreEqual($"{nameof(DefaultAzureCredential)}.{nameof(DefaultAzureCredential.GetToken)}", scopes[0].Name);
-            Assert.AreEqual($"{nameof(ManagedIdentityCredential)}.{nameof(ManagedIdentityCredential.GetToken)}", scopes[1].Name);
         }
 
         [Test]
@@ -268,10 +271,11 @@ namespace Azure.Identity.Tests
                 ExcludeEnvironmentCredential = true,
                 ExcludeInteractiveBrowserCredential = true,
                 ExcludeSharedTokenCacheCredential = true,
+                ExcludeManagedIdentityCredential = true,
             });
 
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
-            var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "Error" }), vscAdapter) { ManagedIdentitySourceFactory = () => default };
+            var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "Error" }), vscAdapter);
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
             List<ClientDiagnosticListener.ProducedDiagnosticScope> scopes;
@@ -282,12 +286,11 @@ namespace Azure.Identity.Tests
                 scopes = diagnosticListener.Scopes;
             }
 
-            Assert.AreEqual(5, scopes.Count);
+            Assert.AreEqual(4, scopes.Count);
             Assert.AreEqual($"{nameof(DefaultAzureCredential)}.{nameof(DefaultAzureCredential.GetToken)}", scopes[0].Name);
-            Assert.AreEqual($"{nameof(ManagedIdentityCredential)}.{nameof(ManagedIdentityCredential.GetToken)}", scopes[1].Name);
-            Assert.AreEqual($"{nameof(VisualStudioCredential)}.{nameof(VisualStudioCredential.GetToken)}", scopes[2].Name);
-            Assert.AreEqual($"{nameof(VisualStudioCodeCredential)}.{nameof(VisualStudioCodeCredential.GetToken)}", scopes[3].Name);
-            Assert.AreEqual($"{nameof(AzureCliCredential)}.{nameof(AzureCliCredential.GetToken)}", scopes[4].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCredential)}.{nameof(VisualStudioCredential.GetToken)}", scopes[1].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCodeCredential)}.{nameof(VisualStudioCodeCredential.GetToken)}", scopes[2].Name);
+            Assert.AreEqual($"{nameof(AzureCliCredential)}.{nameof(AzureCliCredential.GetToken)}", scopes[3].Name);
         }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
@@ -261,6 +261,9 @@ namespace Azure.Identity.Tests
 
             Assert.AreEqual(4, scopes.Count);
             Assert.AreEqual($"{nameof(DefaultAzureCredential)}.{nameof(DefaultAzureCredential.GetToken)}", scopes[0].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCredential)}.{nameof(VisualStudioCredential.GetToken)}", scopes[1].Name);
+            Assert.AreEqual($"{nameof(VisualStudioCodeCredential)}.{nameof(VisualStudioCodeCredential.GetToken)}", scopes[2].Name);
+            Assert.AreEqual($"{nameof(AzureCliCredential)}.{nameof(AzureCliCredential.GetToken)}", scopes[3].Name);
         }
 
         [Test]

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialImdsLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialImdsLiveTests.cs
@@ -80,12 +80,7 @@ namespace Azure.Identity.Tests
 
             var pipeline = CredentialPipeline.GetInstance(options);
 
-            // if we're in playback mode we need to mock the ImdsAvailable call since we won't be able to open a connection
-            var client = (Mode == RecordedTestMode.Playback)
-                ? new MockManagedIdentityClient(pipeline, clientId) { ManagedIdentitySourceFactory = () => new ImdsManagedIdentitySource(pipeline, clientId) }
-                : new ManagedIdentityClient(pipeline, clientId);
-
-            var cred = new ManagedIdentityCredential(client);
+            var cred = new ManagedIdentityCredential(new ManagedIdentityClient(pipeline, clientId));
 
             return cred;
         }

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -24,75 +25,68 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task VerifyImdsRequestWithClientIdMockAsync()
         {
-            using (new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null } }))
-            {
-                var response = CreateMockResponse(200, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions() { Transport = mockTransport };
-                var pipeline = CredentialPipeline.GetInstance(options);
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-                var client = new MockManagedIdentityClient(pipeline, "mock-client-id") { ManagedIdentitySourceFactory = () => new ImdsManagedIdentitySource(pipeline, "mock-client-id") };
+            var response = CreateMockResponse(200, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport };
+            var pipeline = CredentialPipeline.GetInstance(options);
 
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(client));
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", pipeline));
 
-                AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
-                Assert.AreEqual(ExpectedToken, actualToken.Token);
+            Assert.AreEqual(ExpectedToken, actualToken.Token);
 
-                MockRequest request = mockTransport.Requests[0];
+            MockRequest request = mockTransport.Requests[0];
 
-                string query = request.Uri.Query;
+            string query = request.Uri.Query;
 
-                Assert.IsTrue(query.Contains("api-version=2018-02-01"));
-                Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
-                Assert.IsTrue(request.Headers.TryGetValue("Metadata", out string metadataValue));
-                Assert.IsTrue(query.Contains($"client_id=mock-client-id"));
-                Assert.AreEqual("true", metadataValue);
-            }
+            Assert.AreEqual(request.Uri.Host, "169.254.169.254");
+            Assert.AreEqual(request.Uri.Path, "/metadata/identity/oauth2/token");
+            Assert.IsTrue(query.Contains("api-version=2018-02-01"));
+            Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
+            Assert.IsTrue(request.Headers.TryGetValue("Metadata", out string metadataValue));
+            Assert.IsTrue(query.Contains($"client_id=mock-client-id"));
+            Assert.AreEqual("true", metadataValue);
         }
 
         [NonParallelizable]
         [Test]
         public void VerifyImdsRequestFailurePopulatesExceptionMessage()
         {
-            using (new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null } }))
-            {
-                var expectedMessage = "No MSI found for specified ClientId/ResourceId.";
-                var response = CreateErrorMockResponse(400, expectedMessage);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions() { Transport = mockTransport };
-                var pipeline = CredentialPipeline.GetInstance(options);
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-                var client = new MockManagedIdentityClient(pipeline, "mock-client-id") { ManagedIdentitySourceFactory = () => new ImdsManagedIdentitySource(pipeline, "mock-client-id") };
+            var expectedMessage = "No MSI found for specified ClientId/ResourceId.";
+            var response = CreateErrorMockResponse(400, expectedMessage);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport };
+            var pipeline = CredentialPipeline.GetInstance(options);
 
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(client));
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", pipeline));
 
-                var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-                Assert.That(ex.Message, Does.Contain(expectedMessage));
-            }
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            Assert.That(ex.Message, Does.Contain(expectedMessage));
         }
 
         [NonParallelizable]
         [Test]
-        [TestCase(400)]
-        [TestCase(502)]
-        public void VerifyImdsRequestHandlesFailedRequestWithCredentialUnavailableExceptionMockAsync(int responseCode)
+        [TestCase(400, ImdsManagedIdentitySource.IdentityUnavailableError)]
+        [TestCase(502, ImdsManagedIdentitySource.GatewayError)]
+        public void VerifyImdsRequestHandlesFailedRequestWithCredentialUnavailableExceptionMockAsync(int responseCode, string expectedMessage)
         {
-            using (new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null } }))
-            {
-                var response = CreateMockResponse(responseCode, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions() { Transport = mockTransport };
-                var pipeline = CredentialPipeline.GetInstance(options);
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-                var client = new MockManagedIdentityClient(pipeline, "mock-client-id") { ManagedIdentitySourceFactory = () => new ImdsManagedIdentitySource(pipeline, "mock-client-id") };
+            var response = CreateMockResponse(responseCode, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport };
+            var pipeline = CredentialPipeline.GetInstance(options);
 
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(client));
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", pipeline));
 
-                var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
-                Assert.That(ex.Message, Does.Contain(ImdsManagedIdentitySource.IdentityUnavailableError));
-            }
+            Assert.That(ex.Message, Does.Contain(expectedMessage));
         }
 
         [NonParallelizable]
@@ -101,36 +95,33 @@ namespace Azure.Identity.Tests
         [TestCase("mock-client-id")]
         public async Task VerifyIMDSRequestWithPodIdentityEnvVarMockAsync(string clientId)
         {
-            using (new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "https://mock.podid.endpoint/" } }))
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "https://mock.podid.endpoint/" } });
+
+            var response = CreateMockResponse(200, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport };
+            var pipeline = CredentialPipeline.GetInstance(options);
+
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(clientId, pipeline));
+
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+
+            Assert.AreEqual(ExpectedToken, actualToken.Token);
+
+            MockRequest request = mockTransport.SingleRequest;
+
+            Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.podid.endpoint" + ImdsManagedIdentitySource.imddsTokenPath));
+
+            string query = request.Uri.Query;
+
+            Assert.That(query, Does.Contain("api-version=2018-02-01"));
+            Assert.That(query, Does.Contain($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
+            if (clientId != null)
             {
-                var response = CreateMockResponse(200, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions() { Transport = mockTransport };
-                var pipeline = CredentialPipeline.GetInstance(options);
-
-                var client = new MockManagedIdentityClient(pipeline, clientId) { ManagedIdentitySourceFactory = () => ImdsManagedIdentitySource.TryCreateAsync(new ManagedIdentityClientOptions() { ClientId = clientId, Options = options, Pipeline = pipeline }, false, default).GetAwaiter().GetResult()  };
-
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(client));
-
-                AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
-
-                Assert.AreEqual(ExpectedToken, actualToken.Token);
-
-                MockRequest request = mockTransport.SingleRequest;
-
-                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.podid.endpoint" + ImdsManagedIdentitySource.imddsTokenPath));
-
-                string query = request.Uri.Query;
-
-                Assert.That(query, Does.Contain("api-version=2018-02-01"));
-                Assert.That(query, Does.Contain($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
-                if (clientId != null)
-                {
-                    Assert.That(query, Does.Contain($"client_id=mock-client-id"));
-                }
-                Assert.IsTrue(request.Headers.TryGetValue("Metadata", out string actMetadataValue));
-                Assert.AreEqual("true", actMetadataValue);
+                Assert.That(query, Does.Contain($"client_id=mock-client-id"));
             }
+            Assert.IsTrue(request.Headers.TryGetValue("Metadata", out string actMetadataValue));
+            Assert.AreEqual("true", actMetadataValue);
         }
 
         [NonParallelizable]
@@ -139,33 +130,32 @@ namespace Azure.Identity.Tests
         [TestCase("mock-client-id")]
         public async Task VerifyAppService2017RequestWithClientIdMockAsync(string clientId)
         {
-            using (new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", "mock-msi-secret" } }))
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", "mock-msi-secret" }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
+
+            var response = CreateMockResponse(200, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport };
+
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(clientId, options));
+
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+
+            Assert.AreEqual(ExpectedToken, actualToken.Token);
+
+            MockRequest request = mockTransport.SingleRequest;
+
+            Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
+
+            string query = request.Uri.Query;
+
+            Assert.IsTrue(query.Contains("api-version=2017-09-01"));
+            Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
+            if (clientId != null)
             {
-                var response = CreateMockResponse(200, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions() { Transport = mockTransport };
-
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(clientId, options));
-
-                AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
-
-                Assert.AreEqual(ExpectedToken, actualToken.Token);
-
-                MockRequest request = mockTransport.SingleRequest;
-
-                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
-
-                string query = request.Uri.Query;
-
-                Assert.IsTrue(query.Contains("api-version=2017-09-01"));
-                Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
-                if (clientId != null)
-                {
-                    Assert.IsTrue(query.Contains($"clientid=mock-client-id"));
-                }
-                Assert.IsTrue(request.Headers.TryGetValue("secret", out string actSecretValue));
-                Assert.AreEqual("mock-msi-secret", actSecretValue);
+                Assert.IsTrue(query.Contains($"clientid=mock-client-id"));
             }
+            Assert.IsTrue(request.Headers.TryGetValue("secret", out string actSecretValue));
+            Assert.AreEqual("mock-msi-secret", actSecretValue);
         }
 
         [NonParallelizable]
@@ -173,28 +163,27 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task VerifyAppService2019RequestMockAsync()
         {
-            using (new TestEnvVar(new() { { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" } }))
-            {
-                var response = CreateMockResponse(200, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions { Transport = mockTransport };
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
+            var response = CreateMockResponse(200, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions { Transport = mockTransport };
 
-                AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
 
-                Assert.AreEqual(ExpectedToken, token.Token);
+            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
-                MockRequest request = mockTransport.Requests[0];
-                Assert.IsTrue(request.Uri.ToString().StartsWith(EnvironmentVariables.IdentityEndpoint));
+            Assert.AreEqual(ExpectedToken, token.Token);
 
-                string query = request.Uri.Query;
-                Assert.IsTrue(query.Contains("api-version=2019-08-01"));
-                Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
-                Assert.IsTrue(request.Headers.TryGetValue("X-IDENTITY-HEADER", out string identityHeader));
+            MockRequest request = mockTransport.Requests[0];
+            Assert.IsTrue(request.Uri.ToString().StartsWith(EnvironmentVariables.IdentityEndpoint));
 
-                Assert.AreEqual(EnvironmentVariables.IdentityHeader, identityHeader);
-            }
+            string query = request.Uri.Query;
+            Assert.IsTrue(query.Contains("api-version=2019-08-01"));
+            Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
+            Assert.IsTrue(request.Headers.TryGetValue("X-IDENTITY-HEADER", out string identityHeader));
+
+            Assert.AreEqual(EnvironmentVariables.IdentityHeader, identityHeader);
         }
 
         [NonParallelizable]
@@ -203,29 +192,28 @@ namespace Azure.Identity.Tests
         // The test should be removed if and when support for this api version is added back
         public async Task VerifyAppService2017RequestWith2019EnvVarsMockAsync()
         {
-            using (new TestEnvVar(new() { { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" }, { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", "mock-msi-secret" } }))
-            {
-                var response = CreateMockResponse(200, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions() { Transport = mockTransport };
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", "mock-msi-secret" }, { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
+            var response = CreateMockResponse(200, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport };
 
-                AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
 
-                Assert.AreEqual(ExpectedToken, actualToken.Token);
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
-                MockRequest request = mockTransport.Requests[0];
+            Assert.AreEqual(ExpectedToken, actualToken.Token);
 
-                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
+            MockRequest request = mockTransport.Requests[0];
 
-                string query = request.Uri.Query;
+            Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
 
-                Assert.IsTrue(query.Contains("api-version=2017-09-01"));
-                Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
-                Assert.IsTrue(request.Headers.TryGetValue("secret", out string actSecretValue));
-                Assert.AreEqual("mock-msi-secret", actSecretValue);
-            }
+            string query = request.Uri.Query;
+
+            Assert.IsTrue(query.Contains("api-version=2017-09-01"));
+            Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
+            Assert.IsTrue(request.Headers.TryGetValue("secret", out string actSecretValue));
+            Assert.AreEqual("mock-msi-secret", actSecretValue);
         }
 
         [NonParallelizable]
@@ -233,58 +221,56 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task VerifyAppService2019RequestWithClientIdMockAsync()
         {
-            using (new TestEnvVar(new() { { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" } }))
-            {
-                var response = CreateMockResponse(200, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions { Transport = mockTransport };
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", options));
-                AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            var response = CreateMockResponse(200, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions { Transport = mockTransport };
 
-                Assert.AreEqual(ExpectedToken, actualToken.Token);
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", options));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
-                MockRequest request = mockTransport.SingleRequest;
-                Assert.IsTrue(request.Uri.ToString().StartsWith(EnvironmentVariables.IdentityEndpoint));
+            Assert.AreEqual(ExpectedToken, actualToken.Token);
 
-                string query = request.Uri.Query;
-                Assert.IsTrue(query.Contains("api-version=2019-08-01"));
-                Assert.IsTrue(query.Contains("client_id=mock-client-id"));
-                Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
-                Assert.IsTrue(request.Headers.TryGetValue("X-IDENTITY-HEADER", out string identityHeader));
-                Assert.AreEqual(EnvironmentVariables.IdentityHeader, identityHeader);
-            }
+            MockRequest request = mockTransport.SingleRequest;
+            Assert.IsTrue(request.Uri.ToString().StartsWith(EnvironmentVariables.IdentityEndpoint));
+
+            string query = request.Uri.Query;
+            Assert.IsTrue(query.Contains("api-version=2019-08-01"));
+            Assert.IsTrue(query.Contains("client_id=mock-client-id"));
+            Assert.IsTrue(query.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
+            Assert.IsTrue(request.Headers.TryGetValue("X-IDENTITY-HEADER", out string identityHeader));
+            Assert.AreEqual(EnvironmentVariables.IdentityHeader, identityHeader);
         }
 
         [NonParallelizable]
         [Test]
         public async Task VerifyCloudShellMsiRequestMockAsync()
         {
-            using (new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", null } }))
-            {
-                var response = CreateMockResponse(200, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions() { Transport = mockTransport };
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-                ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
-                AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            var response = CreateMockResponse(200, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport };
 
-                Assert.AreEqual(ExpectedToken, actualToken.Token);
+            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
 
-                MockRequest request = mockTransport.Requests[0];
+            Assert.AreEqual(ExpectedToken, actualToken.Token);
 
-                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
-                Assert.IsTrue(request.Content.TryComputeLength(out long contentLen));
+            MockRequest request = mockTransport.Requests[0];
 
-                var content = new byte[contentLen];
-                MemoryStream contentBuff = new MemoryStream(content);
-                request.Content.WriteTo(contentBuff, default);
-                string body = Encoding.UTF8.GetString(content);
+            Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
+            Assert.IsTrue(request.Content.TryComputeLength(out long contentLen));
 
-                Assert.IsTrue(body.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
-                Assert.IsTrue(request.Headers.TryGetValue("Metadata", out string actMetadata));
-                Assert.AreEqual("true", actMetadata);
-            }
+            var content = new byte[contentLen];
+            MemoryStream contentBuff = new MemoryStream(content);
+            request.Content.WriteTo(contentBuff, default);
+            string body = Encoding.UTF8.GetString(content);
+
+            Assert.IsTrue(body.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
+            Assert.IsTrue(request.Headers.TryGetValue("Metadata", out string actMetadata));
+            Assert.AreEqual("true", actMetadata);
         }
 
         [NonParallelizable]
@@ -293,62 +279,68 @@ namespace Azure.Identity.Tests
         [TestCase("mock-client-id")]
         public async Task VerifyCloudShellMsiRequestWithClientIdMockAsync(string clientId)
         {
-            using (new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", null } }))
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
+
+            var response = CreateMockResponse(200, ExpectedToken);
+            var mockTransport = new MockTransport(response);
+            var options = new TokenCredentialOptions() { Transport = mockTransport };
+
+            ManagedIdentityCredential client = InstrumentClient(new ManagedIdentityCredential(clientId, options));
+
+            AccessToken actualToken = await client.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+
+            Assert.AreEqual(ExpectedToken, actualToken.Token);
+
+            MockRequest request = mockTransport.Requests[0];
+
+            Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
+            Assert.IsTrue(request.Content.TryComputeLength(out long contentLen));
+
+            var content = new byte[contentLen];
+            MemoryStream contentBuff = new MemoryStream(content);
+            request.Content.WriteTo(contentBuff, default);
+            string body = Encoding.UTF8.GetString(content);
+
+            Assert.IsTrue(body.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
+            if (clientId != null)
             {
-                var response = CreateMockResponse(200, ExpectedToken);
-                var mockTransport = new MockTransport(response);
-                var options = new TokenCredentialOptions() { Transport = mockTransport };
-
-                ManagedIdentityCredential client = InstrumentClient(new ManagedIdentityCredential(clientId, options));
-
-                AccessToken actualToken = await client.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
-
-                Assert.AreEqual(ExpectedToken, actualToken.Token);
-
-                MockRequest request = mockTransport.Requests[0];
-
-                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
-                Assert.IsTrue(request.Content.TryComputeLength(out long contentLen));
-
-                var content = new byte[contentLen];
-                MemoryStream contentBuff = new MemoryStream(content);
-                request.Content.WriteTo(contentBuff, default);
-                string body = Encoding.UTF8.GetString(content);
-
-                Assert.IsTrue(body.Contains($"resource={Uri.EscapeDataString(ScopeUtilities.ScopesToResource(MockScopes.Default))}"));
-                if (clientId != null)
-                {
-                    Assert.IsTrue(body.Contains($"client_id=mock-client-id"));
-                }
-                Assert.IsTrue(request.Headers.TryGetValue("Metadata", out string actMetadata));
-                Assert.AreEqual("true", actMetadata);
+                Assert.IsTrue(body.Contains($"client_id=mock-client-id"));
             }
+            Assert.IsTrue(request.Headers.TryGetValue("Metadata", out string actMetadata));
+            Assert.AreEqual("true", actMetadata);
         }
 
+        [NonParallelizable]
         [Test]
-        public async Task VerifyMsiUnavailableCredentialException()
+        public async Task VerifyMsiUnavailableOnIMDSAggregateExcpetion()
         {
-            var mockClient = new MockManagedIdentityClient(CredentialPipeline.GetInstance(null)) { ManagedIdentitySourceFactory = () => default };
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "http://169.254.169.001/" } });
 
-            var credential = InstrumentClient(new ManagedIdentityCredential(mockClient));
+            // setting the delay to 1ms and retry mode to fixed to speed up test
+            var options = new TokenCredentialOptions() { Retry = { Delay = TimeSpan.FromMilliseconds(1), Mode = RetryMode.Fixed } };
+
+            var credential = InstrumentClient(new ManagedIdentityCredential(options: options));
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
-            Assert.AreEqual(ManagedIdentityClient.MsiUnavailableError, ex.Message);
+            Assert.That(ex.Message, Does.Contain(ImdsManagedIdentitySource.AggregateError));
 
             await Task.CompletedTask;
         }
 
+        [NonParallelizable]
         [Test]
-        public async Task VerifyClientGetMsiTypeThrows()
+        public async Task VerifyMsiUnavailableOnIMDSRequestFailedExcpetion()
         {
-            var mockClient = new MockManagedIdentityClient(CredentialPipeline.GetInstance(null)) { ManagedIdentitySourceFactory = () => throw new MockClientException("message") };
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "http://169.254.169.001/" } });
 
-            var credential = InstrumentClient(new ManagedIdentityCredential(mockClient));
+            var options = new TokenCredentialOptions() { Retry = { MaxRetries = 0 } };
 
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var credential = InstrumentClient(new ManagedIdentityCredential(options: options));
 
-            Assert.IsInstanceOf(typeof(MockClientException), ex.InnerException);
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+
+            Assert.That(ex.Message, Does.Contain(ImdsManagedIdentitySource.CannotConnectError));
 
             await Task.CompletedTask;
         }
@@ -356,7 +348,9 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task VerifyClientAuthenticateThrows()
         {
-            var mockClient = new MockManagedIdentityClient(CredentialPipeline.GetInstance(null)) { ManagedIdentitySourceFactory = () => new ImdsManagedIdentitySource(default, default), TokenFactory = () => throw new MockClientException("message") };
+            using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
+
+            var mockClient = new MockManagedIdentityClient(CredentialPipeline.GetInstance(null)) { TokenFactory = () => throw new MockClientException("message") };
 
             var credential = InstrumentClient(new ManagedIdentityCredential(mockClient));
 

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -340,7 +340,7 @@ namespace Azure.Identity.Tests
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 
-            Assert.That(ex.Message, Does.Contain(ImdsManagedIdentitySource.CannotConnectError));
+            Assert.That(ex.Message, Does.Contain(ImdsManagedIdentitySource.NoResponseError));
 
             await Task.CompletedTask;
         }

--- a/sdk/identity/Azure.Identity/tests/Mock/MockManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/MockManagedIdentityClient.cs
@@ -24,14 +24,10 @@ namespace Azure.Identity.Tests.Mock
             : base(pipeline, clientId)
         {
         }
-        public Func<ManagedIdentitySource> ManagedIdentitySourceFactory { get; set; }
 
         public Func<AccessToken> TokenFactory { get; set; }
 
         public override ValueTask<AccessToken> AuthenticateAsync(bool async, TokenRequestContext context, CancellationToken cancellationToken)
               => TokenFactory != null ? new ValueTask<AccessToken>(TokenFactory()) : base.AuthenticateAsync(async, context, cancellationToken);
-
-        private protected override ValueTask<ManagedIdentitySource> GetManagedIdentitySourceAsync(bool async, CancellationToken cancellationToken)
-            => ManagedIdentitySourceFactory != null ? new ValueTask<ManagedIdentitySource>(ManagedIdentitySourceFactory()) : base.GetManagedIdentitySourceAsync(async, cancellationToken);
     }
 }

--- a/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/TestDefaultAzureCredentialFactory.cs
@@ -20,13 +20,11 @@ namespace Azure.Identity.Tests.Mock
             _vscAdapter = vscAdapter;
         }
 
-        public Func<ManagedIdentitySource> ManagedIdentitySourceFactory { get; set; }
-
         public override TokenCredential CreateEnvironmentCredential()
             => new EnvironmentCredential(Pipeline);
 
         public override TokenCredential CreateManagedIdentityCredential(string clientId)
-            => new ManagedIdentityCredential(CreateManagedIdentityClient(clientId));
+            => new ManagedIdentityCredential(new ManagedIdentityClient(Pipeline, clientId));
 
         public override TokenCredential CreateSharedTokenCacheCredential(string tenantId, string username)
             => new SharedTokenCacheCredential(tenantId, username, default, Pipeline);
@@ -42,11 +40,6 @@ namespace Azure.Identity.Tests.Mock
 
         public override TokenCredential CreateVisualStudioCodeCredential(string tenantId)
             => new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions { TenantId = tenantId }, Pipeline, default, _fileSystem, _vscAdapter);
-
-        private ManagedIdentityClient CreateManagedIdentityClient(string clientId)
-            => ManagedIdentitySourceFactory != default
-                ? new MockManagedIdentityClient(Pipeline, clientId) { ManagedIdentitySourceFactory = ManagedIdentitySourceFactory }
-                : new ManagedIdentityClient(Pipeline, clientId);
 
         public override TokenCredential CreateAzurePowerShellCredential()
             => new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), Pipeline, _processService);


### PR DESCRIPTION
- Removes initial probing socket connection in `ImdsManagedIdentitySource` so all calls are retriable.
- Removes caching of failed request behavior in `ImdsManagedIdentitySource` to allow application retry behavior without constructing new credentials and clients.

Closes #20617
Fixes #23028
Closes #20609