### PR TITLE
Extend resource group expiration when running live tests

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -159,6 +159,7 @@
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Messaging.EventHubs" Version="5.2.0" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.0.0" />
+    <PackageReference Update="Azure.ResourceManager" Version="1.0.0-beta.2" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.0.0-beta.1" />
     <PackageReference Update="Azure.ResourceManager.Network" Version="1.0.0-beta.1" />
     <PackageReference Update="Azure.ResourceManager.Resources" Version="1.0.0-beta.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -159,7 +159,6 @@
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Messaging.EventHubs" Version="5.2.0" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.0.0" />
-    <PackageReference Update="Azure.ResourceManager" Version="1.0.0-beta.2" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.0.0-beta.1" />
     <PackageReference Update="Azure.ResourceManager.Network" Version="1.0.0-beta.1" />
     <PackageReference Update="Azure.ResourceManager.Resources" Version="1.0.0-beta.1" />

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample2_HelloWorldExtended.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample2_HelloWorldExtended.cs
@@ -10,7 +10,6 @@ using NUnit.Framework.Constraints;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [LiveOnly]
     public partial class ConfigurationSamples
     {
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample3_SetClearReadOnly.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample3_SetClearReadOnly.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [LiveOnly]
     public partial class ConfigurationSamples
     {
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample4_ReadRevisionHistory.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample4_ReadRevisionHistory.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [LiveOnly]
     public partial class ConfigurationSamples
     {
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample5_GetSettingIfChanged.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample5_GetSettingIfChanged.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [LiveOnly]
     public partial class ConfigurationSamples
     {
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample6_UpdateSettingIfUnchanged.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/samples/Sample6_UpdateSettingIfUnchanged.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [LiveOnly]
     public partial class ConfigurationSamples
     {
         [Test]

--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Azure.ResourceManager" />  
     <PackageReference Include="Moq" />
     <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net47'" />
   </ItemGroup>

--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Azure.ResourceManager" />  
     <PackageReference Include="Moq" />
     <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net47'" />
   </ItemGroup>
@@ -21,5 +20,10 @@
     <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)DictionaryHeaders.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)EventSourceEventFormatting.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared" />  
+    <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
   </ItemGroup>
 </Project>

--- a/sdk/core/Azure.Core.TestFramework/src/LiveOnlyAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/LiveOnlyAttribute.cs
@@ -11,7 +11,7 @@ namespace Azure.Core.TestFramework
     /// <summary>
     /// Attribute on test assemblies, classes, or methods that run only against live resources.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = true)]
     public class LiveOnlyAttribute : NUnitAttribute, IApplyToTest
     {
         private readonly bool _alwaysRunLocally;

--- a/sdk/core/Azure.Core.TestFramework/src/LiveTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/LiveTestBase.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading.Tasks;
-using Azure.ResourceManager;
-using Azure.ResourceManager.Resources;
 using NUnit.Framework;
 
 namespace Azure.Core.TestFramework

--- a/sdk/core/Azure.Core.TestFramework/src/LiveTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/LiveTestBase.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
 using NUnit.Framework;
 
 namespace Azure.Core.TestFramework
@@ -15,7 +18,10 @@ namespace Azure.Core.TestFramework
     {
         protected LiveTestBase()
         {
-            TestEnvironment = new TEnvironment();
+            TestEnvironment = new TEnvironment()
+            {
+                Mode = RecordedTestMode.Live
+            };
         }
 
         protected TEnvironment TestEnvironment { get; }

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
@@ -3,10 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.Identity;
-using Azure.ResourceManager;
-using Azure.ResourceManager.Resources;
-using Moq;
 using NUnit.Framework;
 
 namespace Azure.Core.TestFramework

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBaseOfTEnvironment.cs
@@ -3,6 +3,10 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Core.TestFramework

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -40,7 +40,6 @@ namespace Azure.Core.TestFramework
         private readonly string _serviceSdkDirectory;
 
         private static readonly HashSet<Type> s_bootstrappingAttemptedTypes = new();
-        private static readonly HashSet<Type> s_initializedEnvironmentTypes = new();
         private static readonly object s_syncLock = new();
         private static readonly bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         private Exception _bootstrappingException;

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -47,8 +47,6 @@ namespace Azure.Core.TestFramework
         private Exception _bootstrappingException;
         private readonly Type _type;
 
-        protected virtual bool AlwaysRunLiveTestsLocally => false;
-
         protected TestEnvironment()
         {
             if (RepositoryRoot == null)
@@ -245,7 +243,6 @@ namespace Azure.Core.TestFramework
                         s_environmentStateCache[_type] = task;
                     }
                 }
-
                 await task;
             }
 

--- a/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
+++ b/sdk/core/Azure.Core/tests/TestEnvironmentTests.cs
@@ -59,17 +59,22 @@ namespace Azure.Core.Tests
             }
         }
 
-        [Theory]
-        [TestCase(RecordedTestMode.Live)]
         [TestCase(RecordedTestMode.Playback)]
         [TestCase(RecordedTestMode.Record)]
-        [TestCase(RecordedTestMode.None)]
-        public void ReadingRecordedValueInCtorThrows(RecordedTestMode mode)
+        public void ReadingRecordedValueInCtorThrowsInRecordedOrPlayback(RecordedTestMode mode)
         {
             Assert.Throws<InvalidOperationException>(() => new RecordedVariableMisuse(true, mode));
         }
 
-        [Theory]
+        [TestCase(RecordedTestMode.Live)]
+        [TestCase(RecordedTestMode.None)]
+        public void ReadingRecordedValueInCtorDoesNotThrowInLive(RecordedTestMode mode)
+        {
+            // this is allowed when in Live mode since we are not going to look at any record sessions anyway
+            var test = new RecordedVariableMisuse(true, mode);
+            Assert.AreEqual("1", test.Value);
+        }
+
         [TestCase(RecordedTestMode.Live)]
         [TestCase(RecordedTestMode.Playback)]
         [TestCase(RecordedTestMode.Record)]
@@ -80,7 +85,6 @@ namespace Azure.Core.Tests
             Assert.AreEqual("2", test.Value);
         }
 
-        [Theory]
         [TestCase(RecordedTestMode.Live)]
         [TestCase(RecordedTestMode.Playback)]
         [TestCase(RecordedTestMode.Record)]
@@ -91,7 +95,6 @@ namespace Azure.Core.Tests
             Assert.AreEqual("1", test.Value);
         }
 
-        [Theory]
         [TestCase(RecordedTestMode.Live)]
         [TestCase(RecordedTestMode.Playback)]
         [TestCase(RecordedTestMode.Record)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/perf/Infrastructure/ServiceBusPerfTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/perf/Infrastructure/ServiceBusPerfTestBase.cs
@@ -30,7 +30,7 @@ namespace Azure.Messaging.ServiceBus.Perf
 
         protected ServiceBusPerfTestBase(SizeCountOptions options, bool useSessions = false) : base(options)
         {
-            MessageBody = ServiceBusTestBase.GetRandomBuffer(options.Size);
+            MessageBody = ServiceBusTestUtilities.GetRandomBuffer(options.Size);
             _useSessions = useSessions;
             SeededMessageCount = options.Count * OperationCountEstimate;
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample10_ClaimCheck.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample10_ClaimCheck.md
@@ -15,7 +15,7 @@ await containerClient.CreateIfNotExistsAsync();
 Next, we will upload our large message body to a blob, and then assign the blob name to an application property in our `ServiceBusMessage`. In this example, we use a helper method that generates a random byte array of the specified size. For the blob name, we generate a GUID.
 
 ```C# Snippet:UploadMessage
-byte[] body = GetRandomBuffer(1000000);
+byte[] body = ServiceBusTestUtilities.GetRandomBuffer(1000000);
 string blobName = Guid.NewGuid().ToString();
 await containerClient.UploadBlobAsync(blobName, new BinaryData(body));
 var message = new ServiceBusMessage

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
     public class ServiceBusManagementClientLiveTests : RecordedTestBase<ServiceBusTestEnvironment>
     {
         public ServiceBusManagementClientLiveTests(bool isAsync) :
-            base(isAsync: true, RecordedTestMode.Live)
+            base(isAsync: true)
         {
             Sanitizer = new ServiceBusRecordedTestSanitizer();
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
     public class ServiceBusManagementClientLiveTests : RecordedTestBase<ServiceBusTestEnvironment>
     {
         public ServiceBusManagementClientLiveTests(bool isAsync) :
-            base(isAsync: true)
+            base(isAsync: true, RecordedTestMode.Live)
         {
             Sanitizer = new ServiceBusRecordedTestSanitizer();
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Amqp
 {
-    public class AmqpConverterTests : ServiceBusTestBase
+    public class AmqpConverterTests
     {
         [Test]
         public void ConvertAmqpMessageToSBMessage()

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientLiveTests.cs
@@ -122,7 +122,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 var sender = client.CreateSender(scope.QueueName);
 
-                var message = GetMessage(useSessions ? "sessionId" : null);
+                var message = ServiceBusTestUtilities.GetMessage(useSessions ? "sessionId" : null);
                 await sender.SendMessageAsync(message);
                 await sender.DisposeAsync();
                 ServiceBusReceiver receiver;
@@ -166,7 +166,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
                 var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 var sender = client.CreateSender(scope.QueueName);
 
-                var message = GetMessage(useSessions ? "sessionId" : null);
+                var message = ServiceBusTestUtilities.GetMessage(useSessions ? "sessionId" : null);
                 await sender.SendMessageAsync(message);
                 await sender.DisposeAsync();
                 ServiceBusReceiver receiver;
@@ -212,7 +212,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
 
                 Assert.Less(stop - start, duration.Add(duration));
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
 
                 start = DateTime.UtcNow;
                 var receiver = await client.AcceptNextSessionAsync(scope.QueueName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
@@ -46,7 +46,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     sessionId = "sessionId";
                 }
                 int numMessages = 5;
-                var msgs = GetMessages(numMessages, sessionId);
+                var msgs = ServiceBusTestUtilities.GetMessages(numMessages, sessionId);
                 await sender.SendMessagesAsync(msgs);
                 Activity[] sendActivities = AssertSendActivities(useSessions, sender, msgs);
 
@@ -132,7 +132,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 }
 
                 // schedule
-                msgs = GetMessages(numMessages, sessionId);
+                msgs = ServiceBusTestUtilities.GetMessages(numMessages, sessionId);
 
                 foreach (var msg in msgs)
                 {
@@ -158,7 +158,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var batch = await sender.CreateMessageBatchAsync();
                 for (int i = 0; i < numMessages; i++)
                 {
-                    batch.TryAddMessage(GetMessage(sessionId));
+                    batch.TryAddMessage(ServiceBusTestUtilities.GetMessage(sessionId));
                 }
                 await sender.SendMessagesAsync(batch);
                 AssertSendActivities(useSessions, sender, batch.AsEnumerable<ServiceBusMessage>());
@@ -189,7 +189,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 var messageCt = 2;
-                var msgs = GetMessages(messageCt);
+                var msgs = ServiceBusTestUtilities.GetMessages(messageCt);
                 await sender.SendMessagesAsync(msgs);
                 Activity[] sendActivities = AssertSendActivities(false, sender, msgs);
                 messageActivities = sendActivities.Select(a => a.ParentId).ToArray();
@@ -209,7 +209,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     }
                     return Task.CompletedTask;
                 };
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 await processor.StartProcessingAsync();
                 await tcs.Task;
                 await processor.StopProcessingAsync();
@@ -247,7 +247,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 var messageCt = 2;
-                var msgs = GetMessages(messageCt, "sessionId");
+                var msgs = ServiceBusTestUtilities.GetMessages(messageCt, "sessionId");
                 await sender.SendMessagesAsync(msgs);
                 Activity[] sendActivities = AssertSendActivities(false, sender, msgs);
                 messageActivities = sendActivities.Select(a => a.ParentId).ToArray();
@@ -268,7 +268,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     }
                     return Task.CompletedTask;
                 };
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 await processor.StartProcessingAsync();
                 await tcs.Task;
                 await processor.StopProcessingAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -48,7 +48,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchStartEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchCompleteEvent, e => e.Payload.Contains(sender.Identifier));
 
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkStartEvent, e => e.Payload.Contains(sender.Identifier));
@@ -163,7 +163,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchStartEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchCompleteEvent, e => e.Payload.Contains(sender.Identifier));
 
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, "sessionId").AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, "sessionId").AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkStartEvent, e => e.Payload.Contains(sender.Identifier));
@@ -230,7 +230,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                ServiceBusMessage message = GetMessage();
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage();
 
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
@@ -251,7 +251,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                 await using var processor = client.CreateProcessor(scope.QueueName);
                 var tcs = new TaskCompletionSource<bool>();
                 string lockToken = null;
@@ -292,7 +292,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                 await using var processor = client.CreateProcessor(scope.QueueName);
                 var tcs = new TaskCompletionSource<bool>();
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 {
-    public class EventSourceTests : ServiceBusTestBase
+    public class EventSourceTests
     {
         [Test]
         public async Task SendSingleMessageLogsEvents()
@@ -29,7 +29,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 Logger = mockLogger.Object
             };
-            await sender.SendMessageAsync(GetMessage());
+            await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
 
             mockLogger
                 .Verify(
@@ -57,7 +57,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 Logger = mockLogger.Object
             };
-            await sender.SendMessagesAsync(GetMessages(5));
+            await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(5));
 
             mockLogger
                 .Verify(
@@ -93,7 +93,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 .Throws(new Exception());
 
             Assert.That(
-                async () => await sender.SendMessageAsync(GetMessage()),
+                async () => await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage()),
                 Throws.InstanceOf<Exception>());
             mockLogger
                 .Verify(
@@ -178,7 +178,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 .Returns(Task.FromResult((IReadOnlyList<long>) new List<long> { 1 }));
 
             var scheduleTime = DateTimeOffset.UtcNow.AddMinutes(1);
-            await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
+            await sender.ScheduleMessageAsync(ServiceBusTestUtilities.GetMessage(), scheduleTime);
 
             mockLogger
                 .Verify(
@@ -216,7 +216,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             var scheduleTime = DateTimeOffset.UtcNow.AddMinutes(1);
             Assert.That(
-                async () => await sender.ScheduleMessageAsync(GetMessage(), scheduleTime),
+                async () => await sender.ScheduleMessageAsync(ServiceBusTestUtilities.GetMessage(), scheduleTime),
                 Throws.InstanceOf<Exception>());
 
             mockLogger
@@ -1161,7 +1161,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             {
                 Logger = mockLogger.Object
             };
-            processor.ProcessErrorAsync += ExceptionHandler;
+            processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
             processor.ProcessMessageAsync += MessageHandler;
 
             async Task MessageHandler(ProcessMessageEventArgs arg)
@@ -1201,7 +1201,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         public void StartProcessingExceptionLogsEvents()
         {
             var mockLogger = new Mock<ServiceBusEventSource>();
-            var mockConnection = CreateMockConnection();
+            var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
             var processor = new ServiceBusProcessor(mockConnection.Object, "queueName", false, new ServiceBusProcessorOptions
             {
                 AutoCompleteMessages = false,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusLiveTestBase.cs
@@ -9,13 +9,11 @@ using NUnit.Framework;
 namespace Azure.Messaging.ServiceBus.Tests
 {
     [LiveOnly(true)]
-    public abstract class ServiceBusLiveTestBase : ServiceBusTestBase
+    public abstract class ServiceBusLiveTestBase : LiveTestBase<ServiceBusTestEnvironment>
     {
         private const int DefaultTryTimeout = 10;
 
         protected TimeSpan ShortLockDuration = TimeSpan.FromSeconds(10);
-
-        public ServiceBusTestEnvironment TestEnvironment { get; } = ServiceBusTestEnvironment.Instance;
 
         protected ServiceBusClient CreateNoRetryClient(int tryTimeout = DefaultTryTimeout)
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestUtilities.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/ServiceBusTestUtilities.cs
@@ -14,9 +14,9 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests
 {
-    public abstract class ServiceBusTestBase
+    public static class ServiceBusTestUtilities
     {
-        protected List<ServiceBusMessage> GetMessages(int count, string sessionId = null, string partitionKey = null)
+        internal static List<ServiceBusMessage> GetMessages(int count, string sessionId = null, string partitionKey = null)
         {
             var messages = new List<ServiceBusMessage>();
             for (int i = 0; i < count; i++)
@@ -26,7 +26,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             return messages;
         }
 
-        protected ServiceBusMessageBatch AddMessages(ServiceBusMessageBatch batch, int count, string sessionId = null, string partitionKey = null)
+        internal static ServiceBusMessageBatch AddMessages(ServiceBusMessageBatch batch, int count, string sessionId = null, string partitionKey = null)
         {
             for (int i = 0; i < count; i++)
             {
@@ -36,14 +36,14 @@ namespace Azure.Messaging.ServiceBus.Tests
             return batch;
         }
 
-        protected Task ExceptionHandler(ProcessErrorEventArgs eventArgs)
+        internal static Task ExceptionHandler(ProcessErrorEventArgs eventArgs)
         {
             Assert.IsNotNull(eventArgs.CancellationToken);
             Assert.Fail(eventArgs.Exception.ToString());
             return Task.CompletedTask;
         }
 
-        protected ServiceBusMessage GetMessage(string sessionId = null, string partitionKey = null)
+        internal static ServiceBusMessage GetMessage(string sessionId = null, string partitionKey = null)
         {
             var msg = new ServiceBusMessage(GetRandomBuffer(100))
             {
@@ -81,7 +81,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             return text;
         }
 
-        internal ServiceBusConnection GetMockedReceiverConnection()
+        internal static ServiceBusConnection GetMockedReceiverConnection()
         {
             var mockTransportReceiver = new Mock<TransportReceiver>();
             mockTransportReceiver

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -117,7 +117,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
             {
                 var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 var sender = client.CreateSender(scope.QueueName);
-                var msg = new ServiceBusMessage(new BinaryData(GetRandomBuffer(100)));
+                var msg = new ServiceBusMessage(new BinaryData(ServiceBusTestUtilities.GetRandomBuffer(100)));
                 msg.ContentType = "contenttype";
                 msg.CorrelationId = "correlationid";
                 msg.Subject = "label";
@@ -186,7 +186,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
             {
                 var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 var sender = client.CreateSender(scope.TopicName);
-                var msg = new ServiceBusMessage(new BinaryData(GetRandomBuffer(100)));
+                var msg = new ServiceBusMessage(new BinaryData(ServiceBusTestUtilities.GetRandomBuffer(100)));
                 msg.ContentType = "contenttype";
                 msg.CorrelationId = "correlationid";
                 msg.Subject = "label";
@@ -290,8 +290,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                     AmqpMessageBody.FromData(
                     new ReadOnlyMemory<byte>[]
                     {
-                        new ReadOnlyMemory<byte>(GetRandomBuffer(100)),
-                        new ReadOnlyMemory<byte>(GetRandomBuffer(100))
+                        new ReadOnlyMemory<byte>(ServiceBusTestUtilities.GetRandomBuffer(100)),
+                        new ReadOnlyMemory<byte>(ServiceBusTestUtilities.GetRandomBuffer(100))
                     }));
                 msg.AmqpMessage = amqp;
 
@@ -446,8 +446,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                 var msg = new ServiceBusMessage();
                 msg.GetRawAmqpMessage().Body = new AmqpMessageBody(new ReadOnlyMemory<byte>[]
                     {
-                        new ReadOnlyMemory<byte>(GetRandomBuffer(100)),
-                        new ReadOnlyMemory<byte>(GetRandomBuffer(100))
+                        new ReadOnlyMemory<byte>(ServiceBusTestUtilities.GetRandomBuffer(100)),
+                        new ReadOnlyMemory<byte>(ServiceBusTestUtilities.GetRandomBuffer(100))
                     });
                 Guid guid = Guid.NewGuid();
                 msg.GetRawAmqpMessage().Properties.MessageId = new AmqpMessageId(guid.ToString());

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Message
 {
-    public class MessageTests : ServiceBusTestBase
+    public class MessageTests
     {
         [Test]
         [TestCase(null)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -33,7 +33,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 // retrieve more messages than expected when there are more messages available
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads * 2;
-                ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
+                ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, messageSendCt);
 
                 await sender.SendMessagesAsync(messageBatch);
 
@@ -53,7 +53,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var completionSourceIndex = -1;
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 await processor.StartProcessingAsync();
 
                 async Task ProcessMessage(ProcessMessageEventArgs args)
@@ -107,7 +107,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 // retrieve more messages than expected when there are more messages available
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads * 2;
-                ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
+                ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, messageSendCt);
 
                 await sender.SendMessagesAsync(messageBatch);
 
@@ -127,7 +127,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var completionSourceIndex = -1;
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 await processor.StartProcessingAsync();
 
                 async Task ProcessMessage(ProcessMessageEventArgs args)
@@ -188,7 +188,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
 
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads;
-                ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
+                ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, messageSendCt);
 
                 await sender.SendMessagesAsync(messageBatch);
 
@@ -260,7 +260,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
 
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 var messageSendCt = numThreads;
-                ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
+                ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, messageSendCt);
 
                 await sender.SendMessagesAsync(messageBatch);
 
@@ -280,7 +280,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var completionSourceIndex = -1;
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 await processor.StartProcessingAsync();
 
                 async Task ProcessMessage(ProcessMessageEventArgs args)
@@ -327,7 +327,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 int numMessages = 100;
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                ServiceBusMessageBatch messageBatch = AddMessages(batch, numMessages);
+                ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, numMessages);
 
                 await sender.SendMessagesAsync(messageBatch);
                 var options = new ServiceBusProcessorOptions
@@ -343,7 +343,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
 
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
 
@@ -492,7 +492,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                 await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
                     AutoCompleteMessages = true
@@ -505,7 +505,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     return Task.CompletedTask;
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -526,7 +526,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 // very long timeout
                 await using var client = CreateClient(tryTimeout: 120);
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                 await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
                     AutoCompleteMessages = true,
@@ -539,7 +539,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     return Task.CompletedTask;
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -564,7 +564,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessagesAsync(GetMessages(10));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(10));
                 await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
                     AutoCompleteMessages = true,
@@ -579,7 +579,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     await args.CompleteMessageAsync(args.Message);
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -609,7 +609,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                 await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
                     AutoCompleteMessages = true
@@ -787,7 +787,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 int messageCount = 10;
 
                 // send some messages
-                await sender.SendMessagesAsync(GetMessages(messageCount));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messageCount));
 
                 // receive the messages
                 var receiver = client.CreateReceiver(scope.QueueName);
@@ -823,7 +823,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     return Task.CompletedTask;
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -841,7 +841,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var sender = client.CreateSender(scope.QueueName);
                 int messageCount = 10;
 
-                await sender.SendMessagesAsync(GetMessages(messageCount));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messageCount));
 
                 await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
@@ -862,7 +862,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     await Task.Delay(lockDuration.Add(lockDuration));
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -879,7 +879,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var sender = client.CreateSender(scope.QueueName);
                 int messageCount = 200;
 
-                await sender.SendMessagesAsync(GetMessages(messageCount));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messageCount));
 
                 await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
@@ -923,7 +923,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 }
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -14,13 +14,13 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Processor
 {
-    public class ProcessorTests : ServiceBusTestBase
+    public class ProcessorTests
     {
         [Test]
         public void CannotAddNullHandler()
         {
             var processor = new ServiceBusProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 false,
                 new ServiceBusProcessorOptions());
@@ -33,7 +33,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void MustSetMessageHandler()
         {
             var processor = new ServiceBusProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 false,
                 new ServiceBusProcessorOptions());
@@ -45,7 +45,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void MustSetErrorHandler()
         {
             var processor = new ServiceBusProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 false,
                 new ServiceBusProcessorOptions());
@@ -59,7 +59,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CannotAddTwoHandlersToTheSameEvent()
         {
             var processor = new ServiceBusProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 false,
                 new ServiceBusProcessorOptions());
@@ -75,7 +75,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CannotRemoveHandlerThatHasNotBeenAdded()
         {
             var processor = new ServiceBusProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 false,
                 new ServiceBusProcessorOptions());
@@ -98,7 +98,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CanRemoveHandlerThatHasBeenAdded()
         {
             var processor = new ServiceBusProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 false,
                 new ServiceBusProcessorOptions());
@@ -121,9 +121,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [Test]
         public void ProcessorOptionsSetOnClient()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
             var client = new ServiceBusClient(connString);
             var options = new ServiceBusProcessorOptions
             {
@@ -285,7 +285,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public async Task CanDisposeStartedProcessorMultipleTimes()
         {
             var processor = new ServiceBusProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 false,
                 new ServiceBusProcessorOptions());
@@ -301,7 +301,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public async Task CanDisposeClosedProcessor()
         {
             var processor = new ServiceBusProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 false,
                 new ServiceBusProcessorOptions());
@@ -362,7 +362,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [Test]
         public async Task CannotStartProcessorWhenProcessorIsDisposed()
         {
-            var mockConnection = GetMockedReceiverConnection();
+            var mockConnection = ServiceBusTestUtilities.GetMockedReceiverConnection();
 
             var processor = new ServiceBusProcessor(
                 mockConnection,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -112,7 +112,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 for (int i = 0; i < numThreads; i++)
                 {
                     var sessionId = Guid.NewGuid().ToString();
-                    await sender.SendMessageAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
                     sessions.TryAdd(sessionId, null);
                 }
                 var options = new ServiceBusSessionProcessorOptions
@@ -133,7 +133,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var completionSourceIndex = -1;
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 processor.SessionInitializingAsync += SessionInitHandler;
                 processor.SessionClosingAsync += SessionCloseHandler;
 
@@ -142,7 +142,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 async Task SessionInitHandler(ProcessSessionEventArgs args)
                 {
                     Interlocked.Increment(ref sessionOpenEventCt);
-                    byte[] state = GetRandomBuffer(100);
+                    byte[] state = ServiceBusTestUtilities.GetRandomBuffer(100);
                     await args.SetSessionStateAsync(new BinaryData(state));
                     sessions[args.SessionId] = state;
                 }
@@ -280,7 +280,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 for (int i = 0; i < numThreads; i++)
                 {
                     var sessionId = Guid.NewGuid().ToString();
-                    await sender.SendMessageAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
                 }
                 var options = new ServiceBusSessionProcessorOptions
                 {
@@ -293,7 +293,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 await processor.StartProcessingAsync();
 
                 async Task ProcessMessage(ProcessSessionMessageEventArgs args)
@@ -360,7 +360,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 for (int i = 0; i < numThreads; i++)
                 {
                     var sessionId = Guid.NewGuid().ToString();
-                    await sender.SendMessageAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
                     sessions.TryAdd(sessionId, true);
                 }
 
@@ -377,7 +377,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 await using ServiceBusSessionProcessor processor = CreateNoRetryClient().CreateSessionProcessor(scope.QueueName, options);
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 await processor.StartProcessingAsync();
 
                 async Task ProcessMessage(ProcessSessionMessageEventArgs args)
@@ -532,7 +532,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 for (int i = 0; i < numThreads; i++)
                 {
                     sessionId = Guid.NewGuid().ToString();
-                    await sender.SendMessageAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
                     sessions.TryAdd(sessionId, true);
                 }
 
@@ -552,7 +552,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     options);
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 await processor.StartProcessingAsync();
 
                 async Task ProcessMessage(ProcessSessionMessageEventArgs args)
@@ -606,7 +606,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var messageSendCt = numThreads;
                 for (int i = 0; i < numThreads; i++)
                 {
-                    AddMessages(batch, 1, Guid.NewGuid().ToString());
+                    ServiceBusTestUtilities.AddMessages(batch, 1, Guid.NewGuid().ToString());
                 }
 
                 await sender.SendMessagesAsync(batch);
@@ -682,7 +682,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var messageSendCt = numThreads;
                 for (int i = 0; i < numThreads; i++)
                 {
-                    AddMessages(batch, 1, Guid.NewGuid().ToString());
+                    ServiceBusTestUtilities.AddMessages(batch, 1, Guid.NewGuid().ToString());
                 }
 
                 await sender.SendMessagesAsync(batch);
@@ -772,7 +772,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
                 await using var processor = client.CreateSessionProcessor(scope.QueueName, new ServiceBusSessionProcessorOptions
                 {
                     AutoCompleteMessages = true
@@ -785,7 +785,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     return Task.CompletedTask;
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -812,7 +812,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
                 await using var processor = client.CreateSessionProcessor(scope.QueueName);
                 var tcs = new TaskCompletionSource<bool>();
 
@@ -913,18 +913,18 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     var sessionId = Guid.NewGuid().ToString();
                     options.SessionIds.Add(sessionId);
-                    await sender.SendMessageAsync(GetMessage(sessionId));
+                    await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
                     sessions.TryAdd(sessionId, true);
                 }
 
                 // sending 2 more messages and not specifying these sessionIds when creating a processor,
                 // to make sure that these messages will not be received.
                 var sessionId1 = Guid.NewGuid().ToString();
-                await sender.SendMessageAsync(GetMessage(sessionId1));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId1));
                 sessions.TryAdd(sessionId1, true);
 
                 var sessionId2 = Guid.NewGuid().ToString();
-                await sender.SendMessageAsync(GetMessage(sessionId2));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId2));
                 sessions.TryAdd(sessionId2, true);
 
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -937,7 +937,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     options);
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 processor.SessionClosingAsync += SessionCloseHandler;
                 await processor.StartProcessingAsync();
 
@@ -1012,7 +1012,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     var sessionId = Guid.NewGuid().ToString();
                     options.SessionIds.Add(sessionId);
-                    var messages = GetMessages(messagesPerSession, sessionId);
+                    var messages = ServiceBusTestUtilities.GetMessages(messagesPerSession, sessionId);
                     await sender.SendMessagesAsync(messages);
                     sessions.TryAdd(sessionId, true);
                 }
@@ -1156,7 +1156,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ConcurrentDictionary<string, bool> sessions = new ConcurrentDictionary<string, bool>();
 
                 var sessionId = Guid.NewGuid().ToString();
-                await sender.SendMessageAsync(GetMessage(sessionId));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
                 sessions.TryAdd(sessionId, true);
 
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1253,7 +1253,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ConcurrentDictionary<string, bool> sessions = new ConcurrentDictionary<string, bool>();
 
                 var sessionId = Guid.NewGuid().ToString();
-                await sender.SendMessageAsync(GetMessage(sessionId));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
 
                 if (errorSource == ServiceBusErrorSource.AcceptSession)
                 {
@@ -1428,7 +1428,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ConcurrentDictionary<string, bool> sessions = new ConcurrentDictionary<string, bool>();
 
                 var sessionId = Guid.NewGuid().ToString();
-                await sender.SendMessageAsync(GetMessage(sessionId));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage(sessionId));
                 sessions.TryAdd(sessionId, true);
 
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1446,7 +1446,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     options);
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 processor.SessionInitializingAsync += SessionOpenHandler;
                 await processor.StartProcessingAsync();
 
@@ -1499,7 +1499,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 int totalMessages = messagesPerSession * numSessions;
                 for (int i = 0; i < numSessions; i++)
                 {
-                    await sender.SendMessagesAsync(GetMessages(messagesPerSession, Guid.NewGuid().ToString()));
+                    await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messagesPerSession, Guid.NewGuid().ToString()));
                 }
 
                 TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1566,7 +1566,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
                 await using var processor = client.CreateSessionProcessor(scope.QueueName, new ServiceBusSessionProcessorOptions
                 {
                     AutoCompleteMessages = false,
@@ -1580,7 +1580,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     return Task.CompletedTask;
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -1597,7 +1597,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
 
                 // can restart
                 tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
                 await processor.StartProcessingAsync();
                 Assert.IsTrue(processor.IsProcessing);
 
@@ -1606,7 +1606,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 // dispose will close the link, so we should be able to receive from this session
                 await processor.DisposeAsync();
                 Assert.IsTrue(processor.IsClosed);
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
                 var receiver = await client.AcceptSessionAsync(scope.QueueName, "sessionId");
                 var msg = await receiver.ReceiveMessageAsync();
                 Assert.IsNotNull(msg);
@@ -1627,7 +1627,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 // very long timeout
                 await using var client = CreateClient(tryTimeout: 120);
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
                 await using var processor = client.CreateSessionProcessor(scope.QueueName);
                 var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -1637,7 +1637,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     return Task.CompletedTask;
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -1662,7 +1662,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             {
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessagesAsync(GetMessages(10));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(10));
                 await using var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
                     AutoCompleteMessages = true,
@@ -1677,7 +1677,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     await args.CompleteMessageAsync(args.Message);
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -1701,7 +1701,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var sender = client.CreateSender(scope.QueueName);
                 int messageCount = 10;
 
-                await sender.SendMessagesAsync(GetMessages(messageCount, "sessionId"));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messageCount, "sessionId"));
 
                 await using var processor = client.CreateSessionProcessor(scope.QueueName, new ServiceBusSessionProcessorOptions
                 {
@@ -1722,7 +1722,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     await Task.Delay(lockDuration.Add(lockDuration));
                 }
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
                 await processor.StartProcessingAsync();
                 await tcs.Task;
@@ -1742,7 +1742,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 var sender = client.CreateSender(scope.QueueName);
                 int messageCount = 10;
 
-                await sender.SendMessagesAsync(GetMessages(messageCount, "sessionId"));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messageCount, "sessionId"));
 
                 await using var processor = client.CreateSessionProcessor(scope.QueueName, new ServiceBusSessionProcessorOptions
                 {
@@ -1782,7 +1782,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 }
 
                 processor.ProcessMessageAsync += ProcessMessage;
-                processor.ProcessErrorAsync += ExceptionHandler;
+                processor.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
                 processor.SessionClosingAsync += SessionCloseHandler;
 
                 await processor.StartProcessingAsync();
@@ -1815,7 +1815,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
 
                 for (int i = 0; i < messageCount / 2; i++)
                 {
-                    await sender.SendMessagesAsync(GetMessages(2, $"session{i}"));
+                    await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(2, $"session{i}"));
                 }
 
                 await using var processor = client.CreateSessionProcessor(scope.QueueName, new ServiceBusSessionProcessorOptions
@@ -1881,7 +1881,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 await using var client = CreateClient();
                 var sender = client.CreateSender(scope.QueueName);
                 int messageCount = 100;
-                await sender.SendMessagesAsync(GetMessages(messageCount, "sessionId"));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messageCount, "sessionId"));
 
                 await using var processor = client.CreateSessionProcessor(scope.QueueName, new ServiceBusSessionProcessorOptions
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -11,13 +11,13 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Processor
 {
-    public class SessionProcessorTests : ServiceBusTestBase
+    public class SessionProcessorTests
     {
         [Test]
         public void CannotAddNullHandler()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusSessionProcessorOptions());
 
@@ -31,7 +31,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void MustSetMessageHandler()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusSessionProcessorOptions());
 
@@ -42,7 +42,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void MustSetErrorHandler()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusSessionProcessorOptions());
 
@@ -55,7 +55,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CannotAddTwoHandlersToTheSameEvent()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusSessionProcessorOptions());
 
@@ -74,7 +74,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CannotRemoveHandlerThatHasNotBeenAdded()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusSessionProcessorOptions());
 
@@ -102,7 +102,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         public void CanRemoveHandlerThatHasBeenAdded()
         {
             var processor = new ServiceBusSessionProcessor(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "entityPath",
                 new ServiceBusSessionProcessorOptions());
 
@@ -132,9 +132,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
         [Test]
         public void ProcessorOptionsSetOnClient()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
             var client = new ServiceBusClient(connString);
             var options = new ServiceBusSessionProcessorOptions
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> sentMessages = AddMessages(batch, messageCt).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> sentMessages = ServiceBusTestUtilities.AddMessages(batch, messageCt).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -85,7 +85,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> sentMessages = AddMessages(batch, messageCt).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> sentMessages = ServiceBusTestUtilities.AddMessages(batch, messageCt).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -114,7 +114,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                var msgs = GetMessages(2);
+                var msgs = ServiceBusTestUtilities.GetMessages(2);
                 await sender.SendMessagesAsync(msgs);
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var message1 = await receiver.PeekMessageAsync();
@@ -142,7 +142,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 2;
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
                 await sender.SendMessagesAsync(batch);
 
                 var receiver = client.CreateReceiver(scope.QueueName);
@@ -174,7 +174,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
                 await sender.SendMessagesAsync(batch);
                 var receiver = client.CreateReceiver(
                     scope.QueueName,
@@ -227,7 +227,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(60), cancellationToken: cancellationTokenSource.Token),
                     Throws.InstanceOf<TaskCanceledException>());
 
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                 var msg = await receiver.ReceiveMessageAsync();
                 Assert.AreEqual(1, msg.DeliveryCount);
                 var end = DateTime.UtcNow;
@@ -246,7 +246,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -283,7 +283,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -317,8 +317,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                var messages = GetMessages(messageCount);
-                var secondSet = GetMessages(messageCount);
+                var messages = ServiceBusTestUtilities.GetMessages(messageCount);
+                var secondSet = ServiceBusTestUtilities.GetMessages(messageCount);
                 await sender.SendMessagesAsync(messages);
                 _ = Task.Delay(TimeSpan.FromSeconds(30)).ContinueWith(
                     async _ => await sender.SendMessagesAsync(secondSet));
@@ -353,7 +353,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -403,7 +403,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                IEnumerable<ServiceBusMessage> messages = GetMessages(messageCount);
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.GetMessages(messageCount);
 
                 await sender.SendMessagesAsync(messages);
 
@@ -462,7 +462,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -516,7 +516,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -564,7 +564,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -619,7 +619,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
 
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var receivedMsg = await receiver.ReceiveMessageAsync();
@@ -645,7 +645,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -679,7 +679,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                ServiceBusMessage sentMessage = GetMessage();
+                ServiceBusMessage sentMessage = ServiceBusTestUtilities.GetMessage();
                 await sender.SendMessageAsync(sentMessage);
 
                 var clientOptions = new ServiceBusReceiverOptions()
@@ -702,7 +702,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                ServiceBusMessage sentMessage = GetMessage("sessionId");
+                ServiceBusMessage sentMessage = ServiceBusTestUtilities.GetMessage("sessionId");
                 await sender.SendMessageAsync(sentMessage);
 
                 var receiver = client.CreateReceiver(scope.QueueName);
@@ -720,7 +720,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 var messageCount = 1;
-                ServiceBusMessage message = GetMessage();
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage();
                 await sender.SendMessageAsync(message);
 
                 var receiver = client.CreateReceiver(scope.QueueName);
@@ -789,7 +789,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
 
                 var receiver = client.CreateReceiver(scope.QueueName);
 
@@ -809,7 +809,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
 
                 var receiver = client.CreateReceiver(scope.QueueName);
 
@@ -829,7 +829,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
 
                 var receiver = client.CreateReceiver(scope.QueueName);
 
@@ -849,7 +849,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
 
                 var receiver = client.CreateReceiver(scope.QueueName);
 
@@ -869,7 +869,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
 
                 var receiver = client.CreateReceiver(
                     scope.QueueName,
@@ -915,7 +915,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 for (int i = 0; i < sentCount / messagesPerBatch; i++)
                 {
-                    await sender.SendMessagesAsync(GetMessages(messagesPerBatch));
+                    await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(messagesPerBatch));
                 }
 
                 var receiver = client.CreateReceiver(scope.QueueName);
@@ -937,7 +937,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
 
                 var receiver = client.CreateReceiver(scope.QueueName);
 
@@ -961,7 +961,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Receive the first message.
@@ -993,7 +993,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Receive the first batch message.
@@ -1025,7 +1025,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Receive the first message.
@@ -1069,7 +1069,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Receive the first batch message.
@@ -1129,7 +1129,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Peek the first message.
@@ -1161,7 +1161,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), messageCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Peek the first batch message.
@@ -1193,7 +1193,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Receive the messages.
@@ -1229,7 +1229,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Receive the messages.
@@ -1265,7 +1265,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Receive the messages.
@@ -1301,7 +1301,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // Send a batch of messages.
 
-                using var batch = AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
+                using var batch = ServiceBusTestUtilities.AddMessages(await sender.CreateMessageBatchAsync(), sendCount);
                 await sender.SendMessagesAsync(batch);
 
                 // Receive the messages.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -13,15 +13,15 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Receiver
 {
-    public class ReceiverTests : ServiceBusTestBase
+    public class ReceiverTests
     {
         [Test]
         public void ClientProperties()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
-            var queueName = Encoding.Default.GetString(GetRandomBuffer(12));
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
+            var queueName = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var options = new ServiceBusReceiverOptions()
             {
                 ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete
@@ -37,9 +37,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         [Test]
         public void EntityPathConstructedCorrectly()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
             var queueName = "queueName";
             var client = new ServiceBusClient(connString);
             var receiver = client.CreateReceiver(queueName, new ServiceBusReceiverOptions
@@ -64,9 +64,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         [Test]
         public void PeekValidatesMaxMessageCount()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
             var client = new ServiceBusClient(connString);
             var receiver = client.CreateReceiver("queueName");
             Assert.That(
@@ -80,9 +80,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         [Test]
         public void ReceiveValidatesMaxMessageCount()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
             var client = new ServiceBusClient(connString);
             var receiver = client.CreateReceiver("queueName");
             Assert.That(
@@ -108,9 +108,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         [Test]
         public void ReceiveValidatesMaxWaitTime()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
             var client = new ServiceBusClient(connString);
             var receiver = client.CreateReceiver("queue");
             Assert.That(
@@ -125,7 +125,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         public async Task ReceiveValidatesMaxWaitTimePrefetchMode()
         {
             var mockTransportReceiver = new Mock<TransportReceiver>();
-            var mockConnection = CreateMockConnection();
+            var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
             mockConnection.Setup(
                     connection => connection.CreateTransportReceiver(
                         It.IsAny<string>(),
@@ -293,7 +293,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             // mutate the cancellation token to distinguish it from CancellationToken.None
             cts.CancelAfter(100);
 
-            var mockConnection = CreateMockConnection();
+            var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
             mockConnection.Setup(
                 connection => connection.CreateTransportReceiver(
                     It.IsAny<string>(),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var sessionId = Guid.NewGuid().ToString();
                 // send the messages
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> sentMessages = AddMessages(batch, messageCt, sessionId, sessionId)
+                IEnumerable<ServiceBusMessage> sentMessages = ServiceBusTestUtilities.AddMessages(batch, messageCt, sessionId, sessionId)
                     .AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
@@ -79,7 +79,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var sessionId = Guid.NewGuid().ToString();
                 // send the messages
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                ServiceBusMessageBatch messageBatch = AddMessages(batch, messageCt, sessionId);
+                ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, messageCt, sessionId);
 
                 await sender.SendMessagesAsync(messageBatch);
                 ServiceBusReceiver receiver1 = await client.AcceptSessionAsync(
@@ -110,7 +110,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var sessionId = Guid.NewGuid().ToString();
                 // send the messages
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                ServiceBusMessageBatch messagebatch = AddMessages(batch, messageCt, sessionId);
+                ServiceBusMessageBatch messagebatch = ServiceBusTestUtilities.AddMessages(batch, messageCt, sessionId);
 
                 await sender.SendMessagesAsync(messagebatch);
                 ServiceBusReceiver receiver = await client.AcceptNextSessionAsync(scope.QueueName);
@@ -144,7 +144,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var sessionId = Guid.NewGuid().ToString();
                 // send the messages
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                ServiceBusMessageBatch messagebatch = AddMessages(batch, messageCt, sessionId);
+                ServiceBusMessageBatch messagebatch = ServiceBusTestUtilities.AddMessages(batch, messageCt, sessionId);
 
                 await sender.SendMessagesAsync(messagebatch);
 
@@ -178,7 +178,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 foreach (string session in sessions)
                 {
                     using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                    ServiceBusMessageBatch messageBatch = AddMessages(batch, messageCt, session);
+                    ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, messageCt, session);
                     await sender.SendMessagesAsync(messageBatch);
                 }
 
@@ -219,7 +219,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var sessionId = "sessionId1";
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
                 await sender.SendMessagesAsync(batch);
 
                 ServiceBusReceiver receiver = await client.AcceptNextSessionAsync(
@@ -260,7 +260,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 var sessionId = "sessionId1";
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -302,7 +302,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 var sessionId = "sessionId1";
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -349,7 +349,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 var sessionId = "sessionId1";
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -390,7 +390,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 var sessionId = "sessionId1";
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -447,7 +447,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 var sessionId = "sessionId1";
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -512,7 +512,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 var sessionId = "sessionId1";
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
                 var topicName = scope.TopicName;
@@ -588,7 +588,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 var sessionId = "sessionId1";
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, sessionId).AsEnumerable<ServiceBusMessage>();
 
                 await sender.SendMessagesAsync(batch);
 
@@ -633,10 +633,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 var messageCount = 1;
                 var sessionId1 = "sessionId1";
-                ServiceBusMessage message = GetMessage(sessionId1);
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage(sessionId1);
 
                 // send another session message before the one we are interested in to make sure that when isSessionSpecified=true, it is being respected
-                await sender.SendMessageAsync(GetMessage("sessionId2"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId2"));
                 await sender.SendMessageAsync(message);
 
                 ServiceBusSessionReceiver receiver = await client.AcceptSessionAsync(
@@ -682,9 +682,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                await sender.SendMessagesAsync(GetMessages(3, "sessionId1"));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(3, "sessionId1"));
                 // send another session message before the one we are interested in to make sure that when isSessionSpecified=true, it is being respected
-                await sender.SendMessagesAsync(GetMessages(3, "sessionId2"));
+                await sender.SendMessagesAsync(ServiceBusTestUtilities.GetMessages(3, "sessionId2"));
 
                 ServiceBusSessionReceiver receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
@@ -768,7 +768,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                ServiceBusMessage sentMessage = GetMessage();
+                ServiceBusMessage sentMessage = ServiceBusTestUtilities.GetMessage();
                 await sender.SendMessageAsync(sentMessage);
 
                 Assert.That(
@@ -788,7 +788,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 var sessionId = "test-sessionId";
-                ServiceBusMessage message = GetMessage(sessionId);
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage(sessionId);
                 await sender.SendMessageAsync(message);
 
                 ServiceBusSessionReceiver receiver = await client.AcceptSessionAsync(
@@ -833,8 +833,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-                var messages = GetMessages(messageCount, "sessionId");
-                var secondSet = GetMessages(messageCount, "sessionId");
+                var messages = ServiceBusTestUtilities.GetMessages(messageCount, "sessionId");
+                var secondSet = ServiceBusTestUtilities.GetMessages(messageCount, "sessionId");
                 await sender.SendMessagesAsync(messages);
                 _ = Task.Delay(TimeSpan.FromSeconds(30)).ContinueWith(
                     async _ => await sender.SendMessagesAsync(secondSet));
@@ -956,7 +956,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageCount = 10;
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount, "sessionId").AsEnumerable<ServiceBusMessage>();
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.AddMessages(batch, messageCount, "sessionId").AsEnumerable<ServiceBusMessage>();
                 await sender.SendMessagesAsync(batch);
                 var receiver = await client.AcceptSessionAsync(
                     scope.QueueName,
@@ -1011,7 +1011,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     async () => await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(60), cancellationToken: cancellationTokenSource.Token),
                     Throws.InstanceOf<TaskCanceledException>());
 
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
                 var msg = await receiver.ReceiveMessageAsync();
                 Assert.AreEqual(1, msg.DeliveryCount);
                 var end = DateTime.UtcNow;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverTests.cs
@@ -10,13 +10,13 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Receiver
 {
-    public class SessionReceiverTests : ServiceBusTestBase
+    public class SessionReceiverTests
     {
         [Test]
         public void SessionReceiverCannotPerformMessageLock()
         {
             var receiver = new ServiceBusSessionReceiver(
-                GetMockedReceiverConnection(),
+                ServiceBusTestUtilities.GetMockedReceiverConnection(),
                 "fakeQueue",
                 options: new ServiceBusSessionReceiverOptions(),
                 cancellationToken: CancellationToken.None);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample10_ClaimCheck.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample10_ClaimCheck.cs
@@ -29,7 +29,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 {
                     #region Snippet:UploadMessage
 
-                    byte[] body = GetRandomBuffer(1000000);
+                    byte[] body = ServiceBusTestUtilities.GetRandomBuffer(1000000);
                     string blobName = Guid.NewGuid().ToString();
                     await containerClient.UploadBlobAsync(blobName, new BinaryData(body));
                     var message = new ServiceBusMessage

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
             }
         }
 
@@ -32,7 +32,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 var connectionString = TestEnvironment.BuildConnectionStringWithSharedAccessSignature(scope.QueueName, audience);
 
                 await using var sender = new ServiceBusClient(connectionString, options).CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
             }
         }
 
@@ -43,7 +43,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var client = new ServiceBusClient(TestEnvironment.FullyQualifiedNamespace, TestEnvironment.Credential);
                 var sender = client.CreateSender(scope.QueueName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
             }
         }
 
@@ -64,7 +64,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString, options);
 
                 ServiceBusSender sender = client.CreateSender(scope.TopicName);
-                await sender.SendMessageAsync(GetMessage());
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
             }
         }
 
@@ -85,7 +85,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString, options);
 
                 ServiceBusSender sender = client.CreateSender(scope.TopicName);
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
             }
         }
 
@@ -97,7 +97,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
-                ServiceBusMessageBatch messageBatch = AddMessages(batch, 3);
+                ServiceBusMessageBatch messageBatch = ServiceBusTestUtilities.AddMessages(batch, 3);
 
                 await sender.SendMessagesAsync(messageBatch);
             }
@@ -184,7 +184,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var sender = client.CreateSender(scope.QueueName);
                 var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
-                var seq = await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
+                var seq = await sender.ScheduleMessageAsync(ServiceBusTestUtilities.GetMessage(), scheduleTime);
 
                 await using var receiver = client.CreateReceiver(scope.QueueName);
                 ServiceBusReceivedMessage msg = await receiver.PeekMessageAsync(seq);
@@ -204,7 +204,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var sender = client.CreateSender(scope.QueueName);
                 var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
-                var sequenceNums = await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime);
+                var sequenceNums = await sender.ScheduleMessagesAsync(ServiceBusTestUtilities.GetMessages(5), scheduleTime);
                 await using var receiver = client.CreateReceiver(scope.QueueName);
                 foreach (long seq in sequenceNums)
                 {
@@ -237,7 +237,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var sender = client.CreateSender(scope.QueueName);
                 var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
-                var sequenceNums = await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime);
+                var sequenceNums = await sender.ScheduleMessagesAsync(ServiceBusTestUtilities.GetMessages(5), scheduleTime);
                 await using var receiver = client.CreateReceiver(scope.QueueName);
                 foreach (long seq in sequenceNums)
                 {
@@ -270,7 +270,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var sender = client.CreateSender(scope.QueueName);
                 var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
-                var sequenceNums = await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime);
+                var sequenceNums = await sender.ScheduleMessagesAsync(ServiceBusTestUtilities.GetMessages(5), scheduleTime);
                 await using var receiver = client.CreateReceiver(scope.QueueName);
                 foreach (long seq in sequenceNums)
                 {
@@ -313,11 +313,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 var sender = client.CreateSender(scope.QueueName);
                 var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
-                var sequenceNum = await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
+                var sequenceNum = await sender.ScheduleMessageAsync(ServiceBusTestUtilities.GetMessage(), scheduleTime);
                 await sender.DisposeAsync(); // shouldn't close connection, but should close send link
 
-                Assert.That(async () => await sender.SendMessageAsync(GetMessage()), Throws.InstanceOf<ObjectDisposedException>());
-                Assert.That(async () => await sender.ScheduleMessageAsync(GetMessage(), default), Throws.InstanceOf<ObjectDisposedException>());
+                Assert.That(async () => await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage()), Throws.InstanceOf<ObjectDisposedException>());
+                Assert.That(async () => await sender.ScheduleMessageAsync(ServiceBusTestUtilities.GetMessage(), default), Throws.InstanceOf<ObjectDisposedException>());
                 Assert.That(async () => await sender.CancelScheduledMessageAsync(sequenceNum), Throws.InstanceOf<ObjectDisposedException>());
 
                 // receive should still work
@@ -336,7 +336,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 for (int i = 0; i < 10; i++)
                 {
                     await Task.Delay(1000);
-                    await sender.SendMessageAsync(GetMessage());
+                    await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                 }
             }
         }
@@ -350,7 +350,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 var sender = client.CreateSender(scope.QueueName);
                 // this is apparently supported. The session is ignored by the service but can be used
                 // as additional app data. Not recommended.
-                await sender.SendMessageAsync(GetMessage("sessionId"));
+                await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage("sessionId"));
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var msg = await receiver.ReceiveMessageAsync();
                 Assert.AreEqual("sessionId", msg.SessionId);
@@ -364,7 +364,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             {
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).CreateSender(scope.QueueName);
                 Assert.That(
-                    async () => await sender.SendMessageAsync(GetMessage()),
+                    async () => await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage()),
                     Throws.InstanceOf<InvalidOperationException>());
             }
         }
@@ -379,7 +379,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                     TestEnvironment.Credential);
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).CreateSender(scope.QueueName);
                 var messageCt = 10;
-                IEnumerable<ServiceBusMessage> messages = GetMessages(messageCt);
+                IEnumerable<ServiceBusMessage> messages = ServiceBusTestUtilities.GetMessages(messageCt);
                 await sender.SendMessagesAsync(messages);
 
                 var receiver = client.CreateReceiver(scope.QueueName, new ServiceBusReceiverOptions()
@@ -458,12 +458,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var sender = client.CreateSender(scope.QueueName);
 
-                using var batch = AddMessages((await sender.CreateMessageBatchAsync()), 5);
+                using var batch = ServiceBusTestUtilities.AddMessages((await sender.CreateMessageBatchAsync()), 5);
                 await sender.SendMessagesAsync(batch);
 
                 // Close the client and attempt to send another message batch.
 
-                using var anotherBatch = AddMessages((await sender.CreateMessageBatchAsync()), 5);
+                using var anotherBatch = ServiceBusTestUtilities.AddMessages((await sender.CreateMessageBatchAsync()), 5);
                 await client.DisposeAsync();
 
                 Assert.That(async () => await sender.SendMessagesAsync(anotherBatch),
@@ -481,13 +481,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var sender = client.CreateSender(scope.QueueName);
 
-                await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime);
+                await sender.ScheduleMessagesAsync(ServiceBusTestUtilities.GetMessages(5), scheduleTime);
 
                 // Close the client and attempt to schedule another set of messages.
 
                 await client.DisposeAsync();
 
-                Assert.That(async () => await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime),
+                Assert.That(async () => await sender.ScheduleMessagesAsync(ServiceBusTestUtilities.GetMessages(5), scheduleTime),
                     Throws.InstanceOf<ObjectDisposedException>().And.Property(nameof(ObjectDisposedException.ObjectName)).EqualTo(nameof(ServiceBusConnection)));
             }
         }
@@ -502,12 +502,12 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
                 await using var sender = client.CreateSender(scope.QueueName);
 
-                var sequenceNumbers = await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime);
+                var sequenceNumbers = await sender.ScheduleMessagesAsync(ServiceBusTestUtilities.GetMessages(5), scheduleTime);
                 await sender.CancelScheduledMessagesAsync(sequenceNumbers);
 
                 // Close the client and attempt to cancel another set of scheduled messages.
 
-                sequenceNumbers = await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime);
+                sequenceNumbers = await sender.ScheduleMessagesAsync(ServiceBusTestUtilities.GetMessages(5), scheduleTime);
                 await client.DisposeAsync();
 
                 Assert.That(async () => await sender.CancelScheduledMessagesAsync(sequenceNumbers),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Sender
 {
-    public class SenderTests : ServiceBusTestBase
+    public class SenderTests
     {
         [Test]
         public void SendNullMessageShouldThrow()
@@ -40,7 +40,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public async Task SendEmptyListShouldNotThrow()
         {
-            var mock = new Mock<ServiceBusSender>("fake", CreateMockConnection().Object)
+            var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object)
             {
                 CallBase = true
             };
@@ -51,7 +51,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public async Task SendSingleDelegatesToSendList()
         {
-           var mock = new Mock<ServiceBusSender>("fake", CreateMockConnection().Object)
+           var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object)
             {
                 CallBase = true
             };
@@ -99,7 +99,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public async Task ScheduleEmptyListShouldNotThrow()
         {
-            var mock = new Mock<ServiceBusSender>("fake", CreateMockConnection().Object)
+            var mock = new Mock<ServiceBusSender>("fake", ServiceBusTestUtilities.CreateMockConnection().Object)
             {
                 CallBase = true
             };
@@ -113,10 +113,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public void ClientProperties()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
-            var queueName = Encoding.Default.GetString(GetRandomBuffer(12));
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
+            var queueName = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var sender = new ServiceBusClient(connString).CreateSender(queueName);
             Assert.AreEqual(queueName, sender.EntityPath);
             Assert.AreEqual(fullyQualifiedNamespace, sender.FullyQualifiedNamespace);
@@ -126,10 +126,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         [Test]
         public void CreateSenderUsingNullOptionsDoesNotThrow()
         {
-            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var account = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
-            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
-            var queueName = Encoding.Default.GetString(GetRandomBuffer(12));
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(64))}";
+            var queueName = Encoding.Default.GetString(ServiceBusTestUtilities.GetRandomBuffer(12));
             var client = new ServiceBusClient(connString);
 
             Assert.That(() => client.CreateSender(queueName), Throws.Nothing);
@@ -146,7 +146,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             var mockScope = new EntityScopeFactory("mock", "mock");
             var batch = new ServiceBusMessageBatch(mockTransportBatch.Object, mockScope);
             var mockTransportSender = new Mock<TransportSender>();
-            var mockConnection = CreateMockConnection();
+            var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
 
             mockConnection
                 .Setup(connection => connection.CreateTransportSender(It.IsAny<string>(), It.IsAny<ServiceBusRetryPolicy>(), It.IsAny<string>()))
@@ -267,7 +267,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             // mutate the cancellation token to distinguish it from CancellationToken.None
             cts.CancelAfter(100);
 
-            var mockConnection = CreateMockConnection();
+            var mockConnection = ServiceBusTestUtilities.CreateMockConnection();
             mockConnection.Setup(
                     connection => connection.CreateTransportSender(
                         It.IsAny<string>(),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Transactions/TransactionLiveTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 await using var client = CreateClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                ServiceBusMessage message = GetMessage(
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage(
                     sessionEnabled ? "sessionId" : null,
                     partitioned ? "sessionId" : null);
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
@@ -57,8 +57,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 await using var client = CreateClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                ServiceBusMessage message1 = GetMessage("session1");
-                ServiceBusMessage message2 = GetMessage("session2");
+                ServiceBusMessage message1 = ServiceBusTestUtilities.GetMessage("session1");
+                ServiceBusMessage message2 = ServiceBusTestUtilities.GetMessage("session2");
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
                     await sender.SendMessageAsync(message1);
@@ -91,8 +91,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 await using var client = CreateClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                ServiceBusMessage message1 = GetMessage("session1");
-                ServiceBusMessage message2 = GetMessage("session2");
+                ServiceBusMessage message1 = ServiceBusTestUtilities.GetMessage("session1");
+                ServiceBusMessage message2 = ServiceBusTestUtilities.GetMessage("session2");
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
                     await sender.SendMessageAsync(message1);
@@ -114,7 +114,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 await using var client = CreateClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                ServiceBusMessage message = GetMessage();
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage();
                 long seq = await sender.ScheduleMessageAsync(message, DateTimeOffset.UtcNow.AddMinutes(1));
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
@@ -134,13 +134,13 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 await using var client = CreateClient();
                 ServiceBusSender sender = client.CreateSender(scope.TopicName);
 
-                ServiceBusMessage message = GetMessage();
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage();
                 await sender.SendMessageAsync(message);
                 ServiceBusReceiver receiver = client.CreateReceiver(scope.TopicName, scope.SubscriptionNames.First());
                 ServiceBusReceivedMessage received = await receiver.ReceiveMessageAsync();
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    await sender.SendMessageAsync(GetMessage());
+                    await sender.SendMessageAsync(ServiceBusTestUtilities.GetMessage());
                     await receiver.CompleteMessageAsync(received);
                     ts.Complete();
                 }
@@ -164,7 +164,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 await using var client = CreateClient();
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
-                ServiceBusMessage message = GetMessage(
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage(
                     sessionEnabled ? "sessionId" : null,
                     partitioned ? "sessionId" : null);
                 using (var ts = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
@@ -198,7 +198,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
                 string body = Guid.NewGuid().ToString("N");
-                ServiceBusMessage message = GetMessage(
+                ServiceBusMessage message = ServiceBusTestUtilities.GetMessage(
                     sessionEnabled ? "sessionId" : null,
                     partitioned ? "sessionId" : null);
                 await sender.SendMessageAsync(message);
@@ -258,8 +258,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 ServiceBusReceiver receiver = client.CreateReceiver(scope.QueueName);
 
                 string body = Guid.NewGuid().ToString("N");
-                ServiceBusMessage message1 = GetMessage(partitionKey: "1");
-                ServiceBusMessage message2 = GetMessage(partitionKey: "2");
+                ServiceBusMessage message1 = ServiceBusTestUtilities.GetMessage(partitionKey: "1");
+                ServiceBusMessage message2 = ServiceBusTestUtilities.GetMessage(partitionKey: "2");
 
                 // Two send operations to different partitions.
                 var transaction = new CommittableTransaction();
@@ -324,8 +324,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 ServiceBusReceiver receiver = client.CreateReceiver(scope.QueueName);
 
-                ServiceBusMessage message1 = GetMessage();
-                ServiceBusMessage message2 = GetMessage();
+                ServiceBusMessage message1 = ServiceBusTestUtilities.GetMessage();
+                ServiceBusMessage message2 = ServiceBusTestUtilities.GetMessage();
                 await sender.SendMessageAsync(message1);
 
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
@@ -368,8 +368,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 await using var client2 = CreateClient();
                 ServiceBusReceiver receiver = client2.CreateReceiver(scope.QueueName);
 
-                ServiceBusMessage message1 = GetMessage();
-                ServiceBusMessage message2 = GetMessage();
+                ServiceBusMessage message1 = ServiceBusTestUtilities.GetMessage();
+                ServiceBusMessage message2 = ServiceBusTestUtilities.GetMessage();
                 await sender.SendMessageAsync(message1);
 
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
@@ -397,8 +397,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
                 ServiceBusReceiver receiver = client.CreateReceiver(scope.QueueName);
 
-                ServiceBusMessage message1 = GetMessage();
-                ServiceBusMessage message2 = GetMessage();
+                ServiceBusMessage message1 = ServiceBusTestUtilities.GetMessage();
+                ServiceBusMessage message2 = ServiceBusTestUtilities.GetMessage();
                 await sender.SendMessageAsync(message1);
 
                 ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
@@ -795,7 +795,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
 
             await senderA.SendMessageAsync(message);
 
-            processorA.ProcessErrorAsync += ExceptionHandler;
+            processorA.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
             var tcs = new TaskCompletionSource<bool>();
             processorA.ProcessMessageAsync += async args =>
@@ -841,7 +841,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
 
             await senderA.SendMessageAsync(message);
 
-            processorA.ProcessErrorAsync += ExceptionHandler;
+            processorA.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
             var tcs = new TaskCompletionSource<bool>();
             processorA.ProcessMessageAsync += async args =>
@@ -889,7 +889,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
 
             await senderA.SendMessageAsync(message);
 
-            processorA.ProcessErrorAsync += ExceptionHandler;
+            processorA.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
             var tcs = new TaskCompletionSource<bool>();
             processorA.ProcessMessageAsync += async args =>
@@ -934,7 +934,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Transactions
 
             await senderA.SendMessageAsync(message);
 
-            processorA.ProcessErrorAsync += ExceptionHandler;
+            processorA.ProcessErrorAsync += ServiceBusTestUtilities.ExceptionHandler;
 
             var tcs = new TaskCompletionSource<bool>();
             processorA.ProcessMessageAsync += async args =>

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTable.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTable.cs
@@ -9,7 +9,6 @@ using Azure.Data.Tables.Models;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTableAsync.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTableAsync.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTableErrors.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample1_CreateDeleteTableErrors.cs
@@ -8,7 +8,6 @@ using Azure.Data.Tables.Tests;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntities.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntities.cs
@@ -8,7 +8,6 @@ using Azure.Data.Tables.Tests;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntitiesAsync.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample2_CreateDeleteEntitiesAsync.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample3_QueryTables.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample3_QueryTables.cs
@@ -9,7 +9,6 @@ using Azure.Data.Tables.Models;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample3_QueryTablesAsync.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample3_QueryTablesAsync.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample4_QueryEntities.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample4_QueryEntities.cs
@@ -10,7 +10,6 @@ using System.Linq;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample4_QueryEntitiesAsync.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample4_QueryEntitiesAsync.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample5_UpdateUpsertEntities.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample5_UpdateUpsertEntities.cs
@@ -8,7 +8,6 @@ using Azure.Data.Tables.Tests;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample5_UpdateUpsertEntitiesAsync.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample5_UpdateUpsertEntitiesAsync.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample6_TransactionalBatchAsync.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample6_TransactionalBatchAsync.cs
@@ -12,7 +12,6 @@ using Azure.Data.Tables.Models;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample7_Troubleshooting.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample7_Troubleshooting.cs
@@ -9,7 +9,6 @@ using System.Net;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/tables/Azure.Data.Tables/tests/samples/Sample8_CustomizingSerialization.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/samples/Sample8_CustomizingSerialization.cs
@@ -12,7 +12,6 @@ using Azure.Identity;
 
 namespace Azure.Data.Tables.Samples
 {
-    [LiveOnly]
     public partial class TablesSamples : TablesTestEnvironment
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchAsync.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenienceAsync.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.cs
@@ -9,7 +9,6 @@ using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMiningAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMiningAsync.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
@@ -7,7 +7,6 @@ using System;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentAsync.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
@@ -7,7 +7,6 @@ using System;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesAsync.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
@@ -9,7 +9,6 @@ using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchAsync.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs
@@ -9,7 +9,6 @@ using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenienceAsync.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs
@@ -9,7 +9,6 @@ using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
@@ -9,7 +9,6 @@ using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchAsync.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
@@ -10,7 +10,6 @@ using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenienceAsync.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesAsync.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenienceAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesWithCategoriesFilter.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesWithCategoriesFilter.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchAsync.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenienceAsync.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntities.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesAsync_Cancellation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesAsync_Cancellation.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesConvenience.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntitiesConvenienceAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntities_Cancellation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample7_AnalyzeHealthcareEntities_Cancellation.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_ExtractSummary.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_ExtractSummary.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_ExtractSummaryAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_ExtractSummaryAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_ExtractSummaryConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_ExtractSummaryConvenience.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_ExtractSummaryConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample8_ExtractSummaryConvenienceAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples : SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleMoq.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleMoq.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public class SampleMoq
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperation.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenience.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample_AnalyzeOperationConvenienceAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
-    [LiveOnly]
     public partial class TextAnalyticsSamples: SamplesBase<TextAnalyticsTestEnvironment>
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_DocumentStatusAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_DocumentStatusAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputs.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputsAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_MultipleInputsAsync.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_OperationsHistory.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocuments.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_PollIndividualDocumentsAsync.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslation.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslation.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationAsync.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationAsync.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]

--- a/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationWithAzureBlob.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/samples/Sample_StartTranslationWithAzureBlob.cs
@@ -15,7 +15,6 @@ using NUnit.Framework;
 
 namespace Azure.AI.Translation.Document.Samples
 {
-    [LiveOnly]
     public partial class DocumentTranslationSamples : DocumentTranslationLiveTestBase
     {
         [Test]


### PR DESCRIPTION
Also migrate Service Bus tests to inherit from LiveTestBase.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/23853