### PR TITLE
Make Response.IsError functional for clients

### DIFF
--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/LowLevelClientModels/Pet.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/LowLevelClientModels/Pet.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Text.Json;
+using Azure.Core.Pipeline;
 
 namespace Azure.Core.Experimental.Tests.Models
 {
@@ -33,15 +34,14 @@ namespace Azure.Core.Experimental.Tests.Models
         public static implicit operator Pet(Response response)
         {
             // [X] TODO: Add in HLC error semantics
-            // [ ] TODO: Use response.IsError
+            // [X] TODO: Use response.IsError
             // [ ] TODO: Use throw new ResponseFailedException(response);
-            switch (response.Status)
+            if (response.IsError())
             {
-                case 200:
-                    return DeserializePet(JsonDocument.Parse(response.Content.ToMemory()));
-                default:
-                    throw new RequestFailedException("Received a non-success status code.");
+                throw new RequestFailedException("Received a non-success status code.");
             }
+
+            return DeserializePet(JsonDocument.Parse(response.Content.ToMemory()));
         }
 
         private static Pet DeserializePet(JsonDocument document)

--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
@@ -57,7 +57,9 @@ namespace Azure.Core.Experimental.Tests
             _clientDiagnostics = new ClientDiagnostics(options);
             _tokenCredential = credential;
             var authPolicy = new BearerTokenAuthenticationPolicy(_tokenCredential, AuthorizationScopes);
-            Pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new LowLevelCallbackPolicy() }, new HttpPipelinePolicy[] { authPolicy }, new ResponseClassifier());
+
+            // When we move the IsError functionality into Core, we'll move the addition of ResponsePropertiesPolicy to the pipeline into HttpPipelineBuilder.
+            Pipeline = HttpPipelineBuilder.Build(options, new HttpPipelinePolicy[] { new LowLevelCallbackPolicy() }, new HttpPipelinePolicy[] { authPolicy, new ResponsePropertiesPolicy() }, new ResponseClassifier());
             this.endpoint = endpoint;
             apiVersion = options.Version;
         }

--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClientTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClientTests.cs
@@ -67,6 +67,20 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public async Task ModelCastThrowsOnErrorCodeAsync()
+        {
+            var mockResponse = new MockResponse(404);
+
+            // Send the response through the pipeline so IsError is set.
+            var mockTransport = new MockTransport(mockResponse);
+            PetStoreClient client = CreateClient(mockTransport);
+
+            Response response = await client.GetPetAsync("pet1", ResponseStatusOption.NoThrow);
+
+            Assert.Throws<RequestFailedException>(() => { Pet pet = response; });
+        }
+
+        [Test]
         public void CannotGetOutputModelOnFailureCodeAsync()
         {
             var mockResponse = new MockResponse(404);


### PR DESCRIPTION
Missed this in the last [IsError PR](https://github.com/Azure/azure-sdk-for-net/pull/24122).  Fixes https://github.com/azure/azure-sdk-for-net/issues/24225

As long as `Response.IsError` lives in Azure.Core.Experimental, we'll need to add the `ResponsePropertiesPolicy` to LLC clients' pipelines in their constructors, as we're doing here.  When this functionality moves into Azure.Core, we can add this to PipelineBuilder.