### PR TITLE
Identity container testing fixes and improvements

### DIFF
--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -22,3 +22,5 @@ RUN wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsof
     && pwsh --version \
     && apt-get install -y dotnet-runtime-2.1 \
     && dotnet --list-runtimes
+
+RUN pwsh -c Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 resources:
   containers:
     - container: 'ubuntu_netcore_keyring'
-      image: 'azsdkengsys.azurecr.io/testing/ubuntu_netcore_keyring:689585'
+      image: 'azsdkengsys.azurecr.io/testing/ubuntu_netcore_keyring:testwithaz'
       endpoint: 'azsdkengsys'
       options: -ti --cap-add=IPC_LOCK
 
@@ -19,9 +19,6 @@ extends:
     ServiceDirectory: identity
     SupportedClouds: 'Public,UsGov,China,Canary'
     PreSteps:
-      - pwsh: Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
-        displayName: Install Azure PowerShell module
-        condition: and(succeededOrFailed(), startsWith(variables['Agent.JobName'], 'ubuntu_keyring_container'))
       - script: |
           set -x
           export $(dbus-launch)

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 resources:
   containers:
     - container: 'ubuntu_netcore_keyring'
-      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore_keyring:689585'
+      image: 'azsdkengsys.azurecr.io/testing/ubuntu_netcore_keyring:689585'
       endpoint: 'azsdkengsys'
       options: -ti --cap-add=IPC_LOCK
 


### PR DESCRIPTION
- Skip PSModule caching in container jobs
- Install azure powershell modules into identity keyring test image
