### PR TITLE
Update http dependency name & db dependency target

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/HttpHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/HttpHelper.cs
@@ -229,7 +229,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             bool isDbNameEmpty = string.IsNullOrEmpty(dbName);
             if (!isTargetEmpty && !isDbNameEmpty)
             {
-                target = $"{target}/{dbName}";
+                target = $"{target} | {dbName}";
             }
             else if (isTargetEmpty && !isDbNameEmpty)
             {
@@ -310,6 +310,25 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
 
             return target;
+        }
+
+        internal static string GetHttpDependencyName(this AzMonList tagObjects, string httpUrl)
+        {
+            if (string.IsNullOrEmpty(httpUrl))
+            {
+                return null;
+            }
+
+            var httpMethod = AzMonList.GetTagValue(ref tagObjects, SemanticConventions.AttributeHttpMethod)?.ToString();
+            if (!string.IsNullOrEmpty(httpMethod))
+            {
+                if (Uri.TryCreate(httpUrl.ToString(), UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
+                {
+                    return $"{httpMethod} {uri.AbsolutePath}";
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/HttpHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/HttpHelperTests.cs
@@ -570,7 +570,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 hostName = $"{netPeerIp}:{netPeerPort}";
             }
-            string expectedTarget = $"{hostName}/DbName";
+            string expectedTarget = $"{hostName} | DbName";
             string target = PartBTags.GetDbDependencyTarget();
             Assert.Equal(expectedTarget, target);
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -160,5 +160,87 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             Assert.Equal("InProc", remoteDependencyDataTypeForChild);
         }
+
+        [Fact]
+        public void ValidateHttpRemoteDependencyData()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                startTime: DateTime.UtcNow);
+            activity.Stop();
+
+            var httpUrl = "https://www.foo.bar/search";
+            activity.SetStatus(Status.Ok);
+            activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
+            activity.SetTag(SemanticConventions.AttributeHttpUrl, httpUrl); // only adding test via http.url. all possible combinations are covered in HttpHelperTests.
+            activity.SetTag(SemanticConventions.AttributeHttpStatusCode, null);
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var remoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
+
+            Assert.Equal($"GET /search", remoteDependencyData.Name);
+            Assert.Equal(activity.Context.SpanId.ToHexString(), remoteDependencyData.Id);
+            Assert.Equal(httpUrl, remoteDependencyData.Data);
+            Assert.Equal("0", remoteDependencyData.ResultCode);
+            Assert.Equal(activity.Duration.ToString("c", CultureInfo.InvariantCulture), remoteDependencyData.Duration);
+            Assert.Equal(activity.GetStatus() != Status.Error, remoteDependencyData.Success);
+            Assert.True(remoteDependencyData.Properties.Count == 1); //Because of otel_statuscode attribute for activity status. todo: do not add all tags to PartC
+            Assert.True(remoteDependencyData.Measurements.Count == 0);
+        }
+
+        [Fact]
+        public void ValidateDbRemoteDependencyData()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                startTime: DateTime.UtcNow);
+            activity.Stop();
+
+            activity.SetStatus(Status.Ok);
+            activity.SetTag(SemanticConventions.AttributeDbSystem, "mssql");
+            activity.SetTag(SemanticConventions.AttributePeerService, "localhost"); // only adding test via http.url. all possible combinations are covered in HttpHelperTests.
+            activity.SetTag(SemanticConventions.AttributeDbStatement, "Select * from table");
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var remoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
+
+            Assert.Equal(ActivityName, remoteDependencyData.Name);
+            Assert.Equal(activity.Context.SpanId.ToHexString(), remoteDependencyData.Id);
+            Assert.Equal("Select * from table", remoteDependencyData.Data);
+            Assert.Null(remoteDependencyData.ResultCode);
+            Assert.Equal(activity.Duration.ToString("c", CultureInfo.InvariantCulture), remoteDependencyData.Duration);
+            Assert.Equal(activity.GetStatus() != Status.Error, remoteDependencyData.Success);
+            Assert.True(remoteDependencyData.Properties.Count == 1); //Because of otel_statuscode attribute for activity status. todo: do not add all tags to PartC
+            Assert.True(remoteDependencyData.Measurements.Count == 0);
+        }
+
+        [Fact]
+        public void HttpDependencyNameIsActivityDisplayNameByDefault()
+        {
+            using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+            using var activity = activitySource.StartActivity(
+                ActivityName,
+                ActivityKind.Client,
+                parentContext: new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+                startTime: DateTime.UtcNow);
+
+            activity.SetTag(SemanticConventions.AttributeHttpMethod, "GET");
+
+            activity.DisplayName = "HTTP GET";
+
+            var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);
+
+            var remoteDependencyDataName = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags).Name;
+
+            Assert.Equal(activity.DisplayName, remoteDependencyDataName);
+        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -205,7 +205,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             activity.SetStatus(Status.Ok);
             activity.SetTag(SemanticConventions.AttributeDbSystem, "mssql");
-            activity.SetTag(SemanticConventions.AttributePeerService, "localhost"); // only adding test via http.url. all possible combinations are covered in HttpHelperTests.
+            activity.SetTag(SemanticConventions.AttributePeerService, "localhost"); // only adding test via peer.service. all possible combinations are covered in HttpHelperTests.
             activity.SetTag(SemanticConventions.AttributeDbStatement, "Select * from table");
 
             var monitorTags = AzureMonitorConverter.EnumerateActivityTags(activity);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartBTests.cs
@@ -182,7 +182,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
             var remoteDependencyData = TelemetryPartB.GetRemoteDependencyData(activity, ref monitorTags);
 
-            Assert.Equal($"GET /search", remoteDependencyData.Name);
+            Assert.Equal("GET /search", remoteDependencyData.Name);
             Assert.Equal(activity.Context.SpanId.ToHexString(), remoteDependencyData.Id);
             Assert.Equal(httpUrl, remoteDependencyData.Data);
             Assert.Equal("0", remoteDependencyData.ResultCode);


### PR DESCRIPTION
RemoteDependency.name

In case of http: httpMethod + " " + extract the path from Span.httpUrl, following RFC3986 definition. If path is empty then use /. e.g. GET /.

RemoteDependency.Target

In case of **db**:
  * Derive target from `peerService` or `net*` attributes as above.
  * If target derived from `peerService` or `net*` attributes is not null, then append [Span.dbName](../PartB/traces/Span.md#dbname) (if present) using ` | ` delimiter.
  * If target derived from `peerService` or `net*` attributes is null, then assign [Span.dbName](../PartB/traces/Span.md#dbname) (if present) to target.
  * Default: If none of the above are available, assign [Span.dbSystem](../PartB/traces/Span.md#dbsystem) to target.