### PR TITLE
Rename EventSource

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -51,7 +51,7 @@ OpenTelemetry.Sdk.CreateTracerProviderBuilder()
 
 ## Troubleshooting
 
-This exporter logs event using the .NET EventSource to emit information. The exporter logs are available to any EventListener by opting into the source named "OpenTelemetry-TraceExporter-AzureMonitor".
+The Azure Monitor exporter uses EventSource for its own internal logging. The exporter logs are available to any EventListener by opting into the source named "OpenTelemetry-AzureMonitor-Exporter".
 
 ## Next steps
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterEventSource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterEventSource.cs
@@ -8,10 +8,9 @@ using Azure.Core.Shared;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
-    [EventSource(Name = EventSourceName)]
+    [EventSource(Name = "OpenTelemetry-AzureMonitor-Exporter")]
     internal sealed class AzureMonitorExporterEventSource : EventSource
     {
-        private const string EventSourceName = "Microsoft-OpenTelemetry-Exporter-AzureMonitor";
         public static AzureMonitorExporterEventSource Log = new AzureMonitorExporterEventSource();
         public static AzureMonitorExporterEventListener Listener = new AzureMonitorExporterEventListener();
 
@@ -77,6 +76,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         public class AzureMonitorExporterEventListener : EventListener
         {
+            private const string EventSourceName = "OpenTelemetry-AzureMonitor-Exporter";
             private readonly List<EventSource> eventSources = new List<EventSource>();
 
             public override void Dispose()


### PR DESCRIPTION
Using "OpenTelemetry-AzureMonitor-Exporter" so that https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#troubleshooting can be used for troubleshooting