### PR TITLE
Storage test infra refactor

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/Azure.Storage.Blobs.Batch.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/Azure.Storage.Blobs.Batch.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared\Core" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobTestBase.cs" LinkBase="Shared" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobTestEnvironment.cs" LinkBase="Shared" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\ClientBuilderExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageConnectionString.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)SharedAccessSignatureCredentials.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/Azure.Storage.Blobs.Batch.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/Azure.Storage.Blobs.Batch.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobTestBase.cs" LinkBase="Shared" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobTestEnvironment.cs" LinkBase="Shared" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\ClientBuilderExtensions.cs" LinkBase="Shared" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\DisposingContainer.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageConnectionString.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)SharedAccessSignatureCredentials.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
@@ -221,7 +221,7 @@ namespace Azure.Storage.Blobs.Test
             // Create a container using SAS for Auth
             await using DisposingContainer test = await GetTestContainerAsync();
 
-            var serviceClient = Clients.GetServiceClient_SharedKey();
+            var serviceClient = BlobsClientBuilder.GetServiceClient_SharedKey();
             var sas = GetAccountSasCredentials().SasToken;
             var sasServiceClient = InstrumentClient(new BlobServiceClient(serviceClient.Uri, new AzureSasCredential(sas), GetOptions()));
             await using TestScenario scenario = Scenario(sasServiceClient);
@@ -582,9 +582,9 @@ namespace Azure.Storage.Blobs.Test
         public async Task Delete_Error()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobServiceClient invalidServiceClient = InstrumentClient(new BlobServiceClient(
-                Clients.GetServiceClient_SharedKey().Uri,
+                BlobsClientBuilder.GetServiceClient_SharedKey().Uri,
                 GetOptions()));
             BlobBatchClient blobBatchClient = invalidServiceClient.GetBlobBatchClient();
             using BlobBatch batch = blobBatchClient.CreateBatch();
@@ -1019,9 +1019,9 @@ namespace Azure.Storage.Blobs.Test
         public async Task SetBlobAccessTier_Error()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobServiceClient invalidServiceClient = InstrumentClient(new BlobServiceClient(
-                Clients.GetServiceClient_SharedKey().Uri,
+                BlobsClientBuilder.GetServiceClient_SharedKey().Uri,
                 GetOptions()));
             BlobBatchClient blobBatchClient = invalidServiceClient.GetBlobBatchClient();
             using BlobBatch batch = blobBatchClient.CreateBatch();
@@ -1039,7 +1039,7 @@ namespace Azure.Storage.Blobs.Test
         #endregion SetBlobAccessTier
 
         #region Scenario helper
-        private TestScenario Scenario() => Scenario(Clients.GetServiceClient_SharedKey());
+        private TestScenario Scenario() => Scenario(BlobsClientBuilder.GetServiceClient_SharedKey());
         private TestScenario Scenario(BlobServiceClient client) => new TestScenario(this, client);
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
@@ -16,6 +16,7 @@ using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -220,7 +221,7 @@ namespace Azure.Storage.Blobs.Test
             // Create a container using SAS for Auth
             await using DisposingContainer test = await GetTestContainerAsync();
 
-            var serviceClient = GetServiceClient_SharedKey();
+            var serviceClient = Clients.GetServiceClient_SharedKey();
             var sas = GetAccountSasCredentials().SasToken;
             var sasServiceClient = InstrumentClient(new BlobServiceClient(serviceClient.Uri, new AzureSasCredential(sas), GetOptions()));
             await using TestScenario scenario = Scenario(sasServiceClient);
@@ -342,7 +343,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 BlobContainerName = containerName
             };
-            BlobSasQueryParameters sasQueryParameters = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials());
+            BlobSasQueryParameters sasQueryParameters = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials());
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(scenario.Service.Uri)
             {
                 BlobContainerName = containerName,
@@ -424,7 +425,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 BlobContainerName = containerName
             };
-            BlobSasQueryParameters sasQueryParameters = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials());
+            BlobSasQueryParameters sasQueryParameters = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials());
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(scenario.Service.Uri)
             {
                 BlobContainerName = containerName,
@@ -581,9 +582,9 @@ namespace Azure.Storage.Blobs.Test
         public async Task Delete_Error()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
             BlobServiceClient invalidServiceClient = InstrumentClient(new BlobServiceClient(
-                GetServiceClient_SharedKey().Uri,
+                Clients.GetServiceClient_SharedKey().Uri,
                 GetOptions()));
             BlobBatchClient blobBatchClient = invalidServiceClient.GetBlobBatchClient();
             using BlobBatch batch = blobBatchClient.CreateBatch();
@@ -702,7 +703,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 BlobContainerName = containerName
             };
-            BlobSasQueryParameters sasQueryParameters = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials());
+            BlobSasQueryParameters sasQueryParameters = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials());
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(scenario.Service.Uri)
             {
                 BlobContainerName = containerName,
@@ -784,7 +785,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 BlobContainerName = containerName
             };
-            BlobSasQueryParameters sasQueryParameters = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials());
+            BlobSasQueryParameters sasQueryParameters = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials());
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(scenario.Service.Uri)
             {
                 BlobContainerName = containerName,
@@ -1018,9 +1019,9 @@ namespace Azure.Storage.Blobs.Test
         public async Task SetBlobAccessTier_Error()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
             BlobServiceClient invalidServiceClient = InstrumentClient(new BlobServiceClient(
-                GetServiceClient_SharedKey().Uri,
+                Clients.GetServiceClient_SharedKey().Uri,
                 GetOptions()));
             BlobBatchClient blobBatchClient = invalidServiceClient.GetBlobBatchClient();
             using BlobBatch batch = blobBatchClient.CreateBatch();
@@ -1038,7 +1039,7 @@ namespace Azure.Storage.Blobs.Test
         #endregion SetBlobAccessTier
 
         #region Scenario helper
-        private TestScenario Scenario() => Scenario(GetServiceClient_SharedKey());
+        private TestScenario Scenario() => Scenario(Clients.GetServiceClient_SharedKey());
         private TestScenario Scenario(BlobServiceClient client) => new TestScenario(this, client);
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
@@ -11,12 +11,12 @@ using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Batch.Tests;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -13,13 +13,13 @@ using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Shared;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -458,7 +458,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task CreateAsync_EncryptionScopeIdentitySAS()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
 
             Response<UserDelegationKey> userDelegationKey = await oauthService.GetUserDelegationKeyAsync(
@@ -1589,7 +1589,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task AppendBlockFromUriAsync_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -1624,7 +1624,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task AppendBlockFromUriAsync_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -432,7 +432,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             string containerName = GetNewContainerName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName);
-            BlobServiceClient blobServiceClient = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient blobServiceClient = BlobsClientBuilder.GetServiceClient_SharedKey();
 
             AccountSasBuilder accountSasBuilder = new AccountSasBuilder(
                 permissions: AccountSasPermissions.All,
@@ -458,7 +458,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task CreateAsync_EncryptionScopeIdentitySAS()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
 
             Response<UserDelegationKey> userDelegationKey = await oauthService.GetUserDelegationKeyAsync(
@@ -503,7 +503,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task CreateAsync_Error()
         {
             // Arrange
-            BlobServiceClient blobService = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient blobService = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobContainerClient containerClient = InstrumentClient(blobService.GetBlobContainerClient(GetNewContainerName()));
             AppendBlobClient blob = InstrumentClient(containerClient.GetAppendBlobClient(GetNewBlobName()));
 
@@ -689,7 +689,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task CreateIfNotExistsAsync_Error()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobContainerClient containerClient = InstrumentClient(serviceClient.GetBlobContainerClient(GetNewContainerName()));
             AppendBlobClient blob = InstrumentClient(containerClient.GetAppendBlobClient(GetNewBlobName()));
 
@@ -1589,7 +1589,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task AppendBlockFromUriAsync_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -1624,7 +1624,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task AppendBlockFromUriAsync_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -2007,7 +2007,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             AppendBlobClient blob = InstrumentClient(container.GetAppendBlobClient(GetNewBlobName()));
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -19,6 +19,7 @@ using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -78,11 +79,11 @@ namespace Azure.Storage.Blobs.Test
         public void Ctor_TokenAuth_Http()
         {
             // Arrange
-            Uri httpUri = new Uri(TestConfigOAuth.BlobServiceEndpoint).ToHttp();
+            Uri httpUri = new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
-                () => new AppendBlobClient(httpUri, GetOAuthCredential()),
+                () => new AppendBlobClient(httpUri, Tenants.GetOAuthCredential()),
                  new ArgumentException("Cannot use TokenCredential without HTTPS."));
         }
 
@@ -431,7 +432,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             string containerName = GetNewContainerName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName);
-            BlobServiceClient blobServiceClient = GetServiceClient_SharedKey();
+            BlobServiceClient blobServiceClient = Clients.GetServiceClient_SharedKey();
 
             AccountSasBuilder accountSasBuilder = new AccountSasBuilder(
                 permissions: AccountSasPermissions.All,
@@ -478,7 +479,7 @@ namespace Azure.Storage.Blobs.Test
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(test.Container.Uri)
             {
                 BlobName = blobName,
-                Sas = blobSasBuilder.ToSasQueryParameters(userDelegationKey.Value, TestConfigOAuth.AccountName)
+                Sas = blobSasBuilder.ToSasQueryParameters(userDelegationKey.Value, Tenants.TestConfigOAuth.AccountName)
             };
             AppendBlobClient sasBlob = InstrumentClient(new AppendBlobClient(blobUriBuilder.ToUri(), GetOptions()));
 
@@ -502,7 +503,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task CreateAsync_Error()
         {
             // Arrange
-            BlobServiceClient blobService = GetServiceClient_SharedKey();
+            BlobServiceClient blobService = Clients.GetServiceClient_SharedKey();
             BlobContainerClient containerClient = InstrumentClient(blobService.GetBlobContainerClient(GetNewContainerName()));
             AppendBlobClient blob = InstrumentClient(containerClient.GetAppendBlobClient(GetNewBlobName()));
 
@@ -688,7 +689,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task CreateIfNotExistsAsync_Error()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_SharedKey();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_SharedKey();
             BlobContainerClient containerClient = InstrumentClient(serviceClient.GetBlobContainerClient(GetNewContainerName()));
             AppendBlobClient blob = InstrumentClient(containerClient.GetAppendBlobClient(GetNewBlobName()));
 
@@ -2006,7 +2007,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             AppendBlobClient blob = InstrumentClient(container.GetAppendBlobClient(GetNewBlobName()));
 
@@ -2248,9 +2249,9 @@ namespace Azure.Storage.Blobs.Test
             var mock = new Mock<AppendBlobClient>(TestConfigDefault.ConnectionString, "name", "name", new BlobClientOptions()).Object;
             mock = new Mock<AppendBlobClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<AppendBlobClient>(new Uri("https://test/test"), new BlobClientOptions()).Object;
-            mock = new Mock<AppendBlobClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
+            mock = new Mock<AppendBlobClient>(new Uri("https://test/test"), Tenants.GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
             mock = new Mock<AppendBlobClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new BlobClientOptions()).Object;
-            mock = new Mock<AppendBlobClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
+            mock = new Mock<AppendBlobClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
         }
 
         private AppendBlobRequestConditions BuildDestinationAccessConditions(

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -199,7 +199,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task Ctor_AzureSasCredential_UserDelegationSAS()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             var client = test.Container.GetBlobClient(GetNewBlobName());
             await client.UploadAsync(new MemoryStream());
@@ -1355,8 +1355,8 @@ namespace Azure.Storage.Blobs.Test
         {
             // TODO: The tests will temporarily use designated account, containers and blobs to check the
             // existence of OR headers
-            BlobServiceClient sourceServiceClient = Clients.GetServiceClient_SharedKey();
-            BlobServiceClient destinationServiceClient = Clients.GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient sourceServiceClient = BlobsClientBuilder.GetServiceClient_SharedKey();
+            BlobServiceClient destinationServiceClient = BlobsClientBuilder.GetServiceClient_SecondaryAccount_SharedKey();
 
             // This is a PLAYBACK ONLY test with a special container we previously setup, as we can't auto setup policies yet
             BlobContainerClient sourceContainer = InstrumentClient(sourceServiceClient.GetBlobContainerClient("test1"));
@@ -2915,7 +2915,7 @@ namespace Azure.Storage.Blobs.Test
                 await srcBlob.UploadAsync(stream);
             }
 
-            BlobServiceClient secondaryService = Clients.GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient secondaryService = BlobsClientBuilder.GetServiceClient_SecondaryAccount_SharedKey();
             await using DisposingContainer destTest = await GetTestContainerAsync(service: secondaryService);
             {
                 BlockBlobClient destBlob = InstrumentClient(destTest.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -2996,7 +2996,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 await srcBlob.UploadAsync(stream);
             }
-            BlobServiceClient secondaryService = Clients.GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient secondaryService = BlobsClientBuilder.GetServiceClient_SecondaryAccount_SharedKey();
             await using DisposingContainer destTest = await GetTestContainerAsync(service: secondaryService);
 
             BlockBlobClient destBlob = InstrumentClient(destTest.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -3046,7 +3046,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 await srcBlob.UploadAsync(stream);
             }
-            BlobServiceClient secondaryService = Clients.GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient secondaryService = BlobsClientBuilder.GetServiceClient_SecondaryAccount_SharedKey();
             await using DisposingContainer destTest = await GetTestContainerAsync(service: secondaryService);
 
             BlockBlobClient destBlob = InstrumentClient(destTest.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -3512,7 +3512,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncCopyFromUri_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3550,7 +3550,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncCopyFromUri_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3785,7 +3785,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task DeleteAsync_VersionIdentitySAS()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
@@ -3816,7 +3816,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task DeleteAsync_VersionInvalidSAS()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
@@ -3874,7 +3874,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task DeleteAsync_VersionBlobIdentitySAS(BlobSasPermissions blobSasPermissions)
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
@@ -3931,7 +3931,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task DeleteAsync_VersionContainerIdentitySAS(BlobContainerSasPermissions blobContainerSasPermissions)
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
@@ -3967,7 +3967,7 @@ namespace Azure.Storage.Blobs.Test
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
             IDictionary<string, string> metadata = BuildMetadata();
             Response<BlobInfo> metadataResponse = await blob.SetMetadataAsync(metadata);
-            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas(
+            SasQueryParameters sasQueryParameters = BlobsClientBuilder.GetNewAccountSas(
                 resourceTypes: AccountSasResourceTypes.All,
                 permissions: AccountSasPermissions.All);
             BlobBaseClient versionBlob = new BlobBaseClient(
@@ -4035,7 +4035,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task DeleteIfExistsAsync_ContainerNotExists()
         {
-            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobContainerClient container = service.GetBlobContainerClient(GetNewContainerName());
 
             // Arrange
@@ -4219,7 +4219,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task ExistsAsync_ContainerNotExists()
         {
-            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobContainerClient container = service.GetBlobContainerClient(GetNewContainerName());
 
             // Arrange
@@ -4379,7 +4379,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task GetPropertiesAsync_ContainerIdentitySAS()
         {
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -4542,7 +4542,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task GetPropertiesAsync_BlobIdentitySAS()
         {
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
 
@@ -4663,7 +4663,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task GetPropertiesAsync_SnapshotIdentitySAS()
         {
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -4798,8 +4798,8 @@ namespace Azure.Storage.Blobs.Test
         {
             // TODO: The tests will temporarily use designated account, containers and blobs to check the
             // existence of OR headers
-            BlobServiceClient sourceServiceClient = Clients.GetServiceClient_SharedKey();
-            BlobServiceClient destinationServiceClient = Clients.GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient sourceServiceClient = BlobsClientBuilder.GetServiceClient_SharedKey();
+            BlobServiceClient destinationServiceClient = BlobsClientBuilder.GetServiceClient_SecondaryAccount_SharedKey();
 
             // This is a PLAYBACK ONLY test with a special container we previously setup, as we can't auto setup policies yet
             BlobContainerClient sourceContainer = InstrumentClient(sourceServiceClient.GetBlobContainerClient("test1"));
@@ -6476,7 +6476,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task GetSetTagsAsync_BlobIdentityTagSas()
         {
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -6511,7 +6511,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task GetSetTagsAsync_InvalidBlobIdentitySas()
         {
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -6586,7 +6586,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task GetSetTagsAsync_ContainerIdentityTagSas()
         {
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -6620,7 +6620,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task GetSetTagsAsync_InvalidContainerIdentitySas()
         {
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -6656,7 +6656,7 @@ namespace Azure.Storage.Blobs.Test
         {
             await using DisposingContainer test = await GetTestContainerAsync();
             BlobBaseClient blob = await GetNewBlobClient(test.Container);
-            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas(permissions: accountSasPermissions);
+            SasQueryParameters sasQueryParameters = BlobsClientBuilder.GetNewAccountSas(permissions: accountSasPermissions);
             BlobBaseClient sasBlob = new BlobBaseClient(new Uri($"{blob.Uri}?{sasQueryParameters}"), GetOptions());
 
             Dictionary<string, string> tags = BuildTags();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -23,6 +23,7 @@ using Azure.Storage.Test.Shared;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
 namespace Azure.Storage.Blobs.Test
@@ -134,11 +135,11 @@ namespace Azure.Storage.Blobs.Test
         public void Ctor_TokenAuth_Http()
         {
             // Arrange
-            Uri httpUri = new Uri(TestConfigOAuth.BlobServiceEndpoint).ToHttp();
+            Uri httpUri = new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
-                () => new BlobBaseClient(httpUri, GetOAuthCredential()),
+                () => new BlobBaseClient(httpUri, Tenants.GetOAuthCredential()),
                  new ArgumentException("Cannot use TokenCredential without HTTPS."));
         }
 
@@ -1354,8 +1355,8 @@ namespace Azure.Storage.Blobs.Test
         {
             // TODO: The tests will temporarily use designated account, containers and blobs to check the
             // existence of OR headers
-            BlobServiceClient sourceServiceClient = GetServiceClient_SharedKey();
-            BlobServiceClient destinationServiceClient = GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient sourceServiceClient = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient destinationServiceClient = Clients.GetServiceClient_SecondaryAccount_SharedKey();
 
             // This is a PLAYBACK ONLY test with a special container we previously setup, as we can't auto setup policies yet
             BlobContainerClient sourceContainer = InstrumentClient(sourceServiceClient.GetBlobContainerClient("test1"));
@@ -2914,7 +2915,7 @@ namespace Azure.Storage.Blobs.Test
                 await srcBlob.UploadAsync(stream);
             }
 
-            BlobServiceClient secondaryService = GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient secondaryService = Clients.GetServiceClient_SecondaryAccount_SharedKey();
             await using DisposingContainer destTest = await GetTestContainerAsync(service: secondaryService);
             {
                 BlockBlobClient destBlob = InstrumentClient(destTest.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -2995,7 +2996,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 await srcBlob.UploadAsync(stream);
             }
-            BlobServiceClient secondaryService = GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient secondaryService = Clients.GetServiceClient_SecondaryAccount_SharedKey();
             await using DisposingContainer destTest = await GetTestContainerAsync(service: secondaryService);
 
             BlockBlobClient destBlob = InstrumentClient(destTest.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -3045,7 +3046,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 await srcBlob.UploadAsync(stream);
             }
-            BlobServiceClient secondaryService = GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient secondaryService = Clients.GetServiceClient_SecondaryAccount_SharedKey();
             await using DisposingContainer destTest = await GetTestContainerAsync(service: secondaryService);
 
             BlockBlobClient destBlob = InstrumentClient(destTest.Container.GetBlockBlobClient(GetNewBlobName()));
@@ -3966,7 +3967,7 @@ namespace Azure.Storage.Blobs.Test
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
             IDictionary<string, string> metadata = BuildMetadata();
             Response<BlobInfo> metadataResponse = await blob.SetMetadataAsync(metadata);
-            SasQueryParameters sasQueryParameters = GetNewAccountSas(
+            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas(
                 resourceTypes: AccountSasResourceTypes.All,
                 permissions: AccountSasPermissions.All);
             BlobBaseClient versionBlob = new BlobBaseClient(
@@ -4034,7 +4035,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task DeleteIfExistsAsync_ContainerNotExists()
         {
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
             BlobContainerClient container = service.GetBlobContainerClient(GetNewContainerName());
 
             // Arrange
@@ -4218,7 +4219,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task ExistsAsync_ContainerNotExists()
         {
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
             BlobContainerClient container = service.GetBlobContainerClient(GetNewContainerName());
 
             // Arrange
@@ -4394,7 +4395,7 @@ namespace Azure.Storage.Blobs.Test
                 containerName: test.Container.Name,
                 BlobContainerSasPermissions.Read,
                 userDelegationKey: userDelegationKey,
-                TestConfigOAuth.AccountName);
+                Tenants.TestConfigOAuth.AccountName);
 
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(blob.Uri)
             {
@@ -4463,7 +4464,7 @@ namespace Azure.Storage.Blobs.Test
                 BlobName = blobName,
                 Identifier = signedIdentifierId
             };
-            BlobSasQueryParameters sasQueryParameters = sasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials());
+            BlobSasQueryParameters sasQueryParameters = sasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials());
 
             BlobUriBuilder uriBuilder = new BlobUriBuilder(blob.Uri)
             {
@@ -4508,7 +4509,7 @@ namespace Azure.Storage.Blobs.Test
             blobSasBuilder.SetPermissions(
                 BlobSasPermissions.All);
 
-            BlobSasQueryParameters blobSasQueryParameters = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials());
+            BlobSasQueryParameters blobSasQueryParameters = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials());
 
             // Act
             string queryParametersString = blobSasQueryParameters.ToString();
@@ -4681,7 +4682,7 @@ namespace Azure.Storage.Blobs.Test
                 snapshot: snapshotResponse.Value.Snapshot,
                 permissions: SnapshotSasPermissions.Read,
                 userDelegationKey: userDelegationKey,
-                accountName: TestConfigOAuth.AccountName);
+                accountName: Tenants.TestConfigOAuth.AccountName);
 
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(blob.Uri)
             {
@@ -4797,8 +4798,8 @@ namespace Azure.Storage.Blobs.Test
         {
             // TODO: The tests will temporarily use designated account, containers and blobs to check the
             // existence of OR headers
-            BlobServiceClient sourceServiceClient = GetServiceClient_SharedKey();
-            BlobServiceClient destinationServiceClient = GetServiceClient_SecondaryAccount_SharedKey();
+            BlobServiceClient sourceServiceClient = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient destinationServiceClient = Clients.GetServiceClient_SecondaryAccount_SharedKey();
 
             // This is a PLAYBACK ONLY test with a special container we previously setup, as we can't auto setup policies yet
             BlobContainerClient sourceContainer = InstrumentClient(sourceServiceClient.GetBlobContainerClient("test1"));
@@ -6655,7 +6656,7 @@ namespace Azure.Storage.Blobs.Test
         {
             await using DisposingContainer test = await GetTestContainerAsync();
             BlobBaseClient blob = await GetNewBlobClient(test.Container);
-            SasQueryParameters sasQueryParameters = GetNewAccountSas(permissions: accountSasPermissions);
+            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas(permissions: accountSasPermissions);
             BlobBaseClient sasBlob = new BlobBaseClient(new Uri($"{blob.Uri}?{sasQueryParameters}"), GetOptions());
 
             Dictionary<string, string> tags = BuildTags();
@@ -7824,9 +7825,9 @@ namespace Azure.Storage.Blobs.Test
             var mock = new Mock<BlobBaseClient>(TestConfigDefault.ConnectionString, "name", "name", new BlobClientOptions()).Object;
             mock = new Mock<BlobBaseClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<BlobBaseClient>(new Uri("https://test/test"), new BlobClientOptions()).Object;
-            mock = new Mock<BlobBaseClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
+            mock = new Mock<BlobBaseClient>(new Uri("https://test/test"), Tenants.GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
             mock = new Mock<BlobBaseClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new BlobClientOptions()).Object;
-            mock = new Mock<BlobBaseClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
+            mock = new Mock<BlobBaseClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
         }
 
         public IEnumerable<AccessConditionParameters> AccessConditions_Data

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -23,7 +23,6 @@ using Azure.Storage.Test.Shared;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
 namespace Azure.Storage.Blobs.Test

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -199,7 +199,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task Ctor_AzureSasCredential_UserDelegationSAS()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             var client = test.Container.GetBlobClient(GetNewBlobName());
             await client.UploadAsync(new MemoryStream());
@@ -3512,7 +3512,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncCopyFromUri_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3550,7 +3550,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncCopyFromUri_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3785,7 +3785,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task DeleteAsync_VersionIdentitySAS()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
@@ -3816,7 +3816,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task DeleteAsync_VersionInvalidSAS()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
@@ -3874,7 +3874,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task DeleteAsync_VersionBlobIdentitySAS(BlobSasPermissions blobSasPermissions)
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
@@ -3931,7 +3931,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task DeleteAsync_VersionContainerIdentitySAS(BlobContainerSasPermissions blobContainerSasPermissions)
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(oauthService);
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             Response<BlobContentInfo> createResponse = await blob.CreateAsync();
@@ -4379,7 +4379,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task GetPropertiesAsync_ContainerIdentitySAS()
         {
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -4542,7 +4542,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task GetPropertiesAsync_BlobIdentitySAS()
         {
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
 
@@ -4663,7 +4663,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task GetPropertiesAsync_SnapshotIdentitySAS()
         {
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -6476,7 +6476,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task GetSetTagsAsync_BlobIdentityTagSas()
         {
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -6511,7 +6511,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task GetSetTagsAsync_InvalidBlobIdentitySas()
         {
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -6586,7 +6586,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task GetSetTagsAsync_ContainerIdentityTagSas()
         {
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -6620,7 +6620,7 @@ namespace Azure.Storage.Blobs.Test
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task GetSetTagsAsync_InvalidContainerIdentitySas()
         {
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Identity;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Shared;
 using Azure.Storage.Test;
@@ -18,7 +19,6 @@ using Azure.Storage.Tests;
 using Azure.Storage.Tests.Shared;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -18,6 +18,7 @@ using Azure.Storage.Tests;
 using Azure.Storage.Tests.Shared;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -99,11 +100,11 @@ namespace Azure.Storage.Blobs.Test
         public void Ctor_TokenAuth_Http()
         {
             // Arrange
-            Uri httpUri = new Uri(TestConfigOAuth.BlobServiceEndpoint).ToHttp();
+            Uri httpUri = new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
-                () => new BlobClient(httpUri, GetOAuthCredential()),
+                () => new BlobClient(httpUri, Tenants.GetOAuthCredential()),
                  new ArgumentException("Cannot use TokenCredential without HTTPS."));
         }
 
@@ -116,7 +117,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 CustomerProvidedKey = customerProvidedKey
             };
-            Uri httpUri = new Uri(TestConfigDefault.BlobServiceEndpoint).ToHttp();
+            Uri httpUri = new Uri(Tenants.TestConfigDefault.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
@@ -132,12 +133,12 @@ namespace Azure.Storage.Blobs.Test
             BlobClientOptions blobClientOptions = new BlobClientOptions
             {
                 CustomerProvidedKey = customerProvidedKey,
-                EncryptionScope = TestConfigDefault.EncryptionScope
+                EncryptionScope = Tenants.TestConfigDefault.EncryptionScope
             };
 
             // Act
             TestHelper.AssertExpectedException(
-                () => new BlobClient(new Uri(TestConfigDefault.BlobServiceEndpoint), blobClientOptions),
+                () => new BlobClient(new Uri(Tenants.TestConfigDefault.BlobServiceEndpoint), blobClientOptions),
                 new ArgumentException("CustomerProvidedKey and EncryptionScope cannot both be set"));
         }
 
@@ -789,7 +790,7 @@ namespace Azure.Storage.Blobs.Test
 
             var name = GetNewBlobName();
             BlobClient blob = InstrumentClient(test.Container.GetBlobClient(name));
-            var credential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+            var credential = new StorageSharedKeyCredential(Tenants.TestConfigDefault.AccountName, Tenants.TestConfigDefault.AccountKey);
             blob = InstrumentClient(new BlobClient(blob.Uri, credential, GetOptions(true)));
 
             await blob.StagedUploadInternal(
@@ -824,7 +825,7 @@ namespace Azure.Storage.Blobs.Test
 
                 var name = GetNewBlobName();
                 BlobClient blob = InstrumentClient(test.Container.GetBlobClient(name));
-                var credential = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+                var credential = new StorageSharedKeyCredential(Tenants.TestConfigDefault.AccountName, Tenants.TestConfigDefault.AccountKey);
                 blob = InstrumentClient(new BlobClient(blob.Uri, credential, GetOptions(true)));
 
                 await blob.StagedUploadInternal(
@@ -1186,8 +1187,8 @@ namespace Azure.Storage.Blobs.Test
             options.Diagnostics.IsLoggingEnabled = false;
 
             BlobServiceClient service = new BlobServiceClient(
-                new Uri(TestConfigDefault.BlobServiceEndpoint),
-                GetNewSharedKeyCredentials(),
+                new Uri(Tenants.TestConfigDefault.BlobServiceEndpoint),
+                Tenants.GetNewSharedKeyCredentials(),
                 options);
 
             await using DisposingContainer test = await GetTestContainerAsync(service);
@@ -1341,12 +1342,12 @@ namespace Azure.Storage.Blobs.Test
         public void CanMockClientConstructors()
         {
             // One has to call .Object to trigger constructor. It's lazy.
-            var mock = new Mock<BlobClient>(TestConfigDefault.ConnectionString, "name", "name", new BlobClientOptions()).Object;
-            mock = new Mock<BlobClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
+            var mock = new Mock<BlobClient>(Tenants.TestConfigDefault.ConnectionString, "name", "name", new BlobClientOptions()).Object;
+            mock = new Mock<BlobClient>(Tenants.TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<BlobClient>(new Uri("https://test/test"), new BlobClientOptions()).Object;
-            mock = new Mock<BlobClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
+            mock = new Mock<BlobClient>(new Uri("https://test/test"), Tenants.GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
             mock = new Mock<BlobClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new BlobClientOptions()).Object;
-            mock = new Mock<BlobClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
+            mock = new Mock<BlobClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobQuickQueryTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobQuickQueryTests.cs
@@ -10,11 +10,11 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Azure.Storage.Tests.Shared;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobQuickQueryTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobQuickQueryTests.cs
@@ -14,6 +14,7 @@ using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Azure.Storage.Tests.Shared;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -474,7 +474,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobSasBuilder_PreauthorizedAgentObjectId()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string preauthorizedAgentGuid = Recording.Random.NewGuid().ToString();
 
@@ -512,7 +512,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobSasBuilder_CorrelationId()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
 
             await using DisposingContainer test = await GetTestContainerAsync(service: oauthService, containerName: containerName);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -474,7 +474,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobSasBuilder_PreauthorizedAgentObjectId()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string preauthorizedAgentGuid = Recording.Random.NewGuid().ToString();
 
@@ -512,7 +512,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobSasBuilder_CorrelationId()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
 
             await using DisposingContainer test = await GetTestContainerAsync(service: oauthService, containerName: containerName);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -15,6 +15,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -11,11 +11,11 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobIdentitySas_AllPermissions()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -117,7 +117,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobVersionIdentitySas_AllPermissions()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -187,7 +187,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobSnapshotIdentitySas_AllPermissions()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -251,7 +251,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task ContainerIdentitySas_AllPermissions()
         {
             // Arrange
-            BlobServiceClient oauthService = GetServiceClient_OauthAccount();
+            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
@@ -9,6 +9,7 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
 using Azure.Storage.Test.Shared;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -38,7 +39,7 @@ namespace Azure.Storage.Blobs.Test
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(test.Container.Uri)
             {
                 BlobName = blobName,
-                Sas = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials())
+                Sas = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials())
             };
 
             // Act
@@ -103,7 +104,7 @@ namespace Azure.Storage.Blobs.Test
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(blob.Uri)
             {
                 VersionId = createResponse.Value.VersionId,
-                Sas = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials())
+                Sas = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials())
             };
 
             // Act
@@ -173,7 +174,7 @@ namespace Azure.Storage.Blobs.Test
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(blob.Uri)
             {
                 Snapshot = snapshotResponse.Value.Snapshot,
-                Sas = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials())
+                Sas = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials())
             };
 
             // Act
@@ -237,7 +238,7 @@ namespace Azure.Storage.Blobs.Test
             BlobUriBuilder blobUriBuilder = new BlobUriBuilder(test.Container.Uri)
             {
                 BlobName = blobName,
-                Sas = blobSasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials())
+                Sas = blobSasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials())
             };
 
             // Act

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobIdentitySas_AllPermissions()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -117,7 +117,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobVersionIdentitySas_AllPermissions()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -187,7 +187,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task BlobSnapshotIdentitySas_AllPermissions()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);
@@ -251,7 +251,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task ContainerIdentitySas_AllPermissions()
         {
             // Arrange
-            BlobServiceClient oauthService = Clients.GetServiceClient_OAuth();
+            BlobServiceClient oauthService = BlobsClientBuilder.GetServiceClient_OAuth();
             string containerName = GetNewContainerName();
             string blobName = GetNewBlobName();
             await using DisposingContainer test = await GetTestContainerAsync(containerName: containerName, service: oauthService);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasTests.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test.Shared;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -8,14 +8,12 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
-using Microsoft.Identity.Client;
 using NUnit.Framework;
 
 namespace Azure.Storage.Test.Shared
@@ -36,35 +34,41 @@ namespace Azure.Storage.Test.Shared
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
     public abstract class BlobTestBase : StorageTestBase<BlobTestEnvironment>
     {
+        /// <summary>
+        /// Source of test tenants.
+        /// </summary>
+        protected ClientBuilder<BlobServiceClient, BlobClientOptions> ClientBuilder { get; }
+
         protected readonly BlobClientOptions.ServiceVersion _serviceVersion;
         public readonly string ReceivedETag = "\"received\"";
         public readonly string GarbageETag = "\"garbage\"";
         public readonly string ReceivedLeaseId = "received";
 
         protected string SecondaryStorageTenantPrimaryHost() =>
-            new Uri(TestConfigSecondary.BlobServiceEndpoint).Host;
+            new Uri(_tenantConfigurationBuilder.TestConfigSecondary.BlobServiceEndpoint).Host;
 
         protected string SecondaryStorageTenantSecondaryHost() =>
-            new Uri(TestConfigSecondary.BlobServiceSecondaryEndpoint).Host;
+            new Uri(_tenantConfigurationBuilder.TestConfigSecondary.BlobServiceSecondaryEndpoint).Host;
 
         public BlobTestBase(bool async, BlobClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
             : base(async, mode)
         {
             _serviceVersion = serviceVersion;
+            ClientBuilder = new ClientBuilder<BlobServiceClient, BlobClientOptions>(
+                _tenantConfigurationBuilder,
+                (uri, clientOptions) => new BlobServiceClient(uri, clientOptions),
+                (uri, sharedKeyCredential, clientOptions) => new BlobServiceClient(uri, sharedKeyCredential, clientOptions),
+                (uri, tokenCredential, clientOptions) => new BlobServiceClient(uri, tokenCredential, clientOptions),
+                (uri, azureSasCredential, clientOptions) => new BlobServiceClient(uri, azureSasCredential, clientOptions),
+                () => new BlobClientOptions(_serviceVersion));
         }
 
         public DateTimeOffset OldDate => Recording.Now.AddDays(-1);
         public DateTimeOffset NewDate => Recording.Now.AddDays(1);
 
-        public string GetGarbageLeaseId() => Recording.Random.NewGuid().ToString();
-        public string GetNewContainerName() => $"test-container-{Recording.Random.NewGuid()}";
-        public string GetNewBlobName() => $"test-blob-{Recording.Random.NewGuid()}";
-        public string GetNewBlockName() => $"test-block-{Recording.Random.NewGuid()}";
-        public string GetNewNonAsciiBlobName() => $"test-β£©þ‽%3A-{Recording.Random.NewGuid()}";
-
         internal async Task<BlobBaseClient> GetNewBlobClient(BlobContainerClient container, string blobName = default)
         {
-            blobName ??= GetNewBlobName();
+            blobName ??= ClientBuilder.GetNewBlobName();
             BlockBlobClient blob = InstrumentClient(container.GetBlockBlobClient(blobName));
             var data = GetRandomBuffer(Constants.KB);
 
@@ -75,28 +79,19 @@ namespace Azure.Storage.Test.Shared
             return blob;
         }
 
-        public BlobClientOptions GetOptions(bool parallelRange = false, bool enableTenantDiscovery = false)
+        private BlobServiceClient GetServiceClientFromOauthConfig(TenantConfiguration config, bool enableTenantDiscovery)
         {
-            var options = new BlobClientOptions(_serviceVersion)
-            {
-                Diagnostics = { IsLoggingEnabled = true },
-                Retry =
-                {
-                    Mode = RetryMode.Exponential,
-                    MaxRetries = Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60),
-                    NetworkTimeout = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 100 : 400),
-                },
-                EnableTenantDiscovery = enableTenantDiscovery
-            };
-            if (Mode != RecordedTestMode.Live)
-            {
-                options.AddPolicy(new RecordedClientRequestIdPolicy(Recording, parallelRange), HttpPipelinePosition.PerCall);
-            }
-
-            return InstrumentClientOptions(options);
+            var options = ClientBuilder.GetOptions();
+            options.EnableTenantDiscovery = enableTenantDiscovery;
+            return InstrumentClient(
+                new BlobServiceClient(
+                    new Uri(config.BlobServiceEndpoint),
+                    _tenantConfigurationBuilder.GetOAuthCredential(config),
+                    options));
         }
+
+        public BlobServiceClient GetServiceClient_OauthAccount(bool enableTenantDiscovery = false) =>
+            GetServiceClientFromOauthConfig(_tenantConfigurationBuilder.TestConfigOAuth, enableTenantDiscovery);
 
         public BlobClientOptions GetFaultyBlobConnectionOptions(
             int raiseAt = default,
@@ -104,27 +99,16 @@ namespace Azure.Storage.Test.Shared
             Action onFault = default)
         {
             raise = raise ?? new IOException("Simulated connection fault");
-            BlobClientOptions options = GetOptions();
+            BlobClientOptions options = ClientBuilder.GetOptions();
             options.AddPolicy(new FaultyDownloadPipelinePolicy(raiseAt, raise, onFault), HttpPipelinePosition.PerCall);
             return options;
         }
 
-        private BlobServiceClient GetServiceClientFromSharedKeyConfig(TenantConfiguration config, BlobClientOptions options = default)
-            => InstrumentClient(
-                new BlobServiceClient(
-                    new Uri(config.BlobServiceEndpoint),
-                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
-                    options ?? GetOptions()));
+        public BlobBaseClient GetBlobBaseClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+            => GetSecondaryReadBlobBaseClient(_tenantConfigurationBuilder.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
 
-        private BlobServiceClient GetSecondaryReadServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
-        {
-            BlobClientOptions options = GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
-            return InstrumentClient(
-                 new BlobServiceClient(
-                    new Uri(config.BlobServiceEndpoint),
-                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
-                    options));
-        }
+        public BlobContainerClient GetBlobContainerClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+            => GetSecondaryReadBlobContainerClient(_tenantConfigurationBuilder.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
 
         private BlobBaseClient GetSecondaryReadBlobBaseClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
         {
@@ -140,7 +124,7 @@ namespace Azure.Storage.Test.Shared
         {
             BlobClientOptions options = GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
             Uri uri = new Uri(config.BlobServiceEndpoint);
-            string containerName = GetNewContainerName();
+            string containerName = ClientBuilder.GetNewContainerName();
             return InstrumentClient(
                  new BlobContainerClient(
                     uri.AppendToPath(containerName),
@@ -155,7 +139,7 @@ namespace Azure.Storage.Test.Shared
             bool simulate404 = false,
             List<RequestMethod> trackedRequestMethods = null)
         {
-            BlobClientOptions options = GetOptions();
+            BlobClientOptions options = ClientBuilder.GetOptions();
             options.GeoRedundantSecondaryUri = new Uri(config.BlobServiceSecondaryEndpoint);
             options.Retry.MaxRetries = 4;
             testExceptionPolicy = new TestExceptionPolicy(numberOfReadFailuresToSimulate, options.GeoRedundantSecondaryUri, simulate404, trackedRequestMethods);
@@ -163,105 +147,18 @@ namespace Azure.Storage.Test.Shared
             return options;
         }
 
-        private BlobServiceClient GetServiceClientFromOauthConfig(TenantConfiguration config, bool enableTenantDiscovery) =>
-            InstrumentClient(
-                new BlobServiceClient(
+        private BlobServiceClient GetSecondaryReadServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+        {
+            BlobClientOptions options = GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            return InstrumentClient(
+                 new BlobServiceClient(
                     new Uri(config.BlobServiceEndpoint),
-                    GetOAuthCredential(config),
-                    GetOptions(enableTenantDiscovery: enableTenantDiscovery)));
-
-        public BlobServiceClient GetServiceClient_SharedKey(BlobClientOptions options = default)
-            => GetServiceClientFromSharedKeyConfig(TestConfigDefault, options);
+                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
+                    options));
+        }
 
         public BlobServiceClient GetServiceClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
-            => GetSecondaryReadServiceClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
-
-        public BlobBaseClient GetBlobBaseClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
-    => GetSecondaryReadBlobBaseClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
-
-        public BlobContainerClient GetBlobContainerClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
-    => GetSecondaryReadBlobContainerClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
-
-        public BlobServiceClient GetServiceClient_SecondaryAccount_SharedKey()
-            => GetServiceClientFromSharedKeyConfig(TestConfigSecondary);
-
-        public BlobServiceClient GetServiceClient_PreviewAccount_SharedKey()
-            => GetServiceClientFromSharedKeyConfig(TestConfigPreviewBlob);
-
-        public BlobServiceClient GetServiceClient_PremiumBlobAccount_SharedKey()
-            => GetServiceClientFromSharedKeyConfig(TestConfigPremiumBlob);
-
-        public BlobServiceClient GetServiceClient_OauthAccount(bool enableTenantDiscovery = false) =>
-            GetServiceClientFromOauthConfig(TestConfigOAuth, enableTenantDiscovery);
-
-        public BlobServiceClient GetServiceClient_OAuthAccount_SharedKey() =>
-            GetServiceClientFromSharedKeyConfig(TestConfigOAuth);
-
-        public BlobServiceClient GetServiceClient_ManagedDisk() =>
-            GetServiceClientFromSharedKeyConfig(TestConfigManagedDisk);
-
-        public BlobServiceClient GetServiceClient_Hns() =>
-            GetServiceClientFromSharedKeyConfig(TestConfigHierarchicalNamespace);
-
-        public BlobServiceClient GetServiceClient_SoftDelete() =>
-            GetServiceClientFromSharedKeyConfig(TestConfigSoftDelete);
-
-        public BlobServiceClient GetServiceClient_AccountSas(
-            StorageSharedKeyCredential sharedKeyCredentials = default,
-            BlobSasQueryParameters sasCredentials = default)
-            => InstrumentClient(
-                new BlobServiceClient(
-                    new Uri($"{TestConfigDefault.BlobServiceEndpoint}?{sasCredentials ?? GetNewAccountSas(sharedKeyCredentials: sharedKeyCredentials)}"),
-                    GetOptions()));
-
-        public BlobServiceClient GetServiceClient_BlobServiceSas_Container(
-            string containerName,
-            StorageSharedKeyCredential sharedKeyCredentials = default,
-            BlobSasQueryParameters sasCredentials = default)
-            => InstrumentClient(
-                new BlobServiceClient(
-                    new Uri($"{TestConfigDefault.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceSasCredentialsContainer(containerName: containerName, sharedKeyCredentials: sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
-                    GetOptions()));
-
-        public BlobServiceClient GetServiceClient_BlobServiceIdentitySas_Container(
-            string containerName,
-            UserDelegationKey userDelegationKey,
-            BlobSasQueryParameters sasCredentials = default)
-            => InstrumentClient(
-                new BlobServiceClient(
-                    new Uri($"{TestConfigOAuth.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceIdentitySasCredentialsContainer(containerName: containerName, userDelegationKey, TestConfigOAuth.AccountName)}"),
-                    GetOptions()));
-
-        public BlobServiceClient GetServiceClient_BlobServiceSas_Blob(
-            string containerName,
-            string blobName,
-            StorageSharedKeyCredential sharedKeyCredentials = default,
-            BlobSasQueryParameters sasCredentials = default)
-            => InstrumentClient(
-                new BlobServiceClient(
-                    new Uri($"{TestConfigDefault.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceSasCredentialsBlob(containerName: containerName, blobName: blobName, sharedKeyCredentials: sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
-                    GetOptions()));
-
-        public BlobServiceClient GetServiceClient_BlobServiceIdentitySas_Blob(
-            string containerName,
-            string blobName,
-            UserDelegationKey userDelegationKey,
-            BlobSasQueryParameters sasCredentials = default)
-            => InstrumentClient(
-                new BlobServiceClient(
-                    new Uri($"{TestConfigOAuth.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceIdentitySasCredentialsBlob(containerName: containerName, blobName: blobName, userDelegationKey: userDelegationKey, accountName: TestConfigOAuth.AccountName)}"),
-                    GetOptions()));
-
-        public BlobServiceClient GetServiceClient_BlobServiceSas_Snapshot(
-            string containerName,
-            string blobName,
-            string snapshot,
-            StorageSharedKeyCredential sharedKeyCredentials = default,
-            BlobSasQueryParameters sasCredentials = default)
-            => InstrumentClient(
-                new BlobServiceClient(
-                    new Uri($"{TestConfigDefault.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceSasCredentialsSnapshot(containerName: containerName, blobName: blobName, snapshot: snapshot, sharedKeyCredentials: sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
-                    GetOptions()));
+            => GetSecondaryReadServiceClient(_tenantConfigurationBuilder.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
 
         public Security.KeyVault.Keys.KeyClient GetKeyClient_TargetKeyClient()
             => GetKeyClient(TestConfigurations.DefaultTargetKeyVault);
@@ -280,55 +177,49 @@ namespace Azure.Storage.Test.Shared
                 config.ActiveDirectoryApplicationId,
                 config.ActiveDirectoryApplicationSecret);
 
-        public async Task<DisposingContainer> GetTestContainerAsync(
-            BlobServiceClient service = default,
-            string containerName = default,
-            IDictionary<string, string> metadata = default,
-            PublicAccessType? publicAccessType = default,
-            bool premium = default)
-        {
-            containerName ??= GetNewContainerName();
-            service ??= GetServiceClient_SharedKey();
+        public BlobServiceClient GetServiceClient_BlobServiceSas_Container(
+            string containerName,
+            StorageSharedKeyCredential sharedKeyCredentials = default,
+            BlobSasQueryParameters sasCredentials = default)
+            => InstrumentClient(
+                new BlobServiceClient(
+                    new Uri($"{_tenantConfigurationBuilder.TestConfigDefault.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceSasCredentialsContainer(containerName: containerName, sharedKeyCredentials: sharedKeyCredentials ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials())}"),
+                    ClientBuilder.GetOptions()));
 
-            if (publicAccessType == default)
-            {
-                publicAccessType = premium ? PublicAccessType.None : PublicAccessType.BlobContainer;
-            }
+        public BlobServiceClient GetServiceClient_BlobServiceIdentitySas_Container(
+            string containerName,
+            UserDelegationKey userDelegationKey,
+            BlobSasQueryParameters sasCredentials = default)
+            => InstrumentClient(
+                new BlobServiceClient(
+                    new Uri($"{_tenantConfigurationBuilder.TestConfigOAuth.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceIdentitySasCredentialsContainer(containerName: containerName, userDelegationKey, _tenantConfigurationBuilder.TestConfigOAuth.AccountName)}"),
+                    ClientBuilder.GetOptions()));
 
-            BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
-            await container.CreateIfNotExistsAsync(metadata: metadata, publicAccessType: publicAccessType.Value);
-            return new DisposingContainer(container);
-        }
+        public BlobServiceClient GetServiceClient_BlobServiceSas_Blob(
+            string containerName,
+            string blobName,
+            StorageSharedKeyCredential sharedKeyCredentials = default,
+            BlobSasQueryParameters sasCredentials = default)
+            => InstrumentClient(
+                new BlobServiceClient(
+                    new Uri($"{_tenantConfigurationBuilder.TestConfigDefault.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceSasCredentialsBlob(containerName: containerName, blobName: blobName, sharedKeyCredentials: sharedKeyCredentials ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials())}"),
+                    ClientBuilder.GetOptions()));
 
-        public StorageSharedKeyCredential GetNewSharedKeyCredentials()
-            => new StorageSharedKeyCredential(
-                    TestConfigDefault.AccountName,
-                    TestConfigDefault.AccountKey);
-
-        public SasQueryParameters GetNewAccountSas(
-            AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All,
-            AccountSasPermissions permissions = AccountSasPermissions.All,
-            StorageSharedKeyCredential sharedKeyCredentials = default)
-        {
-            var builder = new AccountSasBuilder
-            {
-                Protocol = SasProtocol.None,
-                Services = AccountSasServices.Blobs,
-                ResourceTypes = resourceTypes,
-                StartsOn = Recording.UtcNow.AddHours(-1),
-                ExpiresOn = Recording.UtcNow.AddHours(+1),
-                IPRange = new SasIPRange(IPAddress.None, IPAddress.None),
-                Version = Constants.DefaultSasVersion
-            };
-            builder.SetPermissions(permissions);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
-        }
+        public BlobServiceClient GetServiceClient_BlobServiceIdentitySas_Blob(
+            string containerName,
+            string blobName,
+            UserDelegationKey userDelegationKey,
+            BlobSasQueryParameters sasCredentials = default)
+            => InstrumentClient(
+                new BlobServiceClient(
+                    new Uri($"{_tenantConfigurationBuilder.TestConfigOAuth.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceIdentitySasCredentialsBlob(containerName: containerName, blobName: blobName, userDelegationKey: userDelegationKey, accountName: _tenantConfigurationBuilder.TestConfigOAuth.AccountName)}"),
+                    ClientBuilder.GetOptions()));
 
         public BlobSasQueryParameters GetNewBlobServiceSasCredentialsContainer(string containerName, StorageSharedKeyCredential sharedKeyCredentials = default)
         {
             var builder = GetBlobSasBuilder(containerName);
             builder.SetPermissions(BlobContainerSasPermissions.All);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials());
         }
 
         public BlobSasQueryParameters GetNewBlobServiceIdentitySasCredentialsContainer(string containerName, UserDelegationKey userDelegationKey, string accountName)
@@ -347,7 +238,7 @@ namespace Azure.Storage.Test.Shared
                 BlobSasPermissions.Create |
                 BlobSasPermissions.Delete |
                 BlobSasPermissions.Write);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials());
         }
 
         public BlobSasQueryParameters GetBlobSas(
@@ -359,7 +250,7 @@ namespace Azure.Storage.Test.Shared
         {
             BlobSasBuilder sasBuilder = GetBlobSasBuilder(containerName, blobName, sasVersion: sasVersion);
             sasBuilder.SetPermissions(permissions);
-            return sasBuilder.ToSasQueryParameters(sharedKeyCredential ?? GetNewSharedKeyCredentials());
+            return sasBuilder.ToSasQueryParameters(sharedKeyCredential ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials());
         }
 
         public BlobSasQueryParameters GetBlobIdentitySas(
@@ -383,7 +274,7 @@ namespace Azure.Storage.Test.Shared
         {
             BlobSasBuilder sasBuilder = GetBlobSasBuilder(containerName, sasVersion: sasVersion);
             sasBuilder.SetPermissions(permissions);
-            return sasBuilder.ToSasQueryParameters(sharedKeyCredential ?? GetNewSharedKeyCredentials());
+            return sasBuilder.ToSasQueryParameters(sharedKeyCredential ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials());
         }
 
         public BlobSasQueryParameters GetContainerIdentitySas(
@@ -408,7 +299,7 @@ namespace Azure.Storage.Test.Shared
         {
             BlobSasBuilder sasBuilder = GetBlobSasBuilder(containerName, blobName, snapshot: snapshot, sasVersion: sasVersion);
             sasBuilder.SetPermissions(permissions);
-            return sasBuilder.ToSasQueryParameters(sharedKeyCredential ?? GetNewSharedKeyCredentials());
+            return sasBuilder.ToSasQueryParameters(sharedKeyCredential ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials());
         }
 
         public BlobSasQueryParameters GetSnapshotIdentitySas(
@@ -435,7 +326,7 @@ namespace Azure.Storage.Test.Shared
         {
             BlobSasBuilder sasBuilder = GetBlobSasBuilder(containerName, blobName, blobVersion: blobVersion, sasVersion: sasVersion);
             sasBuilder.SetPermissions(permissions);
-            return sasBuilder.ToSasQueryParameters(sharedKeyCredential ?? GetNewSharedKeyCredentials());
+            return sasBuilder.ToSasQueryParameters(sharedKeyCredential ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials());
         }
 
         public BlobSasQueryParameters GetBlobVersionIdentitySas(
@@ -482,6 +373,25 @@ namespace Azure.Storage.Test.Shared
             return builder.ToSasQueryParameters(userDelegationKey, accountName);
         }
 
+        public BlobServiceClient GetServiceClient_AccountSas(
+            StorageSharedKeyCredential sharedKeyCredentials = default,
+            BlobSasQueryParameters sasCredentials = default)
+            => InstrumentClient(
+                new BlobServiceClient(
+                    new Uri($"{_tenantConfigurationBuilder.TestConfigDefault.BlobServiceEndpoint}?{sasCredentials ?? ClientBuilder.GetNewAccountSas(sharedKeyCredentials: sharedKeyCredentials)}"),
+                    ClientBuilder.GetOptions()));
+
+        public BlobServiceClient GetServiceClient_BlobServiceSas_Snapshot(
+            string containerName,
+            string blobName,
+            string snapshot,
+            StorageSharedKeyCredential sharedKeyCredentials = default,
+            BlobSasQueryParameters sasCredentials = default)
+            => InstrumentClient(
+                new BlobServiceClient(
+                    new Uri($"{_tenantConfigurationBuilder.TestConfigDefault.BlobServiceEndpoint}?{sasCredentials ?? GetNewBlobServiceSasCredentialsSnapshot(containerName: containerName, blobName: blobName, snapshot: snapshot, sharedKeyCredentials: sharedKeyCredentials ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials())}"),
+                    ClientBuilder.GetOptions()));
+
         public BlobSasQueryParameters GetNewBlobServiceSasCredentialsSnapshot(string containerName, string blobName, string snapshot, StorageSharedKeyCredential sharedKeyCredentials = default)
         {
             var builder = new BlobSasBuilder
@@ -490,17 +400,17 @@ namespace Azure.Storage.Test.Shared
                 BlobName = blobName,
                 Snapshot = snapshot,
                 Protocol = SasProtocol.None,
-                StartsOn = Recording.UtcNow.AddHours(-1),
-                ExpiresOn = Recording.UtcNow.AddHours(+1),
+                StartsOn = _tenantConfigurationBuilder.Recording.UtcNow.AddHours(-1),
+                ExpiresOn = _tenantConfigurationBuilder.Recording.UtcNow.AddHours(+1),
                 IPRange = new SasIPRange(IPAddress.None, IPAddress.None),
             };
             builder.SetPermissions(SnapshotSasPermissions.All);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials());
         }
 
         public async Task<PageBlobClient> CreatePageBlobClientAsync(BlobContainerClient container, long size)
         {
-            PageBlobClient blob = InstrumentClient(container.GetPageBlobClient(GetNewBlobName()));
+            PageBlobClient blob = InstrumentClient(container.GetPageBlobClient(ClientBuilder.GetNewBlobName()));
             await blob.CreateIfNotExistsAsync(size, 0).ConfigureAwait(false);
             return blob;
         }
@@ -588,18 +498,18 @@ namespace Azure.Storage.Test.Shared
             if (!includeEndpoint)
             {
                 return new StorageConnectionString(credentials,
-                    (new Uri(TestConfigDefault.BlobServiceEndpoint), new Uri(TestConfigDefault.BlobServiceSecondaryEndpoint)),
-                    (new Uri(TestConfigDefault.QueueServiceEndpoint), new Uri(TestConfigDefault.QueueServiceSecondaryEndpoint)),
-                    (new Uri(TestConfigDefault.TableServiceEndpoint), new Uri(TestConfigDefault.TableServiceSecondaryEndpoint)),
-                    (new Uri(TestConfigDefault.FileServiceEndpoint), new Uri(TestConfigDefault.FileServiceSecondaryEndpoint)));
+                    (new Uri(_tenantConfigurationBuilder.TestConfigDefault.BlobServiceEndpoint), new Uri(_tenantConfigurationBuilder.TestConfigDefault.BlobServiceSecondaryEndpoint)),
+                    (new Uri(_tenantConfigurationBuilder.TestConfigDefault.QueueServiceEndpoint), new Uri(_tenantConfigurationBuilder.TestConfigDefault.QueueServiceSecondaryEndpoint)),
+                    (new Uri(_tenantConfigurationBuilder.TestConfigDefault.TableServiceEndpoint), new Uri(_tenantConfigurationBuilder.TestConfigDefault.TableServiceSecondaryEndpoint)),
+                    (new Uri(_tenantConfigurationBuilder.TestConfigDefault.FileServiceEndpoint), new Uri(_tenantConfigurationBuilder.TestConfigDefault.FileServiceSecondaryEndpoint)));
             }
 
-            (Uri, Uri) blobUri = (new Uri(TestConfigDefault.BlobServiceEndpoint), new Uri(TestConfigDefault.BlobServiceSecondaryEndpoint));
+            (Uri, Uri) blobUri = (new Uri(_tenantConfigurationBuilder.TestConfigDefault.BlobServiceEndpoint), new Uri(_tenantConfigurationBuilder.TestConfigDefault.BlobServiceSecondaryEndpoint));
 
             (Uri, Uri) tableUri = default;
             if (includeTable)
             {
-                tableUri = (new Uri(TestConfigDefault.TableServiceEndpoint), new Uri(TestConfigDefault.TableServiceSecondaryEndpoint));
+                tableUri = (new Uri(_tenantConfigurationBuilder.TestConfigDefault.TableServiceEndpoint), new Uri(_tenantConfigurationBuilder.TestConfigDefault.TableServiceSecondaryEndpoint));
             }
 
             return new StorageConnectionString(
@@ -610,7 +520,7 @@ namespace Azure.Storage.Test.Shared
 
         public async Task EnableSoftDelete()
         {
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = ClientBuilder.GetServiceClient_SharedKey();
             Response<BlobServiceProperties> properties = await service.GetPropertiesAsync();
             properties.Value.DeleteRetentionPolicy = new BlobRetentionPolicy()
             {
@@ -628,7 +538,7 @@ namespace Azure.Storage.Test.Shared
 
         public async Task DisableSoftDelete()
         {
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = ClientBuilder.GetServiceClient_SharedKey();
             Response<BlobServiceProperties> properties = await service.GetPropertiesAsync();
             properties.Value.DeleteRetentionPolicy = new BlobRetentionPolicy() { Enabled = false };
             await service.SetPropertiesAsync(properties);
@@ -646,32 +556,6 @@ namespace Azure.Storage.Test.Shared
                 { "tagKey0", "tagValue0" },
                 { "tagKey1", "tagValue1" }
             };
-
-        public class DisposingContainer : IAsyncDisposable
-        {
-            public BlobContainerClient Container;
-
-            public DisposingContainer(BlobContainerClient client)
-            {
-                Container = client;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                if (Container != null)
-                {
-                    try
-                    {
-                        await Container.DeleteIfExistsAsync();
-                        Container = null;
-                    }
-                    catch
-                    {
-                        // swallow the exception to avoid hiding another test failure
-                    }
-                }
-            }
-        }
 
         public class BlobQueryErrorHandler
         {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -56,6 +56,7 @@ namespace Azure.Storage.Test.Shared
         {
             _serviceVersion = serviceVersion;
             Clients = new ClientBuilder<BlobServiceClient, BlobClientOptions>(
+                ServiceEndpoint.Blob,
                 Tenants,
                 (uri, clientOptions) => new BlobServiceClient(uri, clientOptions),
                 (uri, sharedKeyCredential, clientOptions) => new BlobServiceClient(uri, sharedKeyCredential, clientOptions),

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -15,7 +15,6 @@ using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Test.Shared
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -108,8 +108,8 @@ namespace Azure.Storage.Test.Shared
                     options));
         }
 
-        public BlobServiceClient GetServiceClient_OauthAccount(bool enableTenantDiscovery = false) =>
-            GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, enableTenantDiscovery);
+        public BlobServiceClient GetServiceClient_OauthAccount_TenantDiscovery() =>
+            GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth, true);
 
         public BlobClientOptions GetFaultyBlobConnectionOptions(
             int raiseAt = default,

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -991,7 +991,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task StageBlockFromUriAsync_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -1030,7 +1030,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task StageBlockFromUriAsync_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3709,7 +3709,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncUploadFromUriAsync_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3744,7 +3744,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncUploadFromUriAsync_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -991,7 +991,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task StageBlockFromUriAsync_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -1030,7 +1030,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task StageBlockFromUriAsync_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -2951,7 +2951,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             BlockBlobClient blob = InstrumentClient(container.GetBlockBlobClient(GetNewBlobName()));
 
@@ -2965,7 +2965,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task OpenWriteAsync_NoOverwrite()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             BlockBlobClient blob = InstrumentClient(container.GetBlockBlobClient(GetNewBlobName()));
 
@@ -3709,7 +3709,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncUploadFromUriAsync_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3744,7 +3744,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task SyncUploadFromUriAsync_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -19,6 +19,7 @@ using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
 using static Azure.Storage.Blobs.BlobClientOptions;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
 using Tags = System.Collections.Generic.IDictionary<string, string>;
 
@@ -85,11 +86,11 @@ namespace Azure.Storage.Blobs.Test
         public void Ctor_TokenAuth_Http()
         {
             // Arrange
-            Uri httpUri = new Uri(TestConfigOAuth.BlobServiceEndpoint).ToHttp();
+            Uri httpUri = new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
-                () => new BlockBlobClient(httpUri, GetOAuthCredential()),
+                () => new BlockBlobClient(httpUri, Tenants.GetOAuthCredential()),
                  new ArgumentException("Cannot use TokenCredential without HTTPS."));
         }
 
@@ -2950,7 +2951,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             BlockBlobClient blob = InstrumentClient(container.GetBlockBlobClient(GetNewBlobName()));
 
@@ -2964,7 +2965,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task OpenWriteAsync_NoOverwrite()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             BlockBlobClient blob = InstrumentClient(container.GetBlockBlobClient(GetNewBlobName()));
 
@@ -3819,9 +3820,9 @@ namespace Azure.Storage.Blobs.Test
             var mock = new Mock<BlockBlobClient>(TestConfigDefault.ConnectionString, "name", "name", new BlobClientOptions()).Object;
             mock = new Mock<BlockBlobClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<BlockBlobClient>(new Uri("https://test/test"), new BlobClientOptions()).Object;
-            mock = new Mock<BlockBlobClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
+            mock = new Mock<BlockBlobClient>(new Uri("https://test/test"), Tenants.GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
             mock = new Mock<BlockBlobClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new BlobClientOptions()).Object;
-            mock = new Mock<BlockBlobClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
+            mock = new Mock<BlockBlobClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
         }
 
         private RequestConditions BuildRequestConditions(AccessConditionParameters parameters)

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -12,14 +12,13 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Shared;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.BlobClientOptions;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
 using Tags = System.Collections.Generic.IDictionary<string, string>;
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
@@ -72,31 +72,5 @@ namespace Azure.Storage.Blobs.Tests
             await container.CreateIfNotExistsAsync(metadata: metadata, publicAccessType: publicAccessType.Value);
             return new DisposingContainer(container);
         }
-
-        public class DisposingContainer : IAsyncDisposable
-        {
-            public BlobContainerClient Container;
-
-            public DisposingContainer(BlobContainerClient client)
-            {
-                Container = client;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                if (Container != null)
-                {
-                    try
-                    {
-                        await Container.DeleteIfExistsAsync();
-                        Container = null;
-                    }
-                    catch
-                    {
-                        // swallow the exception to avoid hiding another test failure
-                    }
-                }
-            }
-        }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Test.Shared;
+
+namespace Azure.Storage.Blobs.Tests
+{
+    public static class ClientBuilderExtensions
+    {
+        public static string GetGarbageLeaseId(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+            => clientBuilder.Recording.Random.NewGuid().ToString();
+        public static string GetNewContainerName(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+            => $"test-container-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewBlobName(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+            => $"test-blob-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewBlockName(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+            => $"test-block-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewNonAsciiBlobName(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+            => $"test-β£©þ‽%3A-{clientBuilder.Recording.Random.NewGuid()}";
+
+        public static async Task<DisposingContainer> GetTestContainerAsync(
+            this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder,
+            BlobServiceClient service = default,
+            string containerName = default,
+            IDictionary<string, string> metadata = default,
+            PublicAccessType? publicAccessType = default,
+            bool premium = default)
+        {
+            containerName ??= clientBuilder.GetNewContainerName();
+            service ??= clientBuilder.GetServiceClient_SharedKey();
+
+            if (publicAccessType == default)
+            {
+                publicAccessType = premium ? PublicAccessType.None : PublicAccessType.BlobContainer;
+            }
+
+            BlobContainerClient container = clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(service.GetBlobContainerClient(containerName));
+            await container.CreateIfNotExistsAsync(metadata: metadata, publicAccessType: publicAccessType.Value);
+            return new DisposingContainer(container);
+        }
+
+        public class DisposingContainer : IAsyncDisposable
+        {
+            public BlobContainerClient Container;
+
+            public DisposingContainer(BlobContainerClient client)
+            {
+                Container = client;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                if (Container != null)
+                {
+                    try
+                    {
+                        await Container.DeleteIfExistsAsync();
+                        Container = null;
+                    }
+                    catch
+                    {
+                        // swallow the exception to avoid hiding another test failure
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
@@ -25,6 +25,33 @@ namespace Azure.Storage.Blobs.Tests
         public static string GetNewNonAsciiBlobName(this BlobsClientBuilder clientBuilder)
             => $"test-β£©þ‽%3A-{clientBuilder.Recording.Random.NewGuid()}";
 
+        public static BlobServiceClient GetServiceClient_SharedKey(this BlobsClientBuilder clientBuilder, BlobClientOptions options = default)
+            => clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigDefault, options);
+
+        public static BlobServiceClient GetServiceClient_SecondaryAccount_SharedKey(this BlobsClientBuilder clientBuilder)
+            => clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigSecondary);
+
+        public static BlobServiceClient GetServiceClient_PreviewAccount_SharedKey(this BlobsClientBuilder clientBuilder)
+            => clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigPreviewBlob);
+
+        public static BlobServiceClient GetServiceClient_PremiumBlobAccount_SharedKey(this BlobsClientBuilder clientBuilder)
+            => clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigPremiumBlob);
+
+        public static BlobServiceClient GetServiceClient_OAuth(this BlobsClientBuilder clientBuilder)
+            => clientBuilder.GetServiceClientFromOauthConfig(clientBuilder.Tenants.TestConfigOAuth);
+
+        public static BlobServiceClient GetServiceClient_OAuthAccount_SharedKey(this BlobsClientBuilder clientBuilder) =>
+            clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigOAuth);
+
+        public static BlobServiceClient GetServiceClient_ManagedDisk(this BlobsClientBuilder clientBuilder) =>
+            clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigManagedDisk);
+
+        public static BlobServiceClient GetServiceClient_Hns(this BlobsClientBuilder clientBuilder) =>
+            clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigHierarchicalNamespace);
+
+        public static BlobServiceClient GetServiceClient_SoftDelete(this BlobsClientBuilder clientBuilder) =>
+            clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigSoftDelete);
+
         public static async Task<DisposingContainer> GetTestContainerAsync(
             this BlobsClientBuilder clientBuilder,
             BlobServiceClient service = default,

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
@@ -3,29 +3,30 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.Test.Shared;
+
+using BlobsClientBuilder = Azure.Storage.Test.Shared.ClientBuilder<
+    Azure.Storage.Blobs.BlobServiceClient,
+    Azure.Storage.Blobs.BlobClientOptions>;
 
 namespace Azure.Storage.Blobs.Tests
 {
     public static class ClientBuilderExtensions
     {
-        public static string GetGarbageLeaseId(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+        public static string GetGarbageLeaseId(this BlobsClientBuilder clientBuilder)
             => clientBuilder.Recording.Random.NewGuid().ToString();
-        public static string GetNewContainerName(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+        public static string GetNewContainerName(this BlobsClientBuilder clientBuilder)
             => $"test-container-{clientBuilder.Recording.Random.NewGuid()}";
-        public static string GetNewBlobName(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+        public static string GetNewBlobName(this BlobsClientBuilder clientBuilder)
             => $"test-blob-{clientBuilder.Recording.Random.NewGuid()}";
-        public static string GetNewBlockName(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+        public static string GetNewBlockName(this BlobsClientBuilder clientBuilder)
             => $"test-block-{clientBuilder.Recording.Random.NewGuid()}";
-        public static string GetNewNonAsciiBlobName(this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder)
+        public static string GetNewNonAsciiBlobName(this BlobsClientBuilder clientBuilder)
             => $"test-β£©þ‽%3A-{clientBuilder.Recording.Random.NewGuid()}";
 
         public static async Task<DisposingContainer> GetTestContainerAsync(
-            this ClientBuilder<BlobServiceClient, BlobClientOptions> clientBuilder,
+            this BlobsClientBuilder clientBuilder,
             BlobServiceClient service = default,
             string containerName = default,
             IDictionary<string, string> metadata = default,

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -21,7 +21,6 @@ using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 using static Moq.It;
 
 namespace Azure.Storage.Blobs.Test

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -70,7 +70,7 @@ namespace Azure.Storage.Blobs.Test
             options._clientSideEncryptionOptions = encryptionOptions;
 
             containerName ??= GetNewContainerName();
-            var service = Clients.GetServiceClient_SharedKey(options);
+            var service = BlobsClientBuilder.GetServiceClient_SharedKey(options);
 
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
             await container.CreateAsync(metadata: metadata);

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -21,6 +21,7 @@ using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 using static Moq.It;
 
 namespace Azure.Storage.Blobs.Test
@@ -69,7 +70,7 @@ namespace Azure.Storage.Blobs.Test
             options._clientSideEncryptionOptions = encryptionOptions;
 
             containerName ??= GetNewContainerName();
-            var service = GetServiceClient_SharedKey(options);
+            var service = Clients.GetServiceClient_SharedKey(options);
 
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
             await container.CreateAsync(metadata: metadata);
@@ -276,7 +277,7 @@ namespace Azure.Storage.Blobs.Test
 
                 // download without decrypting
                 var encryptedDataStream = new MemoryStream();
-                await InstrumentClient(new BlobClient(blob.Uri, GetNewSharedKeyCredentials())).DownloadToAsync(encryptedDataStream, cancellationToken: s_cancellationToken);
+                await InstrumentClient(new BlobClient(blob.Uri, Tenants.GetNewSharedKeyCredentials())).DownloadToAsync(encryptedDataStream, cancellationToken: s_cancellationToken);
                 var encryptedData = encryptedDataStream.ToArray();
 
                 // encrypt original data manually for comparison
@@ -410,7 +411,7 @@ namespace Azure.Storage.Blobs.Test
                     {
                         KeyResolver = mockKeyResolver
                     };
-                    await InstrumentClient(new BlobContainerClient(disposable.Container.Uri, GetNewSharedKeyCredentials(), options).GetBlobClient(blobName)).DownloadToAsync(stream, cancellationToken: s_cancellationToken);
+                    await InstrumentClient(new BlobContainerClient(disposable.Container.Uri, Tenants.GetNewSharedKeyCredentials(), options).GetBlobClient(blobName)).DownloadToAsync(stream, cancellationToken: s_cancellationToken);
                     downloadData = stream.ToArray();
                 }
 
@@ -494,7 +495,7 @@ namespace Azure.Storage.Blobs.Test
                 var track2Blob = InstrumentClient(disposable.Container.GetBlobClient(GetNewBlobName()));
 
                 // upload with track 1
-                var creds = GetNewSharedKeyCredentials();
+                var creds = Tenants.GetNewSharedKeyCredentials();
                 var track1Blob = new Microsoft.Azure.Storage.Blob.CloudBlockBlob(
                     track2Blob.Uri,
                     new Microsoft.Azure.Storage.Auth.StorageCredentials(creds.AccountName, creds.GetAccountKey()));
@@ -546,7 +547,7 @@ namespace Azure.Storage.Blobs.Test
                 await track2Blob.UploadAsync(new MemoryStream(data), cancellationToken: s_cancellationToken);
 
                 // download with track 1
-                var creds = GetNewSharedKeyCredentials();
+                var creds = Tenants.GetNewSharedKeyCredentials();
                 var track1Blob = new Microsoft.Azure.Storage.Blob.CloudBlockBlob(
                     track2Blob.Uri,
                     new Microsoft.Azure.Storage.Auth.StorageCredentials(creds.AccountName, creds.GetAccountKey()));
@@ -647,7 +648,7 @@ namespace Azure.Storage.Blobs.Test
                         KeyWrapAlgorithm = "test"
                     };
                     var encryptedDataStream = new MemoryStream();
-                    await InstrumentClient(new BlobClient(blob.Uri, GetNewSharedKeyCredentials(), options)).DownloadToAsync(encryptedDataStream, cancellationToken: s_cancellationToken);
+                    await InstrumentClient(new BlobClient(blob.Uri, Tenants.GetNewSharedKeyCredentials(), options)).DownloadToAsync(encryptedDataStream, cancellationToken: s_cancellationToken);
                 }
                 catch (MockException e)
                 {
@@ -685,7 +686,7 @@ namespace Azure.Storage.Blobs.Test
                 await blob.UploadAsync(new MemoryStream(data));
 
                 // download plaintext range with encrypted client
-                var cryptoClient = InstrumentClient(new BlobClient(blob.Uri, GetNewSharedKeyCredentials(), new SpecializedBlobClientOptions()
+                var cryptoClient = InstrumentClient(new BlobClient(blob.Uri, Tenants.GetNewSharedKeyCredentials(), new SpecializedBlobClientOptions()
                 {
                     ClientSideEncryption = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
                     {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -20,6 +20,7 @@ using Azure.Storage.Test.Shared;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -29,6 +30,9 @@ namespace Azure.Storage.Blobs.Test
             : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
+
+        public BlobServiceClient GetServiceClient_SharedKey(BlobClientOptions options = default)
+            => Clients.GetServiceClient_SharedKey(options);
 
         [RecordedTest]
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_02_02)]
@@ -252,11 +256,11 @@ namespace Azure.Storage.Blobs.Test
         public void Ctor_TokenAuth_Http()
         {
             // Arrange
-            Uri httpUri = new Uri(TestConfigOAuth.BlobServiceEndpoint).ToHttp();
+            Uri httpUri = new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
-                () => new BlobContainerClient(httpUri, GetOAuthCredential()),
+                () => new BlobContainerClient(httpUri, Tenants.GetOAuthCredential()),
                  new ArgumentException("Cannot use TokenCredential without HTTPS."));
         }
 
@@ -421,7 +425,7 @@ namespace Azure.Storage.Blobs.Test
                 | AccountSasPermissions.Update
                 | AccountSasPermissions.Process;
 
-            SasQueryParameters sasQueryParameters = GetNewAccountSas(
+            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas(
                 permissions: permissions);
 
             BlobServiceClient service = new BlobServiceClient(
@@ -2248,7 +2252,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task ListBlobsFlatSegmentAsync_Deleted()
         {
             // Arrange
-            BlobServiceClient blobServiceClient = GetServiceClient_SoftDelete();
+            BlobServiceClient blobServiceClient = Clients.GetServiceClient_SoftDelete();
             await using DisposingContainer test = await GetTestContainerAsync(blobServiceClient);
             string blobName = GetNewBlobName();
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
@@ -2620,7 +2624,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task ListBlobsHierarchySegmentAsync_Deleted()
         {
             // Arrange
-            BlobServiceClient blobServiceClient = GetServiceClient_SoftDelete();
+            BlobServiceClient blobServiceClient = Clients.GetServiceClient_SoftDelete();
             await using DisposingContainer test = await GetTestContainerAsync(blobServiceClient);
             string blobName = GetNewBlobName();
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
@@ -3503,7 +3507,7 @@ namespace Azure.Storage.Blobs.Test
             string newContainerName = GetNewContainerName();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(oldContainerName));
             await container.CreateAsync();
-            SasQueryParameters sasQueryParameters = GetNewAccountSas();
+            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas();
             service = InstrumentClient(new BlobServiceClient(new Uri($"{service.Uri}?{sasQueryParameters}"), GetOptions()));
             BlobContainerClient sasContainer = InstrumentClient(service.GetBlobContainerClient(oldContainerName));
 
@@ -3602,9 +3606,9 @@ namespace Azure.Storage.Blobs.Test
             var mock = new Mock<BlobContainerClient>(TestConfigDefault.ConnectionString, "name", new BlobClientOptions()).Object;
             mock = new Mock<BlobContainerClient>(TestConfigDefault.ConnectionString, "name").Object;
             mock = new Mock<BlobContainerClient>(new Uri("https://test/test"), new BlobClientOptions()).Object;
-            mock = new Mock<BlobContainerClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
+            mock = new Mock<BlobContainerClient>(new Uri("https://test/test"), Tenants.GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
             mock = new Mock<BlobContainerClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new BlobClientOptions()).Object;
-            mock = new Mock<BlobContainerClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
+            mock = new Mock<BlobContainerClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
         }
 
         #region Secondary Storage

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Storage.Blobs.Test
         }
 
         public BlobServiceClient GetServiceClient_SharedKey(BlobClientOptions options = default)
-            => Clients.GetServiceClient_SharedKey(options);
+            => BlobsClientBuilder.GetServiceClient_SharedKey(options);
 
         [RecordedTest]
         [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_02_02)]
@@ -393,7 +393,7 @@ namespace Azure.Storage.Blobs.Test
         {
             // Arrange
             var containerName = GetNewContainerName();
-            BlobServiceClient service = Clients.GetServiceClient_OAuth();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_OAuth();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
 
             try
@@ -425,7 +425,7 @@ namespace Azure.Storage.Blobs.Test
                 | AccountSasPermissions.Update
                 | AccountSasPermissions.Process;
 
-            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas(
+            SasQueryParameters sasQueryParameters = BlobsClientBuilder.GetNewAccountSas(
                 permissions: permissions);
 
             BlobServiceClient service = new BlobServiceClient(
@@ -2252,7 +2252,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task ListBlobsFlatSegmentAsync_Deleted()
         {
             // Arrange
-            BlobServiceClient blobServiceClient = Clients.GetServiceClient_SoftDelete();
+            BlobServiceClient blobServiceClient = BlobsClientBuilder.GetServiceClient_SoftDelete();
             await using DisposingContainer test = await GetTestContainerAsync(blobServiceClient);
             string blobName = GetNewBlobName();
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
@@ -2624,7 +2624,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task ListBlobsHierarchySegmentAsync_Deleted()
         {
             // Arrange
-            BlobServiceClient blobServiceClient = Clients.GetServiceClient_SoftDelete();
+            BlobServiceClient blobServiceClient = BlobsClientBuilder.GetServiceClient_SoftDelete();
             await using DisposingContainer test = await GetTestContainerAsync(blobServiceClient);
             string blobName = GetNewBlobName();
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
@@ -3507,7 +3507,7 @@ namespace Azure.Storage.Blobs.Test
             string newContainerName = GetNewContainerName();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(oldContainerName));
             await container.CreateAsync();
-            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas();
+            SasQueryParameters sasQueryParameters = BlobsClientBuilder.GetNewAccountSas();
             service = InstrumentClient(new BlobServiceClient(new Uri($"{service.Uri}?{sasQueryParameters}"), GetOptions()));
             BlobContainerClient sasContainer = InstrumentClient(service.GetBlobContainerClient(oldContainerName));
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -13,6 +13,7 @@ using Azure.Core.TestFramework;
 using Azure.Identity;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Shared;
 using Azure.Storage.Test;
@@ -20,7 +21,6 @@ using Azure.Storage.Test.Shared;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -393,7 +393,7 @@ namespace Azure.Storage.Blobs.Test
         {
             // Arrange
             var containerName = GetNewContainerName();
-            BlobServiceClient service = GetServiceClient_OauthAccount();
+            BlobServiceClient service = Clients.GetServiceClient_OAuth();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
 
             try

--- a/sdk/storage/Azure.Storage.Blobs/tests/DisposingContainer.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/DisposingContainer.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.Blobs.Tests
+{
+    public class DisposingContainer : IAsyncDisposable
+    {
+        public BlobContainerClient Container;
+
+        public DisposingContainer(BlobContainerClient client)
+        {
+            Container = client;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Container != null)
+            {
+                try
+                {
+                    await Container.DeleteIfExistsAsync();
+                    Container = null;
+                }
+                catch
+                {
+                    // swallow the exception to avoid hiding another test failure
+                }
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/ImmutableStorageWithVersioningTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ImmutableStorageWithVersioningTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
@@ -60,7 +61,7 @@ namespace Azure.Storage.Blobs.Test
         public void SetUp()
         {
             _containerName = Recording.GetVariable(nameof(_containerName), _containerName);
-            _containerClient = Clients.GetServiceClient_OAuthAccount_SharedKey().GetBlobContainerClient(_containerName);
+            _containerClient = BlobsClientBuilder.GetServiceClient_OAuthAccount_SharedKey().GetBlobContainerClient(_containerName);
         }
 
         [OneTimeTearDown]
@@ -244,7 +245,7 @@ namespace Azure.Storage.Blobs.Test
             BlobBaseClient blob = await GetNewBlobClient(_containerClient, GetNewBlobName());
 
             BlobServiceClient sharedKeyServiceClient = InstrumentClient(
-                Clients.GetServiceClient_OAuthAccount_SharedKey());
+                BlobsClientBuilder.GetServiceClient_OAuthAccount_SharedKey());
             Uri serviceSasUri = sharedKeyServiceClient.GenerateAccountSasUri(
                 sasPermissions,
                 Recording.UtcNow.AddDays(1),
@@ -287,7 +288,7 @@ namespace Azure.Storage.Blobs.Test
             BlobBaseClient blob = await GetNewBlobClient(_containerClient, GetNewBlobName());
 
             BlobContainerClient sharedKeyContainer = InstrumentClient(
-                Clients.GetServiceClient_OAuthAccount_SharedKey().GetBlobContainerClient(_containerClient.Name));
+                BlobsClientBuilder.GetServiceClient_OAuthAccount_SharedKey().GetBlobContainerClient(_containerClient.Name));
             Uri containerSasUri = sharedKeyContainer.GenerateSasUri(sasPermissions, Recording.UtcNow.AddDays(1));
             BlobBaseClient sasBlobClient = InstrumentClient(new BlobContainerClient(containerSasUri, GetOptions()).GetBlobBaseClient(blob.Name));
 
@@ -325,7 +326,7 @@ namespace Azure.Storage.Blobs.Test
             BlobBaseClient blob = await GetNewBlobClient(_containerClient, GetNewBlobName());
 
             BlobBaseClient sharedKeyBlob = InstrumentClient(
-                Clients.GetServiceClient_OAuthAccount_SharedKey()
+                BlobsClientBuilder.GetServiceClient_OAuthAccount_SharedKey()
                     .GetBlobContainerClient(_containerClient.Name)
                     .GetBlobBaseClient(blob.Name));
             Uri blobSasUri = sharedKeyBlob.GenerateSasUri(sasPermissions, Recording.UtcNow.AddDays(1));

--- a/sdk/storage/Azure.Storage.Blobs/tests/ImmutableStorageWithVersioningTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ImmutableStorageWithVersioningTests.cs
@@ -60,7 +60,7 @@ namespace Azure.Storage.Blobs.Test
         public void SetUp()
         {
             _containerName = Recording.GetVariable(nameof(_containerName), _containerName);
-            _containerClient = GetServiceClient_OAuthAccount_SharedKey().GetBlobContainerClient(_containerName);
+            _containerClient = Clients.GetServiceClient_OAuthAccount_SharedKey().GetBlobContainerClient(_containerName);
         }
 
         [OneTimeTearDown]
@@ -70,9 +70,9 @@ namespace Azure.Storage.Blobs.Test
             {
                 var configuration = TestConfigurations.DefaultTargetOAuthTenant;
                 var containerClient = new BlobServiceClient(
-                    new Uri(TestConfigOAuth.BlobServiceEndpoint),
-                    new StorageSharedKeyCredential(TestConfigOAuth.AccountName,
-                    TestConfigOAuth.AccountKey))
+                    new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint),
+                    new StorageSharedKeyCredential(Tenants.TestConfigOAuth.AccountName,
+                    Tenants.TestConfigOAuth.AccountKey))
                     .GetBlobContainerClient(_containerName);
                 await foreach (BlobItem blobItem in containerClient.GetBlobsAsync(BlobTraits.ImmutabilityPolicy | BlobTraits.LegalHold))
                 {
@@ -244,7 +244,7 @@ namespace Azure.Storage.Blobs.Test
             BlobBaseClient blob = await GetNewBlobClient(_containerClient, GetNewBlobName());
 
             BlobServiceClient sharedKeyServiceClient = InstrumentClient(
-                GetServiceClient_OAuthAccount_SharedKey());
+                Clients.GetServiceClient_OAuthAccount_SharedKey());
             Uri serviceSasUri = sharedKeyServiceClient.GenerateAccountSasUri(
                 sasPermissions,
                 Recording.UtcNow.AddDays(1),
@@ -287,7 +287,7 @@ namespace Azure.Storage.Blobs.Test
             BlobBaseClient blob = await GetNewBlobClient(_containerClient, GetNewBlobName());
 
             BlobContainerClient sharedKeyContainer = InstrumentClient(
-                GetServiceClient_OAuthAccount_SharedKey().GetBlobContainerClient(_containerClient.Name));
+                Clients.GetServiceClient_OAuthAccount_SharedKey().GetBlobContainerClient(_containerClient.Name));
             Uri containerSasUri = sharedKeyContainer.GenerateSasUri(sasPermissions, Recording.UtcNow.AddDays(1));
             BlobBaseClient sasBlobClient = InstrumentClient(new BlobContainerClient(containerSasUri, GetOptions()).GetBlobBaseClient(blob.Name));
 
@@ -325,7 +325,7 @@ namespace Azure.Storage.Blobs.Test
             BlobBaseClient blob = await GetNewBlobClient(_containerClient, GetNewBlobName());
 
             BlobBaseClient sharedKeyBlob = InstrumentClient(
-                GetServiceClient_OAuthAccount_SharedKey()
+                Clients.GetServiceClient_OAuthAccount_SharedKey()
                     .GetBlobContainerClient(_containerClient.Name)
                     .GetBlobBaseClient(blob.Name));
             Uri blobSasUri = sharedKeyBlob.GenerateSasUri(sasPermissions, Recording.UtcNow.AddDays(1));
@@ -374,7 +374,7 @@ namespace Azure.Storage.Blobs.Test
                 Snapshot = snapshotResponse.Value.Snapshot
             };
             blobSasBuilder.SetPermissions(sasPermissions);
-            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigOAuth.AccountName, TestConfigOAuth.AccountKey);
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(Tenants.TestConfigOAuth.AccountName, Tenants.TestConfigOAuth.AccountKey);
             BlobUriBuilder uriBuilder = new BlobUriBuilder(blob.Uri)
             {
                 Snapshot = snapshotResponse.Value.Snapshot,
@@ -432,7 +432,7 @@ namespace Azure.Storage.Blobs.Test
                 Version = metadataResponse.Value.VersionId
             };
             blobSasBuilder.SetPermissions(sasPermissions);
-            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigOAuth.AccountName, TestConfigOAuth.AccountKey);
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(Tenants.TestConfigOAuth.AccountName, Tenants.TestConfigOAuth.AccountKey);
             BlobUriBuilder uriBuilder = new BlobUriBuilder(blob.Uri)
             {
                 VersionId = metadataResponse.Value.VersionId,

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -2967,7 +2967,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UploadPagesFromUriAsync_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3007,7 +3007,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UploadPagesFromUriAsync_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = GetServiceClient_OauthAccount();
+            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -22,6 +22,7 @@ using Azure.Storage.Test.Shared;
 using Azure.Storage.Tests;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -87,11 +88,11 @@ namespace Azure.Storage.Blobs.Test
         public void Ctor_TokenAuth_Http()
         {
             // Arrange
-            Uri httpUri = new Uri(TestConfigOAuth.BlobServiceEndpoint).ToHttp();
+            Uri httpUri = new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
-                () => new PageBlobClient(httpUri, GetOAuthCredential()),
+                () => new PageBlobClient(httpUri, Tenants.GetOAuthCredential()),
                  new ArgumentException("Cannot use TokenCredential without HTTPS."));
         }
 
@@ -2354,7 +2355,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task StartCopyIncrementalAsync_AccessTier()
         {
-            BlobServiceClient premiumService = GetServiceClient_PremiumBlobAccount_SharedKey();
+            BlobServiceClient premiumService = Clients.GetServiceClient_PremiumBlobAccount_SharedKey();
             await using DisposingContainer test = await GetTestContainerAsync(service: premiumService, premium: true);
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
@@ -2394,7 +2395,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task StartCopyIncrementalAsync_AccessTierFail()
         {
-            BlobServiceClient premiumService = GetServiceClient_PremiumBlobAccount_SharedKey();
+            BlobServiceClient premiumService = Clients.GetServiceClient_PremiumBlobAccount_SharedKey();
             await using DisposingContainer test = await GetTestContainerAsync(service: premiumService, premium: true);
 
             // Arrange
@@ -2429,7 +2430,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task SetTierAsync_AccessTier()
         {
-            BlobServiceClient premiumService = GetServiceClient_PremiumBlobAccount_SharedKey();
+            BlobServiceClient premiumService = Clients.GetServiceClient_PremiumBlobAccount_SharedKey();
             await using DisposingContainer test = await GetTestContainerAsync(service: premiumService, premium: true);
 
             // Arrange
@@ -2446,7 +2447,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task SetTierAsync_AccessTierFail()
         {
-            BlobServiceClient premiumService = GetServiceClient_PremiumBlobAccount_SharedKey();
+            BlobServiceClient premiumService = Clients.GetServiceClient_PremiumBlobAccount_SharedKey();
             await using DisposingContainer test = await GetTestContainerAsync(service: premiumService, premium: true);
             // Arrange
             PageBlobClient blob = await CreatePageBlobClientAsync(test.Container, Constants.KB);
@@ -3342,7 +3343,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SharedKey();
+            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             PageBlobClient blob = InstrumentClient(container.GetPageBlobClient(GetNewBlobName()));
 
@@ -3663,9 +3664,9 @@ namespace Azure.Storage.Blobs.Test
             var mock = new Mock<PageBlobClient>(TestConfigDefault.ConnectionString, "name", "name", new BlobClientOptions()).Object;
             mock = new Mock<PageBlobClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<PageBlobClient>(new Uri("https://test/test"), new BlobClientOptions()).Object;
-            mock = new Mock<PageBlobClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
+            mock = new Mock<PageBlobClient>(new Uri("https://test/test"), Tenants.GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
             mock = new Mock<PageBlobClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new BlobClientOptions()).Object;
-            mock = new Mock<PageBlobClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
+            mock = new Mock<PageBlobClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
         }
 
         public static PageBlobRequestConditions BuildAccessConditions(

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -22,7 +22,6 @@ using Azure.Storage.Test.Shared;
 using Azure.Storage.Tests;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -2355,7 +2355,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task StartCopyIncrementalAsync_AccessTier()
         {
-            BlobServiceClient premiumService = Clients.GetServiceClient_PremiumBlobAccount_SharedKey();
+            BlobServiceClient premiumService = BlobsClientBuilder.GetServiceClient_PremiumBlobAccount_SharedKey();
             await using DisposingContainer test = await GetTestContainerAsync(service: premiumService, premium: true);
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
@@ -2395,7 +2395,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task StartCopyIncrementalAsync_AccessTierFail()
         {
-            BlobServiceClient premiumService = Clients.GetServiceClient_PremiumBlobAccount_SharedKey();
+            BlobServiceClient premiumService = BlobsClientBuilder.GetServiceClient_PremiumBlobAccount_SharedKey();
             await using DisposingContainer test = await GetTestContainerAsync(service: premiumService, premium: true);
 
             // Arrange
@@ -2430,7 +2430,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task SetTierAsync_AccessTier()
         {
-            BlobServiceClient premiumService = Clients.GetServiceClient_PremiumBlobAccount_SharedKey();
+            BlobServiceClient premiumService = BlobsClientBuilder.GetServiceClient_PremiumBlobAccount_SharedKey();
             await using DisposingContainer test = await GetTestContainerAsync(service: premiumService, premium: true);
 
             // Arrange
@@ -2447,7 +2447,7 @@ namespace Azure.Storage.Blobs.Test
         [RecordedTest]
         public async Task SetTierAsync_AccessTierFail()
         {
-            BlobServiceClient premiumService = Clients.GetServiceClient_PremiumBlobAccount_SharedKey();
+            BlobServiceClient premiumService = BlobsClientBuilder.GetServiceClient_PremiumBlobAccount_SharedKey();
             await using DisposingContainer test = await GetTestContainerAsync(service: premiumService, premium: true);
             // Arrange
             PageBlobClient blob = await CreatePageBlobClientAsync(test.Container, Constants.KB);
@@ -2967,7 +2967,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UploadPagesFromUriAsync_SourceBearerToken()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3007,7 +3007,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UploadPagesFromUriAsync_SourceBearerTokenFail()
         {
             // Arrange
-            BlobServiceClient serviceClient = Clients.GetServiceClient_OAuth();
+            BlobServiceClient serviceClient = BlobsClientBuilder.GetServiceClient_OAuth();
             await using DisposingContainer test = await GetTestContainerAsync(
                 service: serviceClient,
                 publicAccessType: PublicAccessType.None);
@@ -3343,7 +3343,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SharedKey();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             PageBlobClient blob = InstrumentClient(container.GetPageBlobClient(GetNewBlobName()));
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -556,7 +556,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task GetUserDelegationKey()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_OauthAccount();
+            BlobServiceClient service = Clients.GetServiceClient_OAuth();
 
             // Act
             Response<UserDelegationKey> response = await service.GetUserDelegationKeyAsync(startsOn: null, expiresOn: Recording.UtcNow.AddHours(1));
@@ -581,7 +581,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task GetUserDelegationKey_ArgumentException()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_OauthAccount();
+            BlobServiceClient service = Clients.GetServiceClient_OAuth();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<ArgumentException>(

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -9,12 +9,12 @@ using Azure.Core.TestFramework;
 using Azure.Identity;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -14,6 +14,7 @@ using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Test
 {
@@ -23,6 +24,9 @@ namespace Azure.Storage.Blobs.Test
             : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
+
+        public BlobServiceClient GetServiceClient_SharedKey(BlobClientOptions options = default)
+            => Clients.GetServiceClient_SharedKey(options);
 
         [RecordedTest]
         public void Ctor_ConnectionString()
@@ -78,11 +82,11 @@ namespace Azure.Storage.Blobs.Test
         public void Ctor_TokenAuth_Http()
         {
             // Arrange
-            Uri httpUri = new Uri(TestConfigOAuth.BlobServiceEndpoint).ToHttp();
+            Uri httpUri = new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
-                () => new BlobServiceClient(httpUri, GetOAuthCredential()),
+                () => new BlobServiceClient(httpUri, Tenants.GetOAuthCredential()),
                  new ArgumentException("Cannot use TokenCredential without HTTPS."));
         }
 
@@ -328,7 +332,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task ListContainersSegmentAsync_Deleted()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SoftDelete();
+            BlobServiceClient service = Clients.GetServiceClient_SoftDelete();
             string containerName = GetNewContainerName();
             BlobContainerClient containerClient = InstrumentClient(service.GetBlobContainerClient(containerName));
             await containerClient.CreateAsync();
@@ -390,7 +394,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task GetAccountInfoAsync_HnsTrue()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_Hns();
+            BlobServiceClient service = Clients.GetServiceClient_Hns();
 
             // Act
             Response<AccountInfo> response = await service.GetAccountInfoAsync();
@@ -538,7 +542,7 @@ namespace Azure.Storage.Blobs.Test
             BlobServiceClient service = InstrumentClient(
                 new BlobServiceClient(
                     new Uri(TestConfigDefault.BlobServiceSecondaryEndpoint),
-                    GetNewSharedKeyCredentials(),
+                    Tenants.GetNewSharedKeyCredentials(),
                     GetOptions()));
 
             // Act
@@ -697,7 +701,7 @@ namespace Azure.Storage.Blobs.Test
             await Delay(2000);
 
             // Act
-            SasQueryParameters sasQueryParameters = GetNewAccountSas(permissions: accountSasPermissions);
+            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas(permissions: accountSasPermissions);
             BlobServiceClient sasServiceClient = new BlobServiceClient(new Uri($"{service.Uri}?{sasQueryParameters}"), GetOptions());
             List<TaggedBlobItem> blobs = new List<TaggedBlobItem>();
             await foreach (Page<TaggedBlobItem> page in sasServiceClient.FindBlobsByTagsAsync(expression).AsPages())
@@ -731,7 +735,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UndeleteBlobContainerAsync()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SoftDelete();
+            BlobServiceClient service = Clients.GetServiceClient_SoftDelete();
             string containerName = GetNewContainerName();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
             await container.CreateAsync();
@@ -759,7 +763,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UndeleteBlobContainerAsync_Error()
         {
             // Arrange
-            BlobServiceClient service = GetServiceClient_SoftDelete();
+            BlobServiceClient service = Clients.GetServiceClient_SoftDelete();
             string containerName = GetNewContainerName();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
 
@@ -851,7 +855,7 @@ namespace Azure.Storage.Blobs.Test
             string newContainerName = GetNewContainerName();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(oldContainerName));
             await container.CreateAsync();
-            SasQueryParameters sasQueryParameters = GetNewAccountSas();
+            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas();
             service = InstrumentClient(new BlobServiceClient(new Uri($"{service.Uri}?{sasQueryParameters}"), GetOptions()));
 
             // Act
@@ -1145,9 +1149,9 @@ namespace Azure.Storage.Blobs.Test
             var mock = new Mock<BlobServiceClient>(TestConfigDefault.ConnectionString, new BlobClientOptions()).Object;
             mock = new Mock<BlobServiceClient>(TestConfigDefault.ConnectionString).Object;
             mock = new Mock<BlobServiceClient>(new Uri("https://test/test"), new BlobClientOptions()).Object;
-            mock = new Mock<BlobServiceClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
+            mock = new Mock<BlobServiceClient>(new Uri("https://test/test"), Tenants.GetNewSharedKeyCredentials(), new BlobClientOptions()).Object;
             mock = new Mock<BlobServiceClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new BlobClientOptions()).Object;
-            mock = new Mock<BlobServiceClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
+            mock = new Mock<BlobServiceClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new BlobClientOptions()).Object;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage.Blobs.Test
         }
 
         public BlobServiceClient GetServiceClient_SharedKey(BlobClientOptions options = default)
-            => Clients.GetServiceClient_SharedKey(options);
+            => BlobsClientBuilder.GetServiceClient_SharedKey(options);
 
         [RecordedTest]
         public void Ctor_ConnectionString()
@@ -332,7 +332,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task ListContainersSegmentAsync_Deleted()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SoftDelete();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SoftDelete();
             string containerName = GetNewContainerName();
             BlobContainerClient containerClient = InstrumentClient(service.GetBlobContainerClient(containerName));
             await containerClient.CreateAsync();
@@ -394,7 +394,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task GetAccountInfoAsync_HnsTrue()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_Hns();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_Hns();
 
             // Act
             Response<AccountInfo> response = await service.GetAccountInfoAsync();
@@ -556,7 +556,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task GetUserDelegationKey()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_OAuth();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_OAuth();
 
             // Act
             Response<UserDelegationKey> response = await service.GetUserDelegationKeyAsync(startsOn: null, expiresOn: Recording.UtcNow.AddHours(1));
@@ -581,7 +581,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task GetUserDelegationKey_ArgumentException()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_OAuth();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_OAuth();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<ArgumentException>(
@@ -701,7 +701,7 @@ namespace Azure.Storage.Blobs.Test
             await Delay(2000);
 
             // Act
-            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas(permissions: accountSasPermissions);
+            SasQueryParameters sasQueryParameters = BlobsClientBuilder.GetNewAccountSas(permissions: accountSasPermissions);
             BlobServiceClient sasServiceClient = new BlobServiceClient(new Uri($"{service.Uri}?{sasQueryParameters}"), GetOptions());
             List<TaggedBlobItem> blobs = new List<TaggedBlobItem>();
             await foreach (Page<TaggedBlobItem> page in sasServiceClient.FindBlobsByTagsAsync(expression).AsPages())
@@ -735,7 +735,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UndeleteBlobContainerAsync()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SoftDelete();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SoftDelete();
             string containerName = GetNewContainerName();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
             await container.CreateAsync();
@@ -763,7 +763,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UndeleteBlobContainerAsync_Error()
         {
             // Arrange
-            BlobServiceClient service = Clients.GetServiceClient_SoftDelete();
+            BlobServiceClient service = BlobsClientBuilder.GetServiceClient_SoftDelete();
             string containerName = GetNewContainerName();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
 
@@ -855,7 +855,7 @@ namespace Azure.Storage.Blobs.Test
             string newContainerName = GetNewContainerName();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(oldContainerName));
             await container.CreateAsync();
-            SasQueryParameters sasQueryParameters = Clients.GetNewAccountSas();
+            SasQueryParameters sasQueryParameters = BlobsClientBuilder.GetNewAccountSas();
             service = InstrumentClient(new BlobServiceClient(new Uri($"{service.Uri}?{sasQueryParameters}"), GetOptions()));
 
             // Act

--- a/sdk/storage/Azure.Storage.Blobs/tests/TenantDiscoveryBlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/TenantDiscoveryBlobBaseClientTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Storage.Blobs.Tests
         [RecordedTest]
         public async Task ExistsAsync_WithTenantDiscovery()
         {
-            await using DisposingContainer test = await GetTestContainerAsync(GetServiceClient_OauthAccount(true));
+            await using DisposingContainer test = await GetTestContainerAsync(GetServiceClient_OauthAccount_TenantDiscovery());
 
             // Arrange
             BlobBaseClient blob = await GetNewBlobClient(test.Container);

--- a/sdk/storage/Azure.Storage.Blobs/tests/TenantDiscoveryBlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/TenantDiscoveryBlobBaseClientTests.cs
@@ -6,6 +6,7 @@ using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
+using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Tests
 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/TenantDiscoveryBlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/TenantDiscoveryBlobBaseClientTests.cs
@@ -4,9 +4,9 @@
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
-using static Azure.Storage.Blobs.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Blobs.Tests
 {

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
@@ -146,7 +146,7 @@ namespace Azure.Storage.Test.Shared
                 _getServiceClientStorageSharedKeyCredential(
                     new Uri(config.BlobServiceEndpoint),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
-                    options ?? AzureCoreRecordedTestBase.InstrumentClientOptions(_getServiceClientOptions())));
+                    options ?? GetOptions()));
 
         private TServiceClient GetServiceClientFromOauthConfig(
             TenantConfiguration config,
@@ -155,7 +155,7 @@ namespace Azure.Storage.Test.Shared
                 _getServiceClientTokenCredential(
                     new Uri(config.BlobServiceEndpoint),
                     Tenants.GetOAuthCredential(config),
-                    options ?? AzureCoreRecordedTestBase.InstrumentClientOptions(_getServiceClientOptions())));
+                    options ?? GetOptions()));
 
         public TServiceClientOptions GetOptions(bool parallelRange = false)
         {

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
@@ -58,7 +58,6 @@ namespace Azure.Storage.Test.Shared
         private readonly GetServiceClientTokenCredential _getServiceClientTokenCredential;
         private readonly GetServiceClient _getServiceClient;
         private readonly GetServiceClientOptions _getServiceClientOptions;
-        private readonly InstrumentClientOptions _instrumentClientOptions;
 
         private readonly TenantConfigurationBuilder _tenantConfigurationBuilder;
 
@@ -109,6 +108,12 @@ namespace Azure.Storage.Test.Shared
         public TServiceClient GetServiceClient_ManagedDisk() =>
             GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigManagedDisk);
 
+        public TServiceClient GetServiceClient_PremiumBlob() =>
+            GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigPremiumBlob);
+
+        public TServiceClient GetServiceClient_PremiumFile() =>
+            GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigPremiumFile);
+
         public TServiceClient GetServiceClient_Hns() =>
             GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigHierarchicalNamespace);
 
@@ -156,7 +161,7 @@ namespace Azure.Storage.Test.Shared
                 options.AddPolicy(new RecordedClientRequestIdPolicy(Recording, parallelRange), HttpPipelinePosition.PerCall);
             }
 
-            return _instrumentClientOptions(options);
+            return AzureCoreRecordedTestBase.InstrumentClientOptions(options);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
@@ -148,7 +148,9 @@ namespace Azure.Storage.Test.Shared
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
                     options ?? _getServiceClientOptions()));
 
-        private TServiceClient GetServiceClientFromOauthConfig(TenantConfiguration config, TServiceClientOptions options = default)
+        private TServiceClient GetServiceClientFromOauthConfig(
+            TenantConfiguration config,
+            TServiceClientOptions options = default)
             => AzureCoreRecordedTestBase.InstrumentClient(
                 _getServiceClientTokenCredential(
                     new Uri(config.BlobServiceEndpoint),

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
@@ -146,7 +146,7 @@ namespace Azure.Storage.Test.Shared
                 _getServiceClientStorageSharedKeyCredential(
                     new Uri(config.BlobServiceEndpoint),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
-                    options ?? _getServiceClientOptions()));
+                    options ?? AzureCoreRecordedTestBase.InstrumentClientOptions(_getServiceClientOptions())));
 
         private TServiceClient GetServiceClientFromOauthConfig(
             TenantConfiguration config,
@@ -155,7 +155,7 @@ namespace Azure.Storage.Test.Shared
                 _getServiceClientTokenCredential(
                     new Uri(config.BlobServiceEndpoint),
                     Tenants.GetOAuthCredential(config),
-                    options ?? _getServiceClientOptions()));
+                    options ?? AzureCoreRecordedTestBase.InstrumentClientOptions(_getServiceClientOptions())));
 
         public TServiceClientOptions GetOptions(bool parallelRange = false)
         {

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
@@ -60,7 +60,7 @@ namespace Azure.Storage.Test.Shared
         private readonly GetServiceClientOptions _getServiceClientOptions;
 
         private readonly ServiceEndpoint _serviceEndpoint;
-        private TenantConfigurationBuilder Tenants { get; }
+        public TenantConfigurationBuilder Tenants { get; }
 
         public RecordedTestBase AzureCoreRecordedTestBase => Tenants.AzureCoreRecordedTestBase;
 
@@ -93,38 +93,6 @@ namespace Azure.Storage.Test.Shared
             _getServiceClientOptions = getServiceClientOptions;
         }
 
-        public TServiceClient GetServiceClient_SharedKey(TServiceClientOptions options = default)
-            => GetServiceClientFromSharedKeyConfig(Tenants.TestConfigDefault, options);
-
-        public TServiceClient GetServiceClient_SecondaryAccount_SharedKey()
-            => GetServiceClientFromSharedKeyConfig(Tenants.TestConfigSecondary);
-
-        public TServiceClient GetServiceClient_PreviewAccount_SharedKey()
-            => GetServiceClientFromSharedKeyConfig(Tenants.TestConfigPreviewBlob);
-
-        public TServiceClient GetServiceClient_PremiumBlobAccount_SharedKey()
-            => GetServiceClientFromSharedKeyConfig(Tenants.TestConfigPremiumBlob);
-        public TServiceClient GetServiceClient_OAuth() =>
-            GetServiceClientFromOauthConfig(Tenants.TestConfigOAuth);
-
-        public TServiceClient GetServiceClient_OAuthAccount_SharedKey() =>
-            GetServiceClientFromSharedKeyConfig(Tenants.TestConfigOAuth);
-
-        public TServiceClient GetServiceClient_ManagedDisk() =>
-            GetServiceClientFromSharedKeyConfig(Tenants.TestConfigManagedDisk);
-
-        public TServiceClient GetServiceClient_PremiumBlob() =>
-            GetServiceClientFromSharedKeyConfig(Tenants.TestConfigPremiumBlob);
-
-        public TServiceClient GetServiceClient_PremiumFile() =>
-            GetServiceClientFromSharedKeyConfig(Tenants.TestConfigPremiumFile);
-
-        public TServiceClient GetServiceClient_Hns() =>
-            GetServiceClientFromSharedKeyConfig(Tenants.TestConfigHierarchicalNamespace);
-
-        public TServiceClient GetServiceClient_SoftDelete() =>
-            GetServiceClientFromSharedKeyConfig(Tenants.TestConfigSoftDelete);
-
         public SasQueryParameters GetNewAccountSas(
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All,
             AccountSasPermissions permissions = AccountSasPermissions.All,
@@ -153,14 +121,14 @@ namespace Azure.Storage.Test.Shared
                 _ => throw new ArgumentException($"{nameof(_serviceEndpoint)} not properly initialized.")
             };
 
-        private TServiceClient GetServiceClientFromSharedKeyConfig(TenantConfiguration config, TServiceClientOptions options = default)
+        public TServiceClient GetServiceClientFromSharedKeyConfig(TenantConfiguration config, TServiceClientOptions options = default)
             => AzureCoreRecordedTestBase.InstrumentClient(
                 _getServiceClientStorageSharedKeyCredential(
                     new Uri(GetEndpoint(config)),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
                     options ?? GetOptions()));
 
-        private TServiceClient GetServiceClientFromOauthConfig(
+        public TServiceClient GetServiceClientFromOauthConfig(
             TenantConfiguration config,
             TServiceClientOptions options = default)
             => AzureCoreRecordedTestBase.InstrumentClient(

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Storage.Sas;
+
+namespace Azure.Storage.Test.Shared
+{
+    public class ClientBuilder<TServiceClient, TServiceClientOptions>
+        where TServiceClient : class
+        where TServiceClientOptions : ClientOptions
+    {
+        #region Delegate Definitions
+        /// <summary>
+        /// Delegate for accessing a shared key credential constructor for a service client.
+        /// </summary>
+        public delegate TServiceClient GetServiceClientStorageSharedKeyCredential(Uri endpoint, StorageSharedKeyCredential credential, TServiceClientOptions clientOptions);
+
+        /// <summary>
+        /// Delegate for accessing a SAS credential constructor for a service client.
+        /// </summary>
+        public delegate TServiceClient GetServiceClientAzureSasCredential(Uri endpoint, AzureSasCredential credential, TServiceClientOptions clientOptions);
+
+        /// <summary>
+        /// Delegate for accessing a token credential constructor for a service client.
+        /// </summary>
+        public delegate TServiceClient GetServiceClientTokenCredential(Uri endpoint, TokenCredential credential, TServiceClientOptions clientOptions);
+
+        /// <summary>
+        /// Delegate for accessing a credential-less constructor for a service client.
+        /// </summary>
+        public delegate TServiceClient GetServiceClient(Uri endpoint, TServiceClientOptions clientOptions);
+
+        /// <summary>
+        /// Delegate for accessing constructor for service client options.
+        /// </summary>
+        /// <param name="serviceVersion"></param>
+        /// <returns></returns>
+        public delegate TServiceClientOptions GetServiceClientOptions();
+
+        /// <summary>
+        /// Delegate for applying Azure Core client instrumentation to a service client.
+        /// </summary>
+        public delegate TClient InstrumentServiceClient<TClient>(TClient client);
+
+        /// <summary>
+        /// Delegate for applying Azure Core client options instrumentation to client options.
+        /// </summary>
+        public delegate TServiceClientOptions InstrumentClientOptions(TServiceClientOptions client);
+        #endregion
+
+        private readonly GetServiceClientStorageSharedKeyCredential _getServiceClientStorageSharedKeyCredential;
+        private readonly GetServiceClientAzureSasCredential _getServiceClientAzureSasCredential;
+        private readonly GetServiceClientTokenCredential _getServiceClientTokenCredential;
+        private readonly GetServiceClient _getServiceClient;
+        private readonly GetServiceClientOptions _getServiceClientOptions;
+        private readonly InstrumentClientOptions _instrumentClientOptions;
+
+        private readonly TenantConfigurationBuilder _tenantConfigurationBuilder;
+
+        public RecordedTestBase AzureCoreRecordedTestBase => _tenantConfigurationBuilder.AzureCoreRecordedTestBase;
+
+        public TestRecording Recording => AzureCoreRecordedTestBase.Recording;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="tenantConfigurationBuilder">Source of tenants for appropriate service clients.</param>
+        /// <param name="getServiceClient">Constructs a service client from the given arguments.</param>
+        /// <param name="getServiceClientStorageSharedKeyCredential">Constructs a service client from the given arguments.</param>
+        /// <param name="getServiceClientTokenCredential">Constructs a service client from the given arguments.</param>
+        /// <param name="getServiceClientAzureSasCredential">Constructs a service client from the given arguments.</param>
+        /// <param name="instrumentClient">Delegate to the test environment's InstrumentClient functionality.</param>
+        public ClientBuilder(
+            TenantConfigurationBuilder tenantConfigurationBuilder,
+            GetServiceClient getServiceClient,
+            GetServiceClientStorageSharedKeyCredential getServiceClientStorageSharedKeyCredential,
+            GetServiceClientTokenCredential getServiceClientTokenCredential,
+            GetServiceClientAzureSasCredential getServiceClientAzureSasCredential,
+            GetServiceClientOptions getServiceClientOptions)
+        {
+            _tenantConfigurationBuilder = tenantConfigurationBuilder;
+            _getServiceClient = getServiceClient;
+            _getServiceClientStorageSharedKeyCredential = getServiceClientStorageSharedKeyCredential;
+            _getServiceClientTokenCredential = getServiceClientTokenCredential;
+            _getServiceClientAzureSasCredential = getServiceClientAzureSasCredential;
+            _getServiceClientOptions = getServiceClientOptions;
+        }
+
+        public TServiceClient GetServiceClient_SharedKey(TServiceClientOptions options = default)
+            => GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigDefault, options);
+
+        public TServiceClient GetServiceClient_SecondaryAccount_SharedKey()
+            => GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigSecondary);
+
+        public TServiceClient GetServiceClient_PreviewAccount_SharedKey()
+            => GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigPreviewBlob);
+
+        public TServiceClient GetServiceClient_PremiumBlobAccount_SharedKey()
+            => GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigPremiumBlob);
+
+        public TServiceClient GetServiceClient_OAuthAccount_SharedKey() =>
+            GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigOAuth);
+
+        public TServiceClient GetServiceClient_ManagedDisk() =>
+            GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigManagedDisk);
+
+        public TServiceClient GetServiceClient_Hns() =>
+            GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigHierarchicalNamespace);
+
+        public TServiceClient GetServiceClient_SoftDelete() =>
+            GetServiceClientFromSharedKeyConfig(_tenantConfigurationBuilder.TestConfigSoftDelete);
+
+        public SasQueryParameters GetNewAccountSas(
+            AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All,
+            AccountSasPermissions permissions = AccountSasPermissions.All,
+            StorageSharedKeyCredential sharedKeyCredentials = default)
+        {
+            var builder = new AccountSasBuilder
+            {
+                Protocol = SasProtocol.None,
+                Services = AccountSasServices.Blobs,
+                ResourceTypes = resourceTypes,
+                StartsOn = Recording.UtcNow.AddHours(-1),
+                ExpiresOn = Recording.UtcNow.AddHours(+1),
+                IPRange = new SasIPRange(IPAddress.None, IPAddress.None),
+                Version = Constants.DefaultSasVersion
+            };
+            builder.SetPermissions(permissions);
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? _tenantConfigurationBuilder.GetNewSharedKeyCredentials());
+        }
+
+        private TServiceClient GetServiceClientFromSharedKeyConfig(TenantConfiguration config, TServiceClientOptions options = default)
+            => AzureCoreRecordedTestBase.InstrumentClient(
+                _getServiceClientStorageSharedKeyCredential(
+                    new Uri(config.BlobServiceEndpoint),
+                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
+                    options ?? _getServiceClientOptions()));
+
+        public TServiceClientOptions GetOptions(bool parallelRange = false)
+        {
+            var options = _getServiceClientOptions();
+            options.Diagnostics.IsLoggingEnabled = true;
+            options.Retry.Mode = RetryMode.Exponential;
+            options.Retry.MaxRetries = Constants.MaxReliabilityRetries;
+            options.Retry.Delay = TimeSpan.FromSeconds(Recording.Mode == RecordedTestMode.Playback ? 0.01 : 1);
+            options.Retry.MaxDelay = TimeSpan.FromSeconds(Recording.Mode == RecordedTestMode.Playback ? 0.1 : 60);
+            options.Retry.NetworkTimeout = TimeSpan.FromSeconds(Recording.Mode == RecordedTestMode.Playback ? 100 : 400);
+
+            if (Recording.Mode != RecordedTestMode.Live)
+            {
+                options.AddPolicy(new RecordedClientRequestIdPolicy(Recording, parallelRange), HttpPipelinePosition.PerCall);
+            }
+
+            return _instrumentClientOptions(options);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ServiceEndpoint.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ServiceEndpoint.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Storage.Test.Shared
+{
+    public enum ServiceEndpoint
+    {
+        None = 0,
+        Blob, File, Queue
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.Test.Shared
         }
 
         public StorageTestBase(bool async, RecordedTestMode? mode = null)
-            : base(async, RecordedTestMode.Playback)
+            : base(async, mode)
         {
             Sanitizer = new StorageRecordedTestSanitizer();
             Tenants = new TenantConfigurationBuilder(this);

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.Test.Shared
         }
 
         public StorageTestBase(bool async, RecordedTestMode? mode = null)
-            : base(async, mode)
+            : base(async, RecordedTestMode.Playback)
         {
             Sanitizer = new StorageRecordedTestSanitizer();
             Tenants = new TenantConfigurationBuilder(this);

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -37,88 +37,13 @@ namespace Azure.Storage.Test.Shared
             : base(async, mode)
         {
             Sanitizer = new StorageRecordedTestSanitizer();
+            _tenantConfigurationBuilder = new TenantConfigurationBuilder(Recording);
         }
 
         /// <summary>
-        /// Gets the tenant to use by default for our tests.
+        /// Source of test tenants.
         /// </summary>
-        public TenantConfiguration TestConfigDefault => GetTestConfig(
-                "Storage_TestConfigDefault",
-                () => TestConfigurations.DefaultTargetTenant);
-
-        /// <summary>
-        /// Gets the tenant to use for any tests that require Read Access
-        /// Geo-Redundant Storage to be setup.
-        /// </summary>
-        public TenantConfiguration TestConfigSecondary => GetTestConfig(
-                "Storage_TestConfigSecondary",
-                () => TestConfigurations.DefaultSecondaryTargetTenant);
-
-        /// <summary>
-        /// Gets the tenant to use for any tests that require Premium SSDs.
-        /// </summary>
-        public TenantConfiguration TestConfigPremiumBlob => GetTestConfig(
-                "Storage_TestConfigPremiumBlob",
-                () => TestConfigurations.DefaultTargetPremiumBlobTenant);
-
-        /// <summary>
-        /// Gets the tenant to use for any tests that require preview features.
-        /// </summary>
-        public TenantConfiguration TestConfigPreviewBlob => GetTestConfig(
-                "Storage_TestConfigPreviewBlob",
-                () => TestConfigurations.DefaultTargetPreviewBlobTenant);
-
-        /// <summary>
-        /// Gets the tenant to use for any tests that require authentication
-        /// with Azure AD.
-        /// </summary>
-        public TenantConfiguration TestConfigOAuth => GetTestConfig(
-                "Storage_TestConfigOAuth",
-                () => TestConfigurations.DefaultTargetOAuthTenant);
-
-        /// <summary>
-        /// Gets the tenant to use for any tests that require authentication
-        /// with Azure AD.
-        /// </summary>
-        public TenantConfiguration TestConfigHierarchicalNamespace => GetTestConfig(
-                "Storage_TestConfigHierarchicalNamespace",
-                () => TestConfigurations.DefaultTargetHierarchicalNamespaceTenant);
-
-        /// <summary>
-        /// Gets the tenant to use for any tests that require authentication
-        /// with Azure AD.
-        /// </summary>
-        public TenantConfiguration TestConfigManagedDisk => GetTestConfig(
-                "Storage_TestConfigManagedDisk",
-                () => TestConfigurations.DefaultTargetManagedDiskTenant);
-
-        /// <summary>
-        /// Gets the tenant to use for any tests that require authentication
-        /// with Azure AD.
-        /// </summary>
-        public TenantConfiguration TestConfigSoftDelete => GetTestConfig(
-                "Storage_TestConfigSoftDelete",
-                () => TestConfigurations.DefaultTargetSoftDeleteTenant);
-
-        /// <summary>
-        /// Gets the tenant to use for any tests premium files.
-        /// </summary>
-        public TenantConfiguration TestConfigPremiumFile => GetTestConfig(
-                "Storage_TestConfigPremiumFile",
-                () => TestConfigurations.DefaultPremiumFileTenant);
-
-        /// <summary>
-        /// Gets a cache used for storing serialized tenant configurations.  Do
-        /// not get values from this directly; use GetTestConfig.
-        /// </summary>
-        private readonly Dictionary<string, string> _recordingConfigCache =
-            new Dictionary<string, string>();
-
-        /// <summary>
-        /// Gets a cache used for storing deserialized tenant configurations.
-        /// Do not get values from this directly; use GetTestConfig.
-        private readonly Dictionary<string, TenantConfiguration> _playbackConfigCache =
-            new Dictionary<string, TenantConfiguration>();
+        protected readonly TenantConfigurationBuilder _tenantConfigurationBuilder;
 
         /// <summary>
         /// We need to clear the playback cache before every test because
@@ -127,55 +52,7 @@ namespace Azure.Storage.Test.Shared
         /// </summary>
         [SetUp]
         public virtual void ClearCaches() =>
-            _playbackConfigCache.Clear();
-
-        /// <summary>
-        /// Get or create a test configuration tenant to use with our tests.
-        ///
-        /// If we're recording, we'll save a sanitized version of the test
-        /// configuarion.  If we're playing recorded tests, we'll use the
-        /// serialized test configuration.  If we're running the tests live,
-        /// we'll just return the value.
-        ///
-        /// While we cache things internally, DO NOT cache them elsewhere
-        /// because we need each test to have its configuration recorded.
-        /// </summary>
-        /// <param name="name">The name of the session record variable.</param>
-        /// <param name="getTenant">
-        /// A function to get the tenant.  This is wrapped in a Func becuase
-        /// we'll throw Assert.Inconclusive if you try to access a tenant with
-        /// an invalid config file.
-        /// </param>
-        /// <returns>A test tenant to use with our tests.</returns>
-        private TenantConfiguration GetTestConfig(string name, Func<TenantConfiguration> getTenant)
-        {
-            TenantConfiguration config;
-            string text;
-            switch (Mode)
-            {
-                case RecordedTestMode.Playback:
-                    if (!_playbackConfigCache.TryGetValue(name, out config))
-                    {
-                        text = Recording.GetVariable(name, null);
-                        config = TenantConfiguration.Parse(text);
-                        _playbackConfigCache[name] = config;
-                    }
-                    break;
-                case RecordedTestMode.Record:
-                    config = getTenant();
-                    if (!_recordingConfigCache.TryGetValue(name, out text))
-                    {
-                        text = TenantConfiguration.Serialize(config, true);
-                        _recordingConfigCache[name] = text;
-                    }
-                    Recording.GetVariable(name, text);
-                    break;
-                default:
-                    config = getTenant();
-                    break;
-            }
-            return config;
-        }
+            _tenantConfigurationBuilder.ClearPlaybackCache();
 
         public DateTimeOffset GetUtcNow() => Recording.UtcNow;
 
@@ -213,25 +90,6 @@ namespace Azure.Storage.Test.Shared
             return IPAddress.Parse(ipString);
         }
 
-        public TokenCredential GetOAuthCredential() =>
-            GetOAuthCredential(TestConfigOAuth);
-
-        public TokenCredential GetOAuthCredential(TenantConfiguration config) =>
-            GetOAuthCredential(
-                config.ActiveDirectoryTenantId,
-                config.ActiveDirectoryApplicationId,
-                config.ActiveDirectoryApplicationSecret,
-                new Uri(config.ActiveDirectoryAuthEndpoint));
-
-        public TokenCredential GetOAuthCredential(string tenantId, string appId, string secret, Uri authorityHost) =>
-            Mode == RecordedTestMode.Playback ?
-                (TokenCredential) new StorageTestTokenCredential() :
-                new ClientSecretCredential(
-                    tenantId,
-                    appId,
-                    secret,
-                    new TokenCredentialOptions() { AuthorityHost = authorityHost });
-
         internal SharedAccessSignatureCredentials GetAccountSasCredentials(
             AccountSasServices services = AccountSasServices.All,
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All,
@@ -245,7 +103,7 @@ namespace Azure.Storage.Test.Shared
                 Protocol = SasProtocol.Https,
             };
             sasBuilder.SetPermissions(permissions);
-            var cred = new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey);
+            var cred = new StorageSharedKeyCredential(_tenantConfigurationBuilder.TestConfigDefault.AccountName, _tenantConfigurationBuilder.TestConfigDefault.AccountKey);
             return new SharedAccessSignatureCredentials(sasBuilder.ToSasQueryParameters(cred).ToString());
         }
 
@@ -473,19 +331,6 @@ namespace Azure.Storage.Test.Shared
             return stream;
         }
 
-        private class StorageTestTokenCredential : TokenCredential
-        {
-            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
-            {
-                return new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
-            }
-
-            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
-            {
-                return new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue);
-            }
-        }
-
         public string AccountSasPermissionsToPermissionsString(AccountSasPermissions permissions)
         {
             var sb = new StringBuilder();
@@ -543,7 +388,7 @@ namespace Azure.Storage.Test.Shared
                 return "auth token";
             }
 
-            tenantConfiguration ??= TestConfigOAuth;
+            tenantConfiguration ??= _tenantConfigurationBuilder.TestConfigOAuth;
 
             IConfidentialClientApplication application = ConfidentialClientApplicationBuilder.Create(tenantConfiguration.ActiveDirectoryApplicationId)
                 .WithAuthority(AzureCloudInstance.AzurePublic, tenantConfiguration.ActiveDirectoryTenantId)

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -37,13 +37,15 @@ namespace Azure.Storage.Test.Shared
             : base(async, mode)
         {
             Sanitizer = new StorageRecordedTestSanitizer();
-            _tenantConfigurationBuilder = new TenantConfigurationBuilder(Recording);
+            Tenants = new TenantConfigurationBuilder(this);
         }
 
         /// <summary>
         /// Source of test tenants.
         /// </summary>
-        protected readonly TenantConfigurationBuilder _tenantConfigurationBuilder;
+        protected readonly TenantConfigurationBuilder Tenants;
+
+        protected TenantConfiguration TestConfigDefault => Tenants.TestConfigDefault;
 
         /// <summary>
         /// We need to clear the playback cache before every test because
@@ -52,7 +54,7 @@ namespace Azure.Storage.Test.Shared
         /// </summary>
         [SetUp]
         public virtual void ClearCaches() =>
-            _tenantConfigurationBuilder.ClearPlaybackCache();
+            Tenants.ClearPlaybackCache();
 
         public DateTimeOffset GetUtcNow() => Recording.UtcNow;
 
@@ -103,7 +105,7 @@ namespace Azure.Storage.Test.Shared
                 Protocol = SasProtocol.Https,
             };
             sasBuilder.SetPermissions(permissions);
-            var cred = new StorageSharedKeyCredential(_tenantConfigurationBuilder.TestConfigDefault.AccountName, _tenantConfigurationBuilder.TestConfigDefault.AccountKey);
+            var cred = new StorageSharedKeyCredential(Tenants.TestConfigDefault.AccountName, Tenants.TestConfigDefault.AccountKey);
             return new SharedAccessSignatureCredentials(sasBuilder.ToSasQueryParameters(cred).ToString());
         }
 
@@ -388,7 +390,7 @@ namespace Azure.Storage.Test.Shared
                 return "auth token";
             }
 
-            tenantConfiguration ??= _tenantConfigurationBuilder.TestConfigOAuth;
+            tenantConfiguration ??= Tenants.TestConfigOAuth;
 
             IConfidentialClientApplication application = ConfidentialClientApplicationBuilder.Create(tenantConfiguration.ActiveDirectoryApplicationId)
                 .WithAuthority(AzureCloudInstance.AzurePublic, tenantConfiguration.ActiveDirectoryTenantId)

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfigurationBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfigurationBuilder.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Identity;
+
+namespace Azure.Storage.Test.Shared
+{
+    public class TenantConfigurationBuilder
+    {
+        /// <summary>
+        /// Reference to the base test class all tests that touch the wire inherit from.
+        /// </summary>
+        /// <remarks>
+        /// The base test classes have functionality we can't fully abandon just yet,
+        /// so we need to hold onto a reference to them to access critical functionality.
+        /// </remarks>
+        public RecordedTestBase AzureCoreRecordedTestBase { get; }
+
+        /// <summary>
+        /// Recording reference.
+        /// </summary>
+        public TestRecording Recording => AzureCoreRecordedTestBase.Recording;
+
+        /// <summary>
+        /// Gets a cache used for storing deserialized tenant configurations.
+        /// Do not get values from this directly; use GetTestConfig.
+        private readonly Dictionary<string, TenantConfiguration> _playbackConfigCache =
+            new Dictionary<string, TenantConfiguration>();
+
+        /// <summary>
+        /// Gets a cache used for storing serialized tenant configurations.  Do
+        /// not get values from this directly; use GetTestConfig.
+        /// </summary>
+        private readonly Dictionary<string, string> _recordingConfigCache =
+            new Dictionary<string, string>();
+
+        public TenantConfigurationBuilder(RecordedTestBase recordedTestBase)
+        {
+            AzureCoreRecordedTestBase = recordedTestBase;
+        }
+
+        /// <summary>
+        /// Clears caches for recording playback.
+        /// </summary>
+        public void ClearPlaybackCache() =>
+            _playbackConfigCache.Clear();
+
+        /// <summary>
+        /// Gets the tenant to use by default for our tests.
+        /// </summary>
+        public TenantConfiguration TestConfigDefault => GetTestConfig(
+                "Storage_TestConfigDefault",
+                () => TestConfigurations.DefaultTargetTenant);
+
+        /// <summary>
+        /// Gets the tenant to use for any tests that require Read Access
+        /// Geo-Redundant Storage to be setup.
+        /// </summary>
+        public TenantConfiguration TestConfigSecondary => GetTestConfig(
+                "Storage_TestConfigSecondary",
+                () => TestConfigurations.DefaultSecondaryTargetTenant);
+
+        /// <summary>
+        /// Gets the tenant to use for any tests that require Premium SSDs.
+        /// </summary>
+        public TenantConfiguration TestConfigPremiumBlob => GetTestConfig(
+                "Storage_TestConfigPremiumBlob",
+                () => TestConfigurations.DefaultTargetPremiumBlobTenant);
+
+        /// <summary>
+        /// Gets the tenant to use for any tests that require preview features.
+        /// </summary>
+        public TenantConfiguration TestConfigPreviewBlob => GetTestConfig(
+                "Storage_TestConfigPreviewBlob",
+                () => TestConfigurations.DefaultTargetPreviewBlobTenant);
+
+        /// <summary>
+        /// Gets the tenant to use for any tests that require authentication
+        /// with Azure AD.
+        /// </summary>
+        public TenantConfiguration TestConfigOAuth => GetTestConfig(
+                "Storage_TestConfigOAuth",
+                () => TestConfigurations.DefaultTargetOAuthTenant);
+
+        /// <summary>
+        /// Gets the tenant to use for any tests that require authentication
+        /// with Azure AD.
+        /// </summary>
+        public TenantConfiguration TestConfigHierarchicalNamespace => GetTestConfig(
+                "Storage_TestConfigHierarchicalNamespace",
+                () => TestConfigurations.DefaultTargetHierarchicalNamespaceTenant);
+
+        /// <summary>
+        /// Gets the tenant to use for any tests that require authentication
+        /// with Azure AD.
+        /// </summary>
+        public TenantConfiguration TestConfigManagedDisk => GetTestConfig(
+                "Storage_TestConfigManagedDisk",
+                () => TestConfigurations.DefaultTargetManagedDiskTenant);
+
+        /// <summary>
+        /// Gets the tenant to use for any tests that require authentication
+        /// with Azure AD.
+        /// </summary>
+        public TenantConfiguration TestConfigSoftDelete => GetTestConfig(
+                "Storage_TestConfigSoftDelete",
+                () => TestConfigurations.DefaultTargetSoftDeleteTenant);
+
+        /// <summary>
+        /// Gets the tenant to use for any tests premium files.
+        /// </summary>
+        public TenantConfiguration TestConfigPremiumFile => GetTestConfig(
+                "Storage_TestConfigPremiumFile",
+                () => TestConfigurations.DefaultPremiumFileTenant);
+
+        public StorageSharedKeyCredential GetNewSharedKeyCredentials()
+            => new StorageSharedKeyCredential(
+                    TestConfigDefault.AccountName,
+                    TestConfigDefault.AccountKey);
+
+        public TokenCredential GetOAuthCredential() =>
+            GetOAuthCredential(TestConfigOAuth);
+
+        public TokenCredential GetOAuthCredential(TenantConfiguration config) =>
+            GetOAuthCredential(
+                config.ActiveDirectoryTenantId,
+                config.ActiveDirectoryApplicationId,
+                config.ActiveDirectoryApplicationSecret,
+                new Uri(config.ActiveDirectoryAuthEndpoint));
+
+        public TokenCredential GetOAuthCredential(string tenantId, string appId, string secret, Uri authorityHost) =>
+            Recording.Mode == RecordedTestMode.Playback ?
+                (TokenCredential)new StorageTestTokenCredential() :
+                new ClientSecretCredential(
+                    tenantId,
+                    appId,
+                    secret,
+                    new TokenCredentialOptions() { AuthorityHost = authorityHost });
+
+        /// <summary>
+        /// Get or create a test configuration tenant to use with our tests.
+        ///
+        /// If we're recording, we'll save a sanitized version of the test
+        /// configuarion.  If we're playing recorded tests, we'll use the
+        /// serialized test configuration.  If we're running the tests live,
+        /// we'll just return the value.
+        ///
+        /// While we cache things internally, DO NOT cache them elsewhere
+        /// because we need each test to have its configuration recorded.
+        /// </summary>
+        /// <param name="name">The name of the session record variable.</param>
+        /// <param name="getTenant">
+        /// A function to get the tenant.  This is wrapped in a Func becuase
+        /// we'll throw Assert.Inconclusive if you try to access a tenant with
+        /// an invalid config file.
+        /// </param>
+        /// <returns>A test tenant to use with our tests.</returns>
+        private TenantConfiguration GetTestConfig(string name, Func<TenantConfiguration> getTenant)
+        {
+            TenantConfiguration config;
+            string text;
+            switch (Recording.Mode)
+            {
+                case RecordedTestMode.Playback:
+                    if (!_playbackConfigCache.TryGetValue(name, out config))
+                    {
+                        text = Recording.GetVariable(name, null);
+                        config = TenantConfiguration.Parse(text);
+                        _playbackConfigCache[name] = config;
+                    }
+                    break;
+                case RecordedTestMode.Record:
+                    config = getTenant();
+                    if (!_recordingConfigCache.TryGetValue(name, out text))
+                    {
+                        text = TenantConfiguration.Serialize(config, true);
+                        _recordingConfigCache[name] = text;
+                    }
+                    Recording.GetVariable(name, text);
+                    break;
+                default:
+                    config = getTenant();
+                    break;
+            }
+            return config;
+        }
+
+        private class StorageTestTokenCredential : TokenCredential
+        {
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                return new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+            }
+
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                return new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue);
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfigurationBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfigurationBuilder.cs
@@ -124,6 +124,11 @@ namespace Azure.Storage.Test.Shared
                     TestConfigDefault.AccountName,
                     TestConfigDefault.AccountKey);
 
+        public StorageSharedKeyCredential GetNewHnsSharedKeyCredentials()
+            => new StorageSharedKeyCredential(
+                    TestConfigHierarchicalNamespace.AccountName,
+                    TestConfigHierarchicalNamespace.AccountKey);
+
         public TokenCredential GetOAuthCredential() =>
             GetOAuthCredential(TestConfigOAuth);
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientBuilderExtensions.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Storage.Files.DataLake.Models;
+using Azure.Storage.Test;
+using Azure.Storage.Test.Shared;
+using NUnit.Framework;
+
+using DataLakeClientBuilder = Azure.Storage.Test.Shared.ClientBuilder<
+    Azure.Storage.Files.DataLake.DataLakeServiceClient,
+    Azure.Storage.Files.DataLake.DataLakeClientOptions>;
+
+namespace Azure.Storage.Files.DataLake.Tests
+{
+    public static class ClientBuilderExtensions
+    {
+        public static string GetGarbageLeaseId(this DataLakeClientBuilder clientBuilder)
+            => clientBuilder.Recording.Random.NewGuid().ToString();
+        public static string GetNewFileSystemName(this DataLakeClientBuilder clientBuilder)
+            => $"test-filesystem-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewDirectoryName(this DataLakeClientBuilder clientBuilder)
+            => $"test-directory-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewNonAsciiDirectoryName(this DataLakeClientBuilder clientBuilder)
+            => $"test-dire¢t Ø®ϒ%3A-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewFileName(this DataLakeClientBuilder clientBuilder)
+            => $"test-file-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewNonAsciiFileName(this DataLakeClientBuilder clientBuilder)
+            => $"test-ƒ¡£€‽%3A-{clientBuilder.Recording.Random.NewGuid()}";
+
+        public static async Task<DisposingFileSystem> GetNewFileSystem(
+            this DataLakeClientBuilder clientBuilder,
+            DataLakeServiceClient service = default,
+            string fileSystemName = default,
+            IDictionary<string, string> metadata = default,
+            PublicAccessType? publicAccessType = default,
+            bool premium = default)
+        {
+            fileSystemName ??= clientBuilder.GetNewFileSystemName();
+            service ??= clientBuilder.GetServiceClient_SharedKey();
+
+            if (publicAccessType == default)
+            {
+                publicAccessType = premium ? PublicAccessType.None : PublicAccessType.FileSystem;
+            }
+
+            DataLakeFileSystemClient fileSystem = clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(service.GetFileSystemClient(fileSystemName));
+
+            // due to a service issue, if the initial container creation request times out, subsequent requests
+            // can return a ContainerAlreadyExists code even though the container doesn't really exist.
+            // we delay until after the service cache timeout and then attempt to create the container one more time.
+            // If this attempt still fails, we mark the test as inconclusive.
+            // TODO Remove this handling after the service bug is fixed https://github.com/Azure/azure-sdk-for-net/issues/9399
+            try
+            {
+                await StorageTestBase<DataLakeTestEnvironment>.RetryAsync(
+                    clientBuilder.AzureCoreRecordedTestBase.Recording.Mode,
+                    async () => await fileSystem.CreateAsync(metadata: metadata, publicAccessType: publicAccessType.Value),
+                    ex => ex.ErrorCode == Blobs.Models.BlobErrorCode.ContainerAlreadyExists,
+                    retryDelay: TestConstants.DataLakeRetryDelay,
+                    retryAttempts: 1);
+            }
+            catch (RequestFailedException storageRequestFailedException)
+            when (storageRequestFailedException.ErrorCode == Blobs.Models.BlobErrorCode.ContainerAlreadyExists)
+            {
+                // if we still get this error after retrying, mark the test as inconclusive
+                TestContext.Out.WriteLine(
+                    $"{TestContext.CurrentContext.Test.Name} is inconclusive due to hitting " +
+                    $"the DataLake service bug described in https://github.com/Azure/azure-sdk-for-net/issues/9399");
+                Assert.Inconclusive(); // passing the message in Inconclusive call doesn't show up in Console output.
+            }
+
+            return new DisposingFileSystem(fileSystem);
+        }
+
+        public class DisposingFileSystem : IAsyncDisposable
+        {
+            public DataLakeFileSystemClient FileSystem;
+
+            public DisposingFileSystem(DataLakeFileSystemClient fileSystem)
+            {
+                FileSystem = fileSystem;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                if (FileSystem != null)
+                {
+                    try
+                    {
+                        await FileSystem.DeleteIfExistsAsync();
+                        FileSystem = null;
+                    }
+                    catch
+                    {
+                        // swallow the exception to avoid hiding another test failure
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientBuilderExtensions.cs
@@ -30,6 +30,9 @@ namespace Azure.Storage.Files.DataLake.Tests
         public static string GetNewNonAsciiFileName(this DataLakeClientBuilder clientBuilder)
             => $"test-ƒ¡£€‽%3A-{clientBuilder.Recording.Random.NewGuid()}";
 
+        public static DataLakeServiceClient GetServiceClient_Hns(this DataLakeClientBuilder clientBuilder) =>
+            clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigHierarchicalNamespace);
+
         public static async Task<DisposingFileSystem> GetNewFileSystem(
             this DataLakeClientBuilder clientBuilder,
             DataLakeServiceClient service = default,

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientBuilderExtensions.cs
@@ -77,31 +77,5 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             return new DisposingFileSystem(fileSystem);
         }
-
-        public class DisposingFileSystem : IAsyncDisposable
-        {
-            public DataLakeFileSystemClient FileSystem;
-
-            public DisposingFileSystem(DataLakeFileSystemClient fileSystem)
-            {
-                FileSystem = fileSystem;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                if (FileSystem != null)
-                {
-                    try
-                    {
-                        await FileSystem.DeleteIfExistsAsync();
-                        FileSystem = null;
-                    }
-                    catch
-                    {
-                        // swallow the exception to avoid hiding another test failure
-                    }
-                }
-            }
-        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientBuilderExtensions.cs
@@ -39,7 +39,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             bool premium = default)
         {
             fileSystemName ??= clientBuilder.GetNewFileSystemName();
-            service ??= clientBuilder.GetServiceClient_SharedKey();
+            service ??= clientBuilder.GetServiceClient_Hns();
 
             if (publicAccessType == default)
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
@@ -10,6 +10,7 @@ using Azure.Storage.Files.DataLake.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
+using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
@@ -60,7 +61,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             accountSasBuilder.SetPermissions(permissionsString);
 
-            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigHierarchicalNamespace.AccountName, TestConfigHierarchicalNamespace.AccountKey);
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(Tenants.TestConfigHierarchicalNamespace.AccountName, Tenants.TestConfigHierarchicalNamespace.AccountKey);
 
             Uri uri = new Uri($"{test.FileSystem.Uri}?{accountSasBuilder.ToSasQueryParameters(sharedKeyCredential)}");
 
@@ -109,7 +110,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             dataLakeSasBuilder.SetPermissions(permissions);
 
-            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigHierarchicalNamespace.AccountName, TestConfigHierarchicalNamespace.AccountKey);
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(Tenants.TestConfigHierarchicalNamespace.AccountName, Tenants.TestConfigHierarchicalNamespace.AccountKey);
 
             DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(test.FileSystem.Uri)
             {
@@ -145,7 +146,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 rawPermissions: permissionsString,
                 normalize: true);
 
-            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigHierarchicalNamespace.AccountName, TestConfigHierarchicalNamespace.AccountKey);
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(Tenants.TestConfigHierarchicalNamespace.AccountName, Tenants.TestConfigHierarchicalNamespace.AccountKey);
 
             DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(test.FileSystem.Uri)
             {
@@ -552,7 +553,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             dataLakeSasBuilder.SetPermissions(DataLakeSasPermissions.All);
 
-            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(TestConfigHierarchicalNamespace.AccountName, TestConfigHierarchicalNamespace.AccountKey);
+            StorageSharedKeyCredential sharedKeyCredential = new StorageSharedKeyCredential(Tenants.TestConfigHierarchicalNamespace.AccountName, Tenants.TestConfigHierarchicalNamespace.AccountKey);
 
             DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(subdirectory3.Uri)
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeSasBuilderTests.cs
@@ -10,7 +10,6 @@ using Azure.Storage.Files.DataLake.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
-using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -37,7 +37,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         /// <summary>
         /// Source of clients.
         /// </summary>
-        protected ClientBuilder<DataLakeServiceClient, DataLakeClientOptions> Clients { get; }
+        protected ClientBuilder<DataLakeServiceClient, DataLakeClientOptions> DataLakeClientBuilder { get; }
 
         protected readonly DataLakeClientOptions.ServiceVersion _serviceVersion;
         public readonly string ReceivedETag = "\"received\"";
@@ -63,7 +63,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             : base(async, mode)
         {
             _serviceVersion = serviceVersion;
-            Clients = new ClientBuilder<DataLakeServiceClient, DataLakeClientOptions>(
+            DataLakeClientBuilder = new ClientBuilder<DataLakeServiceClient, DataLakeClientOptions>(
                 ServiceEndpoint.Blob,
                 Tenants,
                 (uri, clientOptions) => new DataLakeServiceClient(uri, clientOptions),
@@ -78,12 +78,12 @@ namespace Azure.Storage.Files.DataLake.Tests
 
         public DateTimeOffset OldDate => Recording.Now.AddDays(-1);
         public DateTimeOffset NewDate => Recording.Now.AddDays(1);
-        public string GetGarbageLeaseId() => Clients.GetGarbageLeaseId();
-        public string GetNewFileSystemName() => Clients.GetNewFileSystemName();
-        public string GetNewDirectoryName() => Clients.GetNewDirectoryName();
-        public string GetNewNonAsciiDirectoryName() => Clients.GetNewNonAsciiDirectoryName();
-        public string GetNewFileName() => Clients.GetNewFileName();
-        public string GetNewNonAsciiFileName() => Clients.GetNewNonAsciiFileName();
+        public string GetGarbageLeaseId() => DataLakeClientBuilder.GetGarbageLeaseId();
+        public string GetNewFileSystemName() => DataLakeClientBuilder.GetNewFileSystemName();
+        public string GetNewDirectoryName() => DataLakeClientBuilder.GetNewDirectoryName();
+        public string GetNewNonAsciiDirectoryName() => DataLakeClientBuilder.GetNewNonAsciiDirectoryName();
+        public string GetNewFileName() => DataLakeClientBuilder.GetNewFileName();
+        public string GetNewNonAsciiFileName() => DataLakeClientBuilder.GetNewNonAsciiFileName();
 
         public async Task<DisposingFileSystem> GetNewFileSystem(
             DataLakeServiceClient service = default,
@@ -91,10 +91,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             IDictionary<string, string> metadata = default,
             PublicAccessType? publicAccessType = default,
             bool premium = default)
-            => await Clients.GetNewFileSystem(service, fileSystemName, metadata, publicAccessType, premium);
+            => await DataLakeClientBuilder.GetNewFileSystem(service, fileSystemName, metadata, publicAccessType, premium);
 
         public DataLakeClientOptions GetOptions(bool parallelRange = false)
-            => Clients.GetOptions(parallelRange);
+            => DataLakeClientBuilder.GetOptions(parallelRange);
 
         public DataLakeClientOptions GetFaultyDataLakeConnectionOptions(
             int raiseAt = default,

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -14,7 +14,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
-using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -14,6 +14,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
+using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
@@ -33,6 +34,11 @@ namespace Azure.Storage.Files.DataLake.Tests
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
     public abstract class DataLakeTestBase : StorageTestBase<DataLakeTestEnvironment>
     {
+        /// <summary>
+        /// Source of clients.
+        /// </summary>
+        protected ClientBuilder<DataLakeServiceClient, DataLakeClientOptions> Clients { get; }
+
         protected readonly DataLakeClientOptions.ServiceVersion _serviceVersion;
         public readonly string ReceivedETag = "\"received\"";
         public readonly string GarbageETag = "\"garbage\"";
@@ -57,38 +63,37 @@ namespace Azure.Storage.Files.DataLake.Tests
             : base(async, mode)
         {
             _serviceVersion = serviceVersion;
+            Clients = new ClientBuilder<DataLakeServiceClient, DataLakeClientOptions>(
+                Tenants,
+                (uri, clientOptions) => new DataLakeServiceClient(uri, clientOptions),
+                (uri, sharedKeyCredential, clientOptions) => new DataLakeServiceClient(uri, sharedKeyCredential, clientOptions),
+                (uri, tokenCredential, clientOptions) => new DataLakeServiceClient(uri, tokenCredential, clientOptions),
+                (uri, azureSasCredential, clientOptions) => new DataLakeServiceClient(uri, azureSasCredential, clientOptions),
+                () => new DataLakeClientOptions(_serviceVersion));
         }
+
+        public TenantConfiguration TestConfigHierarchicalNamespace
+            => Tenants.TestConfigHierarchicalNamespace;
 
         public DateTimeOffset OldDate => Recording.Now.AddDays(-1);
         public DateTimeOffset NewDate => Recording.Now.AddDays(1);
-        public string GetGarbageLeaseId() => Recording.Random.NewGuid().ToString();
-        public string GetNewFileSystemName() => $"test-filesystem-{Recording.Random.NewGuid()}";
-        public string GetNewDirectoryName() => $"test-directory-{Recording.Random.NewGuid()}";
-        public string GetNewNonAsciiDirectoryName() => $"test-dire¢t Ø®ϒ%3A-{Recording.Random.NewGuid()}";
-        public string GetNewFileName() => $"test-file-{Recording.Random.NewGuid()}";
-        public string GetNewNonAsciiFileName() => $"test-ƒ¡£€‽%3A-{Recording.Random.NewGuid()}";
+        public string GetGarbageLeaseId() => Clients.GetGarbageLeaseId();
+        public string GetNewFileSystemName() => Clients.GetNewFileSystemName();
+        public string GetNewDirectoryName() => Clients.GetNewDirectoryName();
+        public string GetNewNonAsciiDirectoryName() => Clients.GetNewNonAsciiDirectoryName();
+        public string GetNewFileName() => Clients.GetNewFileName();
+        public string GetNewNonAsciiFileName() => Clients.GetNewNonAsciiFileName();
+
+        public async Task<DisposingFileSystem> GetNewFileSystem(
+            DataLakeServiceClient service = default,
+            string fileSystemName = default,
+            IDictionary<string, string> metadata = default,
+            PublicAccessType? publicAccessType = default,
+            bool premium = default)
+            => await Clients.GetNewFileSystem(service, fileSystemName, metadata, publicAccessType, premium);
 
         public DataLakeClientOptions GetOptions(bool parallelRange = false)
-        {
-            var options = new DataLakeClientOptions(_serviceVersion)
-            {
-                Diagnostics = { IsLoggingEnabled = true },
-                Retry =
-                {
-                    Mode = RetryMode.Exponential,
-                    MaxRetries = Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60),
-                    NetworkTimeout = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 100 : 400),
-                },
-            };
-            if (Mode != RecordedTestMode.Live)
-            {
-                options.AddPolicy(new RecordedClientRequestIdPolicy(Recording, parallelRange), HttpPipelinePosition.PerCall);
-            }
-
-            return InstrumentClientOptions(options);
-        }
+            => Clients.GetOptions(parallelRange);
 
         public DataLakeClientOptions GetFaultyDataLakeConnectionOptions(
             int raiseAt = default,
@@ -101,73 +106,20 @@ namespace Azure.Storage.Files.DataLake.Tests
             return options;
         }
 
-        public DataLakeServiceClient GetServiceClientFromSharedKeyConfig(TenantConfiguration config)
-            => InstrumentClient(
-                new DataLakeServiceClient(
-                    new Uri(config.BlobServiceEndpoint),
-                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
-                    GetOptions()));
-
         public DataLakeServiceClient GetServiceClientFromOauthConfig(TenantConfiguration config)
             => InstrumentClient(
                 new DataLakeServiceClient(
                     (new Uri(config.BlobServiceEndpoint)).ToHttps(),
-                    GetOAuthCredential(config),
+                    Tenants.GetOAuthCredential(config),
                     GetOptions()));
 
-        public DataLakeServiceClient GetServiceClient_SharedKey()
-            => GetServiceClientFromSharedKeyConfig(TestConfigHierarchicalNamespace);
-
         public DataLakeServiceClient GetServiceClient_OAuth()
-            => GetServiceClientFromOauthConfig(TestConfigHierarchicalNamespace);
+            => GetServiceClientFromOauthConfig(Tenants.TestConfigHierarchicalNamespace);
 
         public StorageSharedKeyCredential GetStorageSharedKeyCredentials()
             => new StorageSharedKeyCredential(
                 TestConfigHierarchicalNamespace.AccountName,
                 TestConfigHierarchicalNamespace.AccountKey);
-
-        public async Task<DisposingFileSystem> GetNewFileSystem(
-            DataLakeServiceClient service = default,
-            string fileSystemName = default,
-            IDictionary<string, string> metadata = default,
-            PublicAccessType? publicAccessType = default,
-            bool premium = default)
-        {
-            fileSystemName ??= GetNewFileSystemName();
-            service ??= GetServiceClient_SharedKey();
-
-            if (publicAccessType == default)
-            {
-                publicAccessType = premium ? PublicAccessType.None : PublicAccessType.FileSystem;
-            }
-
-            DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(fileSystemName));
-
-            // due to a service issue, if the initial container creation request times out, subsequent requests
-            // can return a ContainerAlreadyExists code even though the container doesn't really exist.
-            // we delay until after the service cache timeout and then attempt to create the container one more time.
-            // If this attempt still fails, we mark the test as inconclusive.
-            // TODO Remove this handling after the service bug is fixed https://github.com/Azure/azure-sdk-for-net/issues/9399
-            try
-            {
-                await RetryAsync(
-                    async () => await fileSystem.CreateAsync(metadata: metadata, publicAccessType: publicAccessType.Value),
-                    ex => ex.ErrorCode == Blobs.Models.BlobErrorCode.ContainerAlreadyExists,
-                    retryDelay: TestConstants.DataLakeRetryDelay,
-                    retryAttempts: 1);
-            }
-            catch (RequestFailedException storageRequestFailedException)
-            when (storageRequestFailedException.ErrorCode == Blobs.Models.BlobErrorCode.ContainerAlreadyExists)
-            {
-                // if we still get this error after retrying, mark the test as inconclusive
-                TestContext.Out.WriteLine(
-                    $"{TestContext.CurrentContext.Test.Name} is inconclusive due to hitting " +
-                    $"the DataLake service bug described in https://github.com/Azure/azure-sdk-for-net/issues/9399");
-                Assert.Inconclusive(); // passing the message in Inconclusive call doesn't show up in Console output.
-            }
-
-            return new DisposingFileSystem(fileSystem);
-        }
 
         public static void AssertValidStoragePathInfo(PathInfo pathInfo)
         {
@@ -216,7 +168,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new DataLakeServiceClient(
-                    new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewAccountSasCredentials(sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
+                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewAccountSasCredentials(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
                     GetOptions()));
 
         public DataLakeServiceClient GetServiceClient_DataLakeServiceSas_FileSystem(
@@ -225,7 +177,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new DataLakeServiceClient(
-                    new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceSasCredentialsFileSystem(fileSystemName: fileSystemName, sharedKeyCredentials: sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
+                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceSasCredentialsFileSystem(fileSystemName: fileSystemName, sharedKeyCredentials: sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
                     GetOptions()));
 
         public DataLakeServiceClient GetServiceClient_DataLakeServiceIdentitySas_FileSystem(
@@ -234,7 +186,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new DataLakeServiceClient(
-                    (new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceIdentitySasCredentialsFileSystem(fileSystemName: fileSystemName, userDelegationKey, TestConfigHierarchicalNamespace.AccountName)}")).ToHttps(),
+                    (new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceIdentitySasCredentialsFileSystem(fileSystemName: fileSystemName, userDelegationKey, Tenants.TestConfigHierarchicalNamespace.AccountName)}")).ToHttps(),
                     GetOptions()));
 
         public DataLakeServiceClient GetServiceClient_DataLakeServiceSas_Path(
@@ -244,7 +196,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new DataLakeServiceClient(
-                    new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceSasCredentialsPath(fileSystemName: fileSystemName, path: path, sharedKeyCredentials: sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
+                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceSasCredentialsPath(fileSystemName: fileSystemName, path: path, sharedKeyCredentials: sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
                     GetOptions()));
 
         public DataLakeServiceClient GetServiceClient_DataLakeServiceIdentitySas_Path(
@@ -254,13 +206,8 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new DataLakeServiceClient(
-                    (new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceIdentitySasCredentialsPath(fileSystemName: fileSystemName, path: path, userDelegationKey: userDelegationKey, accountName: TestConfigHierarchicalNamespace.AccountName)}")).ToHttps(),
+                    (new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceIdentitySasCredentialsPath(fileSystemName: fileSystemName, path: path, userDelegationKey: userDelegationKey, accountName: Tenants.TestConfigHierarchicalNamespace.AccountName)}")).ToHttps(),
                     GetOptions()));
-
-        public StorageSharedKeyCredential GetNewSharedKeyCredentials()
-            => new StorageSharedKeyCredential(
-                    TestConfigHierarchicalNamespace.AccountName,
-                    TestConfigHierarchicalNamespace.AccountKey);
 
         public SasQueryParameters GetNewAccountSasCredentials(StorageSharedKeyCredential sharedKeyCredentials = default)
         {
@@ -280,7 +227,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 AccountSasPermissions.Write |
                 AccountSasPermissions.Delete |
                 AccountSasPermissions.List);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
         }
 
         public DataLakeSasQueryParameters GetNewDataLakeServiceSasCredentialsFileSystem(string fileSystemName, StorageSharedKeyCredential sharedKeyCredentials = default)
@@ -294,7 +241,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 IPRange = new SasIPRange(IPAddress.None, IPAddress.None)
             };
             builder.SetPermissions(DataLakeFileSystemSasPermissions.All);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
         }
 
         public DataLakeSasQueryParameters GetNewDataLakeServiceIdentitySasCredentialsFileSystem(string fileSystemName, UserDelegationKey userDelegationKey, string accountName)
@@ -328,7 +275,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 DataLakeSasPermissions.Create |
                 DataLakeSasPermissions.Delete |
                 DataLakeSasPermissions.Write);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
         }
 
         public DataLakeSasQueryParameters GetNewDataLakeServiceIdentitySasCredentialsPath(string fileSystemName, string path, UserDelegationKey userDelegationKey, string accountName)
@@ -362,24 +309,6 @@ namespace Azure.Storage.Files.DataLake.Tests
             };
             dataLakeSasBuilder.SetPermissions(DataLakeSasPermissions.All);
             return dataLakeSasBuilder.ToSasQueryParameters(userDelegationKey, accountName);
-        }
-
-        public SasQueryParameters GetNewAccountSas(
-            AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All,
-            AccountSasPermissions permissions = AccountSasPermissions.All,
-            StorageSharedKeyCredential sharedKeyCredentials = default)
-        {
-            var builder = new AccountSasBuilder
-            {
-                Protocol = SasProtocol.None,
-                Services = AccountSasServices.Blobs,
-                ResourceTypes = resourceTypes,
-                StartsOn = Recording.UtcNow.AddHours(-1),
-                ExpiresOn = Recording.UtcNow.AddHours(+1),
-                IPRange = new SasIPRange(IPAddress.None, IPAddress.None),
-            };
-            builder.SetPermissions(permissions);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
         }
 
         public string BlobEndpointToDfsEndpoint(string blobEndpoint = default)
@@ -449,32 +378,6 @@ namespace Azure.Storage.Files.DataLake.Tests
                         }
                 }
             };
-
-        public class DisposingFileSystem : IAsyncDisposable
-        {
-            public DataLakeFileSystemClient FileSystem;
-
-            public DisposingFileSystem(DataLakeFileSystemClient fileSystem)
-            {
-                FileSystem = fileSystem;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                if (FileSystem != null)
-                {
-                    try
-                    {
-                        await FileSystem.DeleteIfExistsAsync();
-                        FileSystem = null;
-                    }
-                    catch
-                    {
-                        // swallow the exception to avoid hiding another test failure
-                    }
-                }
-            }
-        }
 
         public string[] PathNames
         => new[]

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -64,6 +64,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         {
             _serviceVersion = serviceVersion;
             Clients = new ClientBuilder<DataLakeServiceClient, DataLakeClientOptions>(
+                ServiceEndpoint.Blob,
                 Tenants,
                 (uri, clientOptions) => new DataLakeServiceClient(uri, clientOptions),
                 (uri, sharedKeyCredential, clientOptions) => new DataLakeServiceClient(uri, sharedKeyCredential, clientOptions),

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -169,7 +169,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new DataLakeServiceClient(
-                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewAccountSasCredentials(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
+                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewAccountSasCredentials(sharedKeyCredentials ?? Tenants.GetNewHnsSharedKeyCredentials())}"),
                     GetOptions()));
 
         public DataLakeServiceClient GetServiceClient_DataLakeServiceSas_FileSystem(
@@ -178,7 +178,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new DataLakeServiceClient(
-                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceSasCredentialsFileSystem(fileSystemName: fileSystemName, sharedKeyCredentials: sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
+                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceSasCredentialsFileSystem(fileSystemName: fileSystemName, sharedKeyCredentials: sharedKeyCredentials ?? Tenants.GetNewHnsSharedKeyCredentials())}"),
                     GetOptions()));
 
         public DataLakeServiceClient GetServiceClient_DataLakeServiceIdentitySas_FileSystem(
@@ -197,7 +197,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new DataLakeServiceClient(
-                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceSasCredentialsPath(fileSystemName: fileSystemName, path: path, sharedKeyCredentials: sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
+                    new Uri($"{Tenants.TestConfigHierarchicalNamespace.BlobServiceEndpoint}?{sasCredentials ?? GetNewDataLakeServiceSasCredentialsPath(fileSystemName: fileSystemName, path: path, sharedKeyCredentials: sharedKeyCredentials ?? Tenants.GetNewHnsSharedKeyCredentials())}"),
                     GetOptions()));
 
         public DataLakeServiceClient GetServiceClient_DataLakeServiceIdentitySas_Path(
@@ -228,7 +228,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 AccountSasPermissions.Write |
                 AccountSasPermissions.Delete |
                 AccountSasPermissions.List);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewHnsSharedKeyCredentials());
         }
 
         public DataLakeSasQueryParameters GetNewDataLakeServiceSasCredentialsFileSystem(string fileSystemName, StorageSharedKeyCredential sharedKeyCredentials = default)
@@ -242,7 +242,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 IPRange = new SasIPRange(IPAddress.None, IPAddress.None)
             };
             builder.SetPermissions(DataLakeFileSystemSasPermissions.All);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewHnsSharedKeyCredentials());
         }
 
         public DataLakeSasQueryParameters GetNewDataLakeServiceIdentitySasCredentialsFileSystem(string fileSystemName, UserDelegationKey userDelegationKey, string accountName)
@@ -276,7 +276,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 DataLakeSasPermissions.Create |
                 DataLakeSasPermissions.Delete |
                 DataLakeSasPermissions.Write);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewHnsSharedKeyCredentials());
         }
 
         public DataLakeSasQueryParameters GetNewDataLakeServiceIdentitySasCredentialsPath(string fileSystemName, string path, UserDelegationKey userDelegationKey, string accountName)

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -15,6 +15,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
 namespace Azure.Storage.Files.DataLake.Tests
@@ -95,7 +96,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             await parentDirectory.CreateSubDirectoryAsync(directoryName);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{parentDirectoryName}/{directoryName}").ToHttps();
             DataLakeDirectoryClient directoryClient = InstrumentClient(new DataLakeDirectoryClient(uri, tokenCredential, GetOptions()));
 
@@ -153,7 +154,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void Ctor_TokenCredential_Http()
         {
             // Arrange
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri(TestConfigHierarchicalNamespace.BlobServiceEndpoint).ToHttp();
 
             // Act
@@ -224,7 +225,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -426,7 +427,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ExistsAsync_FileSystemNotExists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = service.GetFileSystemClient(GetNewFileSystemName());
             DataLakeDirectoryClient directory = InstrumentClient(fileSystemClient.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -491,7 +492,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_FileSystemNotExists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = service.GetFileSystemClient(GetNewFileSystemName());
             DataLakeDirectoryClient directory = InstrumentClient(fileSystemClient.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -1772,7 +1773,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeDirectoryClient rootDirectory = test.FileSystem.GetRootDirectoryClient();
             await rootDirectory.SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -1801,7 +1802,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeDirectoryClient rootDirectory = test.FileSystem.GetRootDirectoryClient();
             await rootDirectory.SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -1829,7 +1830,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem(fileSystemName: fileSystemName);
             await test.FileSystem.GetRootDirectoryClient().SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -2057,7 +2058,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem(fileSystemName: fileSystemName);
             await test.FileSystem.GetRootDirectoryClient().SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -2480,7 +2481,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeDirectoryClient rootDirectory = test.FileSystem.GetRootDirectoryClient();
             await rootDirectory.SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -2509,7 +2510,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeDirectoryClient rootDirectory = test.FileSystem.GetRootDirectoryClient();
             await rootDirectory.SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -2537,7 +2538,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem(fileSystemName: fileSystemName);
             await test.FileSystem.GetRootDirectoryClient().SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -3183,7 +3184,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeDirectoryClient rootDirectory = test.FileSystem.GetRootDirectoryClient();
             await rootDirectory.SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -3212,7 +3213,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeDirectoryClient rootDirectory = test.FileSystem.GetRootDirectoryClient();
             await rootDirectory.SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -3240,7 +3241,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem(fileSystemName: fileSystemName);
             await test.FileSystem.GetRootDirectoryClient().SetAccessControlListAsync(ExecuteOnlyAccessControlList);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{topDirectoryName}").ToHttps();
 
             // Create tree as AAD App
@@ -3904,7 +3905,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateFileAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -3933,7 +3934,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteFileAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -3963,7 +3964,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateSubDirectoryAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -4974,7 +4975,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetPathsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -5435,9 +5436,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             var mock = new Mock<DataLakeDirectoryClient>(TestConfigDefault.ConnectionString, "name", "name", new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakeDirectoryClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<DataLakeDirectoryClient>(new Uri("https://test/test"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakeDirectoryClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakeDirectoryClient>(new Uri("https://test/test"), Tenants.GetNewHnsSharedKeyCredentials(), new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakeDirectoryClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakeDirectoryClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakeDirectoryClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -225,7 +225,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -427,7 +427,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ExistsAsync_FileSystemNotExists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = service.GetFileSystemClient(GetNewFileSystemName());
             DataLakeDirectoryClient directory = InstrumentClient(fileSystemClient.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -492,7 +492,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_FileSystemNotExists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = service.GetFileSystemClient(GetNewFileSystemName());
             DataLakeDirectoryClient directory = InstrumentClient(fileSystemClient.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -3905,7 +3905,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateFileAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -3934,7 +3934,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteFileAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -3964,7 +3964,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateSubDirectoryAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -4975,7 +4975,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetPathsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(GetNewDirectoryName()));
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -15,7 +15,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
 namespace Azure.Storage.Files.DataLake.Tests

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DisposingFileSystem.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DisposingFileSystem.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.Files.DataLake.Tests
+{
+    public class DisposingFileSystem : IAsyncDisposable
+    {
+        public DataLakeFileSystemClient FileSystem;
+
+        public DisposingFileSystem(DataLakeFileSystemClient fileSystem)
+        {
+            FileSystem = fileSystem;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (FileSystem != null)
+            {
+                try
+                {
+                    await FileSystem.DeleteIfExistsAsync();
+                    FileSystem = null;
+                }
+                catch
+                {
+                    // swallow the exception to avoid hiding another test failure
+                }
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -19,7 +19,6 @@ using Azure.Storage.Test;
 using Azure.Storage.Tests.Shared;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -19,6 +19,7 @@ using Azure.Storage.Test;
 using Azure.Storage.Tests.Shared;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
@@ -100,7 +101,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             await directory.CreateFileAsync(fileName);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{directoryName}/{fileName}").ToHttps();
             DataLakeFileClient fileClient = InstrumentClient(new DataLakeFileClient(uri, tokenCredential, GetOptions()));
 
@@ -118,7 +119,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void Ctor_TokenCredential_Http()
         {
             // Arrange
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri(TestConfigHierarchicalNamespace.BlobServiceEndpoint).ToHttp();
 
             // Act
@@ -224,7 +225,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeFileClient file = InstrumentClient(fileSystem.GetFileClient(GetNewFileName()));
 
@@ -436,7 +437,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ExistsAsync_FileSystemNotExists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = service.GetFileSystemClient(GetNewFileSystemName());
             DataLakeFileClient file = InstrumentClient(fileSystemClient.GetFileClient(GetNewFileName()));
 
@@ -501,7 +502,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_FileSystemNotExists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = service.GetFileSystemClient(GetNewFileSystemName());
             DataLakeFileClient file = InstrumentClient(fileSystemClient.GetFileClient(GetNewFileName()));
 
@@ -4675,7 +4676,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeFileClient file = InstrumentClient(fileSystem.GetFileClient(GetNewFileName()));
 
@@ -5194,9 +5195,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             var mock = new Mock<DataLakeFileClient>(TestConfigDefault.ConnectionString, "name", "name", new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakeFileClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<DataLakeFileClient>(new Uri("https://test/test"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakeFileClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakeFileClient>(new Uri("https://test/test"), Tenants.GetNewHnsSharedKeyCredentials(), new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakeFileClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakeFileClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakeFileClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -225,7 +225,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeFileClient file = InstrumentClient(fileSystem.GetFileClient(GetNewFileName()));
 
@@ -437,7 +437,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ExistsAsync_FileSystemNotExists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = service.GetFileSystemClient(GetNewFileSystemName());
             DataLakeFileClient file = InstrumentClient(fileSystemClient.GetFileClient(GetNewFileName()));
 
@@ -502,7 +502,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_FileSystemNotExists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = service.GetFileSystemClient(GetNewFileSystemName());
             DataLakeFileClient file = InstrumentClient(fileSystemClient.GetFileClient(GetNewFileName()));
 
@@ -4676,7 +4676,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeFileClient file = InstrumentClient(fileSystem.GetFileClient(GetNewFileName()));
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -14,6 +14,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
@@ -28,7 +29,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task Ctor_Uri()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             await service.CreateFileSystemAsync(fileSystemName);
 
@@ -55,7 +56,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task Ctor_SharedKey()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             await service.CreateFileSystemAsync(fileSystemName);
 
@@ -84,13 +85,13 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task Ctor_TokenCredential()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             await service.CreateFileSystemAsync(fileSystemName);
 
             try
             {
-                TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+                TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
                 Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}").ToHttps();
                 DataLakeFileSystemClient fileSystemClient = InstrumentClient(new DataLakeFileSystemClient(uri, tokenCredential, GetOptions()));
 
@@ -167,7 +168,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void Ctor_TokenCredential_Http()
         {
             // Arrange
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri(TestConfigHierarchicalNamespace.BlobServiceEndpoint).ToHttp();
 
             // Act
@@ -247,7 +248,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             var fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(fileSystemName));
 
@@ -350,7 +351,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_Metadata()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             IDictionary<string, string> metadata = BuildMetadata();
 
@@ -369,7 +370,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_PublicAccess()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -387,7 +388,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             // ContainerUri is intentually created twice
             await fileSystemClient.CreateAsync();
@@ -405,7 +406,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateIfNotExistAsync_NotExists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             try
@@ -427,7 +428,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateIfNotExistAsync_Exists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             try
             {
@@ -450,7 +451,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateIfNotExistsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeFileSystemClient unauthorizedFileSystem = InstrumentClient(new DataLakeFileSystemClient(fileSystemClient.Uri, GetOptions()));
 
@@ -481,7 +482,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ExistsAsync_NotExists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -512,7 +513,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteAsync()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystem.CreateIfNotExistsAsync();
 
@@ -559,7 +560,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -575,7 +576,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 parameters.LeaseId = await SetupFileSystemLeaseCondition(fileSystem, parameters.LeaseId, garbageLeaseId);
@@ -618,7 +619,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_Exists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystemClient.CreateIfNotExistsAsync();
 
@@ -636,7 +637,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_NotExists()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -682,7 +683,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeFileSystemClient unauthorizedFileSystem = InstrumentClient(new DataLakeFileSystemClient(fileSystemClient.Uri, GetOptions()));
 
@@ -806,7 +807,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetPathsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -871,7 +872,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetPropertiesAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileService = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -938,7 +939,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetMetadataAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient container = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             IDictionary<string, string> metadata = BuildMetadata();
 
@@ -955,7 +956,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 parameters.LeaseId = await SetupFileSystemLeaseCondition(fileSystem, parameters.LeaseId, garbageLeaseId);
@@ -1090,7 +1091,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateFileAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -1116,7 +1117,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteFileAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -1142,7 +1143,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateDirectoryAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -1231,7 +1232,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteDirectoryAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -1244,7 +1245,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task AquireLeaseAsync()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystem.CreateIfNotExistsAsync();
             var id = Recording.Random.NewGuid().ToString();
@@ -1303,7 +1304,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task AcquireLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
@@ -1320,7 +1321,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1376,7 +1377,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task RenewLeaseAsync()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystem.CreateIfNotExistsAsync();
 
@@ -1437,7 +1438,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task RenewLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
 
@@ -1453,7 +1454,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1486,7 +1487,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_ConditionsFail_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1571,7 +1572,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ReleaseLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
 
@@ -1614,7 +1615,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_ConditionsFail_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1701,7 +1702,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ChangeLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
 
@@ -1717,7 +1718,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
 
@@ -1754,7 +1755,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_ConditionsFail_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1841,7 +1842,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task BreakLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
 
@@ -1857,7 +1858,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
 
@@ -1892,7 +1893,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_ConditionsFail_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1975,7 +1976,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetAccessPolicyAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -1988,7 +1989,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetAccessPolicy_Lease()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystem.CreateIfNotExistsAsync();
             string garbageLeaseId = GetGarbageLeaseId();
@@ -2124,7 +2125,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 FileSystemName = test.FileSystem.Name,
                 Identifier = signedIdentifiers[0].Id
             };
-            DataLakeSasQueryParameters sasQueryParameters = sasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials());
+            DataLakeSasQueryParameters sasQueryParameters = sasBuilder.ToSasQueryParameters(Tenants.GetNewHnsSharedKeyCredentials());
 
             DataLakeFileSystemClient sasFileSystem
                 = InstrumentClient(new DataLakeFileSystemClient(
@@ -2259,7 +2260,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             PublicAccessType publicAccessType = PublicAccessType.FileSystem;
             DataLakeSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -2278,7 +2279,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 PublicAccessType publicAccessType = PublicAccessType.FileSystem;
                 DataLakeSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
-                DataLakeServiceClient service = GetServiceClient_SharedKey();
+                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
 
@@ -2531,7 +2532,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetDeletedPathsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -2572,7 +2573,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task UndeletePathAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -2617,7 +2618,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task Rename()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    string oldFileSystemName = GetNewFileName();
         //    string newFileSystemName = GetNewFileName();
         //    DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(oldFileSystemName));
@@ -2640,7 +2641,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameAsync_AccountSas()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    string oldFileSystemName = GetNewFileName();
         //    string newFileSystemName = GetNewFileName();
         //    DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(oldFileSystemName));
@@ -2666,7 +2667,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameAsync_Error()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
         //    // Act
@@ -2681,7 +2682,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameAsync_SourceLease()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    string oldFileSystemName = GetNewFileSystemName();
         //    string newFileSystemName = GetNewFileSystemName();
         //    DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(oldFileSystemName));
@@ -2714,7 +2715,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameAsync_SourceLeaseFailed()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    string oldFileSystemName = GetNewFileSystemName();
         //    string newFileSystemName = GetNewFileSystemName();
         //    DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(oldFileSystemName));
@@ -3014,9 +3015,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             var mock = new Mock<DataLakeFileSystemClient>(TestConfigDefault.ConnectionString, "name", new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakeFileSystemClient>(TestConfigDefault.ConnectionString, "name").Object;
             mock = new Mock<DataLakeFileSystemClient>(new Uri("https://test/test"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakeFileSystemClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakeFileSystemClient>(new Uri("https://test/test"), Tenants.GetNewHnsSharedKeyCredentials(), new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakeFileSystemClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakeFileSystemClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakeFileSystemClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
         }
 
         private IEnumerable<AccessConditionParameters> Conditions_Data

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -14,7 +14,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task Ctor_Uri()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             await service.CreateFileSystemAsync(fileSystemName);
 
@@ -56,7 +56,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task Ctor_SharedKey()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             await service.CreateFileSystemAsync(fileSystemName);
 
@@ -85,7 +85,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task Ctor_TokenCredential()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             await service.CreateFileSystemAsync(fileSystemName);
 
@@ -248,7 +248,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             var fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(fileSystemName));
 
@@ -351,7 +351,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_Metadata()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             IDictionary<string, string> metadata = BuildMetadata();
 
@@ -370,7 +370,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_PublicAccess()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -388,7 +388,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             // ContainerUri is intentually created twice
             await fileSystemClient.CreateAsync();
@@ -406,7 +406,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateIfNotExistAsync_NotExists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             try
@@ -428,7 +428,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateIfNotExistAsync_Exists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             try
             {
@@ -451,7 +451,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateIfNotExistsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeFileSystemClient unauthorizedFileSystem = InstrumentClient(new DataLakeFileSystemClient(fileSystemClient.Uri, GetOptions()));
 
@@ -482,7 +482,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ExistsAsync_NotExists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -513,7 +513,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteAsync()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystem.CreateIfNotExistsAsync();
 
@@ -560,7 +560,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -576,7 +576,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 parameters.LeaseId = await SetupFileSystemLeaseCondition(fileSystem, parameters.LeaseId, garbageLeaseId);
@@ -619,7 +619,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_Exists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystemClient.CreateIfNotExistsAsync();
 
@@ -637,7 +637,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_NotExists()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -683,7 +683,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteIfExistsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             DataLakeFileSystemClient unauthorizedFileSystem = InstrumentClient(new DataLakeFileSystemClient(fileSystemClient.Uri, GetOptions()));
 
@@ -807,7 +807,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetPathsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -872,7 +872,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetPropertiesAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileService = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -939,7 +939,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetMetadataAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient container = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             IDictionary<string, string> metadata = BuildMetadata();
 
@@ -956,7 +956,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 parameters.LeaseId = await SetupFileSystemLeaseCondition(fileSystem, parameters.LeaseId, garbageLeaseId);
@@ -1091,7 +1091,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateFileAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -1117,7 +1117,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteFileAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -1143,7 +1143,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateDirectoryAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -1232,7 +1232,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteDirectoryAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -1245,7 +1245,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task AquireLeaseAsync()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystem.CreateIfNotExistsAsync();
             var id = Recording.Random.NewGuid().ToString();
@@ -1304,7 +1304,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task AcquireLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
@@ -1321,7 +1321,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1377,7 +1377,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task RenewLeaseAsync()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystem.CreateIfNotExistsAsync();
 
@@ -1438,7 +1438,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task RenewLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
 
@@ -1454,7 +1454,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1487,7 +1487,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_ConditionsFail_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1572,7 +1572,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ReleaseLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
 
@@ -1615,7 +1615,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_ConditionsFail_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1702,7 +1702,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task ChangeLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
 
@@ -1718,7 +1718,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
 
@@ -1755,7 +1755,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_ConditionsFail_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1842,7 +1842,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task BreakLeaseAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             var id = Recording.Random.NewGuid().ToString();
 
@@ -1858,7 +1858,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_Conditions_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
 
@@ -1893,7 +1893,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             foreach (AccessConditionParameters parameters in NoLease_ConditionsFail_Data)
             {
                 // Arrange
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -1976,7 +1976,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetAccessPolicyAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -1989,7 +1989,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetAccessPolicy_Lease()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             await fileSystem.CreateIfNotExistsAsync();
             string garbageLeaseId = GetGarbageLeaseId();
@@ -2260,7 +2260,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             PublicAccessType publicAccessType = PublicAccessType.FileSystem;
             DataLakeSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
 
             // Act
@@ -2279,7 +2279,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 PublicAccessType publicAccessType = PublicAccessType.FileSystem;
                 DataLakeSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
-                DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+                DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
                 await fileSystem.CreateIfNotExistsAsync();
 
@@ -2532,7 +2532,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetDeletedPathsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act
@@ -2573,7 +2573,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task UndeletePathAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = service.GetFileSystemClient(GetNewFileSystemName());
 
             // Act

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/PathClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/PathClientTests.cs
@@ -10,6 +10,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
@@ -76,7 +77,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             string directoryName = GetNewDirectoryName();
             await test.FileSystem.CreateDirectoryAsync(directoryName);
 
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri($"{TestConfigHierarchicalNamespace.BlobServiceEndpoint}/{fileSystemName}/{directoryName}").ToHttps();
             DataLakePathClient pathClient = InstrumentClient(new DataLakePathClient(uri, tokenCredential, GetOptions()));
 
@@ -132,7 +133,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void Ctor_TokenCredential_Http()
         {
             // Arrange
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri(TestConfigHierarchicalNamespace.BlobServiceEndpoint).ToHttp();
 
             // Act
@@ -392,9 +393,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             var mock = new Mock<DataLakePathClient>(TestConfigDefault.ConnectionString, "name", "name", new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakePathClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<DataLakePathClient>(new Uri("https://test/test"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakePathClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakePathClient>(new Uri("https://test/test"), Tenants.GetNewHnsSharedKeyCredentials(), new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakePathClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakePathClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakePathClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/PathClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/PathClientTests.cs
@@ -10,7 +10,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -14,7 +14,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -147,7 +147,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         {
             // Arrange
             string sas = GetNewAccountSasCredentials().ToString();
-            Uri uri = Clients.GetServiceClient_Hns().Uri;
+            Uri uri = DataLakeClientBuilder.GetServiceClient_Hns().Uri;
 
             // Act
             var sasClient = InstrumentClient(new DataLakeServiceClient(uri, new AzureSasCredential(sas), GetOptions()));
@@ -162,7 +162,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         {
             // Arrange
             string sas = GetNewAccountSasCredentials().ToString();
-            Uri uri = Clients.GetServiceClient_Hns().Uri;
+            Uri uri = DataLakeClientBuilder.GetServiceClient_Hns().Uri;
             uri = new Uri(uri.ToString() + "?" + sas);
 
             // Act
@@ -188,7 +188,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetUserDelegationKey_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -200,7 +200,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetFileSystemsAsync()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             // Ensure at least one container
             await using (await GetNewFileSystem(service: service))
             {
@@ -217,7 +217,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task GetFileSystemsAsync_Marker()
         {
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             // Ensure at least one container
             await using DisposingFileSystem test = await GetNewFileSystem(service: service);
 
@@ -238,7 +238,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [AsyncOnly]
         public async Task GetFileSystemsAsync_MaxResults()
         {
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             // Ensure at least one container
             await GetNewFileSystem(service: service);
             await using DisposingFileSystem test = await GetNewFileSystem(service: service);
@@ -256,7 +256,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task GetFileSystemsAsync_Prefix()
         {
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             var prefix = "aaa";
             var fileSystemName = prefix + GetNewFileSystemName();
             // Ensure at least one container
@@ -274,7 +274,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task GetFileSystemsAsync_Metadata()
         {
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             // Ensure at least one container
             await using DisposingFileSystem test = await GetNewFileSystem(service: service);
 
@@ -296,7 +296,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetFileSystemsAsync_Deleted()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(fileSystemName));
             await fileSystemClient.CreateAsync();
@@ -318,7 +318,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetFileSystemsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -334,7 +334,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateFileSystemAsync()
         {
             var name = GetNewFileSystemName();
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             try
             {
                 DataLakeFileSystemClient fileSystem = InstrumentClient((await service.CreateFileSystemAsync(name)).Value);
@@ -351,7 +351,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteFileSystemAsync()
         {
             var name = GetNewFileSystemName();
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient((await service.CreateFileSystemAsync(name)).Value);
 
             await service.DeleteFileSystemAsync(name);
@@ -364,7 +364,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task UndeleteFileSystemAsync()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(fileSystemName));
             await fileSystem.CreateAsync();
@@ -392,7 +392,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task UndeleteFileSystemAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             string fileSytemName = GetNewFileSystemName();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(fileSytemName));
 
@@ -406,7 +406,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetPropertiesAsync()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
 
             // Act
             Response<DataLakeServiceProperties> response = await service.GetPropertiesAsync();
@@ -421,7 +421,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = InstrumentClient(
                 new DataLakeServiceClient(
-                    Clients.GetServiceClient_Hns().Uri,
+                    DataLakeClientBuilder.GetServiceClient_Hns().Uri,
                     GetOptions()));
 
             // Act
@@ -436,7 +436,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_DeleteRetentionPolicy()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeRetentionPolicy originalRetentionPolicy = properties.DeleteRetentionPolicy;
             properties.DeleteRetentionPolicy = new DataLakeRetentionPolicy
@@ -466,7 +466,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_Logging()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeAnalyticsLogging originalLogging = properties.Logging;
             properties.Logging = new DataLakeAnalyticsLogging
@@ -506,7 +506,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetProperties_HourAndMinuteMetrics()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeMetrics originalHourMetrics = properties.HourMetrics;
             DataLakeMetrics originalMinuteMetrics = properties.MinuteMetrics;
@@ -565,7 +565,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_Cors()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeCorsRule[] originalCors = properties.Cors.ToArray();
             properties.Cors =
@@ -602,7 +602,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_StaticWebsite()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeStaticWebsite originalStaticWebsite = properties.StaticWebsite;
             string errorDocument404Path = "error/404.html";
@@ -637,11 +637,11 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
+            DataLakeServiceClient service = DataLakeClientBuilder.GetServiceClient_Hns();
             DataLakeServiceProperties properties = (await service.GetPropertiesAsync()).Value;
             DataLakeServiceClient invalidService = InstrumentClient(
                 new DataLakeServiceClient(
-                    Clients.GetServiceClient_Hns().Uri,
+                    DataLakeClientBuilder.GetServiceClient_Hns().Uri,
                     GetOptions()));
 
             // Act

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -14,6 +14,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Files.DataLake.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
@@ -60,7 +61,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task Ctor_TokenCredential()
         {
             // Arrange
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri(TestConfigHierarchicalNamespace.BlobServiceEndpoint).ToHttps();
             DataLakeServiceClient serviceClient = InstrumentClient(new DataLakeServiceClient(uri, tokenCredential, GetOptions()));
 
@@ -128,7 +129,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public void Ctor_TokenCredential_Http()
         {
             // Arrange
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace);
             Uri uri = new Uri(TestConfigHierarchicalNamespace.BlobServiceEndpoint).ToHttp();
 
             // Act
@@ -146,7 +147,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         {
             // Arrange
             string sas = GetNewAccountSasCredentials().ToString();
-            Uri uri = GetServiceClient_SharedKey().Uri;
+            Uri uri = Clients.GetServiceClient_Hns().Uri;
 
             // Act
             var sasClient = InstrumentClient(new DataLakeServiceClient(uri, new AzureSasCredential(sas), GetOptions()));
@@ -161,7 +162,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         {
             // Arrange
             string sas = GetNewAccountSasCredentials().ToString();
-            Uri uri = GetServiceClient_SharedKey().Uri;
+            Uri uri = Clients.GetServiceClient_Hns().Uri;
             uri = new Uri(uri.ToString() + "?" + sas);
 
             // Act
@@ -187,7 +188,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetUserDelegationKey_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -199,7 +200,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetFileSystemsAsync()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             // Ensure at least one container
             await using (await GetNewFileSystem(service: service))
             {
@@ -216,7 +217,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task GetFileSystemsAsync_Marker()
         {
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             // Ensure at least one container
             await using DisposingFileSystem test = await GetNewFileSystem(service: service);
 
@@ -237,7 +238,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [AsyncOnly]
         public async Task GetFileSystemsAsync_MaxResults()
         {
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             // Ensure at least one container
             await GetNewFileSystem(service: service);
             await using DisposingFileSystem test = await GetNewFileSystem(service: service);
@@ -255,7 +256,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task GetFileSystemsAsync_Prefix()
         {
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             var prefix = "aaa";
             var fileSystemName = prefix + GetNewFileSystemName();
             // Ensure at least one container
@@ -273,7 +274,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         [RecordedTest]
         public async Task GetFileSystemsAsync_Metadata()
         {
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             // Ensure at least one container
             await using DisposingFileSystem test = await GetNewFileSystem(service: service);
 
@@ -295,7 +296,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetFileSystemsAsync_Deleted()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(fileSystemName));
             await fileSystemClient.CreateAsync();
@@ -317,7 +318,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetFileSystemsAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -333,7 +334,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task CreateFileSystemAsync()
         {
             var name = GetNewFileSystemName();
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             try
             {
                 DataLakeFileSystemClient fileSystem = InstrumentClient((await service.CreateFileSystemAsync(name)).Value);
@@ -350,7 +351,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task DeleteFileSystemAsync()
         {
             var name = GetNewFileSystemName();
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeFileSystemClient fileSystem = InstrumentClient((await service.CreateFileSystemAsync(name)).Value);
 
             await service.DeleteFileSystemAsync(name);
@@ -363,7 +364,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task UndeleteFileSystemAsync()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             string fileSystemName = GetNewFileSystemName();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(fileSystemName));
             await fileSystem.CreateAsync();
@@ -391,7 +392,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task UndeleteFileSystemAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             string fileSytemName = GetNewFileSystemName();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(fileSytemName));
 
@@ -405,7 +406,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task GetPropertiesAsync()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
 
             // Act
             Response<DataLakeServiceProperties> response = await service.GetPropertiesAsync();
@@ -420,7 +421,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = InstrumentClient(
                 new DataLakeServiceClient(
-                    GetServiceClient_SharedKey().Uri,
+                    Clients.GetServiceClient_Hns().Uri,
                     GetOptions()));
 
             // Act
@@ -435,7 +436,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_DeleteRetentionPolicy()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeRetentionPolicy originalRetentionPolicy = properties.DeleteRetentionPolicy;
             properties.DeleteRetentionPolicy = new DataLakeRetentionPolicy
@@ -465,7 +466,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_Logging()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeAnalyticsLogging originalLogging = properties.Logging;
             properties.Logging = new DataLakeAnalyticsLogging
@@ -505,7 +506,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetProperties_HourAndMinuteMetrics()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeMetrics originalHourMetrics = properties.HourMetrics;
             DataLakeMetrics originalMinuteMetrics = properties.MinuteMetrics;
@@ -564,7 +565,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_Cors()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeCorsRule[] originalCors = properties.Cors.ToArray();
             properties.Cors =
@@ -601,7 +602,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_StaticWebsite()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeServiceProperties properties = await service.GetPropertiesAsync();
             DataLakeStaticWebsite originalStaticWebsite = properties.StaticWebsite;
             string errorDocument404Path = "error/404.html";
@@ -636,11 +637,11 @@ namespace Azure.Storage.Files.DataLake.Tests
         public async Task SetPropertiesAsync_Error()
         {
             // Arrange
-            DataLakeServiceClient service = GetServiceClient_SharedKey();
+            DataLakeServiceClient service = Clients.GetServiceClient_Hns();
             DataLakeServiceProperties properties = (await service.GetPropertiesAsync()).Value;
             DataLakeServiceClient invalidService = InstrumentClient(
                 new DataLakeServiceClient(
-                    GetServiceClient_SharedKey().Uri,
+                    Clients.GetServiceClient_Hns().Uri,
                     GetOptions()));
 
             // Act
@@ -655,7 +656,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameFileSystemAsync()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    string oldFileSystemName = GetNewFileName();
         //    string newFileSystemName = GetNewFileName();
         //    DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(oldFileSystemName));
@@ -679,7 +680,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameBlobContainerAsync_AccountSas()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    string oldFileSystemName = GetNewFileName();
         //    string newFileSystemName = GetNewFileName();
         //    DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(oldFileSystemName));
@@ -705,7 +706,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameFileSystemAsync_Error()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
 
         //    // Act
         //    await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -719,7 +720,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameFileSystemAsync_SourceLease()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    string oldFileSystemName = GetNewFileSystemName();
         //    string newFileSystemName = GetNewFileSystemName();
         //    DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(oldFileSystemName));
@@ -752,7 +753,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         //public async Task RenameFileSystemAsync_SourceLeaseFailed()
         //{
         //    // Arrange
-        //    DataLakeServiceClient service = GetServiceClient_SharedKey();
+        //    DataLakeServiceClient service = Clients.GetServiceClient_Hns();
         //    string oldFileSystemName = GetNewFileSystemName();
         //    string newFileSystemName = GetNewFileSystemName();
         //    DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(oldFileSystemName));
@@ -957,9 +958,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             var mock = new Mock<DataLakeServiceClient>(TestConfigDefault.ConnectionString, new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakeServiceClient>(TestConfigDefault.ConnectionString).Object;
             mock = new Mock<DataLakeServiceClient>(new Uri("https://test/test"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakeServiceClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakeServiceClient>(new Uri("https://test/test"), Tenants.GetNewHnsSharedKeyCredentials(), new DataLakeClientOptions()).Object;
             mock = new Mock<DataLakeServiceClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new DataLakeClientOptions()).Object;
-            mock = new Mock<DataLakeServiceClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
+            mock = new Mock<DataLakeServiceClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(TestConfigHierarchicalNamespace), new DataLakeClientOptions()).Object;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ClientBuilderExtensions.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs.Models;
+
+using ShareClientBuilder = Azure.Storage.Test.Shared.ClientBuilder<
+    Azure.Storage.Files.Shares.ShareServiceClient,
+    Azure.Storage.Files.Shares.ShareClientOptions>;
+
+namespace Azure.Storage.Files.Shares.Tests
+{
+    public static class ClientBuilderExtensions
+    {
+        public static string GetNewShareName(this ShareClientBuilder clientBuilder)
+            => $"test-share-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewDirectoryName(this ShareClientBuilder clientBuilder)
+            => $"test-directory-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewNonAsciiDirectoryName(this ShareClientBuilder clientBuilder)
+            => $"test-dire¢t Ø®ϒ%3A-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewFileName(this ShareClientBuilder clientBuilder)
+            => $"test-file-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewNonAsciiFileName(this ShareClientBuilder clientBuilder)
+            => $"test-ƒ¡£€‽%3A-{clientBuilder.Recording.Random.NewGuid()}";
+
+        public static async Task<DisposingShare> GetTestShareAsync(
+            this ShareClientBuilder clientBuilder,
+            ShareServiceClient service = default,
+            string shareName = default,
+            IDictionary<string, string> metadata = default)
+        {
+            service ??= clientBuilder.GetServiceClient_SharedKey();
+            metadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            shareName ??= clientBuilder.GetNewShareName();
+            ShareClient share = clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(service.GetShareClient(shareName));
+            return await DisposingShare.CreateAsync(share, metadata);
+        }
+
+        public static async Task<DisposingDirectory> GetTestDirectoryAsync(
+            this ShareClientBuilder clientBuilder,
+            ShareServiceClient service = default,
+            string shareName = default,
+            string directoryName = default)
+        {
+            DisposingShare test = await clientBuilder.GetTestShareAsync(service, shareName);
+            directoryName ??= clientBuilder.GetNewDirectoryName();
+
+            ShareDirectoryClient directory = clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(test.Share.GetDirectoryClient(directoryName));
+            return await DisposingDirectory.CreateAsync(test, directory);
+        }
+
+        public static async Task<DisposingFile> GetTestFileAsync(
+            this ShareClientBuilder clientBuilder,
+            ShareServiceClient service = default,
+            string shareName = default,
+            string directoryName = default,
+            string fileName = default)
+        {
+            DisposingDirectory test = await clientBuilder.GetTestDirectoryAsync(service, shareName, directoryName);
+            fileName ??= clientBuilder.GetNewFileName();
+            ShareFileClient file = clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(test.Directory.GetFileClient(fileName));
+            return await DisposingFile.CreateAsync(test, file);
+        }
+
+        public class DisposingShare : IAsyncDisposable
+        {
+            public ShareClient Share { get; private set; }
+
+            public static async Task<DisposingShare> CreateAsync(ShareClient share, IDictionary<string, string> metadata)
+            {
+                await share.CreateIfNotExistsAsync(metadata: metadata);
+                return new DisposingShare(share);
+            }
+
+            public DisposingShare(ShareClient share)
+            {
+                Share = share;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                if (Share != null)
+                {
+                    try
+                    {
+                        await Share.DeleteIfExistsAsync();
+                        Share = null;
+                    }
+                    catch
+                    {
+                        // swallow the exception to avoid hiding another test failure
+                    }
+                }
+            }
+        }
+
+        public class DisposingDirectory : IAsyncDisposable
+        {
+            private DisposingShare _test;
+
+            public ShareClient Share => _test.Share;
+            public ShareDirectoryClient Directory { get; }
+
+            public static async Task<DisposingDirectory> CreateAsync(DisposingShare test, ShareDirectoryClient directory)
+            {
+                await directory.CreateIfNotExistsAsync();
+                return new DisposingDirectory(test, directory);
+            }
+
+            private DisposingDirectory(DisposingShare test, ShareDirectoryClient directory)
+            {
+                _test = test;
+                Directory = directory;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _test.DisposeAsync();
+            }
+        }
+
+        public class DisposingFile : IAsyncDisposable
+        {
+            private DisposingDirectory _test;
+
+            public ShareClient Share => _test.Share;
+            public ShareDirectoryClient Directory => _test.Directory;
+            public ShareFileClient File { get; }
+
+            public static async Task<DisposingFile> CreateAsync(DisposingDirectory test, ShareFileClient file)
+            {
+                await file.CreateAsync(maxSize: Constants.MB);
+                return new DisposingFile(test, file);
+            }
+
+            private DisposingFile(DisposingDirectory test, ShareFileClient file)
+            {
+                _test = test;
+                File = file;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _test.DisposeAsync();
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ClientBuilderExtensions.cs
@@ -25,6 +25,18 @@ namespace Azure.Storage.Files.Shares.Tests
         public static string GetNewNonAsciiFileName(this ShareClientBuilder clientBuilder)
             => $"test-ƒ¡£€‽%3A-{clientBuilder.Recording.Random.NewGuid()}";
 
+        public static ShareServiceClient GetServiceClient_SharedKey(this ShareClientBuilder clientBuilder, ShareClientOptions options = default)
+            => clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigDefault, options);
+
+        public static ShareServiceClient GetServiceClient_OAuthAccount_SharedKey(this ShareClientBuilder clientBuilder) =>
+            clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigOAuth);
+
+        public static ShareServiceClient GetServiceClient_PremiumFile(this ShareClientBuilder clientBuilder) =>
+            clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigPremiumFile);
+
+        public static ShareServiceClient GetServiceClient_SoftDelete(this ShareClientBuilder clientBuilder) =>
+            clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigSoftDelete);
+
         public static async Task<DisposingShare> GetTestShareAsync(
             this ShareClientBuilder clientBuilder,
             ShareServiceClient service = default,

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/CopySourceAuthTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/CopySourceAuthTests.cs
@@ -13,6 +13,7 @@ using Azure.Storage.Files.Shares.Models;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
+using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {
@@ -29,8 +30,8 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             BlobServiceClient blobServiceClient = InstrumentClient(new BlobServiceClient(
-                new Uri(TestConfigOAuth.BlobServiceEndpoint),
-                GetOAuthCredential(TestConfigOAuth),
+                new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint),
+                Tenants.GetOAuthCredential(Tenants.TestConfigOAuth),
                 GetBlobOptions()));
             BlobContainerClient containerClient = InstrumentClient(blobServiceClient.GetBlobContainerClient(GetNewShareName()));
 
@@ -43,7 +44,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 using Stream stream = new MemoryStream(data);
                 await appendBlobClient.AppendBlockAsync(stream);
 
-                ShareServiceClient serviceClient = GetServiceClient_OAuth_SharedKey();
+                ShareServiceClient serviceClient = Clients.GetServiceClient_OAuthAccount_SharedKey();
                 await using DisposingShare test = await GetTestShareAsync(
                     service: serviceClient,
                     shareName: GetNewShareName());
@@ -84,8 +85,8 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             BlobServiceClient blobServiceClient = InstrumentClient(new BlobServiceClient(
-                new Uri(TestConfigOAuth.BlobServiceEndpoint),
-                GetOAuthCredential(TestConfigOAuth),
+                new Uri(Tenants.TestConfigOAuth.BlobServiceEndpoint),
+                Tenants.GetOAuthCredential(Tenants.TestConfigOAuth),
                 GetBlobOptions()));
             BlobContainerClient containerClient = InstrumentClient(blobServiceClient.GetBlobContainerClient(GetNewShareName()));
 
@@ -98,7 +99,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 using Stream stream = new MemoryStream(data);
                 await appendBlobClient.AppendBlockAsync(stream);
 
-                ShareServiceClient serviceClient = GetServiceClient_OAuth_SharedKey();
+                ShareServiceClient serviceClient = Clients.GetServiceClient_OAuthAccount_SharedKey();
                 await using DisposingShare test = await GetTestShareAsync(
                     service: serviceClient,
                     shareName: GetNewShareName());

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/CopySourceAuthTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/CopySourceAuthTests.cs
@@ -13,7 +13,6 @@ using Azure.Storage.Files.Shares.Models;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
-using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/CopySourceAuthTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/CopySourceAuthTests.cs
@@ -44,7 +44,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 using Stream stream = new MemoryStream(data);
                 await appendBlobClient.AppendBlockAsync(stream);
 
-                ShareServiceClient serviceClient = Clients.GetServiceClient_OAuthAccount_SharedKey();
+                ShareServiceClient serviceClient = SharesClientBuilder.GetServiceClient_OAuthAccount_SharedKey();
                 await using DisposingShare test = await GetTestShareAsync(
                     service: serviceClient,
                     shareName: GetNewShareName());
@@ -99,7 +99,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 using Stream stream = new MemoryStream(data);
                 await appendBlobClient.AppendBlockAsync(stream);
 
-                ShareServiceClient serviceClient = Clients.GetServiceClient_OAuthAccount_SharedKey();
+                ShareServiceClient serviceClient = SharesClientBuilder.GetServiceClient_OAuthAccount_SharedKey();
                 await using DisposingShare test = await GetTestShareAsync(
                     service: serviceClient,
                     shareName: GetNewShareName());

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -13,7 +13,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -355,7 +355,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ExistsAsync_ShareNotExists()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -463,7 +463,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteIfExists_ShareNotExists()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -509,7 +509,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteAsync()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -697,7 +697,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetMetadataAsync()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -854,7 +854,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -872,7 +872,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles_Min()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -901,7 +901,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandles_Min()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -916,7 +916,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandles_Recursive()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -960,7 +960,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateSubdirectoryAsync()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
 
             ShareDirectoryClient subdir = (await dir.CreateSubdirectoryAsync(GetNewDirectoryName())).Value;
@@ -972,7 +972,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteSubdirectoryAsync()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
 
             var name = GetNewDirectoryName();
@@ -986,7 +986,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateFileAsync()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
 
             ShareFileClient file = (await dir.CreateFileAsync(GetNewFileName(), 1024)).Value;
@@ -998,7 +998,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteFileAsync()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
 
             var name = GetNewFileName();
@@ -1052,7 +1052,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task GetSubdirectoryAsync_AsciiName()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
             string name = GetNewDirectoryName();
 
@@ -1072,7 +1072,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task GetSubdirectoryAsync_NonAsciiName()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
             string name = GetNewDirectoryName();
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -13,6 +13,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {
@@ -354,7 +355,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ExistsAsync_ShareNotExists()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -462,7 +463,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteIfExists_ShareNotExists()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
 
@@ -508,7 +509,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteAsync()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -696,7 +697,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetMetadataAsync()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -853,7 +854,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -871,7 +872,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles_Min()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -900,7 +901,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandles_Min()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -915,7 +916,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandles_Recursive()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -959,7 +960,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateSubdirectoryAsync()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
 
             ShareDirectoryClient subdir = (await dir.CreateSubdirectoryAsync(GetNewDirectoryName())).Value;
@@ -971,7 +972,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteSubdirectoryAsync()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
 
             var name = GetNewDirectoryName();
@@ -985,7 +986,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateFileAsync()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
 
             ShareFileClient file = (await dir.CreateFileAsync(GetNewFileName(), 1024)).Value;
@@ -997,7 +998,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteFileAsync()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
 
             var name = GetNewFileName();
@@ -1051,7 +1052,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task GetSubdirectoryAsync_AsciiName()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
             string name = GetNewDirectoryName();
 
@@ -1071,7 +1072,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task GetSubdirectoryAsync_NonAsciiName()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient dir = test.Directory;
             string name = GetNewDirectoryName();
 
@@ -1594,7 +1595,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var mock = new Mock<ShareDirectoryClient>(TestConfigDefault.ConnectionString, "name", "name", new ShareClientOptions()).Object;
             mock = new Mock<ShareDirectoryClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<ShareDirectoryClient>(new Uri("https://test/test/test"), new ShareClientOptions()).Object;
-            mock = new Mock<ShareDirectoryClient>(new Uri("https://test/test/test"), GetNewSharedKeyCredentials(), new ShareClientOptions()).Object;
+            mock = new Mock<ShareDirectoryClient>(new Uri("https://test/test/test"), Tenants.GetNewSharedKeyCredentials(), new ShareClientOptions()).Object;
             mock = new Mock<ShareDirectoryClient>(new Uri("https://test/test/test"), new AzureSasCredential("foo"), new ShareClientOptions()).Object;
         }
     }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DisposingDirectory.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DisposingDirectory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.Files.Shares.Tests
+{
+    public class DisposingDirectory : IAsyncDisposable
+    {
+        private DisposingShare _test;
+
+        public ShareClient Share => _test.Share;
+        public ShareDirectoryClient Directory { get; }
+
+        public static async Task<DisposingDirectory> CreateAsync(DisposingShare test, ShareDirectoryClient directory)
+        {
+            await directory.CreateIfNotExistsAsync();
+            return new DisposingDirectory(test, directory);
+        }
+
+        private DisposingDirectory(DisposingShare test, ShareDirectoryClient directory)
+        {
+            _test = test;
+            Directory = directory;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _test.DisposeAsync();
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DisposingFile.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DisposingFile.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.Files.Shares.Tests
+{
+    public class DisposingFile : IAsyncDisposable
+    {
+        private DisposingDirectory _test;
+
+        public ShareClient Share => _test.Share;
+        public ShareDirectoryClient Directory => _test.Directory;
+        public ShareFileClient File { get; }
+
+        public static async Task<DisposingFile> CreateAsync(DisposingDirectory test, ShareFileClient file)
+        {
+            await file.CreateAsync(maxSize: Constants.MB);
+            return new DisposingFile(test, file);
+        }
+
+        private DisposingFile(DisposingDirectory test, ShareFileClient file)
+        {
+            _test = test;
+            File = file;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _test.DisposeAsync();
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DisposingShare.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DisposingShare.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.Files.Shares.Tests
+{
+    public class DisposingShare : IAsyncDisposable
+    {
+        public ShareClient Share { get; private set; }
+
+        public static async Task<DisposingShare> CreateAsync(ShareClient share, IDictionary<string, string> metadata)
+        {
+            await share.CreateIfNotExistsAsync(metadata: metadata);
+            return new DisposingShare(share);
+        }
+
+        public DisposingShare(ShareClient share)
+        {
+            Share = share;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Share != null)
+            {
+                try
+                {
+                    await Share.DeleteIfExistsAsync();
+                    Share = null;
+                }
+                catch
+                {
+                    // swallow the exception to avoid hiding another test failure
+                }
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -15,6 +15,7 @@ using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {
@@ -153,7 +154,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -176,7 +177,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task CreateAsync_Lease()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(maxSize: Constants.MB);
@@ -199,7 +200,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task CreateAsync_InvalidLease()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(maxSize: Constants.MB);
@@ -219,7 +220,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_FilePermission()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -238,7 +239,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_FilePermissionAndFilePermissionKeySet()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -261,7 +262,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_FilePermissionTooLarge()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -317,7 +318,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_Metadata()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -339,7 +340,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -374,7 +375,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_02_10)]
         public async Task CreateAsync_4TB()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -453,7 +454,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ExistsAsync_ShareNotExists()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareFileClient file = InstrumentClient(share.GetRootDirectoryClient().GetFileClient(GetNewFileName()));
 
@@ -523,7 +524,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteIfExistsAsync_ShareNotExists()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareFileClient file = InstrumentClient(share.GetRootDirectoryClient().GetFileClient(GetNewFileName()));
 
@@ -576,7 +577,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetMetadataAsync()
         {
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Arrange
@@ -595,7 +596,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetMetadataAsync_Lease()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
             IDictionary<string, string> metadata = BuildMetadata();
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
@@ -619,7 +620,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetMetadataAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
             IDictionary<string, string> metadata = BuildMetadata();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -638,7 +639,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetMetadataAsync_Error()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -655,7 +656,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -675,7 +676,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_Snapshot()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(maxSize: Constants.KB);
@@ -696,7 +697,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_SnapshotFailed()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(maxSize: Constants.KB);
@@ -716,7 +717,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_NoLease()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -735,7 +736,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_Lease()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -762,7 +763,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -787,7 +788,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var directoryName = GetNewDirectoryName();
             var fileName = GetNewFileName();
 
-            await using DisposingFile test = await GetTestFileAsync(shareName: shareName, directoryName: directoryName, fileName: fileName);
+            await using DisposingFile test = await Clients.GetTestFileAsync(shareName: shareName, directoryName: directoryName, fileName: fileName);
             ShareFileClient file = test.File;
 
             // Arrange
@@ -811,7 +812,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var directoryName = GetNewDirectoryName();
             var fileName = GetNewFileName();
 
-            await using DisposingFile test = await GetTestFileAsync(shareName: shareName, directoryName: directoryName, fileName: fileName);
+            await using DisposingFile test = await Clients.GetTestFileAsync(shareName: shareName, directoryName: directoryName, fileName: fileName);
             ShareFileClient file = test.File;
 
             // Arrange
@@ -858,7 +859,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 ShareName = shareName,
                 Identifier = signedIdentifierId
             };
-            SasQueryParameters sasQueryParameters = sasBuilder.ToSasQueryParameters(GetNewSharedKeyCredentials());
+            SasQueryParameters sasQueryParameters = sasBuilder.ToSasQueryParameters(Tenants.GetNewSharedKeyCredentials());
 
             ShareUriBuilder uriBuilder = new ShareUriBuilder(fileClient.Uri)
             {
@@ -883,7 +884,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task GetPropertiesAsync_Error()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -909,7 +910,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -942,7 +943,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -969,7 +970,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
             {
@@ -990,7 +991,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetPropertiesAsync_FilePermission()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1044,7 +1045,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1062,7 +1063,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetPropertiesAsync_FilePermissionAndFilePermissionKeySet()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1087,7 +1088,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetPropertiesAsync_Error()
         {
             var constants = TestConstants.Create(this);
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1111,7 +1112,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteAsync()
         {
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -1125,7 +1126,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task DeleteAsync_Lease()
         {
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -1144,7 +1145,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task DeleteAsync_InvalidLease()
         {
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
             {
@@ -1160,7 +1161,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteAsync_Error()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1176,9 +1177,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync()
         {
             // Arrange
-            await using DisposingFile testSource = await GetTestFileAsync();
+            await using DisposingFile testSource = await Clients.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await GetTestFileAsync();
+            await using DisposingFile testDest = await Clients.GetTestFileAsync();
             ShareFileClient dest = testDest.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1201,9 +1202,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_IgnoreReadOnlyAndSetArchive()
         {
             // Arrange
-            await using DisposingFile testSource = await GetTestFileAsync();
+            await using DisposingFile testSource = await Clients.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await GetTestFileAsync();
+            await using DisposingFile testDest = await Clients.GetTestFileAsync();
             ShareFileClient dest = testSource.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1229,9 +1230,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_FilePermission()
         {
             // Arrange
-            await using DisposingFile testSource = await GetTestFileAsync();
+            await using DisposingFile testSource = await Clients.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await GetTestFileAsync();
+            await using DisposingFile testDest = await Clients.GetTestFileAsync();
             ShareFileClient dest = testSource.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1271,9 +1272,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_CopySmbPropertiesFilePermissionKey()
         {
             // Arrange
-            await using DisposingFile testSource = await GetTestFileAsync();
+            await using DisposingFile testSource = await Clients.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await GetTestFileAsync();
+            await using DisposingFile testDest = await Clients.GetTestFileAsync();
             ShareFileClient dest = testSource.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1314,9 +1315,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_Lease()
         {
             // Arrange
-            await using DisposingFile testSource = await GetTestFileAsync();
+            await using DisposingFile testSource = await Clients.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await GetTestFileAsync();
+            await using DisposingFile testDest = await Clients.GetTestFileAsync();
             ShareFileClient dest = testDest.File;
             ShareFileLease fileLease = await InstrumentClient(dest.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -1347,9 +1348,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingFile testSource = await GetTestFileAsync();
+            await using DisposingFile testSource = await Clients.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await GetTestFileAsync();
+            await using DisposingFile testDest = await Clients.GetTestFileAsync();
             ShareFileClient dest = testDest.File;
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
             {
@@ -1377,9 +1378,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_Metata()
         {
             // Arrange
-            await using DisposingFile testSource = await GetTestFileAsync();
+            await using DisposingFile testSource = await Clients.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await GetTestFileAsync();
+            await using DisposingFile testDest = await Clients.GetTestFileAsync();
             ShareFileClient dest = testSource.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1409,9 +1410,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_NonAsciiSourceUri()
         {
             // Arrange
-            await using DisposingFile testSource = await GetTestFileAsync(fileName: GetNewNonAsciiFileName());
+            await using DisposingFile testSource = await Clients.GetTestFileAsync(fileName: GetNewNonAsciiFileName());
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await GetTestFileAsync();
+            await using DisposingFile testDest = await Clients.GetTestFileAsync();
             ShareFileClient dest = testDest.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1432,7 +1433,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task StartCopyAsync_Error()
         {
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -1444,7 +1445,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task AbortCopyAsync()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1483,7 +1484,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task AbortCopyAsync_Lease()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1533,7 +1534,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task AbortCopyAsync_InvalidLease()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1571,7 +1572,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task AbortCopyAsync_Error()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1591,7 +1592,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var directoryName = GetNewDirectoryName();
             var fileName = GetNewFileName();
 
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
 
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
@@ -1622,7 +1623,7 @@ namespace Azure.Storage.Files.Shares.Tests
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -1668,7 +1669,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DownloadAsync_ZeroFile()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             var fileName = GetNewFileName();
             var file = test.Directory.GetFileClient(fileName);
             await file.CreateAsync(0);
@@ -1690,7 +1691,7 @@ namespace Azure.Storage.Files.Shares.Tests
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -1718,7 +1719,7 @@ namespace Azure.Storage.Files.Shares.Tests
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -1753,7 +1754,7 @@ namespace Azure.Storage.Files.Shares.Tests
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -1868,7 +1869,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -1885,7 +1886,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_NoLease()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
@@ -1907,7 +1908,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_Lease()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
@@ -1933,7 +1934,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileGetRangeListOptions options = new ShareFileGetRangeListOptions
@@ -1954,7 +1955,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task GetRangeListAsync_Error()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1975,7 +1976,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_NoRange()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             byte[] data = GetRandomBuffer(Constants.KB);
@@ -1998,7 +1999,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_Snapshot()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             byte[] data = GetRandomBuffer(Constants.KB);
@@ -2028,7 +2029,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_SnapshotFailed()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileGetRangeListOptions options = new ShareFileGetRangeListOptions
@@ -2047,7 +2048,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListDiffAsync()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             byte[] data = GetRandomBuffer(Constants.KB);
@@ -2091,7 +2092,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListDiffAsync_Error()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileGetRangeListDiffOptions options = new ShareFileGetRangeListDiffOptions
@@ -2110,7 +2111,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListDiffAsync_Lease()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
@@ -2136,7 +2137,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListDiffAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileGetRangeListDiffOptions options = new ShareFileGetRangeListDiffOptions
@@ -2159,7 +2160,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -2182,7 +2183,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -2207,7 +2208,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
             {
@@ -2228,7 +2229,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task UploadRangeAsync_Error()
         {
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -2250,7 +2251,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadRangeAsync_InvalidStreamPosition()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = Constants.KB;
             await file.CreateAsync(size);
@@ -2276,7 +2277,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadRangeAsync_NonZeroStreamPosition()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = Constants.KB;
             long position = 512;
@@ -2456,7 +2457,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadAsync_Stream_InvalidStreamPosition()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = Constants.KB;
             await file.CreateAsync(size);
@@ -2479,7 +2480,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadAsync_NonZeroStreamPosition()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = Constants.KB;
             long position = 512;
@@ -2510,7 +2511,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadAsync_NonZeroStreamPositionMultipleBlocks()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = 2 * Constants.KB;
             long position = 300;
@@ -2545,7 +2546,7 @@ namespace Azure.Storage.Files.Shares.Tests
 
         public async Task ClearRangeAsync()
         {
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             Response<ShareFileUploadInfo> response = await file.ClearRangeAsync(
@@ -2587,7 +2588,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ClearRangeAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -2962,7 +2963,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -2976,7 +2977,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles_Min()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -2990,7 +2991,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3005,7 +3006,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandles_Min()
         {
             // Arrange
-            await using DisposingFile test = await GetTestFileAsync();
+            await using DisposingFile test = await Clients.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -3020,7 +3021,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandles_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3035,7 +3036,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandle_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3051,7 +3052,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task AcquireLeaseAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3075,7 +3076,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task AcquireLeaseAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3092,7 +3093,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ReleaseLeaseAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3114,7 +3115,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ReleaseLeaseAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3131,7 +3132,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ChangeLeaseAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3158,7 +3159,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ChangeLeaseAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3176,7 +3177,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task BreakLeaseAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3200,7 +3201,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task BreakLeaseAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3216,7 +3217,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3238,7 +3239,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_ConcurrentModification_NotAllowed()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3266,7 +3267,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_ConcurrentModification_Allowed()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3291,7 +3292,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_BufferSize()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3324,7 +3325,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_OffsetAndBufferSize()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3361,7 +3362,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = test.Directory.GetFileClient(GetNewFileName());
 
             // Act
@@ -3374,7 +3375,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Lease()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3406,7 +3407,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_InvalidLease()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3431,7 +3432,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_StrangeOffsetsTest()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             int size = Constants.KB;
             byte[] exectedData = GetRandomBuffer(size);
@@ -3474,7 +3475,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_LargeData()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             int size = 1 * Constants.GB;
             byte[] exectedData = GetRandomBuffer(size);
             ShareFileClient file = await test.Directory.CreateFileAsync(GetNewFileName(), size);
@@ -3506,7 +3507,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_CopyReadStreamToAnotherStream()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             long size = 4 * Constants.MB;
             byte[] exectedData = GetRandomBuffer(size);
             ShareFileClient fileClient = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
@@ -3527,7 +3528,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_InvalidParameterTests()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             long size = 4 * Constants.MB;
             byte[] exectedData = GetRandomBuffer(size);
             ShareFileClient fileClient = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
@@ -3557,7 +3558,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Seek_PositionUnchanged()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3584,7 +3585,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Seek_NegativeNewPosition()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3606,7 +3607,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Seek_NewPositionGreaterThanFileLength(bool allowModifications)
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3637,7 +3638,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Seek_Position(long offset, SeekOrigin origin)
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3686,7 +3687,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             int size = Constants.KB;
             int initalPosition = 450;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             byte[] data = GetRandomBuffer(size);
@@ -3734,7 +3735,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             int size = Constants.KB;
             int initalPosition = 450;
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
 
             // Arrange
             byte[] data = GetRandomBuffer(size);
@@ -3771,7 +3772,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetFileClient_AsciiName()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -3793,7 +3794,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetFileClient_NonAsciiName()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -3815,7 +3816,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_NewFile()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(16 * Constants.KB);
 
@@ -3853,7 +3854,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_NewFile_WithUsing()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(16 * Constants.KB);
 
@@ -3891,7 +3892,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_ModifyExistingFile()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(2 * Constants.KB);
 
@@ -3926,7 +3927,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_AlternatingWriteAndFlush()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(Constants.KB);
 
@@ -3959,7 +3960,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3976,7 +3977,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_ProgressReporting()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(Constants.KB);
 
@@ -4008,7 +4009,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_Overwite(bool fileExists)
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             if (fileExists)
             {
@@ -4043,7 +4044,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_OverwriteNoSize()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
 
             // Act
@@ -4058,7 +4059,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_NewFileNoSize()
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
 
             // Act
@@ -4076,7 +4077,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_Lease(bool overwrite)
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(Constants.KB);
 
@@ -4111,7 +4112,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_InvalidLease(bool overwrite)
         {
             // Arrange
-            await using DisposingDirectory test = await GetTestDirectoryAsync();
+            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(Constants.KB);
 
@@ -4436,7 +4437,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var mock = new Mock<ShareFileClient>(TestConfigDefault.ConnectionString, "name", "name", new ShareClientOptions()).Object;
             mock = new Mock<ShareFileClient>(TestConfigDefault.ConnectionString, "name", "name").Object;
             mock = new Mock<ShareFileClient>(new Uri("https://test/test/test"), new ShareClientOptions()).Object;
-            mock = new Mock<ShareFileClient>(new Uri("https://test/test/test"), GetNewSharedKeyCredentials(), new ShareClientOptions()).Object;
+            mock = new Mock<ShareFileClient>(new Uri("https://test/test/test"), Tenants.GetNewSharedKeyCredentials(), new ShareClientOptions()).Object;
             mock = new Mock<ShareFileClient>(new Uri("https://test/test/test"), new AzureSasCredential("foo"), new ShareClientOptions()).Object;
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -15,7 +15,6 @@ using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -154,7 +154,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -177,7 +177,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task CreateAsync_Lease()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(maxSize: Constants.MB);
@@ -200,7 +200,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task CreateAsync_InvalidLease()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(maxSize: Constants.MB);
@@ -220,7 +220,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_FilePermission()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -239,7 +239,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_FilePermissionAndFilePermissionKeySet()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -262,7 +262,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_FilePermissionTooLarge()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -318,7 +318,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task CreateAsync_Metadata()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -340,7 +340,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -375,7 +375,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2020_02_10)]
         public async Task CreateAsync_4TB()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -454,7 +454,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ExistsAsync_ShareNotExists()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareFileClient file = InstrumentClient(share.GetRootDirectoryClient().GetFileClient(GetNewFileName()));
 
@@ -524,7 +524,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteIfExistsAsync_ShareNotExists()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareFileClient file = InstrumentClient(share.GetRootDirectoryClient().GetFileClient(GetNewFileName()));
 
@@ -577,7 +577,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetMetadataAsync()
         {
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Arrange
@@ -596,7 +596,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetMetadataAsync_Lease()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
             IDictionary<string, string> metadata = BuildMetadata();
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
@@ -620,7 +620,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetMetadataAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
             IDictionary<string, string> metadata = BuildMetadata();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -639,7 +639,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetMetadataAsync_Error()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -656,7 +656,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -676,7 +676,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_Snapshot()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(maxSize: Constants.KB);
@@ -697,7 +697,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_SnapshotFailed()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(maxSize: Constants.KB);
@@ -717,7 +717,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_NoLease()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -736,7 +736,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_Lease()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -763,7 +763,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -788,7 +788,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var directoryName = GetNewDirectoryName();
             var fileName = GetNewFileName();
 
-            await using DisposingFile test = await Clients.GetTestFileAsync(shareName: shareName, directoryName: directoryName, fileName: fileName);
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync(shareName: shareName, directoryName: directoryName, fileName: fileName);
             ShareFileClient file = test.File;
 
             // Arrange
@@ -812,7 +812,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var directoryName = GetNewDirectoryName();
             var fileName = GetNewFileName();
 
-            await using DisposingFile test = await Clients.GetTestFileAsync(shareName: shareName, directoryName: directoryName, fileName: fileName);
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync(shareName: shareName, directoryName: directoryName, fileName: fileName);
             ShareFileClient file = test.File;
 
             // Arrange
@@ -884,7 +884,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task GetPropertiesAsync_Error()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -910,7 +910,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -943,7 +943,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -970,7 +970,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
             {
@@ -991,7 +991,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetPropertiesAsync_FilePermission()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1045,7 +1045,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var constants = TestConstants.Create(this);
 
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1063,7 +1063,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task SetPropertiesAsync_FilePermissionAndFilePermissionKeySet()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1088,7 +1088,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetPropertiesAsync_Error()
         {
             var constants = TestConstants.Create(this);
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1112,7 +1112,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteAsync()
         {
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -1126,7 +1126,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task DeleteAsync_Lease()
         {
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -1145,7 +1145,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task DeleteAsync_InvalidLease()
         {
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
             {
@@ -1161,7 +1161,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task DeleteAsync_Error()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1177,9 +1177,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync()
         {
             // Arrange
-            await using DisposingFile testSource = await Clients.GetTestFileAsync();
+            await using DisposingFile testSource = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await Clients.GetTestFileAsync();
+            await using DisposingFile testDest = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient dest = testDest.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1202,9 +1202,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_IgnoreReadOnlyAndSetArchive()
         {
             // Arrange
-            await using DisposingFile testSource = await Clients.GetTestFileAsync();
+            await using DisposingFile testSource = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await Clients.GetTestFileAsync();
+            await using DisposingFile testDest = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient dest = testSource.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1230,9 +1230,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_FilePermission()
         {
             // Arrange
-            await using DisposingFile testSource = await Clients.GetTestFileAsync();
+            await using DisposingFile testSource = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await Clients.GetTestFileAsync();
+            await using DisposingFile testDest = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient dest = testSource.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1272,9 +1272,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_CopySmbPropertiesFilePermissionKey()
         {
             // Arrange
-            await using DisposingFile testSource = await Clients.GetTestFileAsync();
+            await using DisposingFile testSource = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await Clients.GetTestFileAsync();
+            await using DisposingFile testDest = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient dest = testSource.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1315,9 +1315,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_Lease()
         {
             // Arrange
-            await using DisposingFile testSource = await Clients.GetTestFileAsync();
+            await using DisposingFile testSource = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await Clients.GetTestFileAsync();
+            await using DisposingFile testDest = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient dest = testDest.File;
             ShareFileLease fileLease = await InstrumentClient(dest.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -1348,9 +1348,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingFile testSource = await Clients.GetTestFileAsync();
+            await using DisposingFile testSource = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await Clients.GetTestFileAsync();
+            await using DisposingFile testDest = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient dest = testDest.File;
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
             {
@@ -1378,9 +1378,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_Metata()
         {
             // Arrange
-            await using DisposingFile testSource = await Clients.GetTestFileAsync();
+            await using DisposingFile testSource = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await Clients.GetTestFileAsync();
+            await using DisposingFile testDest = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient dest = testSource.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1410,9 +1410,9 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task StartCopyAsync_NonAsciiSourceUri()
         {
             // Arrange
-            await using DisposingFile testSource = await Clients.GetTestFileAsync(fileName: GetNewNonAsciiFileName());
+            await using DisposingFile testSource = await SharesClientBuilder.GetTestFileAsync(fileName: GetNewNonAsciiFileName());
             ShareFileClient source = testSource.File;
-            await using DisposingFile testDest = await Clients.GetTestFileAsync();
+            await using DisposingFile testDest = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient dest = testDest.File;
 
             var data = GetRandomBuffer(Constants.KB);
@@ -1433,7 +1433,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task StartCopyAsync_Error()
         {
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -1445,7 +1445,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task AbortCopyAsync()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1484,7 +1484,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task AbortCopyAsync_Lease()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1534,7 +1534,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [ServiceVersion(Min = ShareClientOptions.ServiceVersion.V2019_07_07)]
         public async Task AbortCopyAsync_InvalidLease()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1572,7 +1572,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task AbortCopyAsync_Error()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1592,7 +1592,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var directoryName = GetNewDirectoryName();
             var fileName = GetNewFileName();
 
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
 
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
@@ -1623,7 +1623,7 @@ namespace Azure.Storage.Files.Shares.Tests
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -1669,7 +1669,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DownloadAsync_ZeroFile()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             var fileName = GetNewFileName();
             var file = test.Directory.GetFileClient(fileName);
             await file.CreateAsync(0);
@@ -1691,7 +1691,7 @@ namespace Azure.Storage.Files.Shares.Tests
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -1719,7 +1719,7 @@ namespace Azure.Storage.Files.Shares.Tests
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -1754,7 +1754,7 @@ namespace Azure.Storage.Files.Shares.Tests
             // Arrange
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -1869,7 +1869,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -1886,7 +1886,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_NoLease()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
@@ -1908,7 +1908,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_Lease()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
@@ -1934,7 +1934,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileGetRangeListOptions options = new ShareFileGetRangeListOptions
@@ -1955,7 +1955,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task GetRangeListAsync_Error()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -1976,7 +1976,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_NoRange()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             byte[] data = GetRandomBuffer(Constants.KB);
@@ -1999,7 +1999,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_Snapshot()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             byte[] data = GetRandomBuffer(Constants.KB);
@@ -2029,7 +2029,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListAsync_SnapshotFailed()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileGetRangeListOptions options = new ShareFileGetRangeListOptions
@@ -2048,7 +2048,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListDiffAsync()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             byte[] data = GetRandomBuffer(Constants.KB);
@@ -2092,7 +2092,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListDiffAsync_Error()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileGetRangeListDiffOptions options = new ShareFileGetRangeListDiffOptions
@@ -2111,7 +2111,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListDiffAsync_Lease()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
@@ -2137,7 +2137,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetRangeListDiffAsync_InvalidLease()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             ShareFileGetRangeListDiffOptions options = new ShareFileGetRangeListDiffOptions
@@ -2160,7 +2160,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             using (var stream = new MemoryStream(data))
@@ -2183,7 +2183,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileLease fileLease = await InstrumentClient(file.GetShareLeaseClient(Recording.Random.NewGuid().ToString())).AcquireAsync();
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
@@ -2208,7 +2208,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             var data = GetRandomBuffer(Constants.KB);
 
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
             ShareFileRequestConditions conditions = new ShareFileRequestConditions
             {
@@ -2229,7 +2229,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [RecordedTest]
         public async Task UploadRangeAsync_Error()
         {
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Arrange
@@ -2251,7 +2251,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadRangeAsync_InvalidStreamPosition()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = Constants.KB;
             await file.CreateAsync(size);
@@ -2277,7 +2277,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadRangeAsync_NonZeroStreamPosition()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = Constants.KB;
             long position = 512;
@@ -2457,7 +2457,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadAsync_Stream_InvalidStreamPosition()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = Constants.KB;
             await file.CreateAsync(size);
@@ -2480,7 +2480,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadAsync_NonZeroStreamPosition()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = Constants.KB;
             long position = 512;
@@ -2511,7 +2511,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UploadAsync_NonZeroStreamPositionMultipleBlocks()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             long size = 2 * Constants.KB;
             long position = 300;
@@ -2546,7 +2546,7 @@ namespace Azure.Storage.Files.Shares.Tests
 
         public async Task ClearRangeAsync()
         {
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             Response<ShareFileUploadInfo> response = await file.ClearRangeAsync(
@@ -2588,7 +2588,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ClearRangeAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
@@ -2963,7 +2963,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -2977,7 +2977,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles_Min()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -2991,7 +2991,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListHandles_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3006,7 +3006,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandles_Min()
         {
             // Arrange
-            await using DisposingFile test = await Clients.GetTestFileAsync();
+            await using DisposingFile test = await SharesClientBuilder.GetTestFileAsync();
             ShareFileClient file = test.File;
 
             // Act
@@ -3021,7 +3021,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandles_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3036,7 +3036,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ForceCloseHandle_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3052,7 +3052,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task AcquireLeaseAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3076,7 +3076,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task AcquireLeaseAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3093,7 +3093,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ReleaseLeaseAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3115,7 +3115,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ReleaseLeaseAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3132,7 +3132,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ChangeLeaseAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3159,7 +3159,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ChangeLeaseAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3177,7 +3177,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task BreakLeaseAsync()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3201,7 +3201,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task BreakLeaseAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3217,7 +3217,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3239,7 +3239,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_ConcurrentModification_NotAllowed()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3267,7 +3267,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_ConcurrentModification_Allowed()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3292,7 +3292,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_BufferSize()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3325,7 +3325,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_OffsetAndBufferSize()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3362,7 +3362,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Error()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = test.Directory.GetFileClient(GetNewFileName());
 
             // Act
@@ -3375,7 +3375,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Lease()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3407,7 +3407,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_InvalidLease()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3432,7 +3432,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_StrangeOffsetsTest()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             int size = Constants.KB;
             byte[] exectedData = GetRandomBuffer(size);
@@ -3475,7 +3475,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_LargeData()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             int size = 1 * Constants.GB;
             byte[] exectedData = GetRandomBuffer(size);
             ShareFileClient file = await test.Directory.CreateFileAsync(GetNewFileName(), size);
@@ -3507,7 +3507,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_CopyReadStreamToAnotherStream()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             long size = 4 * Constants.MB;
             byte[] exectedData = GetRandomBuffer(size);
             ShareFileClient fileClient = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
@@ -3528,7 +3528,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_InvalidParameterTests()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             long size = 4 * Constants.MB;
             byte[] exectedData = GetRandomBuffer(size);
             ShareFileClient fileClient = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
@@ -3558,7 +3558,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Seek_PositionUnchanged()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3585,7 +3585,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Seek_NegativeNewPosition()
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3607,7 +3607,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Seek_NewPositionGreaterThanFileLength(bool allowModifications)
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3638,7 +3638,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenReadAsync_Seek_Position(long offset, SeekOrigin origin)
         {
             int size = Constants.KB;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             var data = GetRandomBuffer(size);
@@ -3687,7 +3687,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             int size = Constants.KB;
             int initalPosition = 450;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             byte[] data = GetRandomBuffer(size);
@@ -3735,7 +3735,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             int size = Constants.KB;
             int initalPosition = 450;
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
 
             // Arrange
             byte[] data = GetRandomBuffer(size);
@@ -3772,7 +3772,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetFileClient_AsciiName()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -3794,7 +3794,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetFileClient_NonAsciiName()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareDirectoryClient directory = test.Directory;
 
             // Act
@@ -3816,7 +3816,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_NewFile()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(16 * Constants.KB);
 
@@ -3854,7 +3854,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_NewFile_WithUsing()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(16 * Constants.KB);
 
@@ -3892,7 +3892,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_ModifyExistingFile()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(2 * Constants.KB);
 
@@ -3927,7 +3927,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_AlternatingWriteAndFlush()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(Constants.KB);
 
@@ -3960,7 +3960,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewDirectoryName()));
@@ -3977,7 +3977,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_ProgressReporting()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(Constants.KB);
 
@@ -4009,7 +4009,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_Overwite(bool fileExists)
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             if (fileExists)
             {
@@ -4044,7 +4044,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_OverwriteNoSize()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
 
             // Act
@@ -4059,7 +4059,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_NewFileNoSize()
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
 
             // Act
@@ -4077,7 +4077,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_Lease(bool overwrite)
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(Constants.KB);
 
@@ -4112,7 +4112,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task OpenWriteAsync_InvalidLease(bool overwrite)
         {
             // Arrange
-            await using DisposingDirectory test = await Clients.GetTestDirectoryAsync();
+            await using DisposingDirectory test = await SharesClientBuilder.GetTestDirectoryAsync();
             ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(GetNewFileName()));
             await file.CreateAsync(Constants.KB);
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -7,7 +7,6 @@ using Azure.Core.TestFramework;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
-using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
 namespace Azure.Storage.Files.Shares.Tests

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -7,6 +7,7 @@ using Azure.Core.TestFramework;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
+using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
 namespace Azure.Storage.Files.Shares.Tests

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -13,6 +13,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
+using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {
@@ -32,6 +33,11 @@ namespace Azure.Storage.Files.Shares.Tests
         LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
     public class FileTestBase : StorageTestBase<StorageTestEnvironment>
     {
+        /// <summary>
+        /// Source of clients.
+        /// </summary>
+        protected ClientBuilder<ShareServiceClient, ShareClientOptions> Clients { get; }
+
         protected readonly ShareClientOptions.ServiceVersion _serviceVersion;
 
         public static Uri s_invalidUri = new Uri("https://error.file.core.windows.net");
@@ -40,13 +46,26 @@ namespace Azure.Storage.Files.Shares.Tests
             : base(async, mode)
         {
             _serviceVersion = serviceVersion;
+            Clients = new ClientBuilder<ShareServiceClient, ShareClientOptions>(
+                Tenants,
+                (uri, clientOptions) => new ShareServiceClient(uri, clientOptions),
+                (uri, sharedKeyCredential, clientOptions) => new ShareServiceClient(uri, sharedKeyCredential, clientOptions),
+                default, // file shares don't suppot oauth
+                (uri, azureSasCredential, clientOptions) => new ShareServiceClient(uri, azureSasCredential, clientOptions),
+                () => new ShareClientOptions(_serviceVersion));
         }
 
-        public string GetNewShareName() => $"test-share-{Recording.Random.NewGuid()}";
-        public string GetNewDirectoryName() => $"test-directory-{Recording.Random.NewGuid()}";
-        public string GetNewNonAsciiDirectoryName() => $"test-dire¢t Ø®ϒ%3A-{Recording.Random.NewGuid()}";
-        public string GetNewFileName() => $"test-file-{Recording.Random.NewGuid()}";
-        public string GetNewNonAsciiFileName() => $"test-ƒ¡£€‽%3A-{Recording.Random.NewGuid()}";
+        public string GetNewShareName() => Clients.GetNewShareName();
+        public string GetNewDirectoryName() => Clients.GetNewShareName();
+        public string GetNewNonAsciiDirectoryName() => Clients.GetNewShareName();
+        public string GetNewFileName() => Clients.GetNewShareName();
+        public string GetNewNonAsciiFileName() => Clients.GetNewShareName();
+
+        public async Task<DisposingShare> GetTestShareAsync(
+            ShareServiceClient service = default,
+            string shareName = default,
+            IDictionary<string, string> metadata = default)
+            => await Clients.GetTestShareAsync(service, shareName, metadata);
 
         public ShareClientOptions GetOptions()
         {
@@ -69,32 +88,6 @@ namespace Azure.Storage.Files.Shares.Tests
             return InstrumentClientOptions(options);
         }
 
-        public async Task<DisposingShare> GetTestShareAsync(ShareServiceClient service = default, string shareName = default, IDictionary<string, string> metadata = default)
-        {
-            service ??= GetServiceClient_SharedKey();
-            metadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            shareName ??= GetNewShareName();
-            ShareClient share = InstrumentClient(service.GetShareClient(shareName));
-            return await DisposingShare.CreateAsync(share, metadata);
-        }
-
-        public async Task<DisposingDirectory> GetTestDirectoryAsync(ShareServiceClient service = default, string shareName = default, string directoryName = default)
-        {
-            DisposingShare test = await GetTestShareAsync(service, shareName);
-            directoryName ??= GetNewDirectoryName();
-
-            ShareDirectoryClient directory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
-            return await DisposingDirectory.CreateAsync(test, directory);
-        }
-
-        public async Task<DisposingFile> GetTestFileAsync(ShareServiceClient service = default, string shareName = default, string directoryName = default, string fileName = default)
-        {
-            DisposingDirectory test = await GetTestDirectoryAsync(service, shareName, directoryName);
-            fileName ??= GetNewFileName();
-            ShareFileClient file = InstrumentClient(test.Directory.GetFileClient(fileName));
-            return await DisposingFile.CreateAsync(test, file);
-        }
-
         public ShareClientOptions GetFaultyFileConnectionOptions(
             int raiseAt = default,
             Exception raise = default,
@@ -106,73 +99,23 @@ namespace Azure.Storage.Files.Shares.Tests
             return options;
         }
 
-        public ShareServiceClient GetServiceClient_SharedKey()
-            => InstrumentClient(
-                new ShareServiceClient(
-                    new Uri(TestConfigDefault.FileServiceEndpoint),
-                    new StorageSharedKeyCredential(
-                        TestConfigDefault.AccountName,
-                        TestConfigDefault.AccountKey),
-                    GetOptions()));
-
-        public ShareServiceClient GetServiceClient_OAuth_SharedKey()
-            => InstrumentClient(
-                new ShareServiceClient(
-                    new Uri(TestConfigOAuth.FileServiceEndpoint),
-                    new StorageSharedKeyCredential(
-                        TestConfigOAuth.AccountName,
-                        TestConfigOAuth.AccountKey),
-                    GetOptions()));
-
-        public ShareServiceClient GetServiceClient_Premium()
-            => InstrumentClient(
-                new ShareServiceClient(
-                    new Uri(TestConfigPremiumBlob.FileServiceEndpoint),
-                    new StorageSharedKeyCredential(
-                        TestConfigPremiumBlob.AccountName,
-                        TestConfigPremiumBlob.AccountKey),
-                    GetOptions()));
-
-        public ShareServiceClient GetServiceClient_SoftDelete()
-            => InstrumentClient(
-                new ShareServiceClient(
-                    new Uri(TestConfigSoftDelete.FileServiceEndpoint),
-                    new StorageSharedKeyCredential(
-                        TestConfigSoftDelete.AccountName,
-                        TestConfigSoftDelete.AccountKey),
-                    GetOptions()));
-
-        public ShareServiceClient GetServiceClient_PremiumFile()
-            => InstrumentClient(
-                new ShareServiceClient(
-                    new Uri(TestConfigPremiumFile.FileServiceEndpoint),
-                    new StorageSharedKeyCredential(
-                        TestConfigPremiumFile.AccountName,
-                        TestConfigPremiumFile.AccountKey),
-                    GetOptions()));
-
         public ShareServiceClient GetServiceClient_AccountSas(StorageSharedKeyCredential sharedKeyCredentials = default, SasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new ShareServiceClient(
-                    new Uri($"{TestConfigDefault.FileServiceEndpoint}?{sasCredentials ?? GetNewAccountSasCredentials(sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
+                    new Uri($"{TestConfigDefault.FileServiceEndpoint}?{sasCredentials ?? GetNewAccountSasCredentials(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
                     GetOptions()));
 
         public ShareServiceClient GetServiceClient_FileServiceSasShare(string shareName, StorageSharedKeyCredential sharedKeyCredentials = default, SasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new ShareServiceClient(
-                    new Uri($"{TestConfigDefault.FileServiceEndpoint}?{sasCredentials ?? GetNewFileServiceSasCredentialsShare(shareName, sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
+                    new Uri($"{TestConfigDefault.FileServiceEndpoint}?{sasCredentials ?? GetNewFileServiceSasCredentialsShare(shareName, sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
                     GetOptions()));
 
         public ShareServiceClient GetServiceClient_FileServiceSasFile(string shareName, string filePath, StorageSharedKeyCredential sharedKeyCredentials = default, SasQueryParameters sasCredentials = default)
             => InstrumentClient(
                 new ShareServiceClient(
-                    new Uri($"{TestConfigDefault.FileServiceEndpoint}?{sasCredentials ?? GetNewFileServiceSasCredentialsFile(shareName, filePath, sharedKeyCredentials ?? GetNewSharedKeyCredentials())}"),
+                    new Uri($"{TestConfigDefault.FileServiceEndpoint}?{sasCredentials ?? GetNewFileServiceSasCredentialsFile(shareName, filePath, sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials())}"),
                     GetOptions()));
-
-        public StorageSharedKeyCredential GetNewSharedKeyCredentials()
-            => new StorageSharedKeyCredential(
-                TestConfigDefault.AccountName,
-                TestConfigDefault.AccountKey);
 
         public SasQueryParameters GetNewAccountSasCredentials(StorageSharedKeyCredential sharedKeyCredentials = default,
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.Container,
@@ -188,7 +131,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 IPRange = new SasIPRange(IPAddress.None, IPAddress.None)
             };
             builder.SetPermissions(permissions);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
         }
 
         public SasQueryParameters GetNewFileServiceSasCredentialsShare(string shareName, StorageSharedKeyCredential sharedKeyCredentials = default)
@@ -202,7 +145,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 IPRange = new SasIPRange(IPAddress.None, IPAddress.None)
             };
             builder.SetPermissions(ShareSasPermissions.All);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
         }
 
         public SasQueryParameters GetNewFileServiceSasCredentialsFile(string shareName, string filePath, StorageSharedKeyCredential sharedKeyCredentials = default)
@@ -217,7 +160,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 IPRange = new SasIPRange(IPAddress.None, IPAddress.None)
             };
             builder.SetPermissions(ShareFileSasPermissions.All);
-            return builder.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
+            return builder.ToSasQueryParameters(sharedKeyCredentials ?? Tenants.GetNewSharedKeyCredentials());
         }
 
         public ShareSignedIdentifier[] BuildSignedIdentifiers() =>
@@ -295,89 +238,6 @@ namespace Azure.Storage.Files.Shares.Tests
             Assert.AreEqual(left.FileLastWrittenOn, right.FileLastWrittenOn);
             Assert.AreEqual(left.FilePermissionKey, right.FilePermissionKey);
             Assert.AreEqual(left.ParentId, right.ParentId);
-        }
-
-        public class DisposingShare : IAsyncDisposable
-        {
-            public ShareClient Share { get; private set; }
-
-            public static async Task<DisposingShare> CreateAsync(ShareClient share, IDictionary<string, string> metadata)
-            {
-                await share.CreateIfNotExistsAsync(metadata: metadata);
-                return new DisposingShare(share);
-            }
-
-            public DisposingShare(ShareClient share)
-            {
-                Share = share;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                if (Share != null)
-                {
-                    try
-                    {
-                        await Share.DeleteIfExistsAsync();
-                        Share = null;
-                    }
-                    catch
-                    {
-                        // swallow the exception to avoid hiding another test failure
-                    }
-                }
-            }
-        }
-
-        public class DisposingDirectory : IAsyncDisposable
-        {
-            private DisposingShare _test;
-
-            public ShareClient Share => _test.Share;
-            public ShareDirectoryClient Directory { get; }
-
-            public static async Task<DisposingDirectory> CreateAsync(DisposingShare test, ShareDirectoryClient directory)
-            {
-                await directory.CreateIfNotExistsAsync();
-                return new DisposingDirectory(test, directory);
-            }
-
-            private DisposingDirectory(DisposingShare test, ShareDirectoryClient directory)
-            {
-                _test = test;
-                Directory = directory;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                await _test.DisposeAsync();
-            }
-        }
-
-        public class DisposingFile : IAsyncDisposable
-        {
-            private DisposingDirectory _test;
-
-            public ShareClient Share => _test.Share;
-            public ShareDirectoryClient Directory => _test.Directory;
-            public ShareFileClient File { get; }
-
-            public static async Task<DisposingFile> CreateAsync(DisposingDirectory test, ShareFileClient file)
-            {
-                await file.CreateAsync(maxSize: Constants.MB);
-                return new DisposingFile(test, file);
-            }
-
-            private DisposingFile(DisposingDirectory test, ShareFileClient file)
-            {
-                _test = test;
-                File = file;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                await _test.DisposeAsync();
-            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -47,6 +47,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             _serviceVersion = serviceVersion;
             Clients = new ClientBuilder<ShareServiceClient, ShareClientOptions>(
+                ServiceEndpoint.File,
                 Tenants,
                 (uri, clientOptions) => new ShareServiceClient(uri, clientOptions),
                 (uri, sharedKeyCredential, clientOptions) => new ShareServiceClient(uri, sharedKeyCredential, clientOptions),
@@ -56,10 +57,10 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         public string GetNewShareName() => Clients.GetNewShareName();
-        public string GetNewDirectoryName() => Clients.GetNewShareName();
-        public string GetNewNonAsciiDirectoryName() => Clients.GetNewShareName();
-        public string GetNewFileName() => Clients.GetNewShareName();
-        public string GetNewNonAsciiFileName() => Clients.GetNewShareName();
+        public string GetNewDirectoryName() => Clients.GetNewDirectoryName();
+        public string GetNewNonAsciiDirectoryName() => Clients.GetNewNonAsciiDirectoryName();
+        public string GetNewFileName() => Clients.GetNewFileName();
+        public string GetNewNonAsciiFileName() => Clients.GetNewNonAsciiFileName();
 
         public async Task<DisposingShare> GetTestShareAsync(
             ShareServiceClient service = default,

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -13,7 +13,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;
-using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.Files.Shares.Tests
         /// <summary>
         /// Source of clients.
         /// </summary>
-        protected ClientBuilder<ShareServiceClient, ShareClientOptions> Clients { get; }
+        protected ClientBuilder<ShareServiceClient, ShareClientOptions> SharesClientBuilder { get; }
 
         protected readonly ShareClientOptions.ServiceVersion _serviceVersion;
 
@@ -46,7 +46,7 @@ namespace Azure.Storage.Files.Shares.Tests
             : base(async, mode)
         {
             _serviceVersion = serviceVersion;
-            Clients = new ClientBuilder<ShareServiceClient, ShareClientOptions>(
+            SharesClientBuilder = new ClientBuilder<ShareServiceClient, ShareClientOptions>(
                 ServiceEndpoint.File,
                 Tenants,
                 (uri, clientOptions) => new ShareServiceClient(uri, clientOptions),
@@ -56,17 +56,17 @@ namespace Azure.Storage.Files.Shares.Tests
                 () => new ShareClientOptions(_serviceVersion));
         }
 
-        public string GetNewShareName() => Clients.GetNewShareName();
-        public string GetNewDirectoryName() => Clients.GetNewDirectoryName();
-        public string GetNewNonAsciiDirectoryName() => Clients.GetNewNonAsciiDirectoryName();
-        public string GetNewFileName() => Clients.GetNewFileName();
-        public string GetNewNonAsciiFileName() => Clients.GetNewNonAsciiFileName();
+        public string GetNewShareName() => SharesClientBuilder.GetNewShareName();
+        public string GetNewDirectoryName() => SharesClientBuilder.GetNewDirectoryName();
+        public string GetNewNonAsciiDirectoryName() => SharesClientBuilder.GetNewNonAsciiDirectoryName();
+        public string GetNewFileName() => SharesClientBuilder.GetNewFileName();
+        public string GetNewNonAsciiFileName() => SharesClientBuilder.GetNewNonAsciiFileName();
 
         public async Task<DisposingShare> GetTestShareAsync(
             ShareServiceClient service = default,
             string shareName = default,
             IDictionary<string, string> metadata = default)
-            => await Clients.GetTestShareAsync(service, shareName, metadata);
+            => await SharesClientBuilder.GetTestShareAsync(service, shareName, metadata);
 
         public ShareClientOptions GetOptions()
         {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -48,7 +48,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             string sas = GetNewAccountSasCredentials(resourceTypes: AccountSasResourceTypes.All, permissions: AccountSasPermissions.All).ToString();
-            Uri uri = Clients.GetServiceClient_SharedKey().Uri;
+            Uri uri = SharesClientBuilder.GetServiceClient_SharedKey().Uri;
 
             // Act
             var sasClient = InstrumentClient(new ShareServiceClient(uri, new AzureSasCredential(sas), GetOptions()));
@@ -63,7 +63,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             string sas = GetNewAccountSasCredentials(resourceTypes: AccountSasResourceTypes.All, permissions: AccountSasPermissions.All).ToString();
-            Uri uri = Clients.GetServiceClient_SharedKey().Uri;
+            Uri uri = SharesClientBuilder.GetServiceClient_SharedKey().Uri;
             uri = new Uri(uri.ToString() + "?" + sas);
 
             // Act
@@ -76,7 +76,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
 
             // Act
             Response<ShareServiceProperties> properties = await service.GetPropertiesAsync();
@@ -111,7 +111,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetPropertiesAsync()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             Response<ShareServiceProperties> properties = await service.GetPropertiesAsync();
             _ = properties.Value.Cors.ToArray();
             properties.Value.Cors.Clear();
@@ -140,7 +140,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetSetServicePropertiesAsync_SmbMultiChannel()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_PremiumFile();
 
             // Act
             Response<ShareServiceProperties> propertiesResponse = await service.GetPropertiesAsync();
@@ -167,7 +167,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetPropertiesAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             Response<ShareServiceProperties> properties = await service.GetPropertiesAsync();
             ShareServiceClient fakeService = InstrumentClient(
                 new ShareServiceClient(
@@ -187,7 +187,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
 
             // Ensure at least one share
             await using DisposingShare test = await GetTestShareAsync(service);
@@ -212,7 +212,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync_Premium()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_PremiumFile();
             string shareName = GetNewShareName();
 
             // Ensure at least one premium share
@@ -242,7 +242,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync_Metadata()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             IDictionary<string, string> metadata = BuildMetadata();
 
             // Ensure at least one share
@@ -269,7 +269,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync_Deleted()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SoftDelete();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SoftDelete();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await share.CreateAsync();
             await share.DeleteAsync();
@@ -288,7 +288,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync_AccessTier()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
 
             // Ensure at least one share
             await using DisposingShare test = await GetTestShareAsync(service);
@@ -340,7 +340,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_PremiumFile();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions options = new ShareCreateOptions
             {
@@ -363,7 +363,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task CreateShareAsync()
         {
             var name = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             try
             {
                 ShareClient share = InstrumentClient((await service.CreateShareAsync(name)).Value);
@@ -380,7 +380,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteShareAsync()
         {
             var name = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient((await service.CreateShareAsync(name)).Value);
 
             await service.DeleteShareAsync(name, false);
@@ -393,7 +393,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UndeleteShareAsync()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SoftDelete();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SoftDelete();
             string shareName = GetNewShareName();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateAsync();
@@ -421,7 +421,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UndeleteShareAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SoftDelete();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SoftDelete();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string fakeVersion = "01D60F8BB59A4652";
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -11,7 +11,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -11,6 +11,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {
@@ -47,7 +48,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             string sas = GetNewAccountSasCredentials(resourceTypes: AccountSasResourceTypes.All, permissions: AccountSasPermissions.All).ToString();
-            Uri uri = GetServiceClient_SharedKey().Uri;
+            Uri uri = Clients.GetServiceClient_SharedKey().Uri;
 
             // Act
             var sasClient = InstrumentClient(new ShareServiceClient(uri, new AzureSasCredential(sas), GetOptions()));
@@ -62,7 +63,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             string sas = GetNewAccountSasCredentials(resourceTypes: AccountSasResourceTypes.All, permissions: AccountSasPermissions.All).ToString();
-            Uri uri = GetServiceClient_SharedKey().Uri;
+            Uri uri = Clients.GetServiceClient_SharedKey().Uri;
             uri = new Uri(uri.ToString() + "?" + sas);
 
             // Act
@@ -75,7 +76,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
 
             // Act
             Response<ShareServiceProperties> properties = await service.GetPropertiesAsync();
@@ -110,7 +111,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetPropertiesAsync()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             Response<ShareServiceProperties> properties = await service.GetPropertiesAsync();
             _ = properties.Value.Cors.ToArray();
             properties.Value.Cors.Clear();
@@ -139,7 +140,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetSetServicePropertiesAsync_SmbMultiChannel()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_PremiumFile();
+            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
 
             // Act
             Response<ShareServiceProperties> propertiesResponse = await service.GetPropertiesAsync();
@@ -166,7 +167,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetPropertiesAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             Response<ShareServiceProperties> properties = await service.GetPropertiesAsync();
             ShareServiceClient fakeService = InstrumentClient(
                 new ShareServiceClient(
@@ -186,7 +187,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
 
             // Ensure at least one share
             await using DisposingShare test = await GetTestShareAsync(service);
@@ -211,7 +212,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync_Premium()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_Premium();
+            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
             string shareName = GetNewShareName();
 
             // Ensure at least one premium share
@@ -241,7 +242,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync_Metadata()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             IDictionary<string, string> metadata = BuildMetadata();
 
             // Ensure at least one share
@@ -268,7 +269,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync_Deleted()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SoftDelete();
+            ShareServiceClient service = Clients.GetServiceClient_SoftDelete();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await share.CreateAsync();
             await share.DeleteAsync();
@@ -287,7 +288,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ListSharesSegmentAsync_AccessTier()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
 
             // Ensure at least one share
             await using DisposingShare test = await GetTestShareAsync(service);
@@ -339,7 +340,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_PremiumFile();
+            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions options = new ShareCreateOptions
             {
@@ -362,7 +363,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task CreateShareAsync()
         {
             var name = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             try
             {
                 ShareClient share = InstrumentClient((await service.CreateShareAsync(name)).Value);
@@ -379,7 +380,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteShareAsync()
         {
             var name = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient((await service.CreateShareAsync(name)).Value);
 
             await service.DeleteShareAsync(name, false);
@@ -392,7 +393,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UndeleteShareAsync()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SoftDelete();
+            ShareServiceClient service = Clients.GetServiceClient_SoftDelete();
             string shareName = GetNewShareName();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateAsync();
@@ -420,7 +421,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task UndeleteShareAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SoftDelete();
+            ShareServiceClient service = Clients.GetServiceClient_SoftDelete();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string fakeVersion = "01D60F8BB59A4652";
 
@@ -616,7 +617,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var mock = new Mock<ShareServiceClient>(TestConfigDefault.ConnectionString, new ShareClientOptions()).Object;
             mock = new Mock<ShareServiceClient>(TestConfigDefault.ConnectionString).Object;
             mock = new Mock<ShareServiceClient>(new Uri("https://test/test/test"), new ShareClientOptions()).Object;
-            mock = new Mock<ShareServiceClient>(new Uri("https://test/test/test"), GetNewSharedKeyCredentials(), new ShareClientOptions()).Object;
+            mock = new Mock<ShareServiceClient>(new Uri("https://test/test/test"), Tenants.GetNewSharedKeyCredentials(), new ShareClientOptions()).Object;
             mock = new Mock<ShareServiceClient>(new Uri("https://test/test/test"), new AzureSasCredential("foo"), new ShareClientOptions()).Object;
         }
     }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -158,7 +158,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void WithSnapshot()
         {
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             var builder = new ShareUriBuilder(share.Uri);
 
@@ -184,7 +184,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             try
@@ -206,7 +206,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             System.Collections.Generic.IDictionary<string, string> metadata = BuildMetadata();
 
@@ -227,7 +227,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions options = new ShareCreateOptions
             {
@@ -251,7 +251,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Share is intentionally created twice
@@ -353,7 +353,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_PremiumFile();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions options = new ShareCreateOptions
             {
@@ -397,7 +397,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -415,7 +415,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateIfNotExistsAsync();
 
@@ -434,7 +434,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareClient unauthorizesShareClient = InstrumentClient(new ShareClient(share.Uri, GetOptions()));
 
@@ -449,7 +449,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -464,7 +464,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateIfNotExistsAsync();
 
@@ -483,7 +483,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareClient unauthorizesShareClient = InstrumentClient(new ShareClient(share.Uri, GetOptions()));
 
@@ -498,7 +498,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateIfNotExistsAsync();
 
@@ -514,7 +514,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -529,7 +529,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareClient unauthorizesShareClient = InstrumentClient(new ShareClient(share.Uri, GetOptions()));
 
@@ -544,7 +544,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteIfExistsAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -568,7 +568,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteIfExistsAsync_LeaseFailed()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -643,7 +643,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_PremiumFile();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions options = new ShareCreateOptions
             {
@@ -665,7 +665,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Ignore("#10044: Re-enable failing Storage tests")]
         public async Task GetPropertiesAsync_Premium()
         {
-            await using DisposingShare test = await GetTestShareAsync(Clients.GetServiceClient_PremiumFile());
+            await using DisposingShare test = await GetTestShareAsync(SharesClientBuilder.GetServiceClient_PremiumFile());
             ShareClient share = test.Share;
 
             // Act
@@ -686,7 +686,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -700,7 +700,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -763,7 +763,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             System.Collections.Generic.IDictionary<string, string> metadata = BuildMetadata();
 
@@ -778,7 +778,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetMetadataAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -855,7 +855,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -869,7 +869,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetAccessPolicyAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -931,7 +931,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetAccessPolicyAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1109,7 +1109,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
 
@@ -1174,7 +1174,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
 
@@ -1189,7 +1189,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetStatisticsAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1248,7 +1248,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -1309,7 +1309,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_PremiumFile();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions createOptions = new ShareCreateOptions
             {
@@ -1335,7 +1335,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             ShareSetPropertiesOptions options = new ShareSetPropertiesOptions
@@ -1368,7 +1368,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -1382,7 +1382,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetQuotaAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1432,7 +1432,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateIfNotExistsAsync(quotaInGB: 1);
 
@@ -1448,7 +1448,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteAsync_IncludeLeasedSnapshots()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await share.CreateIfNotExistsAsync(quotaInGB: 1);
 
@@ -1488,7 +1488,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             await share.CreateAsync(quotaInGB: 1);
@@ -1530,7 +1530,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
 
@@ -1545,7 +1545,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1569,7 +1569,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteAsync_LeaseFailed()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1670,7 +1670,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task AcquireLeaseAsync()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1744,7 +1744,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task AcquireLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             ShareLeaseClient leaseClient = InstrumentClient(shareClient.GetShareLeaseClient(id));
@@ -1797,7 +1797,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ReleaseLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             ShareLeaseClient leaseClient = InstrumentClient(shareClient.GetShareLeaseClient(id));
@@ -1871,7 +1871,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ChangeLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             string newId = Recording.Random.NewGuid().ToString();
@@ -1948,7 +1948,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task BreakLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             string newId = Recording.Random.NewGuid().ToString();
@@ -2000,7 +2000,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task RenewLeaseAsync()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
 
@@ -2030,7 +2030,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task RenewLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
+            ShareServiceClient service = SharesClientBuilder.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             string newId = Recording.Random.NewGuid().ToString();

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -16,6 +16,7 @@ using NUnit.Framework;
 using System.Threading;
 using Azure.Identity;
 using Moq;
+using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {
@@ -157,7 +158,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public void WithSnapshot()
         {
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             var builder = new ShareUriBuilder(share.Uri);
 
@@ -183,7 +184,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             try
@@ -205,7 +206,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             System.Collections.Generic.IDictionary<string, string> metadata = BuildMetadata();
 
@@ -226,7 +227,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions options = new ShareCreateOptions
             {
@@ -250,7 +251,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Share is intentionally created twice
@@ -352,7 +353,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_PremiumFile();
+            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions options = new ShareCreateOptions
             {
@@ -396,7 +397,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -414,7 +415,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateIfNotExistsAsync();
 
@@ -433,7 +434,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareClient unauthorizesShareClient = InstrumentClient(new ShareClient(share.Uri, GetOptions()));
 
@@ -448,7 +449,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -463,7 +464,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateIfNotExistsAsync();
 
@@ -482,7 +483,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareClient unauthorizesShareClient = InstrumentClient(new ShareClient(share.Uri, GetOptions()));
 
@@ -497,7 +498,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateIfNotExistsAsync();
 
@@ -513,7 +514,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -528,7 +529,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareClient unauthorizesShareClient = InstrumentClient(new ShareClient(share.Uri, GetOptions()));
 
@@ -543,7 +544,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteIfExistsAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -567,7 +568,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteIfExistsAsync_LeaseFailed()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -642,7 +643,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_PremiumFile();
+            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions options = new ShareCreateOptions
             {
@@ -664,7 +665,7 @@ namespace Azure.Storage.Files.Shares.Tests
         [Ignore("#10044: Re-enable failing Storage tests")]
         public async Task GetPropertiesAsync_Premium()
         {
-            await using DisposingShare test = await GetTestShareAsync(GetServiceClient_Premium());
+            await using DisposingShare test = await GetTestShareAsync(Clients.GetServiceClient_PremiumFile());
             ShareClient share = test.Share;
 
             // Act
@@ -685,7 +686,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -699,7 +700,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetPropertiesAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -762,7 +763,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             System.Collections.Generic.IDictionary<string, string> metadata = BuildMetadata();
 
@@ -777,7 +778,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetMetadataAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -854,7 +855,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -868,7 +869,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetAccessPolicyAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -930,7 +931,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetAccessPolicyAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1108,7 +1109,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
 
@@ -1173,7 +1174,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
 
@@ -1188,7 +1189,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task GetStatisticsAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1247,7 +1248,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -1308,7 +1309,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_PremiumFile();
+            ShareServiceClient service = Clients.GetServiceClient_PremiumFile();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareCreateOptions createOptions = new ShareCreateOptions
             {
@@ -1334,7 +1335,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             ShareSetPropertiesOptions options = new ShareSetPropertiesOptions
@@ -1367,7 +1368,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Act
@@ -1381,7 +1382,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task SetQuotaAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1431,7 +1432,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             await share.CreateIfNotExistsAsync(quotaInGB: 1);
 
@@ -1447,7 +1448,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteAsync_IncludeLeasedSnapshots()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await share.CreateIfNotExistsAsync(quotaInGB: 1);
 
@@ -1487,7 +1488,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             await share.CreateAsync(quotaInGB: 1);
@@ -1529,7 +1530,7 @@ namespace Azure.Storage.Files.Shares.Tests
         {
             // Arrange
             var shareName = GetNewShareName();
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
             ShareSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
 
@@ -1544,7 +1545,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteAsync_Lease()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1568,7 +1569,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task DeleteAsync_LeaseFailed()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1669,7 +1670,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task AcquireLeaseAsync()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
             string id = Recording.Random.NewGuid().ToString();
@@ -1743,7 +1744,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task AcquireLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             ShareLeaseClient leaseClient = InstrumentClient(shareClient.GetShareLeaseClient(id));
@@ -1796,7 +1797,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ReleaseLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             ShareLeaseClient leaseClient = InstrumentClient(shareClient.GetShareLeaseClient(id));
@@ -1870,7 +1871,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task ChangeLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             string newId = Recording.Random.NewGuid().ToString();
@@ -1947,7 +1948,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task BreakLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             string newId = Recording.Random.NewGuid().ToString();
@@ -1999,7 +2000,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task RenewLeaseAsync()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             await shareClient.CreateAsync();
 
@@ -2029,7 +2030,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public async Task RenewLeaseAsync_Error()
         {
             // Arrange
-            ShareServiceClient service = GetServiceClient_SharedKey();
+            ShareServiceClient service = Clients.GetServiceClient_SharedKey();
             ShareClient shareClient = InstrumentClient(service.GetShareClient(GetNewShareName()));
             string id = Recording.Random.NewGuid().ToString();
             string newId = Recording.Random.NewGuid().ToString();
@@ -2411,7 +2412,7 @@ namespace Azure.Storage.Files.Shares.Tests
             var mock = new Mock<ShareClient>(TestConfigDefault.ConnectionString, "name", new ShareClientOptions()).Object;
             mock = new Mock<ShareClient>(TestConfigDefault.ConnectionString, "name").Object;
             mock = new Mock<ShareClient>(new Uri("https://test/test/test"), new ShareClientOptions()).Object;
-            mock = new Mock<ShareClient>(new Uri("https://test/test/test"), GetNewSharedKeyCredentials(), new ShareClientOptions()).Object;
+            mock = new Mock<ShareClient>(new Uri("https://test/test/test"), Tenants.GetNewSharedKeyCredentials(), new ShareClientOptions()).Object;
             mock = new Mock<ShareClient>(new Uri("https://test/test/test"), new AzureSasCredential("foo"), new ShareClientOptions()).Object;
         }
     }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -16,7 +16,6 @@ using NUnit.Framework;
 using System.Threading;
 using Azure.Identity;
 using Moq;
-using static Azure.Storage.Files.Shares.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Files.Shares.Tests
 {

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientBuilderExtensions.cs
@@ -34,37 +34,5 @@ namespace Azure.Storage.Queues.Tests
 
         public static QueueServiceClient GetServiceClient_OAuth(this QueuesClientBuilder clientBuilder)
             => clientBuilder.GetServiceClientFromOauthConfig(clientBuilder.Tenants.TestConfigOAuth);
-
-        public class DisposingQueue : IAsyncDisposable
-        {
-            public QueueClient Queue { get; private set; }
-
-            public static async Task<DisposingQueue> CreateAsync(QueueClient queue, IDictionary<string, string> metadata)
-            {
-                await queue.CreateIfNotExistsAsync(metadata: metadata);
-                return new DisposingQueue(queue);
-            }
-
-            private DisposingQueue(QueueClient queue)
-            {
-                Queue = queue;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                if (Queue != null)
-                {
-                    try
-                    {
-                        await Queue.DeleteIfExistsAsync();
-                        Queue = null;
-                    }
-                    catch
-                    {
-                        // swallow the exception to avoid hiding another test failure
-                    }
-                }
-            }
-        }
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientBuilderExtensions.cs
@@ -29,6 +29,12 @@ namespace Azure.Storage.Queues.Tests
             return await DisposingQueue.CreateAsync(queue, metadata);
         }
 
+        public static QueueServiceClient GetServiceClient_SharedKey(this QueuesClientBuilder clientBuilder, QueueClientOptions options = default)
+            => clientBuilder.GetServiceClientFromSharedKeyConfig(clientBuilder.Tenants.TestConfigDefault, options);
+
+        public static QueueServiceClient GetServiceClient_OAuth(this QueuesClientBuilder clientBuilder)
+            => clientBuilder.GetServiceClientFromOauthConfig(clientBuilder.Tenants.TestConfigOAuth);
+
         public class DisposingQueue : IAsyncDisposable
         {
             public QueueClient Queue { get; private set; }

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientBuilderExtensions.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using QueuesClientBuilder = Azure.Storage.Test.Shared.ClientBuilder<
+    Azure.Storage.Queues.QueueServiceClient,
+    Azure.Storage.Queues.QueueClientOptions>;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public static class ClientBuilderExtensions
+    {
+        public static string GetNewQueueName(this QueuesClientBuilder clientBuilder)
+            => $"test-queue-{clientBuilder.Recording.Random.NewGuid()}";
+        public static string GetNewMessageId(this QueuesClientBuilder clientBuilder)
+            => $"test-message-{clientBuilder.Recording.Random.NewGuid()}";
+
+        public static async Task<DisposingQueue> GetTestQueueAsync(
+            this QueuesClientBuilder clientBuilder,
+            QueueServiceClient service = default,
+            IDictionary<string, string> metadata = default)
+        {
+            service ??= clientBuilder.GetServiceClient_SharedKey();
+            metadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            QueueClient queue = clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(service.GetQueueClient(clientBuilder.GetNewQueueName()));
+            return await DisposingQueue.CreateAsync(queue, metadata);
+        }
+
+        public class DisposingQueue : IAsyncDisposable
+        {
+            public QueueClient Queue { get; private set; }
+
+            public static async Task<DisposingQueue> CreateAsync(QueueClient queue, IDictionary<string, string> metadata)
+            {
+                await queue.CreateIfNotExistsAsync(metadata: metadata);
+                return new DisposingQueue(queue);
+            }
+
+            private DisposingQueue(QueueClient queue)
+            {
+                Queue = queue;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                if (Queue != null)
+                {
+                    try
+                    {
+                        await Queue.DeleteIfExistsAsync();
+                        Queue = null;
+                    }
+                    catch
+                    {
+                        // swallow the exception to avoid hiding another test failure
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
@@ -21,7 +21,6 @@ using Azure.Storage.Queues.Tests;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 using static Moq.It;
 
 namespace Azure.Storage.Queues.Test

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
@@ -21,6 +21,7 @@ using Azure.Storage.Queues.Tests;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 using static Moq.It;
 
 namespace Azure.Storage.Queues.Test

--- a/sdk/storage/Azure.Storage.Queues/tests/DisposingQueue.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/DisposingQueue.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Azure.Storage.Queues.Tests
+{
+    public class DisposingQueue : IAsyncDisposable
+    {
+        public QueueClient Queue { get; private set; }
+
+        public static async Task<DisposingQueue> CreateAsync(QueueClient queue, IDictionary<string, string> metadata)
+        {
+            await queue.CreateIfNotExistsAsync(metadata: metadata);
+            return new DisposingQueue(queue);
+        }
+
+        private DisposingQueue(QueueClient queue)
+        {
+            Queue = queue;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Queue != null)
+            {
+                try
+                {
+                    await Queue.DeleteIfExistsAsync();
+                    Queue = null;
+                }
+                catch
+                {
+                    // swallow the exception to avoid hiding another test failure
+                }
+            }
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -16,6 +16,7 @@ using Moq;
 using Azure.Storage.Queues.Specialized;
 using Moq.Protected;
 using Azure.Core.TestFramework;
+using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Queues.Test
 {
@@ -124,8 +125,8 @@ namespace Azure.Storage.Queues.Test
         public void Ctor_TokenCredential_Http()
         {
             // Arrange
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
-            Uri uri = new Uri(TestConfigPremiumBlob.BlobServiceEndpoint).ToHttp();
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace);
+            Uri uri = new Uri(Tenants.TestConfigPremiumBlob.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(
@@ -212,7 +213,7 @@ namespace Azure.Storage.Queues.Test
         {
             // Arrange
             var queueName = GetNewQueueName();
-            QueueServiceClient service = GetServiceClient_OauthAccount();
+            QueueServiceClient service = Clients.GetServiceClient_OAuth();
             QueueClient queue = InstrumentClient(service.GetQueueClient(queueName));
 
             try
@@ -1848,7 +1849,7 @@ namespace Azure.Storage.Queues.Test
             mock = new Mock<QueueClient>(new Uri("https://test/test"), new QueueClientOptions()).Object;
             mock = new Mock<QueueClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new QueueClientOptions()).Object;
             mock = new Mock<QueueClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new QueueClientOptions()).Object;
-            mock = new Mock<QueueClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new QueueClientOptions()).Object;
+            mock = new Mock<QueueClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new QueueClientOptions()).Object;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -213,7 +213,7 @@ namespace Azure.Storage.Queues.Test
         {
             // Arrange
             var queueName = GetNewQueueName();
-            QueueServiceClient service = Clients.GetServiceClient_OAuth();
+            QueueServiceClient service = QueuesClientBuilder.GetServiceClient_OAuth();
             QueueClient queue = InstrumentClient(service.GetQueueClient(queueName));
 
             try

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -16,7 +16,6 @@ using Moq;
 using Azure.Storage.Queues.Specialized;
 using Moq.Protected;
 using Azure.Core.TestFramework;
-using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Queues.Test
 {

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
@@ -8,6 +8,7 @@ using Azure.Storage.Queues.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
+using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
 namespace Azure.Storage.Queues.Test

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueSasBuilderTests.cs
@@ -8,7 +8,6 @@ using Azure.Storage.Queues.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
-using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
 namespace Azure.Storage.Queues.Test

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -38,6 +38,7 @@ namespace Azure.Storage.Queues.Tests
             : base(async, mode)
         {
             Clients = new ClientBuilder<QueueServiceClient, QueueClientOptions>(
+                ServiceEndpoint.Queue,
                 Tenants,
                 (uri, clientOptions) => new QueueServiceClient(uri, clientOptions),
                 (uri, sharedKeyCredential, clientOptions) => new QueueServiceClient(uri, sharedKeyCredential, clientOptions),

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -12,7 +12,6 @@ using Azure.Storage.Queues.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
-using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Queues.Tests
 {

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -21,10 +21,10 @@ namespace Azure.Storage.Queues.Tests
         /// <summary>
         /// Source of clients.
         /// </summary>
-        protected ClientBuilder<QueueServiceClient, QueueClientOptions> Clients { get; }
+        protected ClientBuilder<QueueServiceClient, QueueClientOptions> QueuesClientBuilder { get; }
 
-        public string GetNewQueueName() => Clients.GetNewQueueName();
-        public string GetNewMessageId() => Clients.GetNewMessageId();
+        public string GetNewQueueName() => QueuesClientBuilder.GetNewQueueName();
+        public string GetNewMessageId() => QueuesClientBuilder.GetNewMessageId();
 
         protected string SecondaryStorageTenantPrimaryHost() =>
             new Uri(Tenants.TestConfigSecondary.QueueServiceEndpoint).Host;
@@ -37,7 +37,7 @@ namespace Azure.Storage.Queues.Tests
         public QueueTestBase(bool async, RecordedTestMode? mode = null)
             : base(async, mode)
         {
-            Clients = new ClientBuilder<QueueServiceClient, QueueClientOptions>(
+            QueuesClientBuilder = new ClientBuilder<QueueServiceClient, QueueClientOptions>(
                 ServiceEndpoint.Queue,
                 Tenants,
                 (uri, clientOptions) => new QueueServiceClient(uri, clientOptions),
@@ -48,7 +48,7 @@ namespace Azure.Storage.Queues.Tests
         }
 
         public QueueClientOptions GetOptions()
-            => Clients.GetOptions();
+            => QueuesClientBuilder.GetOptions();
 
         public QueueServiceClient GetServiceClient_SharedKey(QueueClientOptions options = default)
             => InstrumentClient(GetServiceClient_SharedKey_UnInstrumented(options));
@@ -131,7 +131,7 @@ namespace Azure.Storage.Queues.Tests
         public async Task<DisposingQueue> GetTestQueueAsync(
             QueueServiceClient service = default,
             IDictionary<string, string> metadata = default)
-            => await Clients.GetTestQueueAsync(service, metadata);
+            => await QueuesClientBuilder.GetTestQueueAsync(service, metadata);
 
         public QueueClient GetEncodingClient(
             string queueName,

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -12,47 +12,42 @@ using Azure.Storage.Queues.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
+using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Queues.Tests
 {
     public class QueueTestBase : StorageTestBase<StorageTestEnvironment>
     {
-        public string GetNewQueueName() => $"test-queue-{Recording.Random.NewGuid()}";
-        public string GetNewMessageId() => $"test-message-{Recording.Random.NewGuid()}";
+        /// <summary>
+        /// Source of clients.
+        /// </summary>
+        protected ClientBuilder<QueueServiceClient, QueueClientOptions> Clients { get; }
+
+        public string GetNewQueueName() => Clients.GetNewQueueName();
+        public string GetNewMessageId() => Clients.GetNewMessageId();
 
         protected string SecondaryStorageTenantPrimaryHost() =>
-            new Uri(TestConfigSecondary.QueueServiceEndpoint).Host;
+            new Uri(Tenants.TestConfigSecondary.QueueServiceEndpoint).Host;
 
         protected string SecondaryStorageTenantSecondaryHost() =>
-            new Uri(TestConfigSecondary.QueueServiceSecondaryEndpoint).Host;
+            new Uri(Tenants.TestConfigSecondary.QueueServiceSecondaryEndpoint).Host;
 
         public QueueTestBase(bool async) : this(async, null) { }
 
         public QueueTestBase(bool async, RecordedTestMode? mode = null)
             : base(async, mode)
         {
+            Clients = new ClientBuilder<QueueServiceClient, QueueClientOptions>(
+                Tenants,
+                (uri, clientOptions) => new QueueServiceClient(uri, clientOptions),
+                (uri, sharedKeyCredential, clientOptions) => new QueueServiceClient(uri, sharedKeyCredential, clientOptions),
+                (uri, tokenCredential, clientOptions) => new QueueServiceClient(uri, tokenCredential, clientOptions),
+                (uri, azureSasCredential, clientOptions) => new QueueServiceClient(uri, azureSasCredential, clientOptions),
+                () => new QueueClientOptions());
         }
 
         public QueueClientOptions GetOptions()
-        {
-            var options = new QueueClientOptions
-            {
-                Diagnostics = { IsLoggingEnabled = true },
-                Retry =
-                {
-                    Mode = RetryMode.Exponential,
-                    MaxRetries = Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60)
-                },
-        };
-            if (Mode != RecordedTestMode.Live)
-            {
-                options.AddPolicy(new RecordedClientRequestIdPolicy(Recording), HttpPipelinePosition.PerCall);
-            }
-
-            return InstrumentClientOptions(options);
-        }
+            => Clients.GetOptions();
 
         public QueueServiceClient GetServiceClient_SharedKey(QueueClientOptions options = default)
             => InstrumentClient(GetServiceClient_SharedKey_UnInstrumented(options));
@@ -94,14 +89,11 @@ namespace Azure.Storage.Queues.Tests
                 config.ActiveDirectoryApplicationId,
                 config.ActiveDirectoryApplicationSecret);
 
-        public QueueServiceClient GetServiceClient_OauthAccount() =>
-            GetServiceClientFromOauthConfig(TestConfigOAuth);
-
         public QueueServiceClient GetServiceClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false)
-=> GetSecondaryReadServiceClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
+            => GetSecondaryReadServiceClient(Tenants.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
 
         public QueueClient GetQueueClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false)
-=> GetSecondaryReadQueueClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
+            => GetSecondaryReadQueueClient(Tenants.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
 
         private QueueServiceClient GetSecondaryReadServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
         {
@@ -135,22 +127,10 @@ namespace Azure.Storage.Queues.Tests
             return options;
         }
 
-        private QueueServiceClient GetServiceClientFromOauthConfig(TenantConfiguration config) =>
-            InstrumentClient(
-                new QueueServiceClient(
-                    new Uri(config.QueueServiceEndpoint),
-                    GetOAuthCredential(config),
-                    GetOptions()));
-
         public async Task<DisposingQueue> GetTestQueueAsync(
             QueueServiceClient service = default,
             IDictionary<string, string> metadata = default)
-        {
-            service ??= GetServiceClient_SharedKey();
-            metadata ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            QueueClient queue = InstrumentClient(service.GetQueueClient(GetNewQueueName()));
-            return await DisposingQueue.CreateAsync(queue, metadata);
-        }
+            => await Clients.GetTestQueueAsync(service, metadata);
 
         public QueueClient GetEncodingClient(
             string queueName,
@@ -231,38 +211,6 @@ namespace Azure.Storage.Queues.Tests
             return new StorageConnectionString(
                     credentials,
                     queueStorageUri: queueUri);
-        }
-
-        public class DisposingQueue : IAsyncDisposable
-        {
-            public QueueClient Queue { get; private set; }
-
-            public static async Task<DisposingQueue> CreateAsync(QueueClient queue, IDictionary<string, string> metadata)
-            {
-                await queue.CreateIfNotExistsAsync(metadata: metadata);
-                return new DisposingQueue(queue);
-            }
-
-            private DisposingQueue(QueueClient queue)
-            {
-                Queue = queue;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                if (Queue != null)
-                {
-                    try
-                    {
-                        await Queue.DeleteIfExistsAsync();
-                        Queue = null;
-                    }
-                    catch
-                    {
-                        // swallow the exception to avoid hiding another test failure
-                    }
-                }
-            }
         }
 
         public QueueSignedIdentifier[] BuildSignedIdentifiers() =>

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -13,7 +13,6 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
-using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Queues.Test
 {

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -13,6 +13,7 @@ using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
+using static Azure.Storage.Queues.Tests.ClientBuilderExtensions;
 
 namespace Azure.Storage.Queues.Test
 {
@@ -51,8 +52,8 @@ namespace Azure.Storage.Queues.Test
         public void Ctor_TokenCredential_Http()
         {
             // Arrange
-            TokenCredential tokenCredential = GetOAuthCredential(TestConfigHierarchicalNamespace);
-            Uri uri = new Uri(TestConfigPremiumBlob.BlobServiceEndpoint).ToHttp();
+            TokenCredential tokenCredential = Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace);
+            Uri uri = new Uri(Tenants.TestConfigPremiumBlob.BlobServiceEndpoint).ToHttp();
 
             // Act
             TestHelper.AssertExpectedException(

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -545,7 +545,7 @@ namespace Azure.Storage.Queues.Test
             mock = new Mock<QueueServiceClient>(new Uri("https://test/test"), new QueueClientOptions()).Object;
             mock = new Mock<QueueServiceClient>(new Uri("https://test/test"), GetNewSharedKeyCredentials(), new QueueClientOptions()).Object;
             mock = new Mock<QueueServiceClient>(new Uri("https://test/test"), new AzureSasCredential("foo"), new QueueClientOptions()).Object;
-            mock = new Mock<QueueServiceClient>(new Uri("https://test/test"), GetOAuthCredential(TestConfigHierarchicalNamespace), new QueueClientOptions()).Object;
+            mock = new Mock<QueueServiceClient>(new Uri("https://test/test"), Tenants.GetOAuthCredential(Tenants.TestConfigHierarchicalNamespace), new QueueClientOptions()).Object;
         }
     }
 }


### PR DESCRIPTION
Pulls some basics of client tests out of `XxxTestBase` hierarchy and into separate utility classes so they can be accessed outside of said hierarchy. Useful for writing unified tests across multiple Storage services without excessive code duplication.

Key Changes:
- `TenantConfigurationBuilder` houses code previously in `StorageTestBase` that grabs `TenantConfiguration`s out of a config file.
- `ClientBuilder` houses genericized code previously in `BlobTestBase`/`DataLakeTestBase`/etc. that creates `XxxServiceClient`s out of results from `TenantConfigurationBuilder`.
- Each service test suite has a `ClientBuilderExtensions` class that decorates the `ClientBuilder` with functionality that doesn't fit easy into generics.

Notes to reviewers:
- This is not intended to be a comprehensive change covering all facets of test infra. It is a starting point that will lead towards better maintenance and immediately open some doors for current testing needs.
- Currently, these separated classes are still dependent on some functionality provided by Azure Core's `RecordedTestBase`, and so we still have to pass in an instance of that. We need access to the `Recording` management and `InstrumentClient`. Not ideal but still a significant improvement.