### PR TITLE
Remove owner role assignments from live test ARM templates

### DIFF
--- a/sdk/digitaltwins/test-resources.bicep
+++ b/sdk/digitaltwins/test-resources.bicep
@@ -9,16 +9,7 @@ param baseName string = resourceGroup().name
 @description('The location of the resource. By default, this is the same as the resource group.')
 param location string = resourceGroup().location
 
-var rbacOwnerRoleDefinitionId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
 var adtOwnerRoleDefinitionId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/bcd981a7-7f74-457b-83e1-cceb9e632ffe'
-
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2018-09-01-preview' = {
-    name: guid(resourceGroup().id)
-    properties: {
-        roleDefinitionId: rbacOwnerRoleDefinitionId
-        principalId: testApplicationOid
-    }
-}
 
 resource digitaltwin 'Microsoft.DigitalTwins/digitalTwinsInstances@2020-03-01-preview' = {
     name: baseName

--- a/sdk/digitaltwins/test-resources.json
+++ b/sdk/digitaltwins/test-resources.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.63.48766",
-      "templateHash": "14469093771711807520"
+      "templateHash": "7080001263714194046"
     }
   },
   "parameters": {
@@ -34,19 +34,9 @@
   },
   "functions": [],
   "variables": {
-    "rbacOwnerRoleDefinitionId": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635', subscription().subscriptionId)]",
     "adtOwnerRoleDefinitionId": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/bcd981a7-7f74-457b-83e1-cceb9e632ffe', subscription().subscriptionId)]"
   },
   "resources": [
-    {
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2018-09-01-preview",
-      "name": "[guid(resourceGroup().id)]",
-      "properties": {
-        "roleDefinitionId": "[variables('rbacOwnerRoleDefinitionId')]",
-        "principalId": "[parameters('testApplicationOid')]"
-      }
-    },
     {
       "type": "Microsoft.DigitalTwins/digitalTwinsInstances",
       "apiVersion": "2020-03-01-preview",

--- a/sdk/iot/test-resources.json
+++ b/sdk/iot/test-resources.json
@@ -46,7 +46,6 @@
     },
     "variables": {
         "iotHubResourceId": "[resourceId('Microsoft.Devices/IotHubs', parameters('baseName'))]",
-        "rbacOwnerRoleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
         "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
         "serviceSasProperties": {
           "canonicalizedResource": "[concat('/blob/', parameters('storageAccountName'),'/',parameters('blobContainerName'))]",
@@ -58,15 +57,6 @@
       }
     },
     "resources": [
-        {
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2018-09-01-preview",
-            "name": "[guid(resourceGroup().id)]",
-            "properties": {
-              "roleDefinitionId": "[variables('rbacOwnerRoleDefinitionId')]",
-              "principalId": "[parameters('testApplicationOid')]"
-            }
-        },
         {
             "type": "Microsoft.Devices/IotHubs",
             "apiVersion": "2020-03-01",

--- a/sdk/timeseriesinsights/test-resources.bicep
+++ b/sdk/timeseriesinsights/test-resources.bicep
@@ -45,17 +45,8 @@ param eventSourceTimestampPropertyName string = '${eventSourceName}TimestampProp
 @description('The name of the shared access key that the Time Series Insights service will use to connect to the event hub.')
 param eventSourceKeyName string = 'service'
 
-var rbacOwnerRoleDefinitionId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
 var storageAccountName = 'tsi${uniqueString(az.resourceGroup().id)}'
 var eventSourceResourceId = resourceId(resourceGroup, 'Microsoft.Devices/IotHubs', iotHubName)
-
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2018-09-01-preview' = {
-    name: guid(az.resourceGroup().id)
-    properties: {
-        roleDefinitionId: rbacOwnerRoleDefinitionId
-        principalId: testApplicationOid
-    }
-}
 
 resource iotHub 'Microsoft.Devices/IotHubs@2020-03-01' = {
     name: iotHubName

--- a/sdk/timeseriesinsights/test-resources.json
+++ b/sdk/timeseriesinsights/test-resources.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.63.48766",
-      "templateHash": "7074975851172708714"
+      "templateHash": "3831110767816828197"
     }
   },
   "parameters": {

--- a/sdk/timeseriesinsights/test-resources.json
+++ b/sdk/timeseriesinsights/test-resources.json
@@ -98,21 +98,11 @@
   },
   "functions": [],
   "variables": {
-    "rbacOwnerRoleDefinitionId": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635', subscription().subscriptionId)]",
     "storageAccountName": "[format('tsi{0}', uniqueString(resourceGroup().id))]",
     "eventSourceResourceId": "[resourceId(parameters('resourceGroup'), 'Microsoft.Devices/IotHubs', parameters('iotHubName'))]",
     "hubKeysId": "[resourceId('Microsoft.Devices/IotHubs/Iothubkeys', parameters('iotHubName'), 'iothubowner')]"
   },
   "resources": [
-    {
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2018-09-01-preview",
-      "name": "[guid(resourceGroup().id)]",
-      "properties": {
-        "roleDefinitionId": "[variables('rbacOwnerRoleDefinitionId')]",
-        "principalId": "[parameters('testApplicationOid')]"
-      }
-    },
     {
       "type": "Microsoft.Devices/IotHubs",
       "apiVersion": "2020-03-01",


### PR DESCRIPTION
- Remove owner role assignment from time series insights ARM template
- Remove owner role assignment from digital twins ARM template
- - Remove owner role assignment from iot ARM template

[Recent updates](https://github.com/Azure/azure-sdk-tools/blob/b9c69e2f593b375552d47acd0ba5e650d5fdd005/eng/common/TestResources/New-TestResources.ps1#L466-L475) to the `New-TestResources.ps1` script will do this assignment on deployment already. It is creating `role assignment already exists` errors for these templates.

FYI @jsquire @heaths @weshaggard @azabbasi 