### PR TITLE
More consistency changes in A.M.Q

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -308,6 +308,7 @@ namespace Azure.Core
             public static string IfModifiedSince { get { throw null; } }
             public static string IfNoneMatch { get { throw null; } }
             public static string IfUnmodifiedSince { get { throw null; } }
+            public static string Prefer { get { throw null; } }
             public static string Range { get { throw null; } }
             public static string Referer { get { throw null; } }
             public static string UserAgent { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -308,6 +308,7 @@ namespace Azure.Core
             public static string IfModifiedSince { get { throw null; } }
             public static string IfNoneMatch { get { throw null; } }
             public static string IfUnmodifiedSince { get { throw null; } }
+            public static string Prefer { get { throw null; } }
             public static string Range { get { throw null; } }
             public static string Referer { get { throw null; } }
             public static string UserAgent { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -308,6 +308,7 @@ namespace Azure.Core
             public static string IfModifiedSince { get { throw null; } }
             public static string IfNoneMatch { get { throw null; } }
             public static string IfUnmodifiedSince { get { throw null; } }
+            public static string Prefer { get { throw null; } }
             public static string Range { get { throw null; } }
             public static string Referer { get { throw null; } }
             public static string UserAgent { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -308,6 +308,7 @@ namespace Azure.Core
             public static string IfModifiedSince { get { throw null; } }
             public static string IfNoneMatch { get { throw null; } }
             public static string IfUnmodifiedSince { get { throw null; } }
+            public static string Prefer { get { throw null; } }
             public static string Range { get { throw null; } }
             public static string Referer { get { throw null; } }
             public static string UserAgent { get { throw null; } }

--- a/sdk/core/Azure.Core/src/HttpHeader.cs
+++ b/sdk/core/Azure.Core/src/HttpHeader.cs
@@ -132,6 +132,10 @@ namespace Azure.Core
             /// </summary>
             public static string IfUnmodifiedSince => "If-Unmodified-Since";
             /// <summary>
+            /// Returns. <code>"Prefer"</code>
+            /// </summary>
+            public static string Prefer => "Prefer";
+            /// <summary>
             /// Returns. <code>"Referer"</code>
             /// </summary>
             public static string Referer => "Referer";

--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -97,7 +97,7 @@ var client = new LogsQueryClient(new DefaultAzureCredential());
 Response<LogsQueryResult> response = await client.QueryAsync(
     workspaceId,
     "AzureActivity | top 10 by TimeGenerated",
-    new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+    new QueryTimeRange(TimeSpan.FromDays(1)));
 
 LogsTable table = response.Value.Table;
 
@@ -127,7 +127,7 @@ string workspaceId = "<workspace_id>";
 Response<IReadOnlyList<MyLogEntryModel>> response = await client.QueryAsync<MyLogEntryModel>(
     workspaceId,
     "AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count",
-    new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+    new QueryTimeRange(TimeSpan.FromDays(1)));
 
 foreach (var logEntryModel in response.Value)
 {
@@ -148,7 +148,7 @@ var client = new LogsQueryClient(new DefaultAzureCredential());
 Response<IReadOnlyList<string>> response = await client.QueryAsync<string>(
     workspaceId,
     "AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count | project ResourceGroup",
-    new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+    new QueryTimeRange(TimeSpan.FromDays(1)));
 
 foreach (var resourceGroup in response.Value)
 {
@@ -167,7 +167,7 @@ var client = new LogsQueryClient(new DefaultAzureCredential());
 Response<LogsQueryResult> response = await client.QueryAsync(
     workspaceId,
     "AzureActivity | top 10 by TimeGenerated",
-    new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+    new QueryTimeRange(TimeSpan.FromDays(1)));
 
 LogsTable table = response.Value.Table;
 
@@ -206,11 +206,11 @@ var batch = new LogsBatchQuery();
 string countQueryId = batch.AddQuery(
     workspaceId,
     "AzureActivity | count",
-    new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+    new QueryTimeRange(TimeSpan.FromDays(1)));
 string topQueryId = batch.AddQuery(
     workspaceId,
     "AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count",
-    new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+    new QueryTimeRange(TimeSpan.FromDays(1)));
 
 Response<LogsBatchQueryResultCollection> response = await client.QueryBatchAsync(batch);
 
@@ -239,7 +239,7 @@ var client = new LogsQueryClient(new DefaultAzureCredential());
 Response<IReadOnlyList<int>> response = await client.QueryAsync<int>(
     workspaceId,
     "AzureActivity | summarize count()",
-    new MonitorQueryTimeRange(TimeSpan.FromDays(1)),
+    new QueryTimeRange(TimeSpan.FromDays(1)),
     options: new LogsQueryOptions
     {
         ServerTimeout = TimeSpan.FromMinutes(10)
@@ -265,7 +265,7 @@ var client = new LogsQueryClient(new DefaultAzureCredential());
 Response<IReadOnlyList<int>> response = await client.QueryAsync<int>(
     workspaceId,
     "AzureActivity | summarize count()",
-    new MonitorQueryTimeRange(TimeSpan.FromDays(1)),
+    new QueryTimeRange(TimeSpan.FromDays(1)),
     options: new LogsQueryOptions
     {
         AdditionalWorkspaces = { additionalWorkspaceId }
@@ -329,7 +329,7 @@ var client = new LogsQueryClient(new DefaultAzureCredential());
 try
 {
     await client.QueryAsync(
-        workspaceId, "My Not So Valid Query", new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        workspaceId, "My Not So Valid Query", new QueryTimeRange(TimeSpan.FromDays(1)));
 }
 catch (Exception e)
 {

--- a/sdk/monitor/Azure.Monitor.Query/api/Azure.Monitor.Query.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.Query/api/Azure.Monitor.Query.netstandard2.0.cs
@@ -3,7 +3,7 @@ namespace Azure.Monitor.Query
     public partial class LogsBatchQuery
     {
         public LogsBatchQuery() { }
-        public virtual string AddQuery(string workspaceId, string query, Azure.Monitor.Query.MonitorQueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null) { throw null; }
+        public virtual string AddQuery(string workspaceId, string query, Azure.Monitor.Query.QueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null) { throw null; }
     }
     public partial class LogsQueryClient
     {
@@ -14,12 +14,12 @@ namespace Azure.Monitor.Query
         public LogsQueryClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.Monitor.Query.LogsQueryClientOptions options) { }
         public System.Uri Endpoint { get { throw null; } }
         public static string CreateQuery(System.FormattableString query) { throw null; }
-        public virtual Azure.Response<Azure.Monitor.Query.Models.LogsQueryResult> Query(string workspaceId, string query, Azure.Monitor.Query.MonitorQueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Monitor.Query.Models.LogsQueryResult>> QueryAsync(string workspaceId, string query, Azure.Monitor.Query.MonitorQueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IReadOnlyList<T>>> QueryAsync<T>(string workspaceId, string query, Azure.Monitor.Query.MonitorQueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.Monitor.Query.Models.LogsQueryResult> Query(string workspaceId, string query, Azure.Monitor.Query.QueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Monitor.Query.Models.LogsQueryResult>> QueryAsync(string workspaceId, string query, Azure.Monitor.Query.QueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IReadOnlyList<T>>> QueryAsync<T>(string workspaceId, string query, Azure.Monitor.Query.QueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Monitor.Query.Models.LogsBatchQueryResultCollection> QueryBatch(Azure.Monitor.Query.LogsBatchQuery batch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Monitor.Query.Models.LogsBatchQueryResultCollection>> QueryBatchAsync(Azure.Monitor.Query.LogsBatchQuery batch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<T>> Query<T>(string workspaceId, string query, Azure.Monitor.Query.MonitorQueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<T>> Query<T>(string workspaceId, string query, Azure.Monitor.Query.QueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class LogsQueryClientOptions : Azure.Core.ClientOptions
     {
@@ -34,10 +34,10 @@ namespace Azure.Monitor.Query
     {
         public LogsQueryOptions() { }
         public System.Collections.Generic.IList<string> AdditionalWorkspaces { get { throw null; } }
+        public bool AllowPartialErrors { get { throw null; } set { } }
         public bool IncludeStatistics { get { throw null; } set { } }
         public bool IncludeVisualization { get { throw null; } set { } }
         public System.TimeSpan? ServerTimeout { get { throw null; } set { } }
-        public bool ThrowOnPartialErrors { get { throw null; } set { } }
     }
     public partial class MetricsQueryClient
     {
@@ -69,25 +69,25 @@ namespace Azure.Monitor.Query
         public string MetricNamespace { get { throw null; } set { } }
         public string OrderBy { get { throw null; } set { } }
         public int? Size { get { throw null; } set { } }
-        public Azure.Monitor.Query.MonitorQueryTimeRange? TimeRange { get { throw null; } set { } }
+        public Azure.Monitor.Query.QueryTimeRange? TimeRange { get { throw null; } set { } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public readonly partial struct MonitorQueryTimeRange : System.IEquatable<Azure.Monitor.Query.MonitorQueryTimeRange>
+    public readonly partial struct QueryTimeRange : System.IEquatable<Azure.Monitor.Query.QueryTimeRange>
     {
-        public MonitorQueryTimeRange(System.DateTimeOffset start, System.DateTimeOffset end) { throw null; }
-        public MonitorQueryTimeRange(System.DateTimeOffset start, System.TimeSpan duration) { throw null; }
-        public MonitorQueryTimeRange(System.TimeSpan duration) { throw null; }
-        public MonitorQueryTimeRange(System.TimeSpan duration, System.DateTimeOffset end) { throw null; }
-        public static Azure.Monitor.Query.MonitorQueryTimeRange All { get { throw null; } }
+        public QueryTimeRange(System.DateTimeOffset start, System.DateTimeOffset end) { throw null; }
+        public QueryTimeRange(System.DateTimeOffset start, System.TimeSpan duration) { throw null; }
+        public QueryTimeRange(System.TimeSpan duration) { throw null; }
+        public QueryTimeRange(System.TimeSpan duration, System.DateTimeOffset end) { throw null; }
+        public static Azure.Monitor.Query.QueryTimeRange All { get { throw null; } }
         public System.TimeSpan Duration { get { throw null; } }
         public System.DateTimeOffset? End { get { throw null; } }
         public System.DateTimeOffset? Start { get { throw null; } }
-        public bool Equals(Azure.Monitor.Query.MonitorQueryTimeRange other) { throw null; }
+        public bool Equals(Azure.Monitor.Query.QueryTimeRange other) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Monitor.Query.MonitorQueryTimeRange left, Azure.Monitor.Query.MonitorQueryTimeRange right) { throw null; }
-        public static implicit operator Azure.Monitor.Query.MonitorQueryTimeRange (System.TimeSpan timeSpan) { throw null; }
-        public static bool operator !=(Azure.Monitor.Query.MonitorQueryTimeRange left, Azure.Monitor.Query.MonitorQueryTimeRange right) { throw null; }
+        public static bool operator ==(Azure.Monitor.Query.QueryTimeRange left, Azure.Monitor.Query.QueryTimeRange right) { throw null; }
+        public static implicit operator Azure.Monitor.Query.QueryTimeRange (System.TimeSpan timeSpan) { throw null; }
+        public static bool operator !=(Azure.Monitor.Query.QueryTimeRange left, Azure.Monitor.Query.QueryTimeRange right) { throw null; }
         public override string ToString() { throw null; }
     }
 }
@@ -97,19 +97,12 @@ namespace Azure.Monitor.Query.Models
     {
         internal LogsBatchQueryResult() { }
         public string Id { get { throw null; } }
-        public Azure.Monitor.Query.Models.LogsBatchQueryResultStatus Status { get { throw null; } }
     }
     public partial class LogsBatchQueryResultCollection : System.Collections.ObjectModel.ReadOnlyCollection<Azure.Monitor.Query.Models.LogsBatchQueryResult>
     {
         internal LogsBatchQueryResultCollection() : base (default(System.Collections.Generic.IList<Azure.Monitor.Query.Models.LogsBatchQueryResult>)) { }
         public Azure.Monitor.Query.Models.LogsBatchQueryResult GetResult(string queryId) { throw null; }
         public System.Collections.Generic.IReadOnlyList<T> GetResult<T>(string queryId) { throw null; }
-    }
-    public enum LogsBatchQueryResultStatus
-    {
-        Success = 0,
-        PartialFailure = 1,
-        Failure = 2,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct LogsColumnType : System.IEquatable<Azure.Monitor.Query.Models.LogsColumnType>
@@ -142,9 +135,16 @@ namespace Azure.Monitor.Query.Models
         internal LogsQueryResult() { }
         public System.Collections.Generic.IReadOnlyList<Azure.Monitor.Query.Models.LogsTable> AllTables { get { throw null; } }
         public Azure.ResponseError Error { get { throw null; } }
+        public Azure.Monitor.Query.Models.LogsQueryResultStatus Status { get { throw null; } }
         public Azure.Monitor.Query.Models.LogsTable Table { get { throw null; } }
         public System.BinaryData GetStatistics() { throw null; }
         public System.BinaryData GetVisualization() { throw null; }
+    }
+    public enum LogsQueryResultStatus
+    {
+        Success = 0,
+        PartialFailure = 1,
+        Failure = 2,
     }
     public partial class LogsTable
     {
@@ -203,8 +203,8 @@ namespace Azure.Monitor.Query.Models
     public partial class MetricAvailability
     {
         internal MetricAvailability() { }
+        public System.TimeSpan? Granularity { get { throw null; } }
         public System.TimeSpan? Retention { get { throw null; } }
-        public System.TimeSpan? TimeGrain { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct MetricClass : System.IEquatable<Azure.Monitor.Query.Models.MetricClass>
@@ -291,7 +291,7 @@ namespace Azure.Monitor.Query.Models
         public System.Collections.Generic.IReadOnlyList<Azure.Monitor.Query.Models.MetricResult> Metrics { get { throw null; } }
         public string Namespace { get { throw null; } }
         public string ResourceRegion { get { throw null; } }
-        public Azure.Monitor.Query.MonitorQueryTimeRange TimeSpan { get { throw null; } }
+        public Azure.Monitor.Query.QueryTimeRange TimeSpan { get { throw null; } }
     }
     public partial class MetricTimeSeriesElement
     {
@@ -342,7 +342,7 @@ namespace Azure.Monitor.Query.Models
     public static partial class MonitorQueryModelFactory
     {
         public static Azure.Monitor.Query.Models.LogsTableColumn LogsTableColumn(string name = null, Azure.Monitor.Query.Models.LogsColumnType type = default(Azure.Monitor.Query.Models.LogsColumnType)) { throw null; }
-        public static Azure.Monitor.Query.Models.MetricAvailability MetricAvailability(System.TimeSpan? timeGrain = default(System.TimeSpan?), System.TimeSpan? retention = default(System.TimeSpan?)) { throw null; }
+        public static Azure.Monitor.Query.Models.MetricAvailability MetricAvailability(System.TimeSpan? granularity = default(System.TimeSpan?), System.TimeSpan? retention = default(System.TimeSpan?)) { throw null; }
         public static Azure.Monitor.Query.Models.MetricValue MetricValue(System.DateTimeOffset timeStamp = default(System.DateTimeOffset), double? average = default(double?), double? minimum = default(double?), double? maximum = default(double?), double? total = default(double?), double? count = default(double?)) { throw null; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.Query/api/Azure.Monitor.Query.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.Query/api/Azure.Monitor.Query.netstandard2.0.cs
@@ -21,10 +21,27 @@ namespace Azure.Monitor.Query
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Monitor.Query.Models.LogsBatchQueryResultCollection>> QueryBatchAsync(Azure.Monitor.Query.LogsBatchQuery batch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<System.Collections.Generic.IReadOnlyList<T>> Query<T>(string workspaceId, string query, Azure.Monitor.Query.QueryTimeRange timeRange, Azure.Monitor.Query.LogsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct LogsQueryClientAudience : System.IEquatable<Azure.Monitor.Query.LogsQueryClientAudience>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public LogsQueryClientAudience(string value) { throw null; }
+        public static Azure.Monitor.Query.LogsQueryClientAudience AzurePublicCloud { get { throw null; } }
+        public bool Equals(Azure.Monitor.Query.LogsQueryClientAudience other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Monitor.Query.LogsQueryClientAudience left, Azure.Monitor.Query.LogsQueryClientAudience right) { throw null; }
+        public static implicit operator Azure.Monitor.Query.LogsQueryClientAudience (string value) { throw null; }
+        public static bool operator !=(Azure.Monitor.Query.LogsQueryClientAudience left, Azure.Monitor.Query.LogsQueryClientAudience right) { throw null; }
+        public override string ToString() { throw null; }
+    }
     public partial class LogsQueryClientOptions : Azure.Core.ClientOptions
     {
         public LogsQueryClientOptions(Azure.Monitor.Query.LogsQueryClientOptions.ServiceVersion version = Azure.Monitor.Query.LogsQueryClientOptions.ServiceVersion.V1) { }
-        public string AuthenticationScope { get { throw null; } set { } }
+        public Azure.Monitor.Query.LogsQueryClientAudience? Audience { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V1 = 1,
@@ -45,6 +62,7 @@ namespace Azure.Monitor.Query
         public MetricsQueryClient(Azure.Core.TokenCredential credential) { }
         public MetricsQueryClient(Azure.Core.TokenCredential credential, Azure.Monitor.Query.MetricsQueryClientOptions options) { }
         public MetricsQueryClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.Monitor.Query.MetricsQueryClientOptions options = null) { }
+        public System.Uri Endpoint { get { throw null; } }
         public virtual Azure.Pageable<Azure.Monitor.Query.Models.MetricDefinition> GetMetricDefinitions(string resourceId, string metricsNamespace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.Monitor.Query.Models.MetricDefinition> GetMetricDefinitionsAsync(string resourceId, string metricsNamespace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.Monitor.Query.Models.MetricNamespace> GetMetricNamespaces(string resourceId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -52,9 +70,30 @@ namespace Azure.Monitor.Query
         public virtual Azure.Response<Azure.Monitor.Query.Models.MetricsQueryResult> Query(string resourceId, System.Collections.Generic.IEnumerable<string> metrics, Azure.Monitor.Query.MetricsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Monitor.Query.Models.MetricsQueryResult>> QueryAsync(string resourceId, System.Collections.Generic.IEnumerable<string> metrics, Azure.Monitor.Query.MetricsQueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct MetricsQueryClientAudience : System.IEquatable<Azure.Monitor.Query.MetricsQueryClientAudience>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public MetricsQueryClientAudience(string value) { throw null; }
+        public static Azure.Monitor.Query.MetricsQueryClientAudience AzureResourceManagerChina { get { throw null; } }
+        public static Azure.Monitor.Query.MetricsQueryClientAudience AzureResourceManagerGermany { get { throw null; } }
+        public static Azure.Monitor.Query.MetricsQueryClientAudience AzureResourceManagerGovernment { get { throw null; } }
+        public static Azure.Monitor.Query.MetricsQueryClientAudience AzureResourceManagerPublicCloud { get { throw null; } }
+        public bool Equals(Azure.Monitor.Query.MetricsQueryClientAudience other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Monitor.Query.MetricsQueryClientAudience left, Azure.Monitor.Query.MetricsQueryClientAudience right) { throw null; }
+        public static implicit operator Azure.Monitor.Query.MetricsQueryClientAudience (string value) { throw null; }
+        public static bool operator !=(Azure.Monitor.Query.MetricsQueryClientAudience left, Azure.Monitor.Query.MetricsQueryClientAudience right) { throw null; }
+        public override string ToString() { throw null; }
+    }
     public partial class MetricsQueryClientOptions : Azure.Core.ClientOptions
     {
         public MetricsQueryClientOptions(Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion version = Azure.Monitor.Query.MetricsQueryClientOptions.ServiceVersion.V2018_01_01) { }
+        public Azure.Monitor.Query.MetricsQueryClientAudience? Audience { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V2018_01_01 = 1,

--- a/sdk/monitor/Azure.Monitor.Query/src/Generated/Models/MetricAvailability.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Generated/Models/MetricAvailability.cs
@@ -18,16 +18,13 @@ namespace Azure.Monitor.Query.Models
         }
 
         /// <summary> Initializes a new instance of MetricAvailability. </summary>
-        /// <param name="timeGrain"> the time grain specifies the aggregation interval for the metric. Expressed as a duration &apos;PT1M&apos;, &apos;P1D&apos;, etc. </param>
+        /// <param name="granularity"> the time grain specifies the aggregation interval for the metric. Expressed as a duration &apos;PT1M&apos;, &apos;P1D&apos;, etc. </param>
         /// <param name="retention"> the retention period for the metric at the specified timegrain.  Expressed as a duration &apos;PT1M&apos;, &apos;P1D&apos;, etc. </param>
-        internal MetricAvailability(TimeSpan? timeGrain, TimeSpan? retention)
+        internal MetricAvailability(TimeSpan? granularity, TimeSpan? retention)
         {
-            TimeGrain = timeGrain;
+            Granularity = granularity;
             Retention = retention;
         }
-
-        /// <summary> the time grain specifies the aggregation interval for the metric. Expressed as a duration &apos;PT1M&apos;, &apos;P1D&apos;, etc. </summary>
-        public TimeSpan? TimeGrain { get; }
         /// <summary> the retention period for the metric at the specified timegrain.  Expressed as a duration &apos;PT1M&apos;, &apos;P1D&apos;, etc. </summary>
         public TimeSpan? Retention { get; }
     }

--- a/sdk/monitor/Azure.Monitor.Query/src/Generated/MonitorQueryModelFactory.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Generated/MonitorQueryModelFactory.cs
@@ -22,12 +22,12 @@ namespace Azure.Monitor.Query.Models
         }
 
         /// <summary> Initializes a new instance of MetricAvailability. </summary>
-        /// <param name="timeGrain"> the time grain specifies the aggregation interval for the metric. Expressed as a duration &apos;PT1M&apos;, &apos;P1D&apos;, etc. </param>
+        /// <param name="granularity"> the time grain specifies the aggregation interval for the metric. Expressed as a duration &apos;PT1M&apos;, &apos;P1D&apos;, etc. </param>
         /// <param name="retention"> the retention period for the metric at the specified timegrain.  Expressed as a duration &apos;PT1M&apos;, &apos;P1D&apos;, etc. </param>
         /// <returns> A new <see cref="Models.MetricAvailability"/> instance for mocking. </returns>
-        public static MetricAvailability MetricAvailability(TimeSpan? timeGrain = null, TimeSpan? retention = null)
+        public static MetricAvailability MetricAvailability(TimeSpan? granularity = null, TimeSpan? retention = null)
         {
-            return new MetricAvailability(timeGrain, retention);
+            return new MetricAvailability(granularity, retention);
         }
 
         /// <summary> Initializes a new instance of MetricValue. </summary>

--- a/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClient.cs
@@ -96,7 +96,7 @@ namespace Azure.Monitor.Query
         /// Response&lt;IReadOnlyList&lt;MyLogEntryModel&gt;&gt; response = await client.QueryAsync&lt;MyLogEntryModel&gt;(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// </code>
         ///
         /// Example of querying a primitive:
@@ -104,7 +104,7 @@ namespace Azure.Monitor.Query
         /// Response&lt;IReadOnlyList&lt;string&gt;&gt; response = await client.QueryAsync&lt;string&gt;(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count | project ResourceGroup&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// </code>
         /// </summary>
         /// <param name="workspaceId">The workspace id to include in the query (<c>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</c>).</param>
@@ -128,7 +128,7 @@ namespace Azure.Monitor.Query
         /// Response&lt;IReadOnlyList&lt;MyLogEntryModel&gt;&gt; response = await client.QueryAsync&lt;MyLogEntryModel&gt;(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// </code>
         ///
         /// Example of querying a primitive:
@@ -136,7 +136,7 @@ namespace Azure.Monitor.Query
         /// Response&lt;IReadOnlyList&lt;string&gt;&gt; response = await client.QueryAsync&lt;string&gt;(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count | project ResourceGroup&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// </code>
         /// </summary>
         /// <param name="workspaceId">The workspace id to include in the query (<c>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</c>).</param>
@@ -214,11 +214,11 @@ namespace Azure.Monitor.Query
         /// string countQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// string topQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         ///
         /// Response&lt;LogsBatchQueryResultCollection&gt; response = await client.QueryBatchAsync(batch);
         ///
@@ -267,11 +267,11 @@ namespace Azure.Monitor.Query
         /// string countQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// string topQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         ///
         /// Response&lt;LogsBatchQueryResultCollection&gt; response = await client.QueryBatchAsync(batch);
         ///
@@ -525,7 +525,7 @@ namespace Azure.Monitor.Query
                     value.Status = value.Error == null ? LogsQueryResultStatus.Success : LogsQueryResultStatus.PartialFailure;
 
                     var responseError = value.Error;
-                    if (responseError != null && options?.ThrowOnPartialErrors != false)
+                    if (responseError != null && options?.AllowPartialErrors != true)
                     {
                         throw value.CreateExceptionForErrorResponse(message.Response.Status);
                     }

--- a/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClient.cs
@@ -28,9 +28,11 @@ namespace Azure.Monitor.Query
 
         /// <summary>
         /// Initializes a new instance of <see cref="LogsQueryClient"/>. Uses the default 'https://api.loganalytics.io' endpoint.
-        /// <code snippet="Snippet:CreateLogsClient" language="csharp">
+        /// <example snippet="Snippet:CreateLogsClient">
+        /// <code language="csharp">
         /// var client = new LogsQueryClient(new DefaultAzureCredential());
         /// </code>
+        /// </example>
         /// </summary>
         /// <param name="credential">The <see cref="TokenCredential"/> instance to use for authentication.</param>
         public LogsQueryClient(TokenCredential credential) : this(credential, null)
@@ -84,7 +86,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Gets the endpoint used for by the client.
+        /// Gets the endpoint used by the client.
         /// </summary>
         public Uri Endpoint { get; }
 
@@ -92,20 +94,24 @@ namespace Azure.Monitor.Query
         /// Executes the logs query. Deserializes the result into a strongly typed model class or a primitive type if the query returns a single column.
         ///
         /// Example of querying a model:
-        /// <code snippet="Snippet:QueryLogsAsModelCall" language="csharp">
+        /// <example snippet="Snippet:QueryLogsAsModelCall">
+        /// <code language="csharp">
         /// Response&lt;IReadOnlyList&lt;MyLogEntryModel&gt;&gt; response = await client.QueryAsync&lt;MyLogEntryModel&gt;(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count&quot;,
         ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// </code>
+        /// </example>
         ///
         /// Example of querying a primitive:
-        /// <code snippet="Snippet:QueryLogsAsPrimitiveCall" language="csharp">
+        /// <example snippet="Snippet:QueryLogsAsPrimitiveCall">
+        /// <code language="csharp">
         /// Response&lt;IReadOnlyList&lt;string&gt;&gt; response = await client.QueryAsync&lt;string&gt;(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count | project ResourceGroup&quot;,
         ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// </code>
+        /// </example>
         /// </summary>
         /// <param name="workspaceId">The workspace id to include in the query (<c>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</c>).</param>
         /// <param name="query">The Kusto query to execute.</param>
@@ -124,20 +130,24 @@ namespace Azure.Monitor.Query
         /// Executes the logs query. Deserializes the result into a strongly typed model class or a primitive type if the query returns a single column.
         ///
         /// Example of querying a model:
-        /// <code snippet="Snippet:QueryLogsAsModelCall" language="csharp">
+        /// <example snippet="Snippet:QueryLogsAsModelCall">
+        /// <code language="csharp">
         /// Response&lt;IReadOnlyList&lt;MyLogEntryModel&gt;&gt; response = await client.QueryAsync&lt;MyLogEntryModel&gt;(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count&quot;,
         ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// </code>
+        /// </example>
         ///
         /// Example of querying a primitive:
-        /// <code snippet="Snippet:QueryLogsAsPrimitiveCall" language="csharp">
+        /// <example snippet="Snippet:QueryLogsAsPrimitiveCall">
+        /// <code language="csharp">
         /// Response&lt;IReadOnlyList&lt;string&gt;&gt; response = await client.QueryAsync&lt;string&gt;(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count | project ResourceGroup&quot;,
         ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// </code>
+        /// </example>
         /// </summary>
         /// <param name="workspaceId">The workspace id to include in the query (<c>xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</c>).</param>
         /// <param name="query">The Kusto query to execute.</param>
@@ -202,7 +212,8 @@ namespace Azure.Monitor.Query
 
         /// <summary>
         /// Submits the batch query. Use the <see cref="LogsBatchQuery"/> to compose a batch query.
-        /// <code snippet="Snippet:BatchQuery" language="csharp">
+        /// <example snippet="Snippet:BatchQuery">
+        /// <code language="csharp">
         /// string workspaceId = &quot;&lt;workspace_id&gt;&quot;;
         ///
         /// var client = new LogsQueryClient(new DefaultAzureCredential());
@@ -231,6 +242,7 @@ namespace Azure.Monitor.Query
         ///     Console.WriteLine($&quot;{logEntryModel.ResourceGroup} had {logEntryModel.Count} events&quot;);
         /// }
         /// </code>
+        /// </example>
         /// </summary>
         /// <param name="batch">The batch of queries to send.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
@@ -254,7 +266,8 @@ namespace Azure.Monitor.Query
 
         /// <summary>
         /// Submits the batch query. Use the <see cref="LogsBatchQuery"/> to compose a batch query.
-        /// <code snippet="Snippet:BatchQuery" language="csharp">
+        /// <example snippet="Snippet:BatchQuery">
+        /// <code language="csharp">
         /// string workspaceId = &quot;&lt;workspace_id&gt;&quot;;
         ///
         /// var client = new LogsQueryClient(new DefaultAzureCredential());
@@ -283,6 +296,7 @@ namespace Azure.Monitor.Query
         ///     Console.WriteLine($&quot;{logEntryModel.ResourceGroup} had {logEntryModel.Count} events&quot;);
         /// }
         /// </code>
+        /// </example>
         /// </summary>
         /// <param name="batch">The batch of Kusto queries to send.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
@@ -503,7 +517,7 @@ namespace Azure.Monitor.Query
             if (timeout != null)
             {
                 message.NetworkTimeout = timeout.Value.Add(_networkTimeoutOffset);
-                message.Request.Headers.SetValue("prefer", $"wait={(int) timeout.Value.TotalSeconds}");
+                message.Request.Headers.SetValue(HttpHeader.Names.Prefer, $"wait={(int) timeout.Value.TotalSeconds}");
             }
 
             if (async)

--- a/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClientAudience.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClientAudience.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+namespace Azure.Monitor.Query
+{
+    /// <summary>
+    /// Cloud audiences available for <see cref="LogsQueryClient"/>.
+    /// </summary>
+    public readonly partial struct LogsQueryClientAudience : IEquatable<LogsQueryClientAudience>
+    {
+        private readonly string _value;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="LogsQueryClientAudience"/> with a given value.
+        /// </summary>
+        public LogsQueryClientAudience(string value)
+        {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary> Azure Public Cloud. </summary>
+        public static LogsQueryClientAudience AzurePublicCloud { get; } = new("https://api.loganalytics.io");
+
+        /// <summary> Determines if two <see cref="LogsQueryClientAudience"/> values are the same. </summary>
+        public static bool operator ==(LogsQueryClientAudience left, LogsQueryClientAudience right) => left.Equals(right);
+        /// <summary> Determines if two <see cref="LogsQueryClientAudience"/> values are not the same. </summary>
+        public static bool operator !=(LogsQueryClientAudience left, LogsQueryClientAudience right) => !left.Equals(right);
+        /// <summary> Converts a string to a <see cref="LogsQueryClientAudience"/>. </summary>
+        public static implicit operator LogsQueryClientAudience(string value) => new(value);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => obj is LogsQueryClientAudience other && Equals(other);
+        /// <inheritdoc />
+        public bool Equals(LogsQueryClientAudience other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        /// <inheritdoc />
+        public override string ToString() => _value;
+    }
+}

--- a/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClientOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClientOptions.cs
@@ -29,7 +29,7 @@ namespace Azure.Monitor.Query
         {
             _version = version;
 
-            Diagnostics.LoggedHeaderNames.Add("prefer");
+            Diagnostics.LoggedHeaderNames.Add(HttpHeader.Names.Prefer);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Gets or sets the audience to use for authentication with Azure Active Directory. The default scope will be used if the property is null.
+        /// Gets or sets the audience to use for authentication with Azure Active Directory. The Azure Public Cloud audience will be used if the property is null.
         /// </summary>
         public LogsQueryClientAudience? Audience { get; set; }
 

--- a/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClientOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/LogsQueryClientOptions.cs
@@ -45,9 +45,9 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Gets or sets the authentication scope to use for authentication with Azure Active Directory. The default scope will be used if the property is null.
+        /// Gets or sets the audience to use for authentication with Azure Active Directory. The default scope will be used if the property is null.
         /// </summary>
-        public string AuthenticationScope { get; set; }
+        public LogsQueryClientAudience? Audience { get; set; }
 
         internal string GetVersionString()
         {

--- a/sdk/monitor/Azure.Monitor.Query/src/LogsQueryOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/LogsQueryOptions.cs
@@ -40,6 +40,6 @@ namespace Azure.Monitor.Query
         /// <summary>
         /// Gets or sets the value indicating whether to throw when a partial error is returned with the logs response.
         /// </summary>
-        public bool ThrowOnPartialErrors { get; set; } = true;
+        public bool AllowPartialErrors { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
@@ -77,7 +77,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Gets the endpoint used for by the client.
+        /// Gets the endpoint used by the client.
         /// </summary>
         public Uri Endpoint { get; }
 

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClient.cs
@@ -57,7 +57,13 @@ namespace Azure.Monitor.Query
 
             _clientDiagnostics = new ClientDiagnostics(options);
 
-            var pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, "https://management.azure.com//.default"));
+            Endpoint = endpoint;
+
+            var pipeline = HttpPipelineBuilder.Build(options,
+                new BearerTokenAuthenticationPolicy(
+                    credential,
+                    $"{options.Audience ?? MetricsQueryClientAudience.AzureResourceManagerPublicCloud}//.default"));
+
             _metricDefinitionsClient = new MetricDefinitionsRestClient(_clientDiagnostics, pipeline, endpoint);
             _metricsRestClient = new MetricsRestClient(_clientDiagnostics, pipeline, endpoint);
             _namespacesRestClient = new MetricNamespacesRestClient(_clientDiagnostics, pipeline, endpoint);
@@ -69,6 +75,11 @@ namespace Azure.Monitor.Query
         protected MetricsQueryClient()
         {
         }
+
+        /// <summary>
+        /// Gets the endpoint used for by the client.
+        /// </summary>
+        public Uri Endpoint { get; }
 
         /// <summary>
         /// Queries metrics for a resource.

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClientAudience.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClientAudience.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+namespace Azure.Monitor.Query
+{
+    /// <summary>
+    /// Cloud audiences available for <see cref="MetricsQueryClient"/>.
+    /// </summary>
+    public readonly partial struct MetricsQueryClientAudience : IEquatable<MetricsQueryClientAudience>
+    {
+        private readonly string _value;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MetricsQueryClientAudience"/> with a given value.
+        /// </summary>
+        public MetricsQueryClientAudience(string value)
+        {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        private const string AzureResourceManagerChinaValue = "https://management.chinacloudapi.cn";
+        private const string AzureResourceManagerGermanyValue = "https://management.microsoftazure.de";
+        private const string AzureResourceManagerGovernmentValue = "https://management.usgovcloudapi.net";
+        private const string AzureResourceManagerPublicCloudValue = "https://management.azure.com";
+
+        /// <summary> Azure China. </summary>
+        public static MetricsQueryClientAudience AzureResourceManagerChina { get; } = new(AzureResourceManagerChinaValue);
+        /// <summary> Azure Germany. </summary>
+        public static MetricsQueryClientAudience AzureResourceManagerGermany { get; } = new(AzureResourceManagerGermanyValue);
+        /// <summary> Azure Government. </summary>
+        public static MetricsQueryClientAudience AzureResourceManagerGovernment { get; } = new(AzureResourceManagerGovernmentValue);
+        /// <summary> Azure Public Cloud. </summary>
+        public static MetricsQueryClientAudience AzureResourceManagerPublicCloud { get; } = new(AzureResourceManagerPublicCloudValue);
+
+        /// <summary> Determines if two <see cref="MetricsQueryClientAudience"/> values are the same. </summary>
+        public static bool operator ==(MetricsQueryClientAudience left, MetricsQueryClientAudience right) => left.Equals(right);
+        /// <summary> Determines if two <see cref="MetricsQueryClientAudience"/> values are not the same. </summary>
+        public static bool operator !=(MetricsQueryClientAudience left, MetricsQueryClientAudience right) => !left.Equals(right);
+        /// <summary> Converts a string to a <see cref="MetricsQueryClientAudience"/>. </summary>
+        public static implicit operator MetricsQueryClientAudience(string value) => new(value);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => obj is MetricsQueryClientAudience other && Equals(other);
+        /// <inheritdoc />
+        public bool Equals(MetricsQueryClientAudience other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
+
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        /// <inheritdoc />
+        public override string ToString() => _value;
+    }
+}

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClientOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClientOptions.cs
@@ -30,6 +30,11 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
+        /// Gets or sets the audience to use for authentication with Azure Active Directory. The default scope will be used if the property is null.
+        /// </summary>
+        public MetricsQueryClientAudience? Audience { get; set; }
+
+        /// <summary>
         /// The versions of Azure Monitor Query service supported by this client
         /// library.
         /// </summary>

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClientOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryClientOptions.cs
@@ -30,7 +30,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Gets or sets the audience to use for authentication with Azure Active Directory. The default scope will be used if the property is null.
+        /// Gets or sets the audience to use for authentication with Azure Active Directory. The Azure Public Cloud audience will be used if the property is null.
         /// </summary>
         public MetricsQueryClientAudience? Audience { get; set; }
 

--- a/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryOptions.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/MetricsQueryOptions.cs
@@ -17,7 +17,7 @@ namespace Azure.Monitor.Query
         /// Gets or sets the timespan over which the metric will be queried.
         /// </summary>
         [CodeGenMember("TimeSpan")]
-        public MonitorQueryTimeRange? TimeRange { get; set; }
+        public QueryTimeRange? TimeRange { get; set; }
 
         /// <summary>
         /// Gets or sets the interval at which to sample metrics.

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQuery.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQuery.cs
@@ -25,7 +25,8 @@ namespace Azure.Monitor.Query
 
         /// <summary>
         /// Adds the specified query to the batch. Results can be retrieved after the query is submitted via the <see cref="LogsQueryClient.QueryBatchAsync"/> call.
-        /// <code snippet="Snippet:BatchQueryAddAndGet" language="csharp">
+        /// <example snippet="Snippet:BatchQueryAddAndGet">
+        /// <code language="csharp">
         /// string countQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | count&quot;,
@@ -40,6 +41,7 @@ namespace Azure.Monitor.Query
         /// var count = response.Value.GetResult&lt;int&gt;(countQueryId).Single();
         /// var topEntries = response.Value.GetResult&lt;MyLogEntryModel&gt;(topQueryId);
         /// </code>
+        /// </example>
         /// </summary>
         /// <param name="workspaceId">The workspace to include in the query.</param>
         /// <param name="query">The query text to execute.</param>
@@ -56,7 +58,7 @@ namespace Azure.Monitor.Query
             };
             if (prefer != null)
             {
-                logQueryRequest.Headers.Add("prefer", prefer);
+                logQueryRequest.Headers.Add(HttpHeader.Names.Prefer, prefer);
             }
             Requests.Add(logQueryRequest);
             return id;

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQuery.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQuery.cs
@@ -29,11 +29,11 @@ namespace Azure.Monitor.Query
         /// string countQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// string topQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         ///
         /// Response&lt;LogsBatchQueryResultCollection&gt; response = await client.QueryBatchAsync(batch);
         ///

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQuery.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQuery.cs
@@ -46,7 +46,7 @@ namespace Azure.Monitor.Query
         /// <param name="timeRange">The timespan over which to query data.</param>
         /// <param name="options">The <see cref="LogsQueryOptions"/> to configure the query.</param>
         /// <returns>The query identifier that has to be passed into <see cref="LogsBatchQueryResultCollection.GetResult"/> to get the result.</returns>
-        public virtual string AddQuery(string workspaceId, string query, MonitorQueryTimeRange timeRange, LogsQueryOptions options = null)
+        public virtual string AddQuery(string workspaceId, string query, QueryTimeRange timeRange, LogsQueryOptions options = null)
         {
             var id = _counter.ToString("G", CultureInfo.InvariantCulture);
             _counter++;

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQueryResult.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQueryResult.cs
@@ -13,11 +13,6 @@ namespace Azure.Monitor.Query.Models
         internal int StatusCode { get; set; }
 
         /// <summary>
-        /// Gets or sets the value indicating whether the batch query was successful.
-        /// </summary>
-        public LogsBatchQueryResultStatus Status { get; internal set; }
-
-        /// <summary>
         /// Gets or sets the query id.
         /// </summary>
         public string Id { get; internal set; }

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQueryResultCollection.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQueryResultCollection.cs
@@ -56,7 +56,7 @@ namespace Azure.Monitor.Query.Models
                                             $" Please use the return value of {nameof(LogsBatchQuery)}.{nameof(LogsBatchQuery.AddQuery)} as the '{nameof(queryId)}' argument.", nameof(queryId));
             }
 
-            if (result.Status == LogsBatchQueryResultStatus.Failure)
+            if (result.Status == LogsQueryResultStatus.Failure)
             {
                 var message = $"Batch query with id '{queryId}' failed.{Environment.NewLine}{result.Error}";
                 throw new RequestFailedException(result.StatusCode, message, result.Error.Code, null);

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQueryResultCollection.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsBatchQueryResultCollection.cs
@@ -30,11 +30,11 @@ namespace Azure.Monitor.Query.Models
         /// string countQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         /// string topQueryId = batch.AddQuery(
         ///     workspaceId,
         ///     &quot;AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count&quot;,
-        ///     new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+        ///     new QueryTimeRange(TimeSpan.FromDays(1)));
         ///
         /// Response&lt;LogsBatchQueryResultCollection&gt; response = await client.QueryBatchAsync(batch);
         ///
@@ -63,7 +63,7 @@ namespace Azure.Monitor.Query.Models
             }
 
             if (result.Error != null &&
-                request?.Options?.ThrowOnPartialErrors != false)
+                request?.Options?.AllowPartialErrors != true)
             {
                 throw result.CreateExceptionForErrorResponse(result.StatusCode);
             }

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResultStatus.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResultStatus.cs
@@ -6,7 +6,7 @@ namespace Azure.Monitor.Query.Models
     /// <summary>
     /// Represents a status of a batch query response.
     /// </summary>
-    public enum LogsBatchQueryResultStatus
+    public enum LogsQueryResultStatus
     {
         /// <summary>
         /// The query succeeded.

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResults.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResults.cs
@@ -68,7 +68,7 @@ namespace Azure.Monitor.Query.Models
             return new RequestFailedException(
                 status,
                 $"The result was returned but contained a partial error. Exceptions for partial errors can be disabled " +
-                $" using {nameof(LogsQueryOptions)}.{nameof(LogsQueryOptions.ThrowOnPartialErrors)}." +
+                $" using {nameof(LogsQueryOptions)}.{nameof(LogsQueryOptions.AllowPartialErrors)}." +
                 $"Partial errors can be inspected using the {nameof(LogsQueryResult)}.{nameof(Error)} property.{Environment.NewLine}" +
                 $"Error:{Environment.NewLine}{Error}",
                 Error.Code,

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResults.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/LogsQueryResults.cs
@@ -38,6 +38,11 @@ namespace Azure.Monitor.Query.Models
         }
 
         /// <summary>
+        /// Gets or sets the value indicating whether the query was successful.
+        /// </summary>
+        public LogsQueryResultStatus Status { get; internal set; }
+
+        /// <summary>
         /// Gets the multi-table result of the query.
         /// </summary>
         [CodeGenMember("Tables")]

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/MetricAvailability.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/MetricAvailability.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+
+namespace Azure.Monitor.Query.Models
+{
+    public partial class MetricAvailability
+    {
+        /// <summary> Specifies the aggregation interval for the metric. </summary>
+        [CodeGenMember("TimeGrain")]
+        public TimeSpan? Granularity { get; }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/MetricAvailability.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/MetricAvailability.cs
@@ -8,7 +8,7 @@ namespace Azure.Monitor.Query.Models
 {
     public partial class MetricAvailability
     {
-        /// <summary> Specifies the aggregation interval for the metric. </summary>
+        /// <summary> Specifies how often a metric value is stored. For example, every second, every 30 seconds, etc. </summary>
         [CodeGenMember("TimeGrain")]
         public TimeSpan? Granularity { get; }
     }

--- a/sdk/monitor/Azure.Monitor.Query/src/Models/MetricsQueryResult.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/Models/MetricsQueryResult.cs
@@ -20,7 +20,7 @@ namespace Azure.Monitor.Query.Models
         /// The timespan for which the data was retrieved.
         /// This may be adjusted in the future and returned back from what was originally requested.
         /// </summary>
-        public MonitorQueryTimeRange TimeSpan => MonitorQueryTimeRange.Parse(_timespan);
+        public QueryTimeRange TimeSpan => QueryTimeRange.Parse(_timespan);
 
         /// <summary> The region of the resource being queried for metrics. </summary>
         [CodeGenMember("Resourceregion")]

--- a/sdk/monitor/Azure.Monitor.Query/src/QueryTimeRange.cs
+++ b/sdk/monitor/Azure.Monitor.Query/src/QueryTimeRange.cs
@@ -11,12 +11,12 @@ namespace Azure.Monitor.Query
     /// <summary>
     /// Represents a span of time over which the query would be executed.
     /// </summary>
-    public readonly struct MonitorQueryTimeRange : IEquatable<MonitorQueryTimeRange>
+    public readonly struct QueryTimeRange : IEquatable<QueryTimeRange>
     {
         /// <summary>
-        /// Represents the maximum <see cref="MonitorQueryTimeRange"/>.
+        /// Represents the maximum <see cref="QueryTimeRange"/>.
         /// </summary>
-        public static MonitorQueryTimeRange All => new MonitorQueryTimeRange(TimeSpan.MaxValue);
+        public static QueryTimeRange All => new QueryTimeRange(TimeSpan.MaxValue);
 
         /// <summary>
         /// Gets the duration of the range.
@@ -34,11 +34,11 @@ namespace Azure.Monitor.Query
         public DateTimeOffset? End { get; }
 
         /// <summary>
-        /// Initializes an instance of <see cref="MonitorQueryTimeRange"/> using a duration value.
+        /// Initializes an instance of <see cref="QueryTimeRange"/> using a duration value.
         /// The exact query range would be determined by the service when executing the query.
         /// </summary>
         /// <param name="duration">The duration of the range.</param>
-        public MonitorQueryTimeRange(TimeSpan duration)
+        public QueryTimeRange(TimeSpan duration)
         {
             Duration = duration;
             Start = null;
@@ -46,11 +46,11 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Initializes an instance of <see cref="MonitorQueryTimeRange"/> using a start time and a duration value.
+        /// Initializes an instance of <see cref="QueryTimeRange"/> using a start time and a duration value.
         /// </summary>
         /// <param name="start">The start of the range.</param>
         /// <param name="duration">The duration of the range.</param>
-        public MonitorQueryTimeRange(DateTimeOffset start, TimeSpan duration)
+        public QueryTimeRange(DateTimeOffset start, TimeSpan duration)
         {
             Duration = duration;
             Start = start;
@@ -58,11 +58,11 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Initializes an instance of <see cref="MonitorQueryTimeRange"/> using a duration and an end time.
+        /// Initializes an instance of <see cref="QueryTimeRange"/> using a duration and an end time.
         /// </summary>
         /// <param name="duration">The duration of the range.</param>
         /// <param name="end">The end of the range.</param>
-        public MonitorQueryTimeRange(TimeSpan duration, DateTimeOffset end)
+        public QueryTimeRange(TimeSpan duration, DateTimeOffset end)
         {
             Duration = duration;
             Start = null;
@@ -70,11 +70,11 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Initializes an instance of <see cref="MonitorQueryTimeRange"/> using a start time and an end time.
+        /// Initializes an instance of <see cref="QueryTimeRange"/> using a start time and an end time.
         /// </summary>
         /// <param name="start">The start of the range.</param>
         /// <param name="end">The end of the range.</param>
-        public MonitorQueryTimeRange(DateTimeOffset start, DateTimeOffset end)
+        public QueryTimeRange(DateTimeOffset start, DateTimeOffset end)
         {
             Duration = end - start;
             Start = start;
@@ -82,10 +82,10 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Converts a <see cref="TimeSpan"/> to a <see cref="MonitorQueryTimeRange"/>.
+        /// Converts a <see cref="TimeSpan"/> to a <see cref="QueryTimeRange"/>.
         /// </summary>
         /// <param name="timeSpan">The <see cref="TimeSpan"/> value to convert.</param>
-        public static implicit operator MonitorQueryTimeRange(TimeSpan timeSpan) => new MonitorQueryTimeRange(timeSpan);
+        public static implicit operator QueryTimeRange(TimeSpan timeSpan) => new QueryTimeRange(timeSpan);
 
         /// <inheritdoc />
         public override string ToString()
@@ -136,7 +136,7 @@ namespace Azure.Monitor.Query
         }
 
         /// <inheritdoc />
-        public bool Equals(MonitorQueryTimeRange other)
+        public bool Equals(QueryTimeRange other)
         {
             return Duration.Equals(other.Duration) &&
                    Nullable.Equals(Start, other.Start) &&
@@ -146,27 +146,27 @@ namespace Azure.Monitor.Query
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            return obj is MonitorQueryTimeRange other && Equals(other);
+            return obj is QueryTimeRange other && Equals(other);
         }
 
         /// <summary>
-        /// Determines if two <see cref="MonitorQueryTimeRange"/> values are the same.
+        /// Determines if two <see cref="QueryTimeRange"/> values are the same.
         /// </summary>
-        /// <param name="left">The first <see cref="MonitorQueryTimeRange"/> to compare.</param>
-        /// <param name="right">The second <see cref="MonitorQueryTimeRange"/> to compare.</param>
+        /// <param name="left">The first <see cref="QueryTimeRange"/> to compare.</param>
+        /// <param name="right">The second <see cref="QueryTimeRange"/> to compare.</param>
         /// <returns>True if <paramref name="left"/> and <paramref name="right"/> are the same; otherwise, false.</returns>
-        public static bool operator ==(MonitorQueryTimeRange left, MonitorQueryTimeRange right)
+        public static bool operator ==(QueryTimeRange left, QueryTimeRange right)
         {
             return left.Equals(right);
         }
 
         /// <summary>
-        /// Determines if two <see cref="MonitorQueryTimeRange"/> values are different.
+        /// Determines if two <see cref="QueryTimeRange"/> values are different.
         /// </summary>
-        /// <param name="left">The first <see cref="MonitorQueryTimeRange"/> to compare.</param>
-        /// <param name="right">The second <see cref="MonitorQueryTimeRange"/> to compare.</param>
+        /// <param name="left">The first <see cref="QueryTimeRange"/> to compare.</param>
+        /// <param name="right">The second <see cref="QueryTimeRange"/> to compare.</param>
         /// <returns>True if <paramref name="left"/> and <paramref name="right"/> are different; otherwise, false.</returns>
-        public static bool operator !=(MonitorQueryTimeRange left, MonitorQueryTimeRange right)
+        public static bool operator !=(QueryTimeRange left, QueryTimeRange right)
         {
             return !left.Equals(right);
         }
@@ -178,12 +178,12 @@ namespace Azure.Monitor.Query
         }
 
         /// <summary>
-        /// Converts a <see cref="string"/> value to it's <see cref="MonitorQueryTimeRange"/> representation.
+        /// Converts a <see cref="string"/> value to it's <see cref="QueryTimeRange"/> representation.
         /// </summary>
         /// <param name="value">The string to convert.</param>
         /// <returns>A <see langword="DateTimeRange" /> equivalent of the string.</returns>
         /// <exception cref="FormatException"><paramref name="value" /> is not in correct format to represent a <see langword="DateTimeRange" /> value.</exception>
-        internal static MonitorQueryTimeRange Parse(string value)
+        internal static QueryTimeRange Parse(string value)
         {
             Argument.AssertNotNullOrWhiteSpace(value, nameof(value));
 
@@ -218,9 +218,9 @@ namespace Azure.Monitor.Query
 
                     return (firstIsDateTime, secondIsDateTime) switch
                     {
-                        (true, true) => new MonitorQueryTimeRange(dateTimeFirst, dateTimeSecond),
-                        (true, false) => new MonitorQueryTimeRange(dateTimeFirst, ParseTimeSpan(parts[1])),
-                        (false, true) => new MonitorQueryTimeRange(ParseTimeSpan(parts[0]), dateTimeSecond),
+                        (true, true) => new QueryTimeRange(dateTimeFirst, dateTimeSecond),
+                        (true, false) => new QueryTimeRange(dateTimeFirst, ParseTimeSpan(parts[1])),
+                        (false, true) => new QueryTimeRange(ParseTimeSpan(parts[0]), dateTimeSecond),
                         _ => throw CreateFormatException()
                     };
                 default:

--- a/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientLiveTests.cs
@@ -54,6 +54,8 @@ namespace Azure.Monitor.Query.Tests
             var resultTable = results.Value.Table;
             CollectionAssert.IsNotEmpty(resultTable.Columns);
 
+            Assert.AreEqual(LogsQueryResultStatus.Success, results.Value.Status);
+
             Assert.AreEqual("a", resultTable.Rows[0].GetString(0));
             Assert.AreEqual("a", resultTable.Rows[0].GetString(LogsTestData.StringColumnName));
 
@@ -91,6 +93,7 @@ namespace Azure.Monitor.Query.Tests
                     ThrowOnPartialErrors = false
                 });
 
+            Assert.AreEqual(LogsQueryResultStatus.PartialFailure, results.Value.Status);
             Assert.NotNull(results.Value.Error.Code);
             Assert.NotNull(results.Value.Error.Message);
         }
@@ -219,15 +222,15 @@ namespace Azure.Monitor.Query.Tests
 
             Response<LogsBatchQueryResultCollection> response = await client.QueryBatchAsync(batch);
 
-            Assert.AreEqual(LogsBatchQueryResultStatus.Success, response.Value.Single(r => r.Id == id1).Status);
+            Assert.AreEqual(LogsQueryResultStatus.Success, response.Value.Single(r => r.Id == id1).Status);
 
             var failedResult = response.Value.Single(r => r.Id == id2);
-            Assert.AreEqual(LogsBatchQueryResultStatus.Failure, failedResult.Status);
+            Assert.AreEqual(LogsQueryResultStatus.Failure, failedResult.Status);
             Assert.NotNull(failedResult.Error.Code);
             Assert.NotNull(failedResult.Error.Message);
 
             var partialResult = response.Value.Single(r => r.Id == id3);
-            Assert.AreEqual(LogsBatchQueryResultStatus.PartialFailure, partialResult.Status);
+            Assert.AreEqual(LogsQueryResultStatus.PartialFailure, partialResult.Status);
             CollectionAssert.IsNotEmpty(partialResult.Table.Rows);
             Assert.NotNull(partialResult.Error.Code);
             Assert.NotNull(partialResult.Error.Message);

--- a/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientLiveTests.cs
@@ -90,7 +90,7 @@ namespace Azure.Monitor.Query.Tests
                 $"set truncationmaxrecords=1; datatable (s: string) ['a', 'b']",
                 _logsTestData.DataTimeRange, new LogsQueryOptions()
                 {
-                    ThrowOnPartialErrors = false
+                    AllowPartialErrors = true
                 });
 
             Assert.AreEqual(LogsQueryResultStatus.PartialFailure, results.Value.Status);
@@ -627,7 +627,7 @@ namespace Azure.Monitor.Query.Tests
                     await client.QueryAsync(TestEnvironment.WorkspaceId, $"range x from 1 to {cnt} step 1 | count", _logsTestData.DataTimeRange, options: new LogsQueryOptions()
                     {
                         ServerTimeout = TimeSpan.FromSeconds(1),
-                        ThrowOnPartialErrors = false
+                        AllowPartialErrors = false
                     });
                 }
                 catch (AggregateException)

--- a/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientClientTests.cs
@@ -73,7 +73,7 @@ namespace Azure.Monitor.Query.Tests
             });
 
             LogsBatchQuery batch = new LogsBatchQuery();
-            batch.AddQuery("wid", "query", MonitorQueryTimeRange.All);
+            batch.AddQuery("wid", "query", QueryTimeRange.All);
 
             LogsBatchQueryResultCollection batchResults = await client.QueryBatchAsync(batch);
             Assert.NotNull(batchResults.GetResult("0"));
@@ -96,7 +96,7 @@ namespace Azure.Monitor.Query.Tests
                 Transport = mockTransport
             });
 
-            await client.QueryAsync("", "", MonitorQueryTimeRange.All);
+            await client.QueryAsync("", "", QueryTimeRange.All);
             StringAssert.StartsWith("https://api.loganalytics.io", uri);
         }
 
@@ -124,7 +124,7 @@ namespace Azure.Monitor.Query.Tests
                 AuthenticationScope = scope
             });
 
-            await client.QueryAsync("", "", MonitorQueryTimeRange.All);
+            await client.QueryAsync("", "", QueryTimeRange.All);
             Assert.AreEqual(new[] { expectedScope }, scopes);
         }
 

--- a/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientSamples.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientSamples.cs
@@ -29,7 +29,7 @@ namespace Azure.Monitor.Query.Tests
             Response<LogsQueryResult> response = await client.QueryAsync(
                 workspaceId,
                 "AzureActivity | top 10 by TimeGenerated",
-                new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+                new QueryTimeRange(TimeSpan.FromDays(1)));
 
             LogsTable table = response.Value.Table;
 
@@ -56,7 +56,7 @@ namespace Azure.Monitor.Query.Tests
             Response<LogsQueryResult> response = await client.QueryAsync(
                 workspaceId,
                 "AzureActivity | top 10 by TimeGenerated",
-                new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+                new QueryTimeRange(TimeSpan.FromDays(1)));
 
             LogsTable table = response.Value.Table;
 
@@ -99,7 +99,7 @@ namespace Azure.Monitor.Query.Tests
             Response<IReadOnlyList<string>> response = await client.QueryAsync<string>(
                 workspaceId,
                 "AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count | project ResourceGroup",
-                new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+                new QueryTimeRange(TimeSpan.FromDays(1)));
             #endregion
 
             foreach (var resourceGroup in response.Value)
@@ -127,7 +127,7 @@ namespace Azure.Monitor.Query.Tests
             Response<IReadOnlyList<MyLogEntryModel>> response = await client.QueryAsync<MyLogEntryModel>(
                 workspaceId,
                 "AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count",
-                new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+                new QueryTimeRange(TimeSpan.FromDays(1)));
             #endregion
 
             foreach (var logEntryModel in response.Value)
@@ -159,11 +159,11 @@ namespace Azure.Monitor.Query.Tests
             string countQueryId = batch.AddQuery(
                 workspaceId,
                 "AzureActivity | count",
-                new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+                new QueryTimeRange(TimeSpan.FromDays(1)));
             string topQueryId = batch.AddQuery(
                 workspaceId,
                 "AzureActivity | summarize Count = count() by ResourceGroup | top 10 by Count",
-                new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+                new QueryTimeRange(TimeSpan.FromDays(1)));
 
             Response<LogsBatchQueryResultCollection> response = await client.QueryBatchAsync(batch);
 
@@ -196,7 +196,7 @@ namespace Azure.Monitor.Query.Tests
             Response<IReadOnlyList<int>> response = await client.QueryAsync<int>(
                 workspaceId,
                 "AzureActivity | summarize count()",
-                new MonitorQueryTimeRange(TimeSpan.FromDays(1)),
+                new QueryTimeRange(TimeSpan.FromDays(1)),
                 options: new LogsQueryOptions
                 {
                     ServerTimeout = TimeSpan.FromMinutes(10)
@@ -228,7 +228,7 @@ namespace Azure.Monitor.Query.Tests
             Response<IReadOnlyList<int>> response = await client.QueryAsync<int>(
                 workspaceId,
                 "AzureActivity | summarize count()",
-                new MonitorQueryTimeRange(TimeSpan.FromDays(1)),
+                new QueryTimeRange(TimeSpan.FromDays(1)),
                 options: new LogsQueryOptions
                 {
                     AdditionalWorkspaces = { additionalWorkspaceId }
@@ -257,7 +257,7 @@ namespace Azure.Monitor.Query.Tests
             try
             {
                 await client.QueryAsync(
-                    workspaceId, "My Not So Valid Query", new MonitorQueryTimeRange(TimeSpan.FromDays(1)));
+                    workspaceId, "My Not So Valid Query", new QueryTimeRange(TimeSpan.FromDays(1)));
             }
             catch (Exception e)
             {

--- a/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/LogsQueryClientTests.cs
@@ -78,6 +78,7 @@ namespace Azure.Monitor.Query.Tests
 
             Assert.ThrowsAsync<RequestFailedException>(() => client.QueryBatchAsync(batch));
 
+            // 3 minutes (180 sec) is the max out of all individual queries
             Assert.AreEqual("wait=180", preferHeader);
             // The network timeout is adjusted with 15 sec buffer
             Assert.AreEqual(TimeSpan.FromMinutes(3).Add(TimeSpan.FromSeconds(15)), networkOverride);

--- a/sdk/monitor/Azure.Monitor.Query/tests/LogsTestData.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/LogsTestData.cs
@@ -42,7 +42,7 @@ namespace Azure.Monitor.Query.Tests
 
         private string TableANameSent => nameof(TableA) + DataVersion + "_" + RetentionWindowStart.DayOfYear;
         public string TableAName => TableANameSent + "_CL";
-        public MonitorQueryTimeRange DataTimeRange => new MonitorQueryTimeRange(RetentionWindowStart, TimeSpan.FromDays(7));
+        public QueryTimeRange DataTimeRange => new QueryTimeRange(RetentionWindowStart, TimeSpan.FromDays(7));
 
         private readonly MonitorQueryClientTestEnvironment _testEnvironment;
 

--- a/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientLiveTests.cs
@@ -57,14 +57,14 @@ namespace Azure.Monitor.Query.Tests
                 new MetricsQueryOptions()
                 {
                     MetricNamespace = _testData.MetricNamespace,
-                    TimeRange = new MonitorQueryTimeRange(_testData.StartTime, duration)
+                    TimeRange = new QueryTimeRange(_testData.StartTime, duration)
                 });
 
             var timeSeriesData = results.Value.Metrics[0].TimeSeries[0].Values;
             Assert.AreEqual(duration.Minutes, timeSeriesData.Count);
             // Average is queried by default
             Assert.True(timeSeriesData.All(d=> d.Average != null));
-            Assert.AreEqual(new MonitorQueryTimeRange(_testData.StartTime, _testData.StartTime + duration), results.Value.TimeSpan);
+            Assert.AreEqual(new QueryTimeRange(_testData.StartTime, _testData.StartTime + duration), results.Value.TimeSpan);
 
             Assert.Null(results.Value.Metrics[0].Error);
         }
@@ -80,7 +80,7 @@ namespace Azure.Monitor.Query.Tests
                 new MetricsQueryOptions
                 {
                     MetricNamespace = _testData.MetricNamespace,
-                    TimeRange = new MonitorQueryTimeRange(_testData.StartTime, _testData.StartTime.Add(_testData.Duration)),
+                    TimeRange = new QueryTimeRange(_testData.StartTime, _testData.StartTime.Add(_testData.Duration)),
                     Aggregations =
                     {
                         MetricAggregationType.Average,
@@ -113,7 +113,7 @@ namespace Azure.Monitor.Query.Tests
                 new MetricsQueryOptions
                 {
                     MetricNamespace = _testData.MetricNamespace,
-                    TimeRange = new MonitorQueryTimeRange(_testData.StartTime, _testData.EndTime),
+                    TimeRange = new QueryTimeRange(_testData.StartTime, _testData.EndTime),
                 });
 
             var timeSeriesData = results.Value.Metrics[0].TimeSeries[0].Values;
@@ -133,7 +133,7 @@ namespace Azure.Monitor.Query.Tests
                 new MetricsQueryOptions
                 {
                     MetricNamespace = _testData.MetricNamespace,
-                    TimeRange = new MonitorQueryTimeRange(_testData.StartTime, _testData.Duration)
+                    TimeRange = new QueryTimeRange(_testData.StartTime, _testData.Duration)
                 });
 
             var timeSeriesData = results.Value.Metrics[0].TimeSeries[0].Values;
@@ -153,7 +153,7 @@ namespace Azure.Monitor.Query.Tests
                 new MetricsQueryOptions
                 {
                     MetricNamespace = _testData.MetricNamespace,
-                    TimeRange = new MonitorQueryTimeRange(_testData.Duration, _testData.EndTime)
+                    TimeRange = new QueryTimeRange(_testData.Duration, _testData.EndTime)
                 });
 
             var timeSeriesData = results.Value.Metrics[0].TimeSeries[0].Values;
@@ -190,7 +190,7 @@ namespace Azure.Monitor.Query.Tests
                 new MetricsQueryOptions
                 {
                     MetricNamespace = _testData.MetricNamespace,
-                    TimeRange = new MonitorQueryTimeRange(_testData.StartTime, _testData.EndTime),
+                    TimeRange = new QueryTimeRange(_testData.StartTime, _testData.EndTime),
                     Granularity = TimeSpan.FromMinutes(5)
                 });
 
@@ -211,7 +211,7 @@ namespace Azure.Monitor.Query.Tests
                 new MetricsQueryOptions
                 {
                     MetricNamespace = _testData.MetricNamespace,
-                    TimeRange = new MonitorQueryTimeRange(_testData.StartTime, _testData.EndTime),
+                    TimeRange = new QueryTimeRange(_testData.StartTime, _testData.EndTime),
                     Filter = $"Name eq '{_testData.Name1}'",
                     Aggregations =
                     {
@@ -234,7 +234,7 @@ namespace Azure.Monitor.Query.Tests
                 new MetricsQueryOptions
                 {
                     MetricNamespace = _testData.MetricNamespace,
-                    TimeRange = new MonitorQueryTimeRange(_testData.StartTime, _testData.EndTime),
+                    TimeRange = new QueryTimeRange(_testData.StartTime, _testData.EndTime),
                     Filter = $"Name eq '*'",
                     Size = 1,
                     Aggregations =

--- a/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MetricsQueryClientTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Monitor.Query.Tests
+{
+    public class MetricsQueryClientTests
+    {
+        [Test]
+        public async Task UsesDefaultEndpoint()
+        {
+            var mockTransport = MockTransport.FromMessageCallback(_ => new MockResponse(200).SetContent("{}"));
+
+            var client = new MetricsQueryClient(new MockCredential(), new MetricsQueryClientOptions()
+            {
+                Transport = mockTransport
+            });
+
+            await client.QueryAsync("rid", new string[]{});
+            StringAssert.StartsWith("https://management.azure.com", mockTransport.SingleRequest.Uri.ToString());
+        }
+
+        [TestCase(null, "https://management.azure.com//.default")]
+        [TestCase("https://management.azure.gov", "https://management.azure.gov//.default")]
+        [TestCase("https://management.azure.cn", "https://management.azure.cn//.default")]
+        public async Task UsesDefaultAuthScope(string scope, string expectedScope)
+        {
+            var mockTransport = MockTransport.FromMessageCallback(_ => new MockResponse(200).SetContent("{}"));
+
+            Mock<MockCredential> mock = new() { CallBase = true };
+
+            string[] scopes = null;
+            mock.Setup(m => m.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
+                .Callback<TokenRequestContext, CancellationToken>((c, _) => scopes = c.Scopes)
+                .CallBase();
+
+            var client = new MetricsQueryClient(mock.Object, new MetricsQueryClientOptions()
+            {
+                Transport = mockTransport,
+                Audience = scope == null ? (MetricsQueryClientAudience?)null : new MetricsQueryClientAudience(scope)
+            });
+
+            await client.QueryAsync("", new string[]{});
+            Assert.AreEqual(new[] { expectedScope }, scopes);
+        }
+
+        [Test]
+        public void ExposesPublicEndpoint()
+        {
+            var client = new MetricsQueryClient(new Uri("https://management.azure.gov"), new MockCredential(), new MetricsQueryClientOptions());
+            Assert.AreEqual(new Uri("https://management.azure.gov"), client.Endpoint);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.Query/tests/MetricsTestData.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MetricsTestData.cs
@@ -110,7 +110,7 @@ namespace Azure.Monitor.Query.Tests
             var metrics = await metricQueryClient.QueryAsync(_testEnvironment.MetricsResource, new[] {MetricName},
                 new MetricsQueryOptions()
                 {
-                    TimeRange = new MonitorQueryTimeRange(StartTime, Duration),
+                    TimeRange = new QueryTimeRange(StartTime, Duration),
                     MetricNamespace = MetricNamespace,
                     Granularity = TimeSpan.FromMinutes(1),
                     Aggregations =

--- a/sdk/monitor/Azure.Monitor.Query/tests/MonitorQueryDateTimeRangeTests.cs
+++ b/sdk/monitor/Azure.Monitor.Query/tests/MonitorQueryDateTimeRangeTests.cs
@@ -14,7 +14,7 @@ namespace Azure.Core.Tests
         public void ToStringDurationTests()
         {
             var duration = TimeSpan.FromMinutes(23);
-            Assert.AreEqual("PT23M", new MonitorQueryTimeRange(duration).ToIsoString());
+            Assert.AreEqual("PT23M", new QueryTimeRange(duration).ToIsoString());
         }
 
         [Test]
@@ -22,7 +22,7 @@ namespace Azure.Core.Tests
         {
             var duration = TimeSpan.FromMinutes(23);
             var endTime = new DateTimeOffset(2021, 5, 4, 3, 2, 1, TimeSpan.Zero);
-            Assert.AreEqual("PT23M/2021-05-04T03:02:01.0000000Z", new MonitorQueryTimeRange(duration, endTime).ToIsoString());
+            Assert.AreEqual("PT23M/2021-05-04T03:02:01.0000000Z", new QueryTimeRange(duration, endTime).ToIsoString());
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace Azure.Core.Tests
         {
             var startTime = new DateTimeOffset(2021, 5, 4, 3, 2, 1, TimeSpan.Zero);
             var duration = TimeSpan.FromMinutes(23);
-            Assert.AreEqual("2021-05-04T03:02:01.0000000Z/PT23M", new MonitorQueryTimeRange(startTime, duration).ToIsoString());
+            Assert.AreEqual("2021-05-04T03:02:01.0000000Z/PT23M", new QueryTimeRange(startTime, duration).ToIsoString());
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace Azure.Core.Tests
             var startTime = new DateTimeOffset(2021, 1, 2, 3, 4, 5, TimeSpan.Zero);
             var endTime = new DateTimeOffset(2021, 5, 4, 3, 2, 1, TimeSpan.Zero);
 
-            Assert.AreEqual("2021-01-02T03:04:05.0000000Z/2021-05-04T03:02:01.0000000Z", new MonitorQueryTimeRange(startTime, endTime).ToIsoString());
+            Assert.AreEqual("2021-01-02T03:04:05.0000000Z/2021-05-04T03:02:01.0000000Z", new QueryTimeRange(startTime, endTime).ToIsoString());
         }
 
         [TestCase("PT23M")]
@@ -48,7 +48,7 @@ namespace Azure.Core.Tests
         [TestCase("2021-01-02T03:04:05.0000000Z/2021-05-04T03:02:01.0000000Z")]
         public void CanRoundtrip(string range)
         {
-            Assert.AreEqual(range, MonitorQueryTimeRange.Parse(range).ToIsoString());
+            Assert.AreEqual(range, QueryTimeRange.Parse(range).ToIsoString());
         }
 
         [RunOnlyOnPlatforms(Windows = true, Reason = "Default formatting differs between platforms.")]
@@ -58,7 +58,7 @@ namespace Azure.Core.Tests
         [TestCase("2021-01-02T03:04:05.0000000Z/2021-05-04T03:02:01.0000000Z", "Start: 1/2/2021 3:04:05 AM +00:00 End: 5/4/2021 3:02:01 AM +00:00")]
         public void ToStringFormats(string range, string expected)
         {
-            Assert.AreEqual(expected, MonitorQueryTimeRange.Parse(range).ToString());
+            Assert.AreEqual(expected, QueryTimeRange.Parse(range).ToString());
         }
 
         [TestCase("A")]
@@ -67,7 +67,7 @@ namespace Azure.Core.Tests
         [TestCase("1000000-05-04T03:02:01.0000000Z/PT23M")]
         public void ParseThrowsFormatExceptionForInvalidInput(string range)
         {
-            var ex = Assert.Throws<FormatException>(() => MonitorQueryTimeRange.Parse(range));
+            var ex = Assert.Throws<FormatException>(() => QueryTimeRange.Parse(range));
             StringAssert.StartsWith("Unable to parse the DateTimeRange value.", ex.Message);
         }
     }

--- a/sdk/monitor/Azure.Monitor.Query/tests/SessionRecords/LogsQueryClientClientLiveTests/CanQueryWithStatisticsBatch(True).json
+++ b/sdk/monitor/Azure.Monitor.Query/tests/SessionRecords/LogsQueryClientClientLiveTests/CanQueryWithStatisticsBatch(True).json
@@ -8,10 +8,10 @@
         "Authorization": "Sanitized",
         "Content-Length": "235",
         "Content-Type": "application/json",
-        "traceparent": "00-fae8a01c5e817f418d79ad9a16e4f6f5-1e3bf61adde3fc4b-00",
+        "traceparent": "00-6b09fa8bbfcd564fa81e522a9e5c3bad-425dc1817e9a0f48-00",
         "User-Agent": [
-          "azsdk-net-Monitor.Query/1.0.0-alpha.20210614.1",
-          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
+          "azsdk-net-Monitor.Query/1.0.0-alpha.20210916.1",
+          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "e15c344896d3896b1a1a36264d0d9b30",
         "x-ms-return-client-request-id": "true"
@@ -21,15 +21,15 @@
           {
             "id": "0",
             "headers": {
-              "prefer": "include-statistics=true"
+              "Prefer": "include-statistics=true"
             },
             "body": {
-              "query": "TableA1_158_CL",
-              "timespan": "2021-06-07T00:00:00.0000000Z/P7D"
+              "query": "TableA1_249_CL",
+              "timespan": "2021-09-06T00:00:00.0000000Z/P7D"
             },
             "path": "/query",
             "method": "POST",
-            "workspace": "0a1f6b9a-caa1-4e5a-ac9a-54aa9b2fb131"
+            "workspace": "97fa26b5-39ef-45ce-8f17-e4359d0d2730"
           }
         ]
       },
@@ -39,14 +39,14 @@
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
         "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 14 Jun 2021 21:37:22 GMT",
+        "Date": "Thu, 16 Sep 2021 17:35:45 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "Vary": [
           "Accept-Encoding",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-7d56d985c5-vgm5v",
+        "Via": "1.1 draft-oms-7d47d4b4cd-tzw4c",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -54,20 +54,192 @@
           {
             "id": "0",
             "status": 200,
-            "headers": {
-              "Age": "2",
-              "request-context": "appId=cid-v1:70941e4f-7e8f-40b7-b730-183893db0297"
-            },
-            "body": "{\u0022tables\u0022:[{\u0022name\u0022:\u0022PrimaryResult\u0022,\u0022columns\u0022:[{\u0022name\u0022:\u0022TenantId\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022SourceSystem\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022MG\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022ManagementGroupName\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022TimeGenerated\u0022,\u0022type\u0022:\u0022datetime\u0022},{\u0022name\u0022:\u0022Computer\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022RawData\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022IntColumn_d\u0022,\u0022type\u0022:\u0022real\u0022},{\u0022name\u0022:\u0022StringColumn_s\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022BoolColumn_b\u0022,\u0022type\u0022:\u0022bool\u0022},{\u0022name\u0022:\u0022FloatColumn_d\u0022,\u0022type\u0022:\u0022real\u0022},{\u0022name\u0022:\u0022Type\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022_ResourceId\u0022,\u0022type\u0022:\u0022string\u0022}],\u0022rows\u0022:[[\u00220a1f6b9a-caa1-4e5a-ac9a-54aa9b2fb131\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-07T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,1,\u0022a\u0022,false,0,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u00220a1f6b9a-caa1-4e5a-ac9a-54aa9b2fb131\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-09T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,3,\u0022b\u0022,true,1.2,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u00220a1f6b9a-caa1-4e5a-ac9a-54aa9b2fb131\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-12T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,1,\u0022c\u0022,false,1.1,\u0022TableA1_158_CL\u0022,\u0022\u0022]]}],\u0022statistics\u0022:{\u0022query\u0022:{\u0022executionTime\u0022:0.0156002,\u0022resourceUsage\u0022:{\u0022cache\u0022:{\u0022memory\u0022:{\u0022hits\u0022:32,\u0022misses\u0022:0,\u0022total\u0022:32},\u0022disk\u0022:{\u0022hits\u0022:0,\u0022misses\u0022:0,\u0022total\u0022:0},\u0022shards\u0022:{\u0022hot\u0022:{\u0022hitbytes\u0022:0,\u0022missbytes\u0022:0,\u0022retrievebytes\u0022:0},\u0022cold\u0022:{\u0022hitbytes\u0022:0,\u0022missbytes\u0022:0,\u0022retrievebytes\u0022:0},\u0022bypassbytes\u0022:0}},\u0022cpu\u0022:{\u0022user\u0022:\u002200:00:00.0156250\u0022,\u0022kernel\u0022:\u002200:00:00.0156250\u0022,\u0022totalCpu\u0022:\u002200:00:00.0312500\u0022},\u0022memory\u0022:{\u0022peakPerNode\u0022:3670976}},\u0022inputDatasetStatistics\u0022:{\u0022extents\u0022:{\u0022total\u0022:1,\u0022scanned\u0022:1,\u0022scannedMinDatetime\u0022:\u00222021-06-14T21:35:26.0703222Z\u0022,\u0022scannedMaxDatetime\u0022:\u00222021-06-14T21:35:26.0703222Z\u0022},\u0022rows\u0022:{\u0022total\u0022:3,\u0022scanned\u0022:3},\u0022rowstores\u0022:{\u0022scannedRows\u0022:0,\u0022scannedValuesSize\u0022:0},\u0022shards\u0022:{\u0022queriesGeneric\u0022:0,\u0022queriesSpecialized\u0022:0}},\u0022datasetStatistics\u0022:[{\u0022tableRowCount\u0022:3,\u0022tableSize\u0022:266}]}}}"
+            "body": {
+              "tables": [
+                {
+                  "name": "PrimaryResult",
+                  "columns": [
+                    {
+                      "name": "TenantId",
+                      "type": "string"
+                    },
+                    {
+                      "name": "SourceSystem",
+                      "type": "string"
+                    },
+                    {
+                      "name": "MG",
+                      "type": "string"
+                    },
+                    {
+                      "name": "ManagementGroupName",
+                      "type": "string"
+                    },
+                    {
+                      "name": "TimeGenerated",
+                      "type": "datetime"
+                    },
+                    {
+                      "name": "Computer",
+                      "type": "string"
+                    },
+                    {
+                      "name": "RawData",
+                      "type": "string"
+                    },
+                    {
+                      "name": "IntColumn_d",
+                      "type": "real"
+                    },
+                    {
+                      "name": "StringColumn_s",
+                      "type": "string"
+                    },
+                    {
+                      "name": "BoolColumn_b",
+                      "type": "bool"
+                    },
+                    {
+                      "name": "FloatColumn_d",
+                      "type": "real"
+                    },
+                    {
+                      "name": "Type",
+                      "type": "string"
+                    },
+                    {
+                      "name": "_ResourceId",
+                      "type": "string"
+                    }
+                  ],
+                  "rows": [
+                    [
+                      "97fa26b5-39ef-45ce-8f17-e4359d0d2730",
+                      "RestAPI",
+                      "",
+                      "",
+                      "2021-09-06T00:00:00Z",
+                      "",
+                      "",
+                      1,
+                      "a",
+                      false,
+                      0,
+                      "TableA1_249_CL",
+                      ""
+                    ],
+                    [
+                      "97fa26b5-39ef-45ce-8f17-e4359d0d2730",
+                      "RestAPI",
+                      "",
+                      "",
+                      "2021-09-08T00:00:00Z",
+                      "",
+                      "",
+                      3,
+                      "b",
+                      true,
+                      1.2,
+                      "TableA1_249_CL",
+                      ""
+                    ],
+                    [
+                      "97fa26b5-39ef-45ce-8f17-e4359d0d2730",
+                      "RestAPI",
+                      "",
+                      "",
+                      "2021-09-11T00:00:00Z",
+                      "",
+                      "",
+                      1,
+                      "c",
+                      false,
+                      1.1,
+                      "TableA1_249_CL",
+                      ""
+                    ]
+                  ]
+                }
+              ],
+              "statistics": {
+                "query": {
+                  "executionTime": 0.2343771,
+                  "resourceUsage": {
+                    "cache": {
+                      "memory": {
+                        "hits": 32,
+                        "misses": 0,
+                        "total": 32
+                      },
+                      "disk": {
+                        "hits": 0,
+                        "misses": 0,
+                        "total": 0
+                      },
+                      "shards": {
+                        "hot": {
+                          "hitbytes": 0,
+                          "missbytes": 0,
+                          "retrievebytes": 0
+                        },
+                        "cold": {
+                          "hitbytes": 0,
+                          "missbytes": 0,
+                          "retrievebytes": 0
+                        },
+                        "bypassbytes": 0
+                      }
+                    },
+                    "cpu": {
+                      "user": "00:00:00",
+                      "kernel": "00:00:00",
+                      "totalCpu": "00:00:00"
+                    },
+                    "memory": {
+                      "peakPerNode": 3670784
+                    }
+                  },
+                  "inputDatasetStatistics": {
+                    "extents": {
+                      "total": 1,
+                      "scanned": 1,
+                      "scannedMinDatetime": "2021-09-14T17:53:42.6822506Z",
+                      "scannedMaxDatetime": "2021-09-14T17:53:42.6822506Z"
+                    },
+                    "rows": {
+                      "total": 3,
+                      "scanned": 3
+                    },
+                    "rowstores": {
+                      "scannedRows": 0,
+                      "scannedValuesSize": 0
+                    },
+                    "shards": {
+                      "queriesGeneric": 0,
+                      "queriesSpecialized": 0
+                    }
+                  },
+                  "datasetStatistics": [
+                    {
+                      "tableRowCount": 3,
+                      "tableSize": 291
+                    }
+                  ]
+                }
+              }
+            }
           }
         ]
       }
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-06-14T14:37:19.5956639-07:00",
+    "DateTimeOffsetNow": "2021-09-16T10:35:40.5497729-07:00",
     "LOGS_ENDPOINT": "https://api.loganalytics.io",
     "RandomSeed": "471662810",
-    "WORKSPACE_ID": "0a1f6b9a-caa1-4e5a-ac9a-54aa9b2fb131"
+    "SECONDARY_WORKSPACE_ID": "4c8821db-58cd-4766-943d-6652ac4d10ef",
+    "SECONDARY_WORKSPACE_KEY": "Kg==",
+    "WORKSPACE_ID": "97fa26b5-39ef-45ce-8f17-e4359d0d2730",
+    "WORKSPACE_KEY": "Kg=="
   }
 }

--- a/sdk/monitor/Azure.Monitor.Query/tests/SessionRecords/LogsQueryClientClientLiveTests/CanQueryWithStatisticsBatch(True)Async.json
+++ b/sdk/monitor/Azure.Monitor.Query/tests/SessionRecords/LogsQueryClientClientLiveTests/CanQueryWithStatisticsBatch(True)Async.json
@@ -8,10 +8,10 @@
         "Authorization": "Sanitized",
         "Content-Length": "235",
         "Content-Type": "application/json",
-        "traceparent": "00-3de6f8156ce8b8499cdc55a1e755a343-c45d6cc5a363d944-00",
+        "traceparent": "00-43da9b30e92518428554c86a821363be-b1890e596ec12a4d-00",
         "User-Agent": [
-          "azsdk-net-Monitor.Query/1.0.0-alpha.20210614.1",
-          "(.NET 5.0.7; Microsoft Windows 10.0.19043)"
+          "azsdk-net-Monitor.Query/1.0.0-alpha.20210916.1",
+          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "e7225792ee0fb81fc825b0c62e8c1f59",
         "x-ms-return-client-request-id": "true"
@@ -21,15 +21,15 @@
           {
             "id": "0",
             "headers": {
-              "prefer": "include-statistics=true"
+              "Prefer": "include-statistics=true"
             },
             "body": {
-              "query": "TableA1_158_CL",
-              "timespan": "2021-06-07T00:00:00.0000000Z/P7D"
+              "query": "TableA1_249_CL",
+              "timespan": "2021-09-06T00:00:00.0000000Z/P7D"
             },
             "path": "/query",
             "method": "POST",
-            "workspace": "e7bf7412-576d-4978-b47c-2edf669e3e2a"
+            "workspace": "97fa26b5-39ef-45ce-8f17-e4359d0d2730"
           }
         ]
       },
@@ -39,14 +39,14 @@
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
         "Connection": "keep-alive",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 14 Jun 2021 21:19:38 GMT",
+        "Date": "Thu, 16 Sep 2021 17:35:46 GMT",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Transfer-Encoding": "chunked",
         "Vary": [
           "Accept-Encoding",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-6476548b75-ql257",
+        "Via": "1.1 draft-oms-7d47d4b4cd-q9hgm",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -58,16 +58,189 @@
               "Age": "0",
               "request-context": "appId=cid-v1:70941e4f-7e8f-40b7-b730-183893db0297"
             },
-            "body": "{\u0022tables\u0022:[{\u0022name\u0022:\u0022PrimaryResult\u0022,\u0022columns\u0022:[{\u0022name\u0022:\u0022TenantId\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022SourceSystem\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022MG\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022ManagementGroupName\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022TimeGenerated\u0022,\u0022type\u0022:\u0022datetime\u0022},{\u0022name\u0022:\u0022Computer\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022RawData\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022IntColumn_d\u0022,\u0022type\u0022:\u0022real\u0022},{\u0022name\u0022:\u0022StringColumn_s\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022BoolColumn_b\u0022,\u0022type\u0022:\u0022bool\u0022},{\u0022name\u0022:\u0022FloatColumn_d\u0022,\u0022type\u0022:\u0022real\u0022},{\u0022name\u0022:\u0022Type\u0022,\u0022type\u0022:\u0022string\u0022},{\u0022name\u0022:\u0022_ResourceId\u0022,\u0022type\u0022:\u0022string\u0022}],\u0022rows\u0022:[[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-07T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,1,\u0022a\u0022,false,0,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-09T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,3,\u0022b\u0022,true,1.2,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-12T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,1,\u0022c\u0022,false,1.1,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-07T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,1,\u0022a\u0022,false,0,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-09T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,3,\u0022b\u0022,true,1.2,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-12T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,1,\u0022c\u0022,false,1.1,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-07T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,1,\u0022a\u0022,false,0,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-09T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,3,\u0022b\u0022,true,1.2,\u0022TableA1_158_CL\u0022,\u0022\u0022],[\u0022e7bf7412-576d-4978-b47c-2edf669e3e2a\u0022,\u0022RestAPI\u0022,\u0022\u0022,\u0022\u0022,\u00222021-06-12T00:00:00Z\u0022,\u0022\u0022,\u0022\u0022,1,\u0022c\u0022,false,1.1,\u0022TableA1_158_CL\u0022,\u0022\u0022]]}],\u0022statistics\u0022:{\u0022query\u0022:{\u0022executionTime\u0022:0.0156478,\u0022resourceUsage\u0022:{\u0022cache\u0022:{\u0022memory\u0022:{\u0022hits\u0022:32,\u0022misses\u0022:0,\u0022total\u0022:32},\u0022disk\u0022:{\u0022hits\u0022:0,\u0022misses\u0022:0,\u0022total\u0022:0},\u0022shards\u0022:{\u0022hot\u0022:{\u0022hitbytes\u0022:0,\u0022missbytes\u0022:0,\u0022retrievebytes\u0022:0},\u0022cold\u0022:{\u0022hitbytes\u0022:0,\u0022missbytes\u0022:0,\u0022retrievebytes\u0022:0},\u0022bypassbytes\u0022:0}},\u0022cpu\u0022:{\u0022user\u0022:\u002200:00:00\u0022,\u0022kernel\u0022:\u002200:00:00\u0022,\u0022totalCpu\u0022:\u002200:00:00\u0022},\u0022memory\u0022:{\u0022peakPerNode\u0022:4719840}},\u0022inputDatasetStatistics\u0022:{\u0022extents\u0022:{\u0022total\u0022:1,\u0022scanned\u0022:1,\u0022scannedMinDatetime\u0022:\u00222021-06-14T18:46:27.9041943Z\u0022,\u0022scannedMaxDatetime\u0022:\u00222021-06-14T18:46:57.2820366Z\u0022},\u0022rows\u0022:{\u0022total\u0022:9,\u0022scanned\u0022:9},\u0022rowstores\u0022:{\u0022scannedRows\u0022:0,\u0022scannedValuesSize\u0022:0},\u0022shards\u0022:{\u0022queriesGeneric\u0022:0,\u0022queriesSpecialized\u0022:0}},\u0022datasetStatistics\u0022:[{\u0022tableRowCount\u0022:9,\u0022tableSize\u0022:788}]}}}"
+            "body": {
+              "tables": [
+                {
+                  "name": "PrimaryResult",
+                  "columns": [
+                    {
+                      "name": "TenantId",
+                      "type": "string"
+                    },
+                    {
+                      "name": "SourceSystem",
+                      "type": "string"
+                    },
+                    {
+                      "name": "MG",
+                      "type": "string"
+                    },
+                    {
+                      "name": "ManagementGroupName",
+                      "type": "string"
+                    },
+                    {
+                      "name": "TimeGenerated",
+                      "type": "datetime"
+                    },
+                    {
+                      "name": "Computer",
+                      "type": "string"
+                    },
+                    {
+                      "name": "RawData",
+                      "type": "string"
+                    },
+                    {
+                      "name": "IntColumn_d",
+                      "type": "real"
+                    },
+                    {
+                      "name": "StringColumn_s",
+                      "type": "string"
+                    },
+                    {
+                      "name": "BoolColumn_b",
+                      "type": "bool"
+                    },
+                    {
+                      "name": "FloatColumn_d",
+                      "type": "real"
+                    },
+                    {
+                      "name": "Type",
+                      "type": "string"
+                    },
+                    {
+                      "name": "_ResourceId",
+                      "type": "string"
+                    }
+                  ],
+                  "rows": [
+                    [
+                      "97fa26b5-39ef-45ce-8f17-e4359d0d2730",
+                      "RestAPI",
+                      "",
+                      "",
+                      "2021-09-06T00:00:00Z",
+                      "",
+                      "",
+                      1,
+                      "a",
+                      false,
+                      0,
+                      "TableA1_249_CL",
+                      ""
+                    ],
+                    [
+                      "97fa26b5-39ef-45ce-8f17-e4359d0d2730",
+                      "RestAPI",
+                      "",
+                      "",
+                      "2021-09-08T00:00:00Z",
+                      "",
+                      "",
+                      3,
+                      "b",
+                      true,
+                      1.2,
+                      "TableA1_249_CL",
+                      ""
+                    ],
+                    [
+                      "97fa26b5-39ef-45ce-8f17-e4359d0d2730",
+                      "RestAPI",
+                      "",
+                      "",
+                      "2021-09-11T00:00:00Z",
+                      "",
+                      "",
+                      1,
+                      "c",
+                      false,
+                      1.1,
+                      "TableA1_249_CL",
+                      ""
+                    ]
+                  ]
+                }
+              ],
+              "statistics": {
+                "query": {
+                  "executionTime": 0.2343771,
+                  "resourceUsage": {
+                    "cache": {
+                      "memory": {
+                        "hits": 32,
+                        "misses": 0,
+                        "total": 32
+                      },
+                      "disk": {
+                        "hits": 0,
+                        "misses": 0,
+                        "total": 0
+                      },
+                      "shards": {
+                        "hot": {
+                          "hitbytes": 0,
+                          "missbytes": 0,
+                          "retrievebytes": 0
+                        },
+                        "cold": {
+                          "hitbytes": 0,
+                          "missbytes": 0,
+                          "retrievebytes": 0
+                        },
+                        "bypassbytes": 0
+                      }
+                    },
+                    "cpu": {
+                      "user": "00:00:00",
+                      "kernel": "00:00:00",
+                      "totalCpu": "00:00:00"
+                    },
+                    "memory": {
+                      "peakPerNode": 3670784
+                    }
+                  },
+                  "inputDatasetStatistics": {
+                    "extents": {
+                      "total": 1,
+                      "scanned": 1,
+                      "scannedMinDatetime": "2021-09-14T17:53:42.6822506Z",
+                      "scannedMaxDatetime": "2021-09-14T17:53:42.6822506Z"
+                    },
+                    "rows": {
+                      "total": 3,
+                      "scanned": 3
+                    },
+                    "rowstores": {
+                      "scannedRows": 0,
+                      "scannedValuesSize": 0
+                    },
+                    "shards": {
+                      "queriesGeneric": 0,
+                      "queriesSpecialized": 0
+                    }
+                  },
+                  "datasetStatistics": [
+                    {
+                      "tableRowCount": 3,
+                      "tableSize": 291
+                    }
+                  ]
+                }
+              }
+            }
           }
         ]
       }
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-06-14T14:19:37.5249139-07:00",
+    "DateTimeOffsetNow": "2021-09-16T10:35:46.0556078-07:00",
     "LOGS_ENDPOINT": "https://api.loganalytics.io",
     "RandomSeed": "1838021031",
-    "WORKSPACE_ID": "e7bf7412-576d-4978-b47c-2edf669e3e2a"
+    "WORKSPACE_ID": "97fa26b5-39ef-45ce-8f17-e4359d0d2730"
   }
 }


### PR DESCRIPTION
Based on VTeam review.

Rename MonitorQueryTimeRange to QueryTimeRange 
Change the default endpoint for logs client. Fixes #24021
Add Endpoint property to query client.
Follow ACR example and add ***Audience types and properties to options.
Use max timeout from batch for the overall request. Fixes #23513 Fixes #20859