### PR TITLE
[DT] Fixing sample Operations History + ChangeLog Release Date

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/CHANGELOG.md
+++ b/sdk/translation/Azure.AI.Translation.Document/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.5 (2021-09-07)
+## 1.0.0-beta.5 (2021-09-08)
 
 ### Breaking Changes
 - `DocumentFilter.CreatedAfter` and `DocumentFilter.CreatedBefore` are now nullable properties.

--- a/sdk/translation/Azure.AI.Translation.Document/README.md
+++ b/sdk/translation/Azure.AI.Translation.Document/README.md
@@ -226,7 +226,7 @@ await foreach (DocumentStatusResult document in operation.Value)
 ```
 
 ### Get Operations History Asynchronously
-Get History of all submitted translation operations
+Get History of submitted translation operations from the last 7 days. The options parameter can be ommitted if the user would like to return all submitted operations.
 
 ```C# Snippet:OperationsHistoryAsync
 int operationsCount = 0;
@@ -235,7 +235,14 @@ int docsCanceled = 0;
 int docsSucceeded = 0;
 int docsFailed = 0;
 
-await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync())
+DateTimeOffset lastWeekTimestamp = DateTimeOffset.Now.AddDays(-7);
+
+var options = new GetTranslationStatusesOptions
+{
+    CreatedAfter = lastWeekTimestamp
+};
+
+await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync(options))
 {
     if (translationStatus.Status == DocumentTranslationStatus.NotStarted ||
         translationStatus.Status == DocumentTranslationStatus.Running)

--- a/sdk/translation/Azure.AI.Translation.Document/samples/Sample3_OperationsHistory.md
+++ b/sdk/translation/Azure.AI.Translation.Document/samples/Sample3_OperationsHistory.md
@@ -1,5 +1,5 @@
 # Translation Operations History
-This sample demonstrates how to get the history for all submitted translation operations on your Translator resource. To get started you will need a Translator endpoint and credentials.  See [README][README] for links and instructions.
+This sample demonstrates how to get the history for submitted translation operations on your Translator resource. To get started you will need a Translator endpoint and credentials.  See [README][README] for links and instructions.
 
 ## Creating a `DocumentTranslationClient`
 
@@ -13,11 +13,11 @@ string apiKey = "<Document Translator Resource API Key>";
 var client = new DocumentTranslationClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 
-## Getting all submitted translation operations
+## Getting submitted translation operations
 
-To get the Translation History, call `GetTranslationsAsync` which returns an AsyncPageable object containing the `TranslationStatusResult` for all submitted translation operations.
+To get the Translation History, call `GetTranslationsAsync` which returns an AsyncPageable object containing the `TranslationStatusResult` for all submitted translation operations.`GetTranslationsAsync` optionally takes a parameter of type `GetTranslationStatusesOptions`, which can be included to define criteria used to filter the returned translation operations.
 
-The sample below gets the total number of documents translated in all submitted operations as well as the details of the operation continuing the largest number of documents.
+The sample below gets the total number of documents translated in operations submitted in the last 7 days while also keeping counts of the total number of documents that have been canceled, succeeded and failed.
 
 ```C# Snippet:OperationsHistoryAsync
 int operationsCount = 0;
@@ -26,7 +26,14 @@ int docsCanceled = 0;
 int docsSucceeded = 0;
 int docsFailed = 0;
 
-await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync())
+DateTimeOffset lastWeekTimestamp = DateTimeOffset.Now.AddDays(-7);
+
+var options = new GetTranslationStatusesOptions
+{
+    CreatedAfter = lastWeekTimestamp
+};
+
+await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync(options))
 {
     if (translationStatus.Status == DocumentTranslationStatus.NotStarted ||
         translationStatus.Status == DocumentTranslationStatus.Running)

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
@@ -34,12 +34,20 @@ namespace Azure.AI.Translation.Document.Samples
 
             TimeSpan pollingInterval = new(1000);
 
-            foreach (TranslationStatusResult translationStatus in client.GetTranslationStatuses())
+            DateTimeOffset lastWeekTimestamp = DateTimeOffset.Now.AddDays(-7);
+
+            var options = new GetTranslationStatusesOptions
+            {
+                CreatedAfter = lastWeekTimestamp
+            };
+
+            foreach (TranslationStatusResult translationStatus in client.GetTranslationStatuses(options))
             {
                 if (translationStatus.Status == DocumentTranslationStatus.NotStarted ||
                     translationStatus.Status == DocumentTranslationStatus.Running)
                 {
                     DocumentTranslationOperation operation = new DocumentTranslationOperation(translationStatus.Id, client);
+                    operation.UpdateStatus();
 
                     while (!operation.HasCompleted)
                     {

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistoryAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistoryAsync.cs
@@ -33,7 +33,14 @@ namespace Azure.AI.Translation.Document.Samples
             int docsSucceeded = 0;
             int docsFailed = 0;
 
-            await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync())
+            DateTimeOffset lastWeekTimestamp = DateTimeOffset.Now.AddDays(-7);
+
+            var options = new GetTranslationStatusesOptions
+            {
+                CreatedAfter = lastWeekTimestamp
+            };
+
+            await foreach (TranslationStatusResult translationStatus in client.GetTranslationStatusesAsync(options))
             {
                 if (translationStatus.Status == DocumentTranslationStatus.NotStarted ||
                     translationStatus.Status == DocumentTranslationStatus.Running)


### PR DESCRIPTION
- Updated changelog to account for release tomorrow.
- Fixed issue in OperationsHistory sample where operation.GetRawResponse can be called before operation.UpdateStatus, thus resulting in an exception being thrown.
- Adjust both sync and async OperationsHistory samples to only include operations from the last 7 days
- Gave context to the options parameter in the readme and sample markdowns.