### PR TITLE
eliminate unnecessary assert

### DIFF
--- a/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableServiceClientLiveTests.cs
@@ -228,7 +228,6 @@ namespace Azure.Data.Tables.Tests
                     {
                         Assert.That(page.Values.Count, Is.GreaterThanOrEqualTo(createdTables.Count));
                     }
-                    Assert.That(page.Values.All(r => createdTables.Contains(r.Name)));
                 }
             }
 


### PR DESCRIPTION
The removed assert can be affected by the presence of tables from other tests and is orthogonal to the scenario being tested. 