### PR TITLE
Attempt to test Monitor test flakiness

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
@@ -15,6 +15,7 @@ using OpenTelemetry.Trace;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 {
+    [NonParallelizable]
     public class TelemetryPartATests
     {
         private const string ResourcePropertyName = "OTel.Resource";


### PR DESCRIPTION
Tests reuse the same ActivitySource name, they can't be run in parallel.