### PR TITLE
Support for customizing load process

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -19,7 +19,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         public virtual System.Collections.Generic.Dictionary<string, string> GetData(System.Collections.Generic.IEnumerable<Azure.Security.KeyVault.Secrets.KeyVaultSecret> secrets) { throw null; }
         public virtual string GetKey(Azure.Security.KeyVault.Secrets.KeyVaultSecret secret) { throw null; }
         public virtual bool Load(Azure.Security.KeyVault.Secrets.SecretProperties secret) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.Security.KeyVault.Secrets.SecretProperties> LoadSecretPropertiesAsync(Azure.Security.KeyVault.Secrets.SecretClient client, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Security.KeyVault.Secrets.SecretProperties> LoadSecretPropertiesAsync(Azure.Security.KeyVault.Secrets.SecretClient client, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace Microsoft.Extensions.Configuration

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -19,6 +19,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         public virtual System.Collections.Generic.Dictionary<string, string> GetData(System.Collections.Generic.IEnumerable<Azure.Security.KeyVault.Secrets.KeyVaultSecret> secrets) { throw null; }
         public virtual string GetKey(Azure.Security.KeyVault.Secrets.KeyVaultSecret secret) { throw null; }
         public virtual bool Load(Azure.Security.KeyVault.Secrets.SecretProperties secret) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.Security.KeyVault.Secrets.SecretProperties> LoadSecretPropertiesAsync(Azure.Security.KeyVault.Secrets.SecretClient client, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace Microsoft.Extensions.Configuration

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
@@ -78,7 +78,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
 
         private async Task LoadAsync()
         {
-            var secretPages = _client.GetPropertiesOfSecretsAsync();
+            var secretPages = _manager.GetPropertiesOfSecretsAsync(_client);
 
             using var secretLoader = new ParallelSecretLoader(_client);
             var newLoadedSecrets = new Dictionary<string, KeyVaultSecret>();

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
@@ -78,7 +78,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
 
         private async Task LoadAsync()
         {
-            var secretPages = _manager.GetPropertiesOfSecretsAsync(_client);
+            var secretPages = _manager.LoadSecretPropertiesAsync(_client);
 
             using var secretLoader = new ParallelSecretLoader(_client);
             var newLoadedSecrets = new Dictionary<string, KeyVaultSecret>();

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
@@ -83,7 +83,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         /// <param name="client">The <see cref="SecretClient"/> to use for retrieving values.</param>
         /// <param name="cancellationToken">A System.Threading.CancellationToken controlling the request lifetime.</param>
         /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
-        public virtual AsyncPageable<SecretProperties> GetPropertiesOfSecretsAsync(SecretClient client, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual AsyncPageable<SecretProperties> LoadSecretPropertiesAsync(SecretClient client, CancellationToken cancellationToken = default(CancellationToken))
         {
             return client.GetPropertiesOfSecretsAsync(cancellationToken);
         }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+
 using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
@@ -72,6 +74,18 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         public virtual bool Load(SecretProperties secret)
         {
             return true;
+        }
+
+        /// <summary>
+        /// Gets a list of the properties of the secrets in the specified vault. You can use this
+        /// method to define which secrets should be loaded.
+        /// </summary>
+        /// <param name="client">The <see cref="SecretClient"/> to use for retrieving values.</param>
+        /// <param name="cancellationToken">A System.Threading.CancellationToken controlling the request lifetime.</param>
+        /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
+        public virtual AsyncPageable<SecretProperties> GetPropertiesOfSecretsAsync(SecretClient client, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return client.GetPropertiesOfSecretsAsync(cancellationToken);
         }
     }
 }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/KeyVaultSecretManager.cs
@@ -83,7 +83,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         /// <param name="client">The <see cref="SecretClient"/> to use for retrieving values.</param>
         /// <param name="cancellationToken">A System.Threading.CancellationToken controlling the request lifetime.</param>
         /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
-        public virtual AsyncPageable<SecretProperties> LoadSecretPropertiesAsync(SecretClient client, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual IAsyncEnumerable<SecretProperties> LoadSecretPropertiesAsync(SecretClient client, CancellationToken cancellationToken = default(CancellationToken))
         {
             return client.GetPropertiesOfSecretsAsync(cancellationToken);
         }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -733,9 +734,10 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
                 _name = name;
             }
 
-            public override AsyncPageable<SecretProperties> LoadSecretPropertiesAsync(SecretClient client, CancellationToken cancellationToken = default)
+            public override async IAsyncEnumerable<SecretProperties> LoadSecretPropertiesAsync(SecretClient client, [EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
-                return client.GetPropertiesOfSecretVersionsAsync(_name, cancellationToken);
+                KeyVaultSecret secret = await client.GetSecretAsync(_name, cancellationToken: cancellationToken);
+                yield return secret.Properties;
             }
         }
     }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -733,7 +733,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
                 _name = name;
             }
 
-            public override AsyncPageable<SecretProperties> GetPropertiesOfSecretsAsync(SecretClient client, CancellationToken cancellationToken = default)
+            public override AsyncPageable<SecretProperties> LoadSecretPropertiesAsync(SecretClient client, CancellationToken cancellationToken = default)
             {
                 return client.GetPropertiesOfSecretVersionsAsync(_name, cancellationToken);
             }


### PR DESCRIPTION
Allow to customize the loading process for the secrets properties via a new virtual method `LoadSecretPropertiesAsync` on `KeyVaultSecretManager`. With this it's possible not to load all secrets from a Azure Key Vault. 

This is useful, when multiple services share the same Azure Key Vault and are only interested on a single secret, which could be for example a JSON document with all key/value in it.

Closes https://github.com/Azure/azure-sdk-for-net/issues/23959

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.
