### PR TITLE
Enable release stage selection at queue time

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -36,9 +36,9 @@ stages:
                   artifact: ${{parameters.ArtifactName}}-signed
                   displayName: 'Store signed packages in ${{parameters.ArtifactName}}-signed artifact'
 
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+  - ${{if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
     - ${{ each artifact in parameters.Artifacts }}:
-      - stage: Release_${{artifact.safeName}}
+      - stage:
         displayName: 'Release: ${{artifact.name}}'
         dependsOn: Signing
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr'))


### PR DESCRIPTION
- Remove the need for safeName and let Devops generate a unique identifier since we only ever use the display name. This allows us to stop setting safeName in all our artifact lists, of course that clean-up is a separate set of work.
- When you are trying to queue a manual run DevOps sets Build.Reason to empty which blocks the full generation of stages in the stage selection UI. To work around this we check for Build.Reason empty or Manual. This allows for teams to uncheck a release stage for any packages that they don't plan to release.