### PR TITLE
update request operation name

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/HttpHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/HttpHelper.cs
@@ -229,7 +229,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             bool isDbNameEmpty = string.IsNullOrEmpty(dbName);
             if (!isTargetEmpty && !isDbNameEmpty)
             {
-                target = $"{target}/{dbName}";
+                target = $"{target} | {dbName}";
             }
             else if (isTargetEmpty && !isDbNameEmpty)
             {
@@ -310,6 +310,25 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
 
             return target;
+        }
+
+        internal static string GetHttpDependencyName(this AzMonList tagObjects, string httpUrl)
+        {
+            if (string.IsNullOrEmpty(httpUrl))
+            {
+                return null;
+            }
+
+            var httpMethod = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpMethod)?.ToString();
+            if (!string.IsNullOrEmpty(httpMethod))
+            {
+                if (Uri.TryCreate(httpUrl.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
+                {
+                    return $"{httpMethod} {uri.AbsolutePath}";
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TagEnumerationState.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TagEnumerationState.cs
@@ -25,6 +25,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             [SemanticConventions.AttributeHttpTarget] = PartBType.Http,
             [SemanticConventions.AttributeHttpUserAgent] = PartBType.Http,
             [SemanticConventions.AttributeHttpClientIP] = PartBType.Http,
+            [SemanticConventions.AttributeHttpRoute] = PartBType.Http,
 
             [SemanticConventions.AttributePeerService] = PartBType.Common,
             [SemanticConventions.AttributeNetPeerName] = PartBType.Common,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -70,7 +70,16 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             var httpMethod = AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeHttpMethod)?.ToString();
             if (!string.IsNullOrWhiteSpace(httpMethod))
             {
-                return $"{httpMethod} {activity.DisplayName}";
+                var httpRoute = AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeHttpRoute)?.ToString();
+                if (!string.IsNullOrEmpty(httpRoute) && !httpRoute.StartsWith("{controller}", StringComparison.OrdinalIgnoreCase))
+                {
+                    return $"{httpMethod} {httpRoute}";
+                }
+                var httpUrl = AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeHttpUrl)?.ToString();
+                if (!string.IsNullOrEmpty(httpUrl) && Uri.TryCreate(httpUrl.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
+                {
+                    return $"{httpMethod} {uri.AbsolutePath}";
+                }
             }
 
             return activity.DisplayName;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -73,7 +73,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 var httpRoute = AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeHttpRoute)?.ToString();
                 // ASPNET instrumentation assigns route as {controller}/{action}/{id} which would result in same name for different operations.
                 // To work around that we will use path from httpUrl.
-                if (!string.IsNullOrEmpty(httpRoute) && !httpRoute.StartsWith("{controller}", StringComparison.OrdinalIgnoreCase))
+                if (!string.IsNullOrEmpty(httpRoute) && !httpRoute.Contains("{controller}"))
                 {
                     return $"{httpMethod} {httpRoute}";
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -71,7 +71,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             if (!string.IsNullOrWhiteSpace(httpMethod))
             {
                 var httpRoute = AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeHttpRoute)?.ToString();
-                // ASPNET instrumentation assigns route as {controller}/{action}/{id} which would result in same name for different operations.
+                // ASP.NET instrumentation assigns route as {controller}/{action}/{id} which would result in the same name for different operations.
                 // To work around that we will use path from httpUrl.
                 if (!string.IsNullOrEmpty(httpRoute) && !httpRoute.StartsWith("{controller}", StringComparison.OrdinalIgnoreCase))
                 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -71,6 +71,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             if (!string.IsNullOrWhiteSpace(httpMethod))
             {
                 var httpRoute = AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeHttpRoute)?.ToString();
+                // ASPNET instrumentation assigns route as {controller}/{action}/{id} which would result in same name for different operations.
+                // To work around that we will use path from httpUrl.
                 if (!string.IsNullOrEmpty(httpRoute) && !httpRoute.StartsWith("{controller}", StringComparison.OrdinalIgnoreCase))
                 {
                     return $"{httpMethod} {httpRoute}";

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/HttpHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/HttpHelperTests.cs
@@ -570,7 +570,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 hostName = $"{netPeerIp}:{netPeerPort}";
             }
-            string expectedTarget = $"{hostName}/DbName";
+            string expectedTarget = $"{hostName} | DbName";
             string target = PartBTags.GetDbDependencyTarget();
             Assert.Equal(expectedTarget, target);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -160,5 +160,87 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             Assert.Equal("InProc", remoteDependencyDataTypeForChild);
         }
+
+        [Fact]
+        public void ValidateHttpRemoteDependencyData()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                startTime: DateTime.UtcNow);
+            activity.Stop();
+
+            var httpUrl = "https://www.foo.bar/search";
+            activity.SetStatus(Status.Ok);
+            activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
+            activity.SetTag(SemanticConventions.AttributeHttpUrl, httpUrl); // only adding test via http.url. all possible combinations are covered in HttpHelperTests.
+            activity.SetTag(SemanticConventions.AttributeHttpStatusCode, null);
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var remoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
+
+            Assert.Equal($"GET /search", remoteDependencyData.Name);
+            Assert.Equal(activity.Context.SpanId.ToHexString(), remoteDependencyData.Id);
+            Assert.Equal(httpUrl, remoteDependencyData.Data);
+            Assert.Equal("0", remoteDependencyData.ResultCode);
+            Assert.Equal(activity.Duration.ToString("c", CultureInfo.InvariantCulture), remoteDependencyData.Duration);
+            Assert.Equal(activity.GetStatus() != Status.Error, remoteDependencyData.Success);
+            Assert.True(remoteDependencyData.Properties.Count == 1); //Because of otel_statuscode attribute for activity status. todo: do not add all tags to PartC
+            Assert.True(remoteDependencyData.Measurements.Count == 0);
+        }
+
+        [Fact]
+        public void ValidateDbRemoteDependencyData()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                startTime: DateTime.UtcNow);
+            activity.Stop();
+
+            activity.SetStatus(Status.Ok);
+            activity.SetTag(SemanticConventions.AttributeDbSystem, "mssql");
+            activity.SetTag(SemanticConventions.AttributePeerService, "localhost"); // only adding test via http.url. all possible combinations are covered in HttpHelperTests.
+            activity.SetTag(SemanticConventions.AttributeDbStatement, "Select * from table");
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var remoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
+
+            Assert.Equal(ActivityName, remoteDependencyData.Name);
+            Assert.Equal(activity.Context.SpanId.ToHexString(), remoteDependencyData.Id);
+            Assert.Equal("Select * from table", remoteDependencyData.Data);
+            Assert.Null(remoteDependencyData.ResultCode);
+            Assert.Equal(activity.Duration.ToString("c", CultureInfo.InvariantCulture), remoteDependencyData.Duration);
+            Assert.Equal(activity.GetStatus() != Status.Error, remoteDependencyData.Success);
+            Assert.True(remoteDependencyData.Properties.Count == 1); //Because of otel_statuscode attribute for activity status. todo: do not add all tags to PartC
+            Assert.True(remoteDependencyData.Measurements.Count == 0);
+        }
+
+        [Fact]
+        public void HttpDependencyNameIsActivityDisplayNameByDefault()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                startTime: DateTime.UtcNow);
+
+            activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
+
+            activity.DisplayName = "HTTP GET";
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var remoteDependencyDataName = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags).Name;
+
+            Assert.Equal(activity.DisplayName, remoteDependencyDataName);
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -205,7 +205,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             activity.SetStatus(Status.Ok);
             activity.SetTag(SemanticConventions.AttributeDbSystem, "mssql");
-            activity.SetTag(SemanticConventions.AttributePeerService, "localhost"); // only adding test via http.url. all possible combinations are covered in HttpHelperTests.
+            activity.SetTag(SemanticConventions.AttributePeerService, "localhost"); // only adding test via peer.service. all possible combinations are covered in HttpHelperTests.
             activity.SetTag(SemanticConventions.AttributeDbStatement, "Select * from table");
 
             var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -48,6 +48,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             var httpUrl = "https://www.foo.bar/search";
             activity.SetStatus(Status.Ok);
             activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
+            activity.SetTag(SemanticConventions.AttributeHttpRoute, "/search");
             activity.SetTag(SemanticConventions.AttributeHttpUrl, httpUrl); // only adding test via http.url. all possible combinations are covered in HttpHelperTests.
             activity.SetTag(SemanticConventions.AttributeHttpStatusCode, null);
 
@@ -55,7 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             var requestData = TelemetryPartB.GetRequestData(activity, ref monitorTags);
 
-            Assert.Equal($"GET {activity.DisplayName}", requestData.Name);
+            Assert.Equal($"GET /search", requestData.Name);
             Assert.Equal(activity.Context.SpanId.ToHexString(), requestData.Id);
             Assert.Equal(httpUrl, requestData.Url);
             Assert.Equal("0", requestData.ResponseCode);


### PR DESCRIPTION
From common schema mapping
1) `httpMethod` + " " + `httpRoute`. 
2) If `httpRoute` is not available then extract the path from `httpUrl`. If path is empty then use `/`. e.g. `GET /`. 
3) If none of the attributes are available then assign Span.Name