### PR TITLE
Adding Retries for InstallationCheck

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -43,18 +43,6 @@ stages:
         dependsOn: Signing
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr'))
         jobs:
-          - job: InstallationCheck
-            condition: ne('${{ artifact.skipPublishPackage }}', 'true')
-            displayName: "Installation Check"
-            steps:
-              - download: current
-                artifact: ${{parameters.ArtifactName}}-signed
-              - pwsh: mkdir InstallationCheck
-                displayName: Create Testing Directory
-              - pwsh: |
-                  $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1 -ArtifactsDirectory ${{parameters.ArtifactName}} -Artifact ${{artifact.name}} -PipelineWorkspace $(Pipeline.Workspace)
-                displayName: Verify Package Installation
-                workingDirectory: $(System.DefaultWorkingDirectory)/InstallationCheck
           - deployment: TagRepository
             displayName: "Create release tag"
             condition: ne(variables['Skip.TagRepository'], 'true')
@@ -69,6 +57,8 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
+                    - download: current
+                      artifact: ${{parameters.ArtifactName}}-signed
                     - template: /eng/common/pipelines/templates/steps/retain-run.yml
                     - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
                       parameters:
@@ -80,6 +70,10 @@ stages:
                         PackageName: ${{artifact.name}}
                         ServiceName: ${{parameters.ServiceDirectory}}
                         ForRelease: true
+                    - pwsh: |
+                        $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1 -ArtifactsDirectory ${{parameters.ArtifactName}} -Artifact ${{artifact.name}} -PipelineWorkspace $(Pipeline.Workspace)
+                      condition: ne('${{ artifact.skipPublishPackage }}', 'true')
+                      displayName: Verify Package Installation
                     - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
                       parameters:
                         ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -71,8 +71,8 @@ stages:
                         ServiceName: ${{parameters.ServiceDirectory}}
                         ForRelease: true
                     - pwsh: |
-                        $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1 -ArtifactsDirectory ${{parameters.ArtifactName}} -Artifact ${{artifact.name}} -PipelineWorkspace $(Pipeline.Workspace)
-                      condition: ne('${{ artifact.skipPublishPackage }}', 'true')
+                        $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1 -ArtifactsDirectory "$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed" -Artifact ${{artifact.name}}
+                      condition: and(succeeded(),ne('${{ artifact.skipPublishPackage }}', 'true'))
                       displayName: Verify Package Installation
                     - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
                       parameters:

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -70,8 +70,12 @@ stages:
                         PackageName: ${{artifact.name}}
                         ServiceName: ${{parameters.ServiceDirectory}}
                         ForRelease: true
-                    - pwsh: |
-                        $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1 -ArtifactsDirectory "$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed" -Artifact ${{artifact.name}}
+                    - task: PowerShell@2
+                      inputs:
+                        filePath: $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1
+                        arguments: >
+                          -ArtifactsDirectory "$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed"
+                          -Artifact ${{artifact.name}}
                       condition: and(succeeded(),ne('${{ artifact.skipPublishPackage }}', 'true'))
                       displayName: Verify Package Installation
                     - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -71,6 +71,7 @@ stages:
                         ServiceName: ${{parameters.ServiceDirectory}}
                         ForRelease: true
                     - task: PowerShell@2
+                      pwsh: true
                       inputs:
                         filePath: $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1
                         arguments: >

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -71,9 +71,9 @@ stages:
                         ServiceName: ${{parameters.ServiceDirectory}}
                         ForRelease: true
                     - task: PowerShell@2
-                      pwsh: true
                       inputs:
                         filePath: $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1
+                        pwsh: true
                         arguments: >
                           -ArtifactsDirectory "$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed"
                           -Artifact ${{artifact.name}}

--- a/eng/scripts/InstallationCheck.ps1
+++ b/eng/scripts/InstallationCheck.ps1
@@ -6,9 +6,6 @@ param (
     [string] $Artifact,
 
     [Parameter()]
-    [string] $PipelineWorkspace,
-
-    [Parameter()]
     [string] $RetryLimit = 30
 )
 

--- a/eng/scripts/InstallationCheck.ps1
+++ b/eng/scripts/InstallationCheck.ps1
@@ -9,24 +9,33 @@ param (
     [string] $PipelineWorkspace
 )
 
-Write-Host "dotnet new console"
-dotnet new console
-$localFeed = "$PipelineWorkspace/$ArtifactsDirectory-signed/$Artifact"
-Write-Host "dotnet nuget add source $localFeed"
-dotnet nuget add source $localFeed
+mkdir InstallationCheck
+cd "InstallationCheck"
 
-$version = (Get-ChildItem "$localFeed/*.nupkg" -Exclude "*.symbols.nupkg" -Name).replace(".nupkg","").replace("$Artifact.","")
+Write-Host "dotnet new console --no-restore"
+dotnet new console --no-restore
+$localFeed = "$PipelineWorkspace/$ArtifactsDirectory-signed/$Artifact"
+
+$version = (Get-Content "$PipelineWorkspace/$ArtifactsDirectory-signed/PackageInfo/$Artifact.json" | ConvertFrom-Json).Version
+
 Write-Host "dotnet add package $Artifact --version $version --no-restore"
 dotnet add package $Artifact --version $version --no-restore
 if ($LASTEXITCODE) {
-    exit $LASTEXITCODE
+  exit $LASTEXITCODE
 }
 
-Write-Host "dotnet nuget locals all --clear"
-dotnet nuget locals all --clear
-
-Write-Host "dotnet restore -s https://api.nuget.org/v3/index.json -s $localFeed --no-cache --verbosity detailed"
-dotnet restore -s https://api.nuget.org/v3/index.json -s $localFeed --no-cache --verbosity detailed
-if ($LASTEXITCODE) {
-    exit $LASTEXITCODE
+while ($retries++ -lt 30) {
+  Write-Host "dotnet restore -s https://api.nuget.org/v3/index.json -s $localFeed --no-cache --verbosity detailed"
+  dotnet restore -s https://api.nuget.org/v3/index.json -s $localFeed --no-cache --verbosity detailed
+  if ($LASTEXITCODE) {
+    if ($retries -ge 30) {
+      exit $LASTEXITCODE
+    }
+    Write-Host "dotnet clean"
+    dotnet clean
+    Write-Host "Restore failed, retrying in 1 minute..."
+    sleep 60
+  } else {
+    break
+  }
 }


### PR DESCRIPTION
This enables InstallationCheck to rerun for 30 minutes, in case of when multiple packages are released from the same pipeline. 

Pipeline Reference:
This one retries for 3 times before getting the correct version:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1081546&view=logs&j=3c922a7d-1305-5297-ba3f-884e0ad84366&t=ad177618-4778-5c7a-f9e0-5bf485085f93&l=920

This is a successful run:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1081550&view=logs&j=3c922a7d-1305-5297-ba3f-884e0ad84366&t=ad177618-4778-5c7a-f9e0-5bf485085f93&l=922



# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
