### PR TITLE
Attempt Simple Resolution to Badly Rendering Docs

### DIFF
--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymTokenFilter.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymTokenFilter.cs
@@ -48,7 +48,7 @@ namespace Azure.Search.Documents.Indexes.Models
         }
         /// <summary> A value indicating whether to case-fold input for matching. Default is false. </summary>
         public bool? IgnoreCase { get; set; }
-        /// <summary> A value indicating whether all words in the list of synonyms (if =&gt; notation is not used) will map to one another. If true, all words in the list of synonyms (if =&gt; notation is not used) will map to one another. The following list: incredible, unbelievable, fabulous, amazing is equivalent to: incredible, unbelievable, fabulous, amazing =&gt; incredible, unbelievable, fabulous, amazing. If false, the following list: incredible, unbelievable, fabulous, amazing will be equivalent to: incredible, unbelievable, fabulous, amazing =&gt; incredible. Default is true. </summary>
+        /// <summary> A value indicating whether all words in the list of synonyms (if => notation is not used) will map to one another. If true, all words in the list of synonyms (if => notation is not used) will map to one another. The following list: incredible, unbelievable, fabulous, amazing is equivalent to: incredible, unbelievable, fabulous, amazing => incredible, unbelievable, fabulous, amazing. If false, the following list: incredible, unbelievable, fabulous, amazing will be equivalent to: incredible, unbelievable, fabulous, amazing => incredible. Default is true. </summary>
         public bool? Expand { get; set; }
     }
 }


### PR DESCRIPTION
@tg-msft's  Complaint in a nutshell:

![image](https://user-images.githubusercontent.com/45376673/132399644-3919df30-08b2-4a2d-ba85-2cbdeb5a3f29.png)

[Rendered on Docs.MS](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.search.models.synonymtokenfilter?view=azure-dotnet#properties)
[Rendered On Github.io](https://azuresdkdocs.blob.core.windows.net/$web/dotnet/Azure.Search.Documents/11.4.0-beta.2/api/Azure.Search.Documents.Indexes.Models/Azure.Search.Documents.Indexes.Models.SynonymTokenFilter.html#Azure_Search_Documents_Indexes_Models_SynonymTokenFilter__ctor_System_String_System_Collections_Generic_IEnumerable_System_String__)
[In Code](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymTokenFilter.cs#L51)

This draft pr attempts to fix it using the simplest possible means. 
