### PR TITLE
Use correct dev lang for .NET CLI commands

### DIFF
--- a/samples/AppSecretsConfig/README.md
+++ b/samples/AppSecretsConfig/README.md
@@ -90,7 +90,7 @@ After deployment completes, make note of the output variables as shown in the ex
 
 You can build, run, and even deploy the sample using [Visual Studio][visualstudio], [Visual Studio Code][visualstudiocode], or the [.NET command line interface (CLI)][dotnet_cli]. Using the `dotnet` CLI, for example, within the directory containing the sample application source run:
 
-```bash
+```dotnetcli
 dotnet build
 ```
 
@@ -134,7 +134,7 @@ Next you'll need to add the App Configuration connection string from the templat
 
 1. In the project folder, run the following to add a variable named `ConnectionStrings:AppConfig` with the `value` of the `appConfigurationConnectionString` output variable:
 
-   ```bash
+   ```dotnetcli
    dotnet user-secrets set "ConnectionStrings:AppConfig" "Endpoint=https://{appconfig-host-name}.azconfig.io;Id={id};Secret={secret}"
    ```
 
@@ -145,13 +145,13 @@ Next you'll need to add the App Configuration connection string from the templat
 
 1. In the project folder, run the following to add a variable named `ConnectionStrings:AppConfig` with the `value` of the `appConfigurationConnectionString` output variable:
 
-   ```bash
+   ```dotnetcli
    dotnet user-secrets set "ConnectionStrings:AppConfig" "Endpoint=https://{appconfig-host-name}.azconfig.io;Id={id};Secret={secret}"
    ```
 
 2. Run the project:
 
-   ```bash
+   ```dotnetcli
    dotnet run
    ```
 
@@ -167,7 +167,7 @@ Using [Azure App Configuration][appconfig_overview] is an efficient way to store
 
 1. Add the following package to your project:
 
-   ```bash
+   ```dotnetcli
    dotnet add package Azure.Identity
    dotnet add package Microsoft.Extensions.Configuration.AzureAppConfiguration
    ```

--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/README.md
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/README.md
@@ -12,7 +12,7 @@ FarmBeats is a B2B PaaS offering from Microsoft that makes it easy for AgriFood 
 
 Install the Azure FarmBeats client library for .NET with [NuGet][client_nuget_package]:
 
-```
+```dotnetcli
 dotnet add package Azure.Verticals.AgriFood.Farming --prerelease
 ```
 

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/README.md
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/README.md
@@ -9,7 +9,7 @@ Microsoft Azure Cognitive Services Anomaly Detector API enables you to monitor a
 ### Install the package
 Install the Azure Anomaly Detector client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.AI.AnomalyDetector --version 3.0.0-preview.3
 ```
 

--- a/sdk/attestation/Azure.Security.Attestation/README.md
+++ b/sdk/attestation/Azure.Security.Attestation/README.md
@@ -23,7 +23,7 @@ Azure Attestation receives evidence from compute entities, turns them into a set
 
 Install the Microsoft Azure Attestation client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Security.Attestation --prerelease
 ```
 
@@ -35,7 +35,7 @@ In order to interact with the Microsoft Azure Attestation service, you'll need t
 Client secret credential authentication is being used in this getting started section but you can find more ways to authenticate with [Azure identity][azure_identity]. To use the [DefaultAzureCredential][DefaultAzureCredential] provider shown below,
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Identity
 ```
 

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/README.md
@@ -10,7 +10,7 @@ The Question Answering service is a cloud-based API service that lets you create
 
 Install the Azure Cognitive Language Services Question Answering client library for .NET with [NuGet][nuget]:
 
-```powershell
+```dotnetcli
 dotnet add package Azure.AI.Language.QuestionAnswering --prerelease
 ```
 

--- a/sdk/communication/Azure.Communication.CallingServer/README.md
+++ b/sdk/communication/Azure.Communication.CallingServer/README.md
@@ -8,7 +8,7 @@ This package contains a C# SDK for Azure Communication Services for Calling.
 ### Install the package
 Install the Azure Communication CallingServer client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Communication.CallingServer --version 1.0.0-beta.2
 ``` 
 

--- a/sdk/communication/Azure.Communication.Chat/README.md
+++ b/sdk/communication/Azure.Communication.Chat/README.md
@@ -10,7 +10,7 @@ This package contains a C# SDK for Azure Communication Services for chat.
 ### Install the package
 Install the Azure Communication Chat client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Communication.Chat 
 ``` 
 

--- a/sdk/communication/Azure.Communication.Common/README.md
+++ b/sdk/communication/Azure.Communication.Common/README.md
@@ -8,7 +8,7 @@ This package contains common code for Azure Communication Service libraries.
 ### Install the package
 Install the Azure Communication Common client library for .NET with [NuGet][nuget].
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Communication.Common --version 1.0.0
 ```
 

--- a/sdk/communication/Azure.Communication.Identity/README.md
+++ b/sdk/communication/Azure.Communication.Identity/README.md
@@ -10,7 +10,7 @@ Azure Communication Identity is managing tokens for Azure Communication Services
 
 Install the Azure Communication Identity client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Communication.Identity --version 1.0.0
 ```
 

--- a/sdk/communication/Azure.Communication.NetworkTraversal/README.md
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/README.md
@@ -9,7 +9,7 @@ Azure Communication Network Traversal enables high bandwidth, low latency connec
 
 Install the Azure Communication Network Traversal client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Communication.NetworkTraversal --version 1.0.0-beta.2
 ```
 

--- a/sdk/communication/Azure.Communication.PhoneNumbers/README.md
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/README.md
@@ -10,7 +10,7 @@ Azure Communication Phone Numbers is managing phone numbers for Azure Communicat
 
 Install the Azure Communication Phone Numbers client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Communication.PhoneNumbers --version 1.0.0
 ```
 

--- a/sdk/communication/Azure.Communication.Sms/README.md
+++ b/sdk/communication/Azure.Communication.Sms/README.md
@@ -8,7 +8,7 @@ This package contains a C# SDK for Azure Communication Services for SMS and Tele
 ### Install the package
 Install the Azure Communication SMS client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Communication.Sms --version 1.0.0
 ``` 
 

--- a/sdk/communication/Azure.ResourceManager.Communication/README.md
+++ b/sdk/communication/Azure.ResourceManager.Communication/README.md
@@ -21,7 +21,7 @@ Use the management library for Azure Communication Services to:
 
 Install the Azure Management SDK for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.ResourceManager.Communication --version 1.0.0
 ``` 
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
@@ -13,7 +13,7 @@ This section should include everything a developer needs to do to install and cr
 
 Install the Confidential Ledger client library for .NET with [NuGet][client_nuget_package]:
 
-```bash
+```dotnetcli
 dotnet add package Azure.Security.ConfidentialLedger --prerelease
 ```
 

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/README.md
@@ -19,7 +19,7 @@ To develop .NET application code that can connect to an Azure Container Registry
 
 Install the Azure Container Registry client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Containers.ContainerRegistry --prerelease
 ```
 

--- a/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/README.md
+++ b/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/README.md
@@ -11,7 +11,7 @@ Install this package if you want to use Newtonsoft.Json to serialize and deseria
 
 Install this package from [NuGet] using the .NET CLI:
 
-```bash
+```dotnetcli
 dotnet add package Microsoft.Azure.Core.NewtonsoftJson
 ```
 

--- a/sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson/README.md
+++ b/sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson/README.md
@@ -10,7 +10,7 @@ Install this package if you use the Microsoft.Spatial package in your applicatio
 
 Install this package from [NuGet] using the .NET CLI:
 
-```bash
+```dotnetcli
 dotnet add package Microsoft.Azure.Core.Spatial.NewtonsoftJson
 ```
 

--- a/sdk/core/Microsoft.Azure.Core.Spatial/README.md
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/README.md
@@ -10,7 +10,7 @@ Install this package if you use the Microsoft.Spatial package in your applicatio
 
 Install this package from [NuGet] using the .NET CLI:
 
-```bash
+```dotnetcli
 dotnet add package Microsoft.Azure.Core.Spatial
 ```
 

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/README.md
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/README.md
@@ -21,7 +21,7 @@ For the best development experience, developers should use the official Microsof
 
 Install the Device Update for IoT Hub client library for .NET with [NuGet](https://www.nuget.org/ ):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.IoT.DeviceUpdate --version 1.0.0-beta.2
 ```
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/perf/README.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/perf/README.md
@@ -22,12 +22,12 @@ The `SetupAsync` method override will create multiple Twins that is configurable
 ## Running the tests
 
 Build a performance test project
-```bash
+```dotnetcli
 dotnet run -c Release -f <supported-framework> --no-build -p <path/to/project/file> -- [parameters needed for the test]
 ```
 
 Run the executable output of a project
-```bash
+```dotnetcli
 dotnet run -c Release -f <supported-framework> --no-build -p <path/to/project/file> -- [parameters needed for the test]
 ```
 

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/README.md
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/README.md
@@ -15,7 +15,7 @@ Use the client library for Azure Event Grid to:
 
 Install the client library from [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Messaging.EventGrid
 ```
 

--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/README.md
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/README.md
@@ -8,7 +8,7 @@ This library can be used to enable publishing CloudNative CloudEvents using the 
 
 Install the client library from [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents
 ```
 

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/README.md
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/README.md
@@ -8,7 +8,7 @@ This extension provides functionality for receiving Event Grid webhook calls in 
 
 Install the Event Grid extension with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Microsoft.Azure.WebJobs.Extensions.EventGrid
 ```
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
@@ -38,7 +38,7 @@ To quickly create the needed resources in Azure and to receive connection string
 
 Install the Azure Event Hubs Event Processor client library for .NET using [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Messaging.EventHubs.Processor
 ```
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md
@@ -39,7 +39,7 @@ To quickly create a basic set of resources in Azure and to receive a connection 
 
 Install the Azure Event Hubs client library for .NET with [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Messaging.EventHubs.Processor
 ```
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -38,7 +38,7 @@ To quickly create a basic set of Event Hubs resources in Azure and to receive a 
 
 Install the Azure Event Hubs client library for .NET with [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Messaging.EventHubs
 ```
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/README.md
@@ -39,7 +39,7 @@ To quickly create a basic set of Event Hubs resources in Azure and to receive a 
 
 Install the Azure Event Hubs client library for .NET with [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Messaging.EventHubs
 ```
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/README.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/README.md
@@ -8,7 +8,7 @@ This extension provides functionality for accessing Azure Event Hubs from an Azu
 
 Install the Event Hubs extension with [NuGet](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.EventHubs):
 
-```Powershell
+```dotnetcli
 dotnet add package Microsoft.Azure.WebJobs.Extensions.EventHubs --version 5.0.0-beta.1
 ```
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/README.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/README.md
@@ -8,7 +8,7 @@ The `Azure.Extensions.AspNetCore.Configuration.Secrets` package allows storing c
 
 Install the package with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Extensions.AspNetCore.Configuration.Secrets
 ```
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/README.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/README.md
@@ -8,7 +8,7 @@ The `Azure.Extensions.AspNetCore.DataProtection.Blobs` package allows storing AS
 
 Install the package with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Extensions.AspNetCore.DataProtection.Blobs
 ```
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/README.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/README.md
@@ -8,7 +8,7 @@ The `Azure.Extensions.AspNetCore.DataProtection.Keys` package allows protecting 
 
 Install the package with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Extensions.AspNetCore.DataProtection.Keys
 ```
 

--- a/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/README.md
+++ b/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/README.md
@@ -10,7 +10,7 @@ Microsoft.Extensions.Azure.Core provides shared primitives to integrate Azure cl
 
 Install the ASP.NET Core integration library using [NuGet][nuget]:
 
-```powershell
+```dotnetcli
 dotnet add package Microsoft.Azure.WebJobs.Extensions.Clients --version 1.0.0-beta.1
 ```
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/README.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/README.md
@@ -10,7 +10,7 @@ Microsoft.Extensions.Azure.Core provides shared primitives to integrate Azure cl
 
 Install the ASP.NET Core integration library using [NuGet][nuget]:
 
-```
+```dotnetcli
 dotnet add package Microsoft.Extensions.Azure
 ```
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -16,7 +16,7 @@ Azure Cognitive Services Form Recognizer is a cloud service that uses machine le
 ### Install the package
 Install the Azure Form Recognizer client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.AI.FormRecognizer
 ``` 
 

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/README.md
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/README.md
@@ -8,7 +8,7 @@ This package follows the [new Azure SDK guidelines](https://azure.github.io/azur
 
 Install the Azure Key Vault management library for .NET with [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.ResourceManager.KeyVault --version 1.0.0-beta.1
 ```
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/README.md
@@ -12,7 +12,7 @@ The Azure Key Vault administration library clients support administrative tasks 
 ### Install the package
 Install the Azure Key Vault administration client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Security.KeyVault.Administration
 ```
 
@@ -31,7 +31,7 @@ Client secret credential authentication is being used in this getting started se
 [Azure identity][azure_identity]. To use the [DefaultAzureCredential][DefaultAzureCredential] provider shown below,
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Identity
 ```
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
@@ -10,7 +10,7 @@ The Azure Key Vault certificates client library enables programmatically managin
 ### Install the package
 Install the Azure Key Vault certificates client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Security.KeyVault.Certificates
 ```
 
@@ -31,7 +31,7 @@ In order to interact with the Azure Key Vault service, you'll need to create an 
 Client secret credential authentication is being used in this getting started section but you can find more ways to authenticate with [Azure identity][azure_identity]. To use the [DefaultAzureCredential][DefaultAzureCredential] provider shown below,
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Identity
 ```
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md
@@ -15,7 +15,7 @@ The Azure Key Vault keys library client supports RSA keys and Elliptic Curve (EC
 ### Install the package
 Install the Azure Key Vault keys client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Security.KeyVault.Keys
 ```
 
@@ -32,7 +32,7 @@ In order to interact with the Key Vault service, you'll need to create an instan
 Client secret credential authentication is being used in this getting started section but you can find more ways to authenticate with [Azure identity][azure_identity]. To use the [DefaultAzureCredential][DefaultAzureCredential] provider shown below,
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Identity
 ```
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/README.md
@@ -10,7 +10,7 @@ The Azure Key Vault secrets client library allows you to securely store and cont
 ### Install the package
 Install the Azure Key Vault secrets client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Security.KeyVault.Secrets
 ```
 
@@ -31,7 +31,7 @@ In order to interact with the Azure Key Vault service, you'll need to create an 
 Client secret credential authentication is being used in this getting started section but you can find more ways to authenticate with [Azure identity][azure_identity]. To use the [DefaultAzureCredential][DefaultAzureCredential] provider shown below,
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Identity
 ```
 

--- a/sdk/keyvault/samples/getcert/README.md
+++ b/sdk/keyvault/samples/getcert/README.md
@@ -59,7 +59,7 @@ To build the sample:
 
 2. Run in the project directory:
 
-   ```bash
+   ```dotnetcli
    dotnet build
    ```
 
@@ -67,7 +67,7 @@ To build the sample:
 
 You can either run the executable you just build, or build and run the project at the same time:
 
-```bash
+```dotnetcli
 dotnet run -- --vault-name <KeyVaultName> -n <CertificateName> -m "Message you want to encrypt and decrypt"
 ```
 

--- a/sdk/keyvault/samples/sharelink/README.md
+++ b/sdk/keyvault/samples/sharelink/README.md
@@ -73,13 +73,13 @@ For more detail about this process, read [Manage storage account keys with Key V
 
 This sample not only demonstrates how to generate SAS definitions and tokens using Key Vault, but defines a REST client using our source generator we use for many other Azure SDKs. To build the project either as a standalone sample or within the [Azure/azure-sdk-for-net](https://github.com/Azure/azure-sdk-for-net) repository using [.NET Core 3.1](https://dot.net) or newer, simply run:
 
-```bash
+```dotnetcli
 dotnet build
 ```
 
 We have no plans to ship a package for Key Vault-managed storage accounts since RBAC is recommended, but if you need support for managed storage accounts you can copy the REST client source into your own projects by running:
 
-```bash
+```dotnetcli
 dotnet build /t:CopySource /p:Destination=<ProjectDirectory>
 ```
 
@@ -87,7 +87,7 @@ The sample project file and _Program.cs_ are not copied automatically. Only the 
 
 You also need to add a reference to Azure.Core in your project. In your project directory where you just copied source run:
 
-```bash
+```dotnetcli
 dotnet add package Azure.Core
 ```
 
@@ -103,7 +103,7 @@ For more options, run `sharelink --help`.
 
 You can also run the application from source using `dotnet run --`, passing any arguments after `--` to the program directly:
 
-```bash
+```dotnetcli
 dotnet run -- --vault-name <KeyVaultName> --storage-account-name <StorageAccountName> --days 2
 ```
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
@@ -15,7 +15,7 @@ Azure Cognitive Services Metrics Advisor is a cloud service that uses machine le
 
 Install the Azure Metrics Advisor client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.AI.MetricsAdvisor
 ```
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -17,11 +17,11 @@ Latest Version: [![Nuget](https://img.shields.io/nuget/vpre/Azure.Monitor.OpenTe
 
 Install the Azure Monitor Exporter for OpenTelemetry .NET with NuGet:
 - via Package Manager: 
-   ```
+   ```powershell
    Install-Package Azure.Monitor.OpenTelemetry.Exporter
    ```
 - via .NET CLI: 
-   ```
+   ```dotnetcli
    dotnet add package Azure.Monitor.OpenTelemetry.Exporter
    ```
 

--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -24,7 +24,7 @@ The Azure Monitor Query client library is used to execute read-only queries agai
 
 Install the Azure Monitor Query client library for .NET with [NuGet][package]:
 
-```
+```dotnetcli
 dotnet add package Azure.Monitor.Query
 ```
 

--- a/sdk/personalizer/Azure.AI.Personalizer/README.md
+++ b/sdk/personalizer/Azure.AI.Personalizer/README.md
@@ -18,7 +18,7 @@ is a cloud-based service that helps your applications choose the best content it
 
 Install the Azure Personalizer client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.AI.Personalizer --version 1.1.0-beta.1
 ```
 

--- a/sdk/personalizer/README.md
+++ b/sdk/personalizer/README.md
@@ -9,7 +9,7 @@ is a cloud-based service that helps your applications choose the best content it
 
 Install the Azure Personalizer client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.AI.Personalizer --version 2.0.0-beta.1
 ```
 

--- a/sdk/purview/Azure.Analytics.Purview.Account/README.md
+++ b/sdk/purview/Azure.Analytics.Purview.Account/README.md
@@ -12,7 +12,7 @@ Azure Purview Account is a fully managed cloud service.
 
 Install the Azure Purview Account client library for .NET with [NuGet][client_nuget_package]:
 
-```
+```dotnetcli
 dotnet add package Azure.Analysis.Purview.Account
 ```
 

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/README.md
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/README.md
@@ -16,7 +16,7 @@ Azure Purview Catalog is a fully managed cloud service whose users can discover 
 
 Install the Azure Purview Catalog client library for .NET with [NuGet][client_nuget_package]:
 
-```
+```dotnetcli
 dotnet add package Azure.Analytics.Purview.Catalog --prerelease
 ```
 

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/README.md
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/README.md
@@ -16,7 +16,7 @@ Azure Purview Scanning is a fully managed cloud service whose users can scan you
 
 Install the Azure Purview Scanning client library for .NET with [NuGet][client_nuget_package]:
 
-```
+```dotnetcli
 dotnet add package Azure.Analytics.Purview.Scanning --prerelease
 ```
 

--- a/sdk/quantum/Azure.Quantum.Jobs/README.md
+++ b/sdk/quantum/Azure.Quantum.Jobs/README.md
@@ -14,7 +14,7 @@ This section should include everything a developer needs to do to install and cr
 
 Install the Azure Quantum Jobs client library for .NET with [NuGet](https://www.nuget.org/):
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Quantum.Jobs --prerelease -v 1.0.0-beta.1
 ```
 

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/README.md
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/README.md
@@ -8,7 +8,7 @@ Azure Schema Registry is a schema repository service hosted by Azure Event Hubs,
 
 Install the Azure Schema Registry client library for .NET with [NuGet][nuget]:
 
-```bash
+```dotnetcli
 dotnet add package --prerelease Azure.Data.SchemaRegistry
 ```
 

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
@@ -8,7 +8,7 @@ Azure Schema Registry is a schema repository service hosted by Azure Event Hubs,
 
 Install the Azure Schema Registry Apache Avro library for .NET with [NuGet][nuget]:
 
-```bash
+```dotnetcli
 dotnet add package Microsoft.Azure.Data.SchemaRegistry.ApacheAvro --version 1.0.0-beta.1
 ```
 

--- a/sdk/search/Azure.Search.Documents/README.md
+++ b/sdk/search/Azure.Search.Documents/README.md
@@ -42,7 +42,7 @@ Use the Azure.Search.Documents client library to:
 
 Install the Azure Cognitive Search client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Search.Documents --version 11.2.0-beta.1
 ```
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -38,7 +38,7 @@ To quickly create the needed Service Bus resources in Azure and to receive a con
 
 Install the Azure Service Bus client library for .NET with [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Messaging.ServiceBus
 ```
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/DeadLetterQueue/README.md
@@ -50,7 +50,7 @@ To build the sample:
 
 2. Run in the project directory:
 
-   ```bash
+   ```dotnetcli
    dotnet build
    ```
 
@@ -63,13 +63,13 @@ You can use any of the [authentication mechanisms](https://docs.microsoft.com/do
 
 To run the sample using Azure Identity:
 
-```bash
+```dotnetcli
 dotnet run -- --namespace <fully qualified namespace> --queue <queue name>
 ```
 ### Use a Service Bus connection string
 The other way to run the sample is by specifying an environment variable that contains the connection string for the namespace you wish to use:
 
-```bash
+```dotnetcli
 dotnet run -- --connection-variable <environment variable name> --queue <queue name>
 ```
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/TopicFilters/README.md
@@ -42,7 +42,7 @@ To build the sample:
 
 2. Run in the project directory:
 
-   ```bash
+   ```dotnetcli
    dotnet build
    ```
 
@@ -56,13 +56,13 @@ You can use any of the [authentication mechanisms](https://docs.microsoft.com/do
 
 To run the sample using Azure Identity:
 
-```bash
+```dotnetcli
 dotnet run -- --namespace <fully qualified namespace>
 ```
 ### Use a Service Bus connection string
 The other way to run the sample is by specifying an environment variable that contains the connection string for the namespace you wish to use:
 
-```bash
+```dotnetcli
 dotnet run -- --connection-variable <environment variable name>
 ```
 

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/README.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/README.md
@@ -8,7 +8,7 @@ This extension provides functionality for accessing Azure Service Bus from an Az
 
 Install the Service Bus extension with [NuGet](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.ServiceBus/):
 
-```Powershell
+```dotnetcli
 dotnet add package Microsoft.Azure.WebJobs.Extensions.ServiceBus --version 5.0.0-beta.1
 ```
 

--- a/sdk/storage/Azure.Storage.Blobs.Batch/README.md
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/README.md
@@ -14,7 +14,7 @@ library allows you to batch multiple Azure Blob Storage operations in a single r
 
 Install the Azure Storage Blobs Batch client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Storage.Blobs.Batch
 ```
 

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/README.md
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/README.md
@@ -16,7 +16,7 @@ process change events that occur in your Blob Storage account at a low cost.
 
 Install the Azure Storage Blobs client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Storage.Blobs.ChangeFeed
 ```
 

--- a/sdk/storage/Azure.Storage.Blobs/README.md
+++ b/sdk/storage/Azure.Storage.Blobs/README.md
@@ -15,7 +15,7 @@ definition, such as text or binary data.
 
 Install the Azure Storage Blobs client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Storage.Blobs
 ```
 

--- a/sdk/storage/Azure.Storage.Common/README.md
+++ b/sdk/storage/Azure.Storage.Common/README.md
@@ -19,7 +19,7 @@ Azure Storage client libraries.
 Install the Azure Storage client library for .NET you'd like to use with
 [NuGet][nuget] and the `Azure.Storage.Common` client library will be included:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Storage.Blobs
 dotnet add package Azure.Storage.Queues
 dotnet add package Azure.Storage.Files.Shares

--- a/sdk/storage/Azure.Storage.Files.DataLake/README.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/README.md
@@ -15,7 +15,7 @@ while making it faster to get up and running with batch, streaming, and interact
 
 Install the Azure Storage Files Data Lake client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Storage.Files.DataLake --version 12.0.0-preview.9
 ```
 

--- a/sdk/storage/Azure.Storage.Files.Shares/README.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/README.md
@@ -17,7 +17,7 @@ being used.
 
 Install the Azure Storage File Shares client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Storage.Files.Shares
 ```
 

--- a/sdk/storage/Azure.Storage.Queues/README.md
+++ b/sdk/storage/Azure.Storage.Queues/README.md
@@ -16,7 +16,7 @@ a storage account.
 
 Install the Azure Storage Queues client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.Storage.Queues
 ```
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -8,7 +8,7 @@ This extension provides functionality for accessing Azure Storage Blobs in Azure
 
 Install the Storage Blobs extension with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.WebJobs.Extensions.Storage.Blobs
 ```
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/README.md
@@ -8,7 +8,7 @@ This package provides infrastruture shared by the other Azure WebJobs Storage li
 
 Install the common library with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.WebJobs.Extensions.Storage.Common
 ```
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/README.md
@@ -8,7 +8,7 @@ This extension provides functionality for accessing Azure Storage Queues in Azur
 
 Install the Storage Queues extension with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.WebJobs.Extensions.Storage.Queues
 ```
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/README.md
@@ -8,7 +8,7 @@ This extension provides functionality for accessing Azure Storage Blobs and Queu
 
 Install the Storage Blobs and Queues extension with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Azure.WebJobs.Extensions.Storage
 ```
 

--- a/sdk/synapse/Azure.Analytics.Synapse.AccessControl/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.AccessControl/README.md
@@ -15,7 +15,7 @@ For the best development experience, developers should use the official Microsof
 ### Install the package
 Install the Azure Synapse Analytics access control client library for .NET with [NuGet](https://www.nuget.org/packages/Azure.Analytics.Synapse.AccessControl/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Analytics.Synapse.AccessControl --version 0.1.0-preview.1
 ```
 

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/README.md
@@ -15,7 +15,7 @@ For the best development experience, developers should use the official Microsof
 ### Install the package
 Install the Azure Synapse Analytics development client library for .NET with [NuGet](https://www.nuget.org/packages/Azure.Analytics.Synapse.Artifacts/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Analytics.Synapse.Artifacts --version 0.1.0-preview.2
 ```
 

--- a/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/README.md
@@ -17,7 +17,7 @@ For the best development experience, developers should use the official Microsof
 ### Install the package
 Install the Azure Synapse Analytics managed private endpoints client library for .NET with [NuGet](https://www.nuget.org/packages/Azure.Analytics.Synapse.ManagedPrivateEndpoints/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Analytics.Synapse.ManagedPrivateEndpoints --version 1.0.0-preview.1
 ```
 

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/README.md
@@ -15,7 +15,7 @@ For the best development experience, developers should use the official Microsof
 ### Install the package
 Install the Azure Synapse Analytics monitoring client library for .NET with [NuGet](https://www.nuget.org/packages/Azure.Analytics.Synapse.Monitoring/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Analytics.Synapse.Monitoring --version 1.0.0-preview.1
 ```
 

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/README.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/README.md
@@ -17,7 +17,7 @@ For the best development experience, developers should use the official Microsof
 ### Install the package
 Install the Spark client library for Azure Synapse Analytics for .NET with [NuGet](https://www.nuget.org/packages/Azure.Analytics.Synapse.Spark/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Analytics.Synapse.Spark --version 0.1.0-preview.1
 ```
 

--- a/sdk/synapse/Microsoft.Azure.Synapse/README.md
+++ b/sdk/synapse/Microsoft.Azure.Synapse/README.md
@@ -19,7 +19,7 @@ For the best development experience, developers should use the official Microsof
 
 Install the Azure Synapse client library for .NET with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Microsoft.Azure.Synapse
 ```
 

--- a/sdk/tables/Azure.Data.Tables/README.md
+++ b/sdk/tables/Azure.Data.Tables/README.md
@@ -20,7 +20,7 @@ The Azure Tables client library can seamlessly target either Azure Table storage
 ### Install the package
 Install the Azure Tables client library for .NET with [NuGet][table_client_nuget_package]:
 
-```
+```dotnetcli
 dotnet add package Azure.Data.Tables --prerelease
 ```
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -17,7 +17,7 @@ Azure Cognitive Services Text Analytics is a cloud service that provides advance
 ### Install the package
 Install the Azure Text Analytics client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.AI.TextAnalytics
 ```
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/perf/Azure.AI.TextAnalytics.Perf/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/perf/Azure.AI.TextAnalytics.Perf/README.md
@@ -6,7 +6,7 @@ The assets in this area comprise a set of performance tests for the [Azure Text 
 
 Run the Text Analytics client library performance tests by executing the command-line application using the `dotnet run` command or, in some environments, your operating system's executable support. The performance tests rely on the same set of environment variables used by the Text Analytics client library's test suite.
 An example test run would be like this:
-```console
+```dotnetcli
 dotnet run --framework netcoreapp3.1 DetectLanguagePerf
 ```
 

--- a/sdk/translation/Azure.AI.Translation.Document/README.md
+++ b/sdk/translation/Azure.AI.Translation.Document/README.md
@@ -13,7 +13,7 @@ Azure Cognitive Services Document Translation is a cloud service that translates
 ### Install the package
 Install the Azure Document Translation client library for .NET with [NuGet][nuget]:
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.AI.Translation.Document --prerelease
 ```
 

--- a/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/README.md
+++ b/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/README.md
@@ -26,13 +26,13 @@ ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(connectio
 
 Install the Video Analyzer Edge client library for .NET with [NuGet](https://www.nuget.org/):
 
-```bash
+```dotnetcli
 dotnet add package Azure.Media.VideoAnalyzer.Edge --prerelease
 ```
 
 Install the Azure IoT Hub SDk for .NET with [NuGet](https://www.nuget.org/):
 
-```bash
+```dotnetcli
 dotnet add package Microsoft.Azure.Devices
 ```
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/README.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/README.md
@@ -24,7 +24,7 @@ This library can be used to do the following actions. Details about the terms us
 
 Install the client library from [NuGet](https://www.nuget.org/):
 
-```PowerShell
+```dotnetcli
 dotnet add package Azure.Messaging.WebPubSub --prerelease
 ```
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/README.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/README.md
@@ -14,7 +14,7 @@ This extension provides functionality for receiving Web PubSub webhook calls in 
 
 Install the Web PubSub extension with [NuGet][nuget]:
 
-```Powershell
+```dotnetcli
 dotnet add package Microsoft.Azure.WebJobs.Extensions.WebPubSub --prerelease
 ```
 


### PR DESCRIPTION
In the SDK _README_ files, switch to using the `dotnetcli` dev lang instead of things like `bash`, `console`, and `powershell`. The result is improved display on docs.microsoft.com. For example:

![image](https://user-images.githubusercontent.com/10702007/133346381-f271e15f-ef29-411f-948b-b77725b79c1b.png)

In the preceding screenshot, notice the ".NET CLI" header text and command colorization that is applied.
