### PR TITLE
[ServiceBus] avoid calling user handler for already expired messages when using ServiceBusProcessor

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -189,6 +189,8 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         internal const int ProcessorStoppingReceiveCanceledEvent = 110;
         internal const int ProcessorStoppingAcceptSessionCanceledEvent = 111;
 
+        internal const int ProcessorMessageLockTokenExpiredEvent = 112;
+
         #endregion
         // add new event numbers here incrementing from previous
 
@@ -869,6 +871,15 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(ProcessorMessageHandlerExceptionEvent, identifier, sequenceNumber, exception, lockToken);
+            }
+        }
+
+        [Event(ProcessorMessageLockTokenExpiredEvent, Level = EventLevel.Warning, Message = "{0}: Message lock token expired before calling user handler: Message: SequenceNumber: {1} Locked Until: {2}.")]
+        public virtual void ProcessorMessageLockTokenExpired(string identifier, long sequenceNumber, DateTimeOffset lockedUntil)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(ProcessorMessageLockTokenExpiredEvent, identifier, sequenceNumber, lockedUntil);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -144,6 +144,13 @@ namespace Azure.Messaging.ServiceBus
 
             try
             {
+                if (message.LockedUntil <= DateTimeOffset.UtcNow)
+                {
+                    ServiceBusEventSource.Log.ProcessorMessageLockTokenExpired(Processor.Identifier, message.SequenceNumber, message.LockedUntil);
+                    await Receiver.AbandonMessageAsync(message.LockTokenGuid, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
                 if (!Receiver.IsSessionReceiver &&
                     Receiver.ReceiveMode == ServiceBusReceiveMode.PeekLock &&
                     AutoRenewLock)


### PR DESCRIPTION
This is to work around the internal workings of the ServiceBusProcessor where it does not automatically renew lock tokens for all messages that could have been prefetched see the [related issue](https://github.com/Azure/azure-sdk-for-net/issues/23704).


* Update ReceiverManager.cs
* Update ServiceBusEventSource.cs with new ProcessorMessageLockTokenExpired event.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
