### PR TITLE
[Event Hubs] Fix Changelog Typo

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.6.1 (20201-09-08)
+## 5.6.1 (2021-09-08)
 
 ### Acknowledgments
 


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a typo in the release date for the current change log entry.