### PR TITLE
Disable XML comment checks on Synapse Track 1 library

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -215,8 +215,8 @@
     $(MSBuildProjectName.Equals('Microsoft.Azure.KeyVault.Cryptography')) or
     $(MSBuildProjectName.Equals('Microsoft.Azure.KeyVault.Extensions')) or
     $(MSBuildProjectName.Equals('Microsoft.Azure.KeyVault.WebKey')) or
-    $(MSBuildProjectName.Equals('Microsoft.Azure.OperationalInsights'))">
-
+    $(MSBuildProjectName.Equals('Microsoft.Azure.OperationalInsights')) or
+    $(MSBuildProjectName.Equals('Microsoft.Azure.Synapse'))">
     <DocumentationFile></DocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR disables XML comment checks for the Synapse Track 1 library.

**Problem**

Synapse CI's are failing with the following type errors:

```
D:\a\_work\1\s\sdk\synapse\Microsoft.Azure.Synapse\src\Generated\Models\ArtifactType.cs(19,29): error CS1591: Missing XML comment for publicly visible type or member 'ArtifactType.Workspace' [D:\a\_work\1\s\sdk\synapse\Microsoft.Azure.Synapse\src\Microsoft.Azure.Synapse.csproj] 
D:\a\_work\1\s\sdk\synapse\Microsoft.Azure.Synapse\src\Generated\Models\Config.cs(16,26): error CS1591: Missing XML comment for publicly visible type or member 'Config' [D:\a\_work\1\s\sdk\synapse\Microsoft.Azure.Synapse\src\Microsoft.Azure.Synapse.csproj]  
```
See: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1092892&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=45862c6e-83c5-515f-73e2-e7009eff9f9b&l=57

**Root Cause**

A recent PR enabled these errors for Track 1 libraries, but did not disable them for Synapse: https://github.com/Azure/azure-sdk-for-net/pull/23824

**Solution**

Disable warnings for Synapse.
