### PR TITLE
Update Docker container for Identity tests

### DIFF
--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -33,8 +33,17 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet_sha512='a444d44007709ceb68d8f72dec0531e17f85f800efc0007ace4fa66ba27f095066930e6c6defcd2f85cdedea2fec25e163f5da461c1c2b8563e5cd7cb47091e0' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    #&& tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
+
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.413/dotnet-sdk-3.1.413-linux-x64.tar.gz \
+    && dotnet_sha512='2a0824f11aba0b79d3f9a36af0395649bc9b4137e61b240a48dccb671df0a5b8c2086054f8e495430b7ed6c344bb3f27ac3dfda5967d863718a6dadeca951a83' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -8,8 +8,8 @@ ENV \
     # Do not generate certificate
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # SDK version
-    DOTNET_SDK_VERSION=5.0.401 \
-    DOTNET_SDK_VERSION2=3.1.413 \
+    DOTNET_SDK_VERSION_5.0=5.0.401 \
+    DOTNET_SDK_VERSION_3_1=3.1.413 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
@@ -33,7 +33,7 @@ RUN apt-get update \
 # 5.0.401-focal-amd64, 5.0-focal-amd64, 5.0.401-focal, 5.0-focal	Dockerfile	Ubuntu 20.04	09/14/2021
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION_5.0/dotnet-sdk-$DOTNET_SDK_VERSION_5.0-linux-x64.tar.gz \
     && dotnet_sha512='a444d44007709ceb68d8f72dec0531e17f85f800efc0007ace4fa66ba27f095066930e6c6defcd2f85cdedea2fec25e163f5da461c1c2b8563e5cd7cb47091e0' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
@@ -43,7 +43,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION2/dotnet-sdk-$DOTNET_SDK_VERSION2-linux-x64.tar.gz \
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION_3_1/dotnet-sdk-$DOTNET_SDK_VERSION_3_1-linux-x64.tar.gz \
     && dotnet_sha512='2a0824f11aba0b79d3f9a36af0395649bc9b4137e61b240a48dccb671df0a5b8c2086054f8e495430b7ed6c344bb3f27ac3dfda5967d863718a6dadeca951a83' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     #&& mkdir -p /usr/share/dotnet31 \

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -20,5 +20,5 @@ RUN wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsof
     && apt-get update \
     && apt-get install -y powershell \
     && pwsh --version \
-    && apt-get install -y dotnet-runtime-2.1 \
+    && apt-get install -y dotnet-runtime-5.0 \
     && dotnet --list-runtimes

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.401-focal AS build
+FROM mcr.microsoft.com/powershell:7.1.4-ubuntu-focal AS build
 
 ENV \
     NO_AT_BRIDGE=1 \
@@ -22,7 +22,8 @@ RUN apt-get update \
         libsecret-1-dev \
         dbus-x11 \
         gnome-keyring \
-        python
+        python \
+        curl
 
 # Below taken from https://hub.docker.com/_/microsoft-dotnet-sdk
 # 5.0.401-focal-amd64, 5.0-focal-amd64, 5.0.401-focal, 5.0-focal	Dockerfile	Ubuntu 20.04	09/14/2021
@@ -32,21 +33,9 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet_sha512='a444d44007709ceb68d8f72dec0531e17f85f800efc0007ace4fa66ba27f095066930e6c6defcd2f85cdedea2fec25e163f5da461c1c2b8563e5cd7cb47091e0' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    #&& tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
-
-# Install PowerShell global tool
-RUN powershell_version=7.1.4 \
-    && curl -SL --output PowerShell.Linux.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
-    && powershell_sha512='b163608ef7ceb5bae84cc8e841ff3dc1a6df129737444084dfeaaa7911c86e0084f5418926541aed97be5886bc4a14c9777741d15192b87c263c0b86b8391e0e' \
-    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
-    && mkdir -p /usr/share/powershell \
-    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
-    && dotnet nuget locals all --clear \
-    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
-    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
-    && chmod 755 /usr/share/powershell/pwsh \
-    # To reduce image size, remove the copy nupkg that nuget keeps.
-    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -9,12 +9,16 @@ ENV \
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # SDK version
     DOTNET_SDK_VERSION=5.0.401 \
+    DOTNET_SDK_VERSION2=3.1.413 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # PowerShell telemetry for docker image usage
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-20.04
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-20.04 \
+    # Setup Dotnet envs
+    DOTNET_ROOT=/usr/share/dotnet  \
+    PATH=$PATH:usr/share/dotnet    
 
 # Install GNOME keyring
 RUN apt-get update \
@@ -35,16 +39,16 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    #&& ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.413/dotnet-sdk-3.1.413-linux-x64.tar.gz \
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION2/dotnet-sdk-$DOTNET_SDK_VERSION2-linux-x64.tar.gz \
     && dotnet_sha512='2a0824f11aba0b79d3f9a36af0395649bc9b4137e61b240a48dccb671df0a5b8c2086054f8e495430b7ed6c344bb3f27ac3dfda5967d863718a6dadeca951a83' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
-    && mkdir -p /usr/share/dotnet \
+    #&& mkdir -p /usr/share/dotnet31 \
     && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    #&& ln -s /usr/share/dotnet31/dotnet /usr/bin/dotnet31 \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
         curl
 
 # Below taken from https://hub.docker.com/_/microsoft-dotnet-sdk
-# 5.0.401-focal-amd64, 5.0-focal-amd64, 5.0.401-focal, 5.0-focal	Dockerfile	Ubuntu 20.04	09/14/2021
+# https://github.com/dotnet/dotnet-docker/blob/ca43690e6e4ac9c21a990a012dc2eb07e78daf08/src/sdk/5.0/focal/amd64/Dockerfile
 
 # Install .NET SDK
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION_5.0/dotnet-sdk-$DOTNET_SDK_VERSION_5.0-linux-x64.tar.gz \
@@ -46,7 +46,6 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION_3_1/dotnet-sdk-$DOTNET_SDK_VERSION_3_1-linux-x64.tar.gz \
     && dotnet_sha512='2a0824f11aba0b79d3f9a36af0395649bc9b4137e61b240a48dccb671df0a5b8c2086054f8e495430b7ed6c344bb3f27ac3dfda5967d863718a6dadeca951a83' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
-    #&& mkdir -p /usr/share/dotnet31 \
     && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -36,3 +36,17 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && rm dotnet.tar.gz \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
+
+# Install PowerShell global tool
+RUN powershell_version=7.1.4 \
+    && curl -SL --output PowerShell.Linux.x64.$powershell_version.nupkg https://pwshtool.blob.core.windows.net/tool/$powershell_version/PowerShell.Linux.x64.$powershell_version.nupkg \
+    && powershell_sha512='b163608ef7ceb5bae84cc8e841ff3dc1a6df129737444084dfeaaa7911c86e0084f5418926541aed97be5886bc4a14c9777741d15192b87c263c0b86b8391e0e' \
+    && echo "$powershell_sha512  PowerShell.Linux.x64.$powershell_version.nupkg" | sha512sum -c - \
+    && mkdir -p /usr/share/powershell \
+    && dotnet tool install --add-source / --tool-path /usr/share/powershell --version $powershell_version PowerShell.Linux.x64 \
+    && dotnet nuget locals all --clear \
+    && rm PowerShell.Linux.x64.$powershell_version.nupkg \
+    && ln -s /usr/share/powershell/pwsh /usr/bin/pwsh \
+    && chmod 755 /usr/share/powershell/pwsh \
+    # To reduce image size, remove the copy nupkg that nuget keeps.
+    && find /usr/share/powershell -print | grep -i '.*[.]nupkg$' | xargs rm

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -1,10 +1,20 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.401-focal AS build
 
 ENV \
     NO_AT_BRIDGE=1 \
     DOCKER_CONTAINER_NAME="ubuntu_netcore_keyring" \
-    PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetCoreSDK-Ubuntu-20.04
+     # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # SDK version
+    DOTNET_SDK_VERSION=5.0.401 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip \
+    # PowerShell telemetry for docker image usage
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-DotnetSDK-Ubuntu-20.04
 
 # Install GNOME keyring
 RUN apt-get update \
@@ -14,11 +24,15 @@ RUN apt-get update \
         gnome-keyring \
         python
 
-# Install PowerShell && .net core runtime 2.1
-RUN wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y powershell \
-    && pwsh --version \
-    && apt-get install -y dotnet-runtime-5.0 \
-    && dotnet --list-runtimes
+# Below taken from https://hub.docker.com/_/microsoft-dotnet-sdk
+# 5.0.401-focal-amd64, 5.0-focal-amd64, 5.0.401-focal, 5.0-focal	Dockerfile	Ubuntu 20.04	09/14/2021
+
+# Install .NET SDK
+RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+    && dotnet_sha512='a444d44007709ceb68d8f72dec0531e17f85f800efc0007ace4fa66ba27f095066930e6c6defcd2f85cdedea2fec25e163f5da461c1c2b8563e5cd7cb47091e0' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -oxzf dotnet.tar.gz ./packs ./sdk ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -39,7 +39,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
-    #&& ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
@@ -49,6 +49,5 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     #&& mkdir -p /usr/share/dotnet31 \
     && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
-    #&& ln -s /usr/share/dotnet31/dotnet /usr/bin/dotnet31 \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -122,7 +122,7 @@ namespace Azure.Identity.Tests
             var result = await PublicClientApplicationBuilder.Create(clientId)
                 .WithTenantId(tenantId)
                 .Build()
-                .AcquireTokenByUsernamePassword(new[] { ".default" }, username, password.ToSecureString())
+                .AcquireTokenByUsernamePassword(new[] { testEnvironment.KeyvaultScope }, username, password.ToSecureString())
                 .ExecuteAsync();
 
             return new AuthenticationRecord(result, clientId);

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -145,7 +145,7 @@ namespace Azure.Identity.Tests
                 .Build();
 
             var retriever = new RefreshTokenRetriever(client.UserTokenCache);
-            await client.AcquireTokenByUsernamePassword(new[] { "https://vault.azure.net/.default" }, username, password.ToSecureString()).ExecuteAsync();
+            await client.AcquireTokenByUsernamePassword(new[] { testEnvironment.KeyvaultScope }, username, password.ToSecureString()).ExecuteAsync();
 
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
             StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -145,7 +145,7 @@ namespace Azure.Identity.Tests
                 .Build();
 
             var retriever = new RefreshTokenRetriever(client.UserTokenCache);
-            await client.AcquireTokenByUsernamePassword(new[] { testEnvironment.KeyvaultScope }, username, password.ToSecureString()).ExecuteAsync();
+            await client.AcquireTokenByUsernamePassword(new[] { "https://vault.azure.net/.default" }, username, password.ToSecureString()).ExecuteAsync();
 
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
             StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -145,7 +145,7 @@ namespace Azure.Identity.Tests
                 .Build();
 
             var retriever = new RefreshTokenRetriever(client.UserTokenCache);
-            await client.AcquireTokenByUsernamePassword(new[] { ".default" }, username, password.ToSecureString()).ExecuteAsync();
+            await client.AcquireTokenByUsernamePassword(new[] { testEnvironment.KeyvaultScope }, username, password.ToSecureString()).ExecuteAsync();
 
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
             StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();

--- a/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
+++ b/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
@@ -31,7 +31,7 @@ namespace Azure.Identity.Tests
 
         public string TestPassword => GetOptionalVariable("AZURE_IDENTITY_TEST_PASSWORD") ?? "SANITIZED";
         public string TestTenantId => GetRecordedOptionalVariable("TENANT_ID") ?? GetRecordedVariable("AZURE_IDENTITY_TEST_TENANTID");
-        public string KeyvaultScope => GetRecordedOptionalVariable("AZURE_KEYVAULT_SCOPE") ?? "SANITIZED";
+        public string KeyvaultScope => GetRecordedOptionalVariable("AZURE_KEYVAULT_SCOPE") ?? "https://vault.azure.net/.default";
 
         public string ServicePrincipalClientId => GetRecordedVariable("IDENTITY_SP_CLIENT_ID");
         public string ServicePrincipalTenantId => GetRecordedVariable("IDENTITY_SP_TENANT_ID");

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 resources:
   containers:
     - container: 'ubuntu_netcore_keyring'
-      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore50401_keyring:powershell714focalnet50401.3'
+      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore50401_keyring:powershell714focalnet50401.4'
       endpoint: 'azsdkengsys'
       options: -ti --cap-add=IPC_LOCK
 

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 resources:
   containers:
     - container: 'ubuntu_netcore_keyring'
-      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore50401_keyring:powershell714focalnet50401.1'
+      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore50401_keyring:powershell714focalnet50401.3'
       endpoint: 'azsdkengsys'
       options: -ti --cap-add=IPC_LOCK
 

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 resources:
   containers:
     - container: 'ubuntu_netcore_keyring'
-      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore_keyring:689585'
+      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore_keyring:chrissdotnet5'
       endpoint: 'azsdkengsys'
       options: -ti --cap-add=IPC_LOCK
 

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 resources:
   containers:
     - container: 'ubuntu_netcore_keyring'
-      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore_keyring:chrissdotnet5'
+      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore50401_keyring:powershell714focalnet50401.1'
       endpoint: 'azsdkengsys'
       options: -ti --cap-add=IPC_LOCK
 


### PR DESCRIPTION
Updates the Docker container for Identity tests.

Note: Some of the nightly tests are failing, but they are orthogonal to these changes. The relevant pipeline for this change is [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1112602&view=logs&j=a193ede0-9885-5d40-0426-f58fbbbff2c5). Prior to this container update, the Build & Test step failed just trying to run `dotnet` commands. 