### PR TITLE
[MetricsAdvisor] Ignoring flaky test

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample04_DetectionConfigurationCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample04_DetectionConfigurationCrudOperations.cs
@@ -13,7 +13,7 @@ namespace Azure.AI.MetricsAdvisor.Samples
     public partial class MetricsAdvisorSamples : MetricsAdvisorTestEnvironment
     {
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/21663")]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/22575")]
         public async Task CreateAndDeleteDetectionConfigurationAsync()
         {
             string endpoint = MetricsAdvisorUri;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample06_AlertConfigurationCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample06_AlertConfigurationCrudOperations.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.MetricsAdvisor.Administration;
 using Azure.AI.MetricsAdvisor.Models;
@@ -14,6 +13,7 @@ namespace Azure.AI.MetricsAdvisor.Samples
     public partial class MetricsAdvisorSamples : MetricsAdvisorTestEnvironment
     {
         [Test]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/22575")]
         public async Task CreateAndDeleteAlertConfigurationAsync()
         {
             string endpoint = MetricsAdvisorUri;


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-net/issues/23603.

Flakiness is caused because of a limitation of the resource we're using (more info in https://github.com/Azure/azure-sdk-for-net/issues/22575).