### PR TITLE
[Event Hubs] Buffered Producer Client Infrastructure (enqueue)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -824,5 +824,16 @@ namespace Azure.Messaging.EventHubs
                 return ResourceManager.GetString("ProcessorLoadBalancingCycleSlowMask", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Events cannot be enqueued processing without the {0} handler set..
+        /// </summary>
+        internal static string CannotEnqueueEventWithoutHandler
+        {
+            get
+            {
+                return ResourceManager.GetString("CannotEnqueueEventWithoutHandler", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -30,7 +30,7 @@
     There are any number of "resheader" rows that contain simple 
     name/value pairs.
     
-    Each data row contains a name, and value. The row also contains a
+    Each data row contains a name, and value. The row also contains a 
     type or mimetype. Type corresponds to a .NET class that support 
     text/value conversion through the TypeConverter architecture. 
     Classes that don't support this are serialized and stored with the 
@@ -226,7 +226,7 @@
     <value>This information is only available when TrackLastEnqueuedEventProperties is set as part of the options.</value>
   </data>
   <data name="CannotStartEventProcessorWithoutHandler" xml:space="preserve">
-    <value>Cannot begin processing without {0} handler set.</value>
+    <value>Cannot begin processing without the {0} handler set.</value>
   </data>
   <data name="RunningEventProcessorCannotPerformOperation" xml:space="preserve">
     <value>The event processor is already running and needs to be stopped in order to perform this operation.</value>
@@ -320,5 +320,8 @@
   </data>
   <data name="ProcessorLoadBalancingCycleSlowMask" xml:space="preserve">
     <value>"A load balancing cycle has taken too long to complete.  A slow cycle can cause stability issues with partition ownership.  Consider investigating storage latency and thread pool health.  Common causes are soft delete being enabled for storage and too many partitions owned.  You may also want to consider increasing the 'PartitionOwnershipExpirationInterval' in the processor options.  Cycle Duration: '{0:0.00}' seconds.  Partition Ownership Interval '{1:0:00}' seconds.")]</value>
+  </data>
+  <data name="CannotEnqueueEventWithoutHandler" xml:space="preserve">
+    <value>Events cannot be enqueued processing without the {0} handler set.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpAnnotatedMessageExtensions.cs
@@ -222,6 +222,19 @@ namespace Azure.Messaging.EventHubs.Amqp
         }
 
         /// <summary>
+        ///   Sets the time that an event was enqueued in the partition on an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="enqueueTime">The value to set as the enqueue time.</param>
+        ///
+        public static void SetEnqueuedTime(this AmqpAnnotatedMessage instance,
+                                           DateTimeOffset enqueueTime)
+        {
+            instance.MessageAnnotations[AmqpProperty.EnqueuedTime.ToString()] = enqueueTime;
+        }
+
+        /// <summary>
         ///   Retrieves the partition key of an event from an <see cref="AmqpAnnotatedMessage" />.
         /// </summary>
         ///
@@ -240,6 +253,19 @@ namespace Azure.Messaging.EventHubs.Amqp
             }
 
             return defaultValue;
+        }
+
+        /// <summary>
+        ///   Sets the partition key of an event on an <see cref="AmqpAnnotatedMessage" />.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="partitionKey">The value to set for the partition key.</param>
+        ///
+        public static void SetPartitionKey(this AmqpAnnotatedMessage instance,
+                                           string partitionKey)
+        {
+            instance.MessageAnnotations[AmqpProperty.PartitionKey.ToString()] = partitionKey;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -1512,6 +1512,88 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that the enqueue of events for publishing has started.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionIdOrKey">The identifier of a partition or the partition hash key used for publishing; identifier or key.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        ///
+        [Event(77, Level = EventLevel.Informational, Message = "Enqueuing events for publishing to Event Hub: {0} (Partition Id/Key: '{1}'), Operation Id: '{2}'.")]
+        public virtual void EventEnqueueStart(string eventHubName,
+                                              string partitionIdOrKey,
+                                              string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(77, eventHubName ?? string.Empty, partitionIdOrKey ?? string.Empty, operationId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that the enqueue of events for publishing has completed.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionIdOrKey">The identifier of a partition or the partition hash key requested when enqueuing the event; identifier or key.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        ///
+        [Event(78, Level = EventLevel.Informational, Message = "Completed enqueuing events for publishing to Event Hub: {0} (Requested Partition Id/Key: '{1}'), Operation Id: '{2}'.")]
+        public virtual void EventEnqueueComplete(string eventHubName,
+                                                 string partitionIdOrKey,
+                                                 string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(78, eventHubName ?? string.Empty, partitionIdOrKey ?? string.Empty, operationId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while enqueuing of events for publishing.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="partitionIdOrKey">The identifier of a partition or the partition hash key requested when enqueuing the event; identifier or key.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(79, Level = EventLevel.Error, Message = "An exception occurred while enqueuing events for publishing to Event Hub: {0} (Requested Partition Id/Key: '{1}'), Operation Id: '{2}'. Error Message: '{3}'")]
+        public virtual void EventEnqueueError(string eventHubName,
+                                              string partitionIdOrKey,
+                                              string operationId,
+                                              string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(79, eventHubName ?? string.Empty, partitionIdOrKey ?? string.Empty, operationId ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an event has been assigned a partition as part of enqueuing it to be published has completed.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub being published to.</param>
+        /// <param name="requestedPartitionIdOrKey">The identifier of a partition or the partition hash key requested when enqueuing the event; identifier or key.</param>
+        /// <param name="assignedPartitionId">The identifier of the partition to which the event was assigned.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        /// <param name="totalBufferedEventCount">The total number of buffered events at the time the enqueue was observed.</param>
+        ///
+        [Event(80, Level = EventLevel.Verbose, Message = "An event being enqueued for publishing to Event Hub: {0} (Requested Partition Id/Key: '{1}') for Operation Id: '{2}' has been enqueued for Partition Id: '{3}'.  Total Buffered Event Count: {4}.")]
+        public virtual void EventEnqueued(string eventHubName,
+                                          string requestedPartitionIdOrKey,
+                                          string assignedPartitionId,
+                                          string operationId,
+                                          int totalBufferedEventCount)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(80, eventHubName ?? string.Empty, requestedPartitionIdOrKey ?? string.Empty, operationId ?? string.Empty, assignedPartitionId ?? string.Empty, totalBufferedEventCount);
+            }
+        }
+
+        /// <summary>
         ///   Indicates that an exception was encountered in an unexpected code path, not directly associated with
         ///   an Event Hubs operation.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EnqueueEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EnqueueEventOptions.cs
@@ -40,5 +40,38 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Deconstructs the instance into its component attributes.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The partition identifier specified by the options.</param>
+        /// <param name="partitionKey">The partition key specified by the options.</param>
+        ///
+        internal void Deconstruct(out string partitionId,
+                                  out string partitionKey)
+        {
+            partitionId = PartitionId;
+            partitionKey = PartitionKey;
+        }
+
+        /// <summary>
+        ///   The set of default attributes for the options, intended to be
+        ///   used as alternative to <see cref="Deconstruct" /> when no options
+        ///   were specified.
+        /// </summary>
+        ///
+        /// <returns>A tuple of the default values for the options attributes.</returns>
+        ///
+        internal static (string PartitionId, string PartitionKey) DeconstructOrUseDefaultAttributes(EnqueueEventOptions options = default)
+        {
+            if (options != null)
+            {
+                (var partitionId, var partitionKey) = options;
+                return (partitionId, partitionKey);
+            }
+
+            return (null, null);
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClientOptions.cs
@@ -16,37 +16,23 @@ namespace Azure.Messaging.EventHubs.Producer
     ///
     internal class EventHubBufferedProducerClientOptions
     {
-        /// <summary> The number of batches that may be sent concurrently to each partition. </summary>
+        /// <summary>The number of batches that may be sent concurrently across all partitions.</summary>
+        private int _maximumConcurrentSends = Environment.ProcessorCount * 2;
+
+        /// <summary>The number of batches that may be sent concurrently to each partition.</summary>
         private int _maximumConcurrentSendsPerPartition = 1;
+
+        /// <summary>The total number of events that can be buffered for publishing at a given time for a given partition.</summary>
+        private int _maximumEventBufferLengthPerPartition = 1500;
+
+        /// <summary> The amount of time to wait for a new event to be enqueued in the buffer before publishing a partially full batch..</summary>
+        private TimeSpan? _maximumWaitTime = TimeSpan.FromMilliseconds(250);
 
         /// <summary>The set of options to use for configuring the connection to the Event Hubs service.</summary>
         private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
-
-        /// <summary>
-        ///   The amount of time to wait for a new event to be added to the buffer before sending a partially
-        ///   full batch.
-        /// </summary>
-        ///
-        /// <value>
-        ///   The default wait time is 250 milliseconds.
-        /// </value>
-        ///
-        public TimeSpan? MaximumWaitTime { get; set; } = TimeSpan.FromMilliseconds(250);
-
-        /// <summary>
-        ///   The total number of events that can be buffered for publishing at a given time across all partitions.
-        ///   Once this capacity is reached, more events can enqueued by calling <see cref="EventHubBufferedProducerClient.EnqueueEventAsync(EventData, EnqueueEventOptions, System.Threading.CancellationToken)" /> or
-        ///   <see cref="EventHubBufferedProducerClient.EnqueueEventsAsync(System.Collections.Generic.IEnumerable{EventData}, EnqueueEventOptions, System.Threading.CancellationToken)" />, which will automatically wait for room to be available.
-        /// </summary>
-        ///
-        /// <value>
-        ///   The default limit is 2,500 queued events.
-        /// </value>
-        ///
-        public int MaximumEventBufferLength { get; set; } = 2500;
 
         /// <summary>
         ///    Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing
@@ -56,7 +42,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <value>
         ///   By default, idempotent retries are disabled.
-        ///</value>
+        /// </value>
         ///
         /// <remarks>
         ///   It is important to note that enabling idempotent retries does not guarantee exactly-once semantics.  The existing
@@ -66,7 +52,91 @@ namespace Azure.Messaging.EventHubs.Producer
         public bool EnableIdempotentRetries { get; set; }
 
         /// <summary>
-        ///   The number of batches that may be sent concurrently to each partition.
+        ///   The amount of time to wait for a new event to be enqueued in the buffer before publishing
+        ///   a partially full batch.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The default wait time is 250 milliseconds.
+        ///
+        ///   <para>If <c>null</c>, attempts to enqueue events will wait forever for room in the buffer to become available
+        ///   unless the operation is canceled.</para>
+        /// </value>
+        ///
+        /// <exception cref="ArgumentOutOfRangeException">Occurs when the requested wait time is negative.</exception>
+        ///
+        public TimeSpan? MaximumWaitTime
+        {
+            get => _maximumWaitTime;
+
+            set
+            {
+                if (value.HasValue)
+                {
+                    Argument.AssertNotNegative(value.Value, nameof(MaximumWaitTime));
+                }
+
+                _maximumWaitTime = value;
+            }
+        }
+
+        /// <summary>
+        ///   The total number of events that can be buffered for publishing at a given time for a given partition.  Once this capacity is reached, more events can enqueued by calling
+        ///   <see cref="EventHubBufferedProducerClient.EnqueueEventAsync(EventData, EnqueueEventOptions, System.Threading.CancellationToken)" /> or
+        ///   <see cref="EventHubBufferedProducerClient.EnqueueEventsAsync(IEnumerable{EventData}, EnqueueEventOptions, System.Threading.CancellationToken)" />, which will automatically wait for room to be available.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The default limit is 1500 queued events for each partition.
+        /// </value>
+        ///
+        /// <exception cref="ArgumentOutOfRangeException">Occurs when the requested count is not between 1 and 1 million (inclusive).</exception>
+        ///
+        public int MaximumEventBufferLengthPerPartition
+        {
+            get => _maximumEventBufferLengthPerPartition;
+            set
+            {
+                // An upper bound of 1 million was chosen because it offers enough room for
+                // 2147 partitions to be completely full before overflowing an integer value.
+                // The current cap for general Event Hubs use is 32 partitions.
+                //
+                // Important enterprise customers can request up to 2000.
+
+                Argument.AssertInRange(value, 1, 1_000_000, nameof(MaximumEventBufferLengthPerPartition));
+                _maximumEventBufferLengthPerPartition = value;
+            }
+        }
+
+        /// <summary>
+        ///   The total number of batches that may be sent concurrently, across all partitions.  This limit takes precedence over
+        ///   the value specified in <see cref="MaximumConcurrentSendsPerPartition" />, ensuring this maximum is respected.
+        /// </summary>
+        ///
+        /// <value>
+        ///   By default, this will be set to twice the number of processors available in the host environment.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   When batches for the same partition are published concurrently, the ordering of events is not guaranteed.  If the order events are published
+        ///   must be maintained, <see cref="MaximumConcurrentSendsPerPartition" /> should not exceed 1.
+        /// </remarks>
+        ///
+        /// <exception cref="ArgumentOutOfRangeException">Occurs when the requested count is not between 1 and 100 (inclusive).</exception>
+        ///
+        public int MaximumConcurrentSends
+        {
+            get => _maximumConcurrentSends;
+            set
+            {
+                Argument.AssertInRange(value, 1, 100, nameof(MaximumConcurrentSends));
+                _maximumConcurrentSends = value;
+            }
+        }
+
+        /// <summary>
+        ///   The number of batches that may be sent concurrently for a given partition.  This option is superseded by
+        ///   the value specified for <see cref="MaximumConcurrentSends" />, ensuring that limit is respected.
         /// </summary>
         ///
         /// <value>
@@ -75,7 +145,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///</value>
         ///
         /// <remarks>
-        ///   When batches are published concurrently, the ordering of events is not guaranteed.  If the order events are published
+        ///   When batches for the same partition are published concurrently, the ordering of events is not guaranteed.  If the order of events
         ///   must be maintained, <see cref="MaximumConcurrentSendsPerPartition" /> should not exceed 1.
         /// </remarks>
         ///
@@ -168,11 +238,12 @@ namespace Azure.Messaging.EventHubs.Producer
             var copiedOptions = new EventHubBufferedProducerClientOptions
             {
                 Identifier = Identifier,
-                MaximumEventBufferLength = MaximumEventBufferLength,
-                MaximumWaitTime = MaximumWaitTime,
                 EnableIdempotentRetries = EnableIdempotentRetries,
                 _connectionOptions = ConnectionOptions.Clone(),
                 _retryOptions = RetryOptions.Clone(),
+                _maximumEventBufferLengthPerPartition = MaximumEventBufferLengthPerPartition,
+                _maximumWaitTime = MaximumWaitTime,
+                _maximumConcurrentSends = MaximumConcurrentSends,
                 _maximumConcurrentSendsPerPartition = MaximumConcurrentSendsPerPartition
             };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpAnnotatedMessageExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpAnnotatedMessageExtensionsTests.cs
@@ -401,6 +401,40 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions" />
+        ///   methods related to the partition key.
+        /// </summary>
+        ///
+        [Test]
+        public void PartitionKeyCanBeSet()
+        {
+            var partitionKey = "fake-key";
+            var message = CreateFullyPopulatedDataBodyMessage();
+
+            Assert.That(message.GetPartitionKey(), Is.Not.EqualTo(partitionKey), "The starting partition key should differ from the value being set.");
+
+            message.SetPartitionKey(partitionKey);
+            Assert.That(message.GetPartitionKey(), Is.EqualTo(partitionKey), "The partition key should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpAnnotatedMessageExtensions" />
+        ///   methods related to the enqueue time.
+        /// </summary>
+        ///
+        [Test]
+        public void EnqueueTimeCanBeSet()
+        {
+            var enqueueTime = new DateTimeOffset(2015, 10, 27, 00, 00, 00, TimeSpan.Zero);
+            var message = CreateFullyPopulatedDataBodyMessage();
+
+            Assert.That(message.GetEnqueuedTime(), Is.Not.EqualTo(enqueueTime), "The starting enqueue time should differ from the value being set.");
+
+            message.SetEnqueuedTime(enqueueTime);
+            Assert.That(message.GetEnqueuedTime(), Is.EqualTo(enqueueTime), "The enqueue time should match.");
+        }
+
+        /// <summary>
         ///   Creates a fully populated message with a consistent set of
         ///   test data.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EnqueueEventOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EnqueueEventOptionsTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Messaging.EventHubs.Producer;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EnqueueEventOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EnqueueEventOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EnqueueEventOptions.Deconstruct" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void OptionsCanBeDeconstructed()
+        {
+            var options = new EnqueueEventOptions
+            {
+                PartitionId = "0",
+                PartitionKey = "some_partition_123"
+            };
+
+            (var partitionId, var partitionKey) = options;
+            Assert.That(partitionId, Is.EqualTo(options.PartitionId), "The partition identifier of the deconstruction should match.");
+            Assert.That(partitionKey, Is.EqualTo(options.PartitionKey), "The partition key of the deconstruction should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EnqueueEventOptions.DeconstructOrUseDefaultAttributes" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void DeconstructOrUseDefaultAttributesUsesOptionsWhenProvided()
+        {
+            var options = new EnqueueEventOptions
+            {
+                PartitionId = "0",
+                PartitionKey = "some_partition_123"
+            };
+
+            (var partitionId, var partitionKey) = EnqueueEventOptions.DeconstructOrUseDefaultAttributes(options);
+            Assert.That(partitionId, Is.EqualTo(options.PartitionId), "The partition identifier of the deconstruction should match.");
+            Assert.That(partitionKey, Is.EqualTo(options.PartitionKey), "The partition key of the deconstruction should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EnqueueEventOptions.Deconstruct" /> and
+        ///   <see cref="EnqueueEventOptions.DeconstructOrUseDefaultAttributes" /> methods.
+        /// </summary>
+        ///
+        [Test]
+        public void DefaultOptionsMatchDefaultDeconstruction()
+        {
+            (var defaultPartitionId, var defaultPartitionKey) = EnqueueEventOptions.DeconstructOrUseDefaultAttributes();
+            (var newPartitionId, var newPartitionKey) = new EnqueueEventOptions();
+
+            Assert.That(defaultPartitionId, Is.EqualTo(newPartitionId), "The partition identifier of the default attributes should match empty deconstruction.");
+            Assert.That(defaultPartitionKey, Is.EqualTo(newPartitionKey), "The partition key of the default attributes should match empty deconstruction.");
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The focus of these changes is to continue fleshing out the buffered producer client, adding the ability to enqueue events to be published.

Pending work:

- Background management task
- Background publishing task
- Flush functionality
- Clear functionality
- Automatic partition assignment
- Partition Key hashing

# Related and References

- [EventHubBufferedProducerClient: Infrastructure and Functionality (#23480)](https://github.com/Azure/azure-sdk-for-net/issues/23480)