### PR TITLE
Prepare RemoteRendering for a 1.1.0 release

### DIFF
--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
+## 1.1.0 (2021-09-17)
 - Ensure the MS-CV header is not redacted in logs. If you are logging an issue, it can be useful to quote this value.
 
 ## 1.0.1 (2021-05-25)

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/Azure.MixedReality.RemoteRendering.csproj
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/Azure.MixedReality.RemoteRendering.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure Mixed Reality ARR Client</AssemblyTitle>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.1.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.1</ApiCompatVersion>
     <PackageTags>Azure MixedReality</PackageTags>


### PR DESCRIPTION
Prepare for the 1.1.0 release. This is API identical to the previous release, but MS-CV values are no longer redacted from the log by default.