### PR TITLE
Update traversal sdk to the latest version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Microsoft.Build.Traversal": "1.0.45"
+    "Microsoft.Build.Traversal": "3.0.23"
   },
   "sdk": {
     "version": "5.0.301",


### PR DESCRIPTION
Updating the traversal SDK as it has had a number of fixes over the last 3 years since it was last updated. Our hope is that some of those fixes might help with some transient race conditions in our parallel builds. 