### PR TITLE
[Event Hubs] Doc and Visibility Updates

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -254,7 +254,6 @@ namespace Azure.Messaging.EventHubs.Consumer
         public override int GetHashCode() { throw null; }
         public static bool operator ==(Azure.Messaging.EventHubs.Consumer.EventPosition left, Azure.Messaging.EventHubs.Consumer.EventPosition right) { throw null; }
         public static bool operator !=(Azure.Messaging.EventHubs.Consumer.EventPosition left, Azure.Messaging.EventHubs.Consumer.EventPosition right) { throw null; }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/ApiCompatBaseline.txt
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/ApiCompatBaseline.txt
@@ -1,0 +1,2 @@
+# Baselining these until the next GA. This is not a compatibility issue; the impacted member was inappropriately tagged as non-visible and provides value for customers being discoverable.
+CannotRemoveAttribute : Attribute 'System.ComponentModel.EditorBrowsableAttribute' exists on 'Azure.Messaging.EventHubs.Consumer.EventPosition.ToString()' in the contract but not the implementation.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
@@ -178,17 +178,16 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   Converts the instance to string representation.
         /// </summary>
         ///
-        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        /// <returns>A <see cref="System.String" /> that represents the position in the event stream.</returns>
         ///
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() =>
             this switch
             {
-                EventPosition _ when (Offset == StartOfStreamOffset) => nameof(Earliest),
-                EventPosition _ when (Offset == EndOfStreamOffset) => nameof(Latest),
-                EventPosition _ when (!string.IsNullOrEmpty(Offset)) => $"Offset: [{ Offset }] | Inclusive: [{ IsInclusive }]",
-                EventPosition _ when (SequenceNumber.HasValue) => $"Sequence Number: [{ SequenceNumber }] | Inclusive: [{ IsInclusive }]",
-                EventPosition _ when (EnqueuedTime.HasValue) => $"Enqueued: [{ EnqueuedTime }]",
+                _ when (Offset == StartOfStreamOffset) => nameof(Earliest),
+                _ when (Offset == EndOfStreamOffset) => nameof(Latest),
+                _ when (!string.IsNullOrEmpty(Offset)) => $"Offset: [{ Offset }] | Inclusive: [{ IsInclusive }]",
+                _ when (SequenceNumber.HasValue) => $"Sequence Number: [{ SequenceNumber }] | Inclusive: [{ IsInclusive }]",
+                _ when (EnqueuedTime.HasValue) => $"Enqueued: [{ EnqueuedTime }]",
                 _ => base.ToString()
             };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -1020,7 +1020,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   to be read.  When no events are available in prefetch the processor will wait until at least one event is available or the requested <see cref="EventProcessorOptions.MaximumWaitTime"/>
         ///   has elapsed.
         ///
-        ///   If no <see cref="EventProcessorOptions.MaximumWaitTime"/> was specified, indicated by setting the option to <c>null</c>, the event processor will continue reading from the Event Hub
+        ///   If <see cref="EventProcessorOptions.MaximumWaitTime"/> is <c>null</c>, the event processor will continue reading from the Event Hub
         ///   partition until a batch with at least one event could be formed and will not dispatch any empty batches to this method.
         ///
         ///   Should an exception occur within the code for this method, the event processor will allow it to bubble and will not surface to the error handler or attempt to handle

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -1016,13 +1016,12 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   requested when the processor was created, depending on the availability of events in the partition within the requested <see cref="EventProcessorOptions.MaximumWaitTime"/>
         ///   interval.
         ///
-        ///   If there are enough events available in the Event Hub partition to fill a batch of the requested size, the processor will populate the batch and dispatch it to this method
-        ///   immediately.  If there were not a sufficient number of events available in the partition to populate a full batch, the event processor will continue reading from the partition
-        ///   to reach the requested batch size until the <see cref="EventProcessorOptions.MaximumWaitTime"/> has elapsed, at which point it will return a batch containing whatever events were
-        ///   available by the end of that period.
+        ///   When events are available in the prefetch queue, they will be used to form the batch as quickly as possible without waiting for additional events from the Event Hub partition
+        ///   to be read.  When no events are available in prefetch the processor will wait until at least one event is available or the requested <see cref="EventProcessorOptions.MaximumWaitTime"/>
+        ///   has elapsed.
         ///
-        ///   If a <see cref="EventProcessorOptions.MaximumWaitTime"/> was not requested, indicated by setting the option to <c>null</c>, the event processor will continue reading from the Event Hub
-        ///   partition until a full batch of the requested size could be populated and will not dispatch any partial batches to this method.
+        ///   If no <see cref="EventProcessorOptions.MaximumWaitTime"/> was specified, indicated by setting the option to <c>null</c>, the event processor will continue reading from the Event Hub
+        ///   partition until a batch with at least one event could be formed and will not dispatch any empty batches to this method.
         ///
         ///   Should an exception occur within the code for this method, the event processor will allow it to bubble and will not surface to the error handler or attempt to handle
         ///   it in any way.  Developers are strongly encouraged to take exception scenarios into account and guard against them using try/catch blocks and other means as appropriate.


### PR DESCRIPTION
# Summary

The focus of these changes is to correct an error in the documentation for the `EventProcessor<T>` and allow the `ToString` method for the `EventPosition` type to appear in Intellisense.  In the latter case, `ToString` is overridden to provide insight into what position in the event stream is represented and has value to customers.

## Note

The `APIChange` tag was used due to APICompat flagging the removal of the `EditorBrowsable` attribute; no other API changes were made.