### PR TITLE
[KeyVault] correct default-value logic of scope in AccessControlClient

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAccessControlClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultAccessControlClient.cs
@@ -236,7 +236,7 @@ namespace Azure.Security.KeyVault.Administration
 
                 return await _definitionsRestClient.CreateOrUpdateAsync(
                     vaultBaseUrl: VaultUri.AbsoluteUri,
-                    scope: options.RoleScope == default ? options.RoleScope.ToString() : KeyVaultRoleScope.Global.ToString(),
+                    scope: options.RoleScope != default ? options.RoleScope.ToString() : KeyVaultRoleScope.Global.ToString(),
                     roleDefinitionName: options.RoleDefinitionName.ToString(),
                     parameters: parameters,
                     cancellationToken: cancellationToken)
@@ -268,7 +268,7 @@ namespace Azure.Security.KeyVault.Administration
 
                 return _definitionsRestClient.CreateOrUpdate(
                     vaultBaseUrl: VaultUri.AbsoluteUri,
-                    scope: options.RoleScope == default ? options.RoleScope.ToString() : KeyVaultRoleScope.Global.ToString(),
+                    scope: options.RoleScope != default ? options.RoleScope.ToString() : KeyVaultRoleScope.Global.ToString(),
                     roleDefinitionName: options.RoleDefinitionName.ToString(),
                     parameters: parameters,
                     cancellationToken: cancellationToken);

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlClientLiveTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System;
 using Azure.Security.KeyVault.Administration.Models;
 using System.Text.Json;
+using Azure.Security.KeyVault.Keys;
 
 namespace Azure.Security.KeyVault.Administration.Tests
 {
@@ -150,6 +151,45 @@ namespace Azure.Security.KeyVault.Administration.Tests
 
             Guid roleAssignmentName = Recording.Random.NewGuid();
             KeyVaultRoleAssignment result = await Client.CreateRoleAssignmentAsync(KeyVaultRoleScope.Global, definitionToAssign.Id, TestEnvironment.ClientObjectId, roleAssignmentName).ConfigureAwait(false);
+
+            RegisterForCleanup(result);
+
+            Assert.That(result.Id, Is.Not.Null);
+            Assert.That(result.Name, Is.Not.Null);
+            Assert.That(result.Type, Is.Not.Null);
+            Assert.That(result.Properties.PrincipalId, Is.EqualTo(TestEnvironment.ClientObjectId));
+            Assert.That(result.Properties.RoleDefinitionId, Is.EqualTo(definitionToAssign.Id));
+        }
+
+        [RecordedTest]
+        public async Task CreateKeysRoleAssignment()
+        {
+            List<KeyVaultRoleDefinition> definitions = await Client.GetRoleDefinitionsAsync(KeyVaultRoleScope.Global).ToEnumerableAsync().ConfigureAwait(false);
+            KeyVaultRoleDefinition definitionToAssign = definitions.First(d => d.RoleName.Contains(RoleName));
+
+            Guid roleAssignmentName = Recording.Random.NewGuid();
+            KeyVaultRoleAssignment result = await Client.CreateRoleAssignmentAsync(KeyVaultRoleScope.Keys, definitionToAssign.Id, TestEnvironment.ClientObjectId, roleAssignmentName).ConfigureAwait(false);
+
+            RegisterForCleanup(result);
+
+            Assert.That(result.Id, Is.Not.Null);
+            Assert.That(result.Name, Is.Not.Null);
+            Assert.That(result.Type, Is.Not.Null);
+            Assert.That(result.Properties.PrincipalId, Is.EqualTo(TestEnvironment.ClientObjectId));
+            Assert.That(result.Properties.RoleDefinitionId, Is.EqualTo(definitionToAssign.Id));
+        }
+
+        [RecordedTest]
+        public async Task CreateKeyRoleAssignment()
+        {
+            List<KeyVaultRoleDefinition> definitions = await Client.GetRoleDefinitionsAsync(KeyVaultRoleScope.Global).ToEnumerableAsync().ConfigureAwait(false);
+            KeyVaultRoleDefinition definitionToAssign = definitions.First(d => d.RoleName.Contains(RoleName));
+
+            string keyName = Recording.GenerateId();
+            await KeyClient.CreateOctKeyAsync(new(keyName));
+
+            Guid roleAssignmentName = Recording.Random.NewGuid();
+            KeyVaultRoleAssignment result = await Client.CreateRoleAssignmentAsync(new KeyVaultRoleScope($"/keys/{keyName}"), definitionToAssign.Id, TestEnvironment.ClientObjectId, roleAssignmentName).ConfigureAwait(false);
 
             RegisterForCleanup(result);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlClientLiveTests.cs
@@ -186,10 +186,10 @@ namespace Azure.Security.KeyVault.Administration.Tests
             KeyVaultRoleDefinition definitionToAssign = definitions.First(d => d.RoleName.Contains(RoleName));
 
             string keyName = Recording.GenerateId();
-            await KeyClient.CreateOctKeyAsync(new(keyName));
+            KeyVaultKey key = await KeyClient.CreateOctKeyAsync(new(keyName));
 
             Guid roleAssignmentName = Recording.Random.NewGuid();
-            KeyVaultRoleAssignment result = await Client.CreateRoleAssignmentAsync(new KeyVaultRoleScope($"/keys/{keyName}"), definitionToAssign.Id, TestEnvironment.ClientObjectId, roleAssignmentName).ConfigureAwait(false);
+            KeyVaultRoleAssignment result = await Client.CreateRoleAssignmentAsync(new KeyVaultRoleScope(key.Id), definitionToAssign.Id, TestEnvironment.ClientObjectId, roleAssignmentName).ConfigureAwait(false);
 
             RegisterForCleanup(result);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateKeyRoleAssignment.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateKeyRoleAssignment.json
@@ -5,12 +5,12 @@
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "traceparent": "00-73c41a3f02e167489f661907f00f11f5-a67eaaee97cff34a-00",
+        "traceparent": "00-11510dedf7d430488853cc1ead300879-534b95e4d1bd764f-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "c23c658117723d55cd717f5f53da57f6",
+        "x-ms-client-request-id": "f39419e32d5e207b8276741feed26821",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -25,8 +25,8 @@
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
-        "x-ms-request-id": "ec7d9372-11ae-11ec-9ace-000d3aed5f27",
-        "x-ms-server-latency": "0"
+        "x-ms-request-id": "e9969ac8-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": "OK"
     },
@@ -36,12 +36,12 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-73c41a3f02e167489f661907f00f11f5-a67eaaee97cff34a-00",
+        "traceparent": "00-11510dedf7d430488853cc1ead300879-534b95e4d1bd764f-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "c23c658117723d55cd717f5f53da57f6",
+        "x-ms-client-request-id": "f39419e32d5e207b8276741feed26821",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,8 +57,8 @@
         "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "eca07e8c-11ae-11ec-9ace-000d3aed5f27",
-        "x-ms-server-latency": "1"
+        "x-ms-request-id": "ea253f1c-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "value": [
@@ -301,19 +301,105 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleAssignments/8172d5e4-1db7-e9e5-c84a-d8c05c75332c?api-version=7.3-preview",
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/1220993825/create?api-version=7.3-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-9d76641995c0e94f8a0420099c05562f-1903540315372e49-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.3.0-alpha.20210909.1",
+          "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0b2bf301956eaa81d91e4268a7135ff3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-request-id": "ea3844f4-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/1220993825/create?api-version=7.3-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-9d76641995c0e94f8a0420099c05562f-1903540315372e49-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.3.0-alpha.20210909.1",
+          "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0b2bf301956eaa81d91e4268a7135ff3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "oct"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "360",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "southcentralus",
+        "x-ms-request-id": "ea47bea2-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "194"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1631220349,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1631220349
+        },
+        "key": {
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/1220993825/85a3f526b0ab07f939cfe8f68876f7cf",
+          "kty": "oct-HSM"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/1220993825/providers/Microsoft.Authorization/roleAssignments/4a2b7890-d0d1-9fa7-2151-f2eb553aabf7?api-version=7.3-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "196",
         "Content-Type": "application/json",
-        "traceparent": "00-fa870217d529c345843b21ea18f83069-0b79bb326c02c442-00",
+        "traceparent": "00-d8afe3fbbd81fb4c8a81dae8c45d23dc-f68e00f59a10414f-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "4334c2dd2f65d8f7bbd070f3aadcca55",
+        "x-ms-client-request-id": "0fd3d4fc332384741248840f38b8db62",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -325,7 +411,7 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "398",
+        "Content-Length": "413",
         "Content-Security-Policy": "default-src \u0027self\u0027",
         "Content-Type": "application/json; charset=utf-8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
@@ -333,16 +419,16 @@
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "ecb1a57c-11ae-11ec-9ace-000d3aed5f27",
-        "x-ms-server-latency": "54"
+        "x-ms-request-id": "ea783b2c-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "123"
       },
       "ResponseBody": {
-        "id": "/providers/Microsoft.Authorization/roleAssignments/8172d5e4-1db7-e9e5-c84a-d8c05c75332c",
-        "name": "8172d5e4-1db7-e9e5-c84a-d8c05c75332c",
+        "id": "/providers/Microsoft.Authorization/roleAssignments/4a2b7890-d0d1-9fa7-2151-f2eb553aabf7",
+        "name": "4a2b7890-d0d1-9fa7-2151-f2eb553aabf7",
         "properties": {
           "principalId": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
           "roleDefinitionId": "Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8",
-          "scope": "/"
+          "scope": "/keys/1220993825"
         },
         "type": "Microsoft.Authorization/roleAssignments"
       }
@@ -351,6 +437,6 @@
   "Variables": {
     "AZURE_MANAGEDHSM_URL": "https://heathskeyvaulthsm.managedhsm.azure.net/",
     "CLIENT_OBJECTID": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
-    "RandomSeed": "1820470144"
+    "RandomSeed": "1025917508"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateKeyRoleAssignmentAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateKeyRoleAssignmentAsync.json
@@ -5,12 +5,12 @@
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "traceparent": "00-73c41a3f02e167489f661907f00f11f5-a67eaaee97cff34a-00",
+        "traceparent": "00-501d1cb0c8223049b119e55f56e20748-42fd97f2be7a6441-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "c23c658117723d55cd717f5f53da57f6",
+        "x-ms-client-request-id": "0fb9337a302b0a9cde6ced82789f7ce5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -25,7 +25,7 @@
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
-        "x-ms-request-id": "ec7d9372-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-request-id": "eb8f4096-11ae-11ec-9ace-000d3aed5f27",
         "x-ms-server-latency": "0"
       },
       "ResponseBody": "OK"
@@ -36,12 +36,12 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-73c41a3f02e167489f661907f00f11f5-a67eaaee97cff34a-00",
+        "traceparent": "00-501d1cb0c8223049b119e55f56e20748-42fd97f2be7a6441-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "c23c658117723d55cd717f5f53da57f6",
+        "x-ms-client-request-id": "0fb9337a302b0a9cde6ced82789f7ce5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,8 +57,8 @@
         "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "eca07e8c-11ae-11ec-9ace-000d3aed5f27",
-        "x-ms-server-latency": "1"
+        "x-ms-request-id": "eba8cd36-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "0"
       },
       "ResponseBody": {
         "value": [
@@ -301,19 +301,75 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleAssignments/8172d5e4-1db7-e9e5-c84a-d8c05c75332c?api-version=7.3-preview",
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/2129738813/create?api-version=7.3-preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "13",
+        "Content-Type": "application/json",
+        "traceparent": "00-c275ebf48d17c94f982bf6533b38b443-5f88ec67aed2b145-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Keys/4.3.0-alpha.20210909.1",
+          "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "62820690782ab6b79d826722ea8c39e0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "kty": "oct"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "360",
+        "Content-Security-Policy": "default-src \u0027self\u0027",
+        "Content-Type": "application/json; charset=utf-8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
+        "x-ms-keyvault-region": "southcentralus",
+        "x-ms-request-id": "ebb618c4-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "178"
+      },
+      "ResponseBody": {
+        "attributes": {
+          "created": 1631220351,
+          "enabled": true,
+          "exportable": false,
+          "recoverableDays": 7,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "updated": 1631220351
+        },
+        "key": {
+          "key_ops": [
+            "wrapKey",
+            "decrypt",
+            "encrypt",
+            "unwrapKey",
+            "sign",
+            "verify"
+          ],
+          "kid": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/2129738813/baae727e3abb0d9a0ee3a9039a3f64e3",
+          "kty": "oct-HSM"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/2129738813/providers/Microsoft.Authorization/roleAssignments/49a2f926-d8db-b99a-5b5b-b820da13597a?api-version=7.3-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "196",
         "Content-Type": "application/json",
-        "traceparent": "00-fa870217d529c345843b21ea18f83069-0b79bb326c02c442-00",
+        "traceparent": "00-6cfe5b90ac427b439475f20f1031711c-682ebfbc227d764a-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "4334c2dd2f65d8f7bbd070f3aadcca55",
+        "x-ms-client-request-id": "26691b9871f9ba5001598ead35e8f4df",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -325,7 +381,7 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "398",
+        "Content-Length": "413",
         "Content-Security-Policy": "default-src \u0027self\u0027",
         "Content-Type": "application/json; charset=utf-8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
@@ -333,16 +389,16 @@
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "ecb1a57c-11ae-11ec-9ace-000d3aed5f27",
-        "x-ms-server-latency": "54"
+        "x-ms-request-id": "ebe37d32-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "96"
       },
       "ResponseBody": {
-        "id": "/providers/Microsoft.Authorization/roleAssignments/8172d5e4-1db7-e9e5-c84a-d8c05c75332c",
-        "name": "8172d5e4-1db7-e9e5-c84a-d8c05c75332c",
+        "id": "/providers/Microsoft.Authorization/roleAssignments/49a2f926-d8db-b99a-5b5b-b820da13597a",
+        "name": "49a2f926-d8db-b99a-5b5b-b820da13597a",
         "properties": {
           "principalId": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
           "roleDefinitionId": "Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8",
-          "scope": "/"
+          "scope": "/keys/2129738813"
         },
         "type": "Microsoft.Authorization/roleAssignments"
       }
@@ -351,6 +407,6 @@
   "Variables": {
     "AZURE_MANAGEDHSM_URL": "https://heathskeyvaulthsm.managedhsm.azure.net/",
     "CLIENT_OBJECTID": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
-    "RandomSeed": "1820470144"
+    "RandomSeed": "364369614"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateKeysRoleAssignment.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateKeysRoleAssignment.json
@@ -5,12 +5,12 @@
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "traceparent": "00-73c41a3f02e167489f661907f00f11f5-a67eaaee97cff34a-00",
+        "traceparent": "00-8a2fe5837fe57d47a3f62aa08c36a815-08eebb5629528a4f-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "c23c658117723d55cd717f5f53da57f6",
+        "x-ms-client-request-id": "220578db1da1a687649cda434d03515a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -25,8 +25,8 @@
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
-        "x-ms-request-id": "ec7d9372-11ae-11ec-9ace-000d3aed5f27",
-        "x-ms-server-latency": "0"
+        "x-ms-request-id": "ead5344e-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "1"
       },
       "ResponseBody": "OK"
     },
@@ -36,12 +36,12 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-73c41a3f02e167489f661907f00f11f5-a67eaaee97cff34a-00",
+        "traceparent": "00-8a2fe5837fe57d47a3f62aa08c36a815-08eebb5629528a4f-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "c23c658117723d55cd717f5f53da57f6",
+        "x-ms-client-request-id": "220578db1da1a687649cda434d03515a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,7 +57,7 @@
         "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "eca07e8c-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-request-id": "eaf77176-11ae-11ec-9ace-000d3aed5f27",
         "x-ms-server-latency": "1"
       },
       "ResponseBody": {
@@ -301,19 +301,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleAssignments/8172d5e4-1db7-e9e5-c84a-d8c05c75332c?api-version=7.3-preview",
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/providers/Microsoft.Authorization/roleAssignments/6c9ce85e-986e-d072-b6dc-8b5f24f93c3c?api-version=7.3-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "196",
         "Content-Type": "application/json",
-        "traceparent": "00-fa870217d529c345843b21ea18f83069-0b79bb326c02c442-00",
+        "traceparent": "00-e8653c4d4a9cc84da86c3f5208ea110f-c6c1f48c65453e45-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "4334c2dd2f65d8f7bbd070f3aadcca55",
+        "x-ms-client-request-id": "bff92b1b9f75d6d49a7233057924a2e0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -325,7 +325,7 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "398",
+        "Content-Length": "402",
         "Content-Security-Policy": "default-src \u0027self\u0027",
         "Content-Type": "application/json; charset=utf-8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
@@ -333,16 +333,16 @@
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "ecb1a57c-11ae-11ec-9ace-000d3aed5f27",
-        "x-ms-server-latency": "54"
+        "x-ms-request-id": "eb048262-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "50"
       },
       "ResponseBody": {
-        "id": "/providers/Microsoft.Authorization/roleAssignments/8172d5e4-1db7-e9e5-c84a-d8c05c75332c",
-        "name": "8172d5e4-1db7-e9e5-c84a-d8c05c75332c",
+        "id": "/providers/Microsoft.Authorization/roleAssignments/6c9ce85e-986e-d072-b6dc-8b5f24f93c3c",
+        "name": "6c9ce85e-986e-d072-b6dc-8b5f24f93c3c",
         "properties": {
           "principalId": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
           "roleDefinitionId": "Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8",
-          "scope": "/"
+          "scope": "/keys"
         },
         "type": "Microsoft.Authorization/roleAssignments"
       }
@@ -351,6 +351,6 @@
   "Variables": {
     "AZURE_MANAGEDHSM_URL": "https://heathskeyvaulthsm.managedhsm.azure.net/",
     "CLIENT_OBJECTID": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
-    "RandomSeed": "1820470144"
+    "RandomSeed": "91278647"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateKeysRoleAssignmentAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateKeysRoleAssignmentAsync.json
@@ -5,12 +5,12 @@
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "traceparent": "00-73c41a3f02e167489f661907f00f11f5-a67eaaee97cff34a-00",
+        "traceparent": "00-75d61b71fdee374384d8c4a8ff158549-876cb0ac2cc4ba46-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "c23c658117723d55cd717f5f53da57f6",
+        "x-ms-client-request-id": "d3824b3ddc1f539f5e23351401794fb2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -25,7 +25,7 @@
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
-        "x-ms-request-id": "ec7d9372-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-request-id": "ec1f66f8-11ae-11ec-9ace-000d3aed5f27",
         "x-ms-server-latency": "0"
       },
       "ResponseBody": "OK"
@@ -36,12 +36,12 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-73c41a3f02e167489f661907f00f11f5-a67eaaee97cff34a-00",
+        "traceparent": "00-75d61b71fdee374384d8c4a8ff158549-876cb0ac2cc4ba46-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "c23c658117723d55cd717f5f53da57f6",
+        "x-ms-client-request-id": "d3824b3ddc1f539f5e23351401794fb2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -57,7 +57,7 @@
         "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "eca07e8c-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-request-id": "ec40021e-11ae-11ec-9ace-000d3aed5f27",
         "x-ms-server-latency": "1"
       },
       "ResponseBody": {
@@ -301,19 +301,19 @@
       }
     },
     {
-      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleAssignments/8172d5e4-1db7-e9e5-c84a-d8c05c75332c?api-version=7.3-preview",
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/keys/providers/Microsoft.Authorization/roleAssignments/b23251f1-31f5-65aa-80cd-6fddc9545c53?api-version=7.3-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "196",
         "Content-Type": "application/json",
-        "traceparent": "00-fa870217d529c345843b21ea18f83069-0b79bb326c02c442-00",
+        "traceparent": "00-ea15008c9d337d4bb9582ee92ee5f1cf-8e51be6800ce4d42-00",
         "User-Agent": [
           "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
           "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
-        "x-ms-client-request-id": "4334c2dd2f65d8f7bbd070f3aadcca55",
+        "x-ms-client-request-id": "8aac9335d667bbf756ff98f98046fc0e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -325,7 +325,7 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "398",
+        "Content-Length": "402",
         "Content-Security-Policy": "default-src \u0027self\u0027",
         "Content-Type": "application/json; charset=utf-8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
@@ -333,16 +333,16 @@
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "ecb1a57c-11ae-11ec-9ace-000d3aed5f27",
-        "x-ms-server-latency": "54"
+        "x-ms-request-id": "ec4cb766-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "48"
       },
       "ResponseBody": {
-        "id": "/providers/Microsoft.Authorization/roleAssignments/8172d5e4-1db7-e9e5-c84a-d8c05c75332c",
-        "name": "8172d5e4-1db7-e9e5-c84a-d8c05c75332c",
+        "id": "/providers/Microsoft.Authorization/roleAssignments/b23251f1-31f5-65aa-80cd-6fddc9545c53",
+        "name": "b23251f1-31f5-65aa-80cd-6fddc9545c53",
         "properties": {
           "principalId": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
           "roleDefinitionId": "Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8",
-          "scope": "/"
+          "scope": "/keys"
         },
         "type": "Microsoft.Authorization/roleAssignments"
       }
@@ -351,6 +351,6 @@
   "Variables": {
     "AZURE_MANAGEDHSM_URL": "https://heathskeyvaulthsm.managedhsm.azure.net/",
     "CLIENT_OBJECTID": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
-    "RandomSeed": "1820470144"
+    "RandomSeed": "189284264"
   }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateRoleAssignment.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/SessionRecords/AccessControlClientLiveTests/CreateRoleAssignment.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://heathskvtesthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleDefinitions?api-version=7.3-preview",
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleDefinitions?api-version=7.3-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
-        "traceparent": "00-777c5536ed72d74cbc546e339855b8d3-a1dcc622ca11bb4c-00",
+        "traceparent": "00-d7c7dd8092b6ca4fb0b8f4c1311dd793-5d023b665fbaaa47-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210713.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
+          "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5e8636028f65bb56594d809618e68b9c",
         "x-ms-return-client-request-id": "true"
@@ -24,22 +24,22 @@
         "WWW-Authenticate": "Bearer authorization=\u0022https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://managedhsm.azure.net\u0022",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-build-version": "1.0.20210605-1-ffd80f31-develop",
-        "x-ms-request-id": "bbf64ec4-e4bd-11eb-b193-000d3a72214d",
+        "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
+        "x-ms-request-id": "eb2e9a52-11ae-11ec-9ace-000d3aed5f27",
         "x-ms-server-latency": "0"
       },
       "ResponseBody": "OK"
     },
     {
-      "RequestUri": "https://heathskvtesthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleDefinitions?api-version=7.3-preview",
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleDefinitions?api-version=7.3-preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-777c5536ed72d74cbc546e339855b8d3-a1dcc622ca11bb4c-00",
+        "traceparent": "00-d7c7dd8092b6ca4fb0b8f4c1311dd793-5d023b665fbaaa47-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210713.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
+          "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5e8636028f65bb56594d809618e68b9c",
         "x-ms-return-client-request-id": "true"
@@ -48,16 +48,16 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "7151",
+        "Content-Length": "6648",
         "Content-Security-Policy": "default-src \u0027self\u0027",
         "Content-Type": "application/json; charset=utf-8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
-        "x-ms-build-version": "1.0.20210605-1-ffd80f31-develop",
+        "x-ms-build-version": "1.0.20210809-1-5b391b3f-develop",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "bc0ec7ec-e4bd-11eb-b193-000d3a72214d",
+        "x-ms-request-id": "eb52053c-11ae-11ec-9ace-000d3aed5f27",
         "x-ms-server-latency": "1"
       },
       "ResponseBody": {
@@ -296,46 +296,22 @@
               "type": "AKVBuiltInRole"
             },
             "type": "Microsoft.Authorization/roleDefinitions"
-          },
-          {
-            "id": "Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/b34c69ea-d07f-5c4d-a9ea-5999dcd6292d",
-            "name": "b34c69ea-d07f-5c4d-a9ea-5999dcd6292d",
-            "properties": {
-              "assignableScopes": [
-                "/"
-              ],
-              "description": "roleZdL21pfk",
-              "permissions": [
-                {
-                  "actions": [],
-                  "dataActions": [
-                    "Microsoft.KeyVault/managedHsm/keys/create",
-                    "Microsoft.KeyVault/managedHsm/securitydomain/download/action"
-                  ],
-                  "notActions": [],
-                  "notDataActions": []
-                }
-              ],
-              "roleName": "",
-              "type": "CustomRole"
-            },
-            "type": "Microsoft.Authorization/roleDefinitions"
           }
         ]
       }
     },
     {
-      "RequestUri": "https://heathskvtesthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleAssignments/16093e51-ef8c-fc75-0e2d-28064b66eddd?api-version=7.3-preview",
+      "RequestUri": "https://heathskeyvaulthsm.managedhsm.azure.net/providers/Microsoft.Authorization/roleAssignments/16093e51-ef8c-fc75-0e2d-28064b66eddd?api-version=7.3-preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "196",
         "Content-Type": "application/json",
-        "traceparent": "00-ca793ec5464fec4ebb2562bc41acb846-83aae987faace245-00",
+        "traceparent": "00-15fb6f67db6fd7449f6357ce3a55b938-ce3d87760b79d642-00",
         "User-Agent": [
-          "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210713.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-Security.KeyVault.Administration/4.1.0-alpha.20210909.1",
+          "(.NET 5.0.9; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "2129f472d471715137093daa26bce307",
         "x-ms-return-client-request-id": "true"
@@ -343,7 +319,7 @@
       "RequestBody": {
         "properties": {
           "roleDefinitionId": "Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8",
-          "principalId": "0aa95430-9a7f-4c8e-8cf6-579278e68947"
+          "principalId": "80b633fb-ce49-4272-9872-d34b1f3a2ba9"
         }
       },
       "StatusCode": 201,
@@ -357,14 +333,14 @@
         "X-Frame-Options": "SAMEORIGIN",
         "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=Ipv4;",
         "x-ms-keyvault-region": "southcentralus",
-        "x-ms-request-id": "bc19abd0-e4bd-11eb-b193-000d3a72214d",
-        "x-ms-server-latency": "79"
+        "x-ms-request-id": "eb5e3fc8-11ae-11ec-9ace-000d3aed5f27",
+        "x-ms-server-latency": "54"
       },
       "ResponseBody": {
         "id": "/providers/Microsoft.Authorization/roleAssignments/16093e51-ef8c-fc75-0e2d-28064b66eddd",
         "name": "16093e51-ef8c-fc75-0e2d-28064b66eddd",
         "properties": {
-          "principalId": "0aa95430-9a7f-4c8e-8cf6-579278e68947",
+          "principalId": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
           "roleDefinitionId": "Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/7b127d3c-77bd-4e3e-bbe0-dbb8971fa7f8",
           "scope": "/"
         },
@@ -373,8 +349,8 @@
     }
   ],
   "Variables": {
-    "AZURE_MANAGEDHSM_URL": "https://heathskvtesthsm.managedhsm.azure.net/",
-    "CLIENT_OBJECTID": "0aa95430-9a7f-4c8e-8cf6-579278e68947",
+    "AZURE_MANAGEDHSM_URL": "https://heathskeyvaulthsm.managedhsm.azure.net/",
+    "CLIENT_OBJECTID": "80b633fb-ce49-4272-9872-d34b1f3a2ba9",
     "RandomSeed": "1126588322"
   }
 }


### PR DESCRIPTION
Seems the logic to determine the default value for `scope` is reversed


# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
