### PR TITLE
[Event Hubs] Use SafeClose to Abort Sessions

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -21,6 +21,8 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 - Serialization of event data from Event Hubs has been tweaked for greater efficiency.  _(A community contribution, courtesy of [johnthcall](https://github.com/johnthcall))_
 
+- Adjusted the approach used to abandon AMQP sessions when an exception occurs while opening a link to ensure that the transport library does not continue to hold an unnecessary reference.
+
 - Documentation has been enhanced to provide additional context for client library types, notably detailing non-obvious validations applied to parameters and options members.
 
 ## 5.6.0 (2021-08-10)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -614,11 +614,11 @@ namespace Azure.Messaging.EventHubs.Amqp
             }
             catch
             {
-                // Aborting the session will perform any necessary cleanup of
+                // Closing the session will perform any necessary cleanup of
                 // the associated link as well.
 
                 StopTrackingLinkAsActive(link);
-                session?.Abort();
+                session?.SafeClose();
                 throw;
             }
         }
@@ -737,11 +737,11 @@ namespace Azure.Messaging.EventHubs.Amqp
             }
             catch
             {
-                // Aborting the session will perform any necessary cleanup of
+                // Closing the session will perform any necessary cleanup of
                 // the associated link as well.
 
                 StopTrackingLinkAsActive(link, refreshTimer);
-                session?.Abort();
+                session?.SafeClose();
                 throw;
             }
         }
@@ -849,11 +849,11 @@ namespace Azure.Messaging.EventHubs.Amqp
             }
             catch
             {
-                // Aborting the session will perform any necessary cleanup of
+                // Closing the session will perform any necessary cleanup of
                 // the associated link as well.
 
                 StopTrackingLinkAsActive(link, refreshTimer);
-                session?.Abort();
+                session?.SafeClose();
                 throw;
             }
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to move from `Abort` to `SafeClose` when the AMQP session needs to be abandoned after an exception while opening an AMQP link.  This was recommended by the author of the AMQP transport library in order to ensure that the transport clears state and  releases the session completely.

# References and Related

- [ServiceBus: Use SafeClose (#23733)](https://github.com/Azure/azure-sdk-for-net/pull/23733)