### PR TITLE
Fix assert for GetTables

### DIFF
--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
@@ -216,7 +216,7 @@ namespace Azure.Data.Tables.Tests
 
                 // Get the table list.
                 var remainingItems = createdTables.Count;
-                await foreach (var page in service.QueryAsync( /*maxPerPage: pageCount*/).AsPages(pageSizeHint: pageCount))
+                await foreach (var page in service.QueryAsync( /*maxPerPage: pageCount*/ ).AsPages(pageSizeHint: pageCount))
                 {
                     Assert.That(page.Values, Is.Not.Empty);
                     if (pageCount.HasValue)

--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
@@ -202,7 +202,7 @@ namespace Azure.Data.Tables.Tests
         [TestCase(5)]
         public async Task GetTablesReturnsTablesWithAndWithoutPagination(int? pageCount)
         {
-            var createdTables = new List<string>() { tableName };
+            var createdTables = new List<string> { tableName };
 
             try
             {
@@ -216,7 +216,7 @@ namespace Azure.Data.Tables.Tests
 
                 // Get the table list.
                 var remainingItems = createdTables.Count;
-                await foreach (var page in service.QueryAsync(/*maxPerPage: pageCount*/).AsPages(pageSizeHint: pageCount))
+                await foreach (var page in service.QueryAsync( /*maxPerPage: pageCount*/).AsPages(pageSizeHint: pageCount))
                 {
                     Assert.That(page.Values, Is.Not.Empty);
                     if (pageCount.HasValue)
@@ -226,7 +226,7 @@ namespace Azure.Data.Tables.Tests
                     }
                     else
                     {
-                        Assert.That(page.Values.Count, Is.EqualTo(createdTables.Count));
+                        Assert.That(page.Values.Count, Is.GreaterThanOrEqualTo(createdTables.Count));
                     }
                     Assert.That(page.Values.All(r => createdTables.Contains(r.Name)));
                 }


### PR DESCRIPTION
Fixes the GetTables test so that the Assert is not affected by additional tables existing unrelated to this test.