### PR TITLE
Update DefaultAzureCredential to not use statically cached credential chain

### DIFF
--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -54,7 +54,7 @@ namespace Azure.Identity
         private readonly CredentialPipeline _pipeline;
         private readonly AsyncLockWithValue<TokenCredential> _credentialLock;
 
-        private TokenCredential[] _sources;
+        internal TokenCredential[] Sources { get; private set; }
 
         internal DefaultAzureCredential() : this(false) { }
 
@@ -81,7 +81,7 @@ namespace Azure.Identity
         internal DefaultAzureCredential(DefaultAzureCredentialFactory factory, DefaultAzureCredentialOptions options)
         {
             _pipeline = factory.Pipeline;
-            _sources = GetDefaultAzureCredentialChain(factory, options);
+            Sources = GetDefaultAzureCredentialChain(factory, options);
             _credentialLock = new AsyncLockWithValue<TokenCredential>();
         }
 
@@ -131,8 +131,8 @@ namespace Azure.Identity
                 else
                 {
                     TokenCredential credential;
-                    (token, credential) = await GetTokenFromSourcesAsync(_sources, requestContext, async, cancellationToken).ConfigureAwait(false);
-                    _sources = default;
+                    (token, credential) = await GetTokenFromSourcesAsync(Sources, requestContext, async, cancellationToken).ConfigureAwait(false);
+                    Sources = default;
                     asyncLock.SetValue(credential);
                     AzureIdentityEventSource.Singleton.DefaultAzureCredentialCredentialSelected(credential.GetType().FullName);
                 }

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -186,7 +186,14 @@ namespace Azure.Identity
         {
             if (options is null)
             {
-                return s_defaultCredentialChain;
+                // only use the statically cache credential chain if the compat switch
+                // EnableLegacyDefaultCredentialCaching has been set
+                if (IdentityCompatSwitches.EnableLegacyDefaultCredentialCaching)
+                {
+                    return s_defaultCredentialChain;
+                }
+
+                options = new DefaultAzureCredentialOptions();
             }
 
             int i = 0;

--- a/sdk/identity/Azure.Identity/src/IdentityCompatSwitches.cs
+++ b/sdk/identity/Azure.Identity/src/IdentityCompatSwitches.cs
@@ -13,6 +13,8 @@ namespace Azure.Identity
         internal const string DisableCP1ExecutionEnvVar = "AZURE_IDENTITY_DISABLE_CP1";
         internal const string DisableMultiTenantAuthSwitchName = "Azure.Identity.DisableMultiTenantAuth";
         internal const string DisableMultiTenantAuthEnvVar = "AZURE_IDENTITY_DISABLE_MULTITENANTAUTH";
+        internal const string EnableLegacyDefaultCredentialCachingSwitchName = "Azure.Identity.EnableLegacyDefaultCredentialCaching";
+        internal const string EnableLegacyDefaultCredentialCachingEnvVar = "AZURE_IDENTITY_ENABLE_LEGACYDEFAULTCREDENTIALCACHING";
 
         public static bool DisableInteractiveBrowserThreadpoolExecution
             => AppContextSwitchHelper.GetConfigValue(DisableInteractiveThreadpoolExecutionSwitchName, DisableInteractiveThreadpoolExecutionEnvVar);
@@ -22,5 +24,8 @@ namespace Azure.Identity
 
         public static bool DisableTenantDiscovery
             => AppContextSwitchHelper.GetConfigValue(DisableMultiTenantAuthSwitchName, DisableMultiTenantAuthEnvVar);
+
+        public static bool EnableLegacyDefaultCredentialCaching
+            => AppContextSwitchHelper.GetConfigValue(EnableLegacyDefaultCredentialCachingSwitchName, EnableLegacyDefaultCredentialCachingEnvVar);
     }
 }

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Identity.Tests
         {
             var cred = new DefaultAzureCredential();
 
-            TokenCredential[] sources = cred._sources();
+            TokenCredential[] sources = cred.Sources;
 
             Assert.NotNull(sources);
             Assert.AreEqual(sources.Length, 8);
@@ -45,7 +45,7 @@ namespace Azure.Identity.Tests
         {
             var cred = new DefaultAzureCredential(includeInteractive);
 
-            TokenCredential[] sources = cred._sources();
+            TokenCredential[] sources = cred.Sources;
 
             Assert.NotNull(sources);
             Assert.AreEqual(sources.Length, 8);

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
@@ -587,5 +587,46 @@ namespace Azure.Identity.Tests
 
             return credFactory;
         }
+
+        [Test]
+        [NonParallelizable]
+        public void VerifyLegacyDefaultCredentialCompatSwitchHonored(
+            [Values(true, false, null)] bool? setLegacySwitch,
+            [Values(true, false, null)] bool? setLegacyEnvVar)
+        {
+            TestAppContextSwitch ctx = null;
+            TestEnvVar env = null;
+            try
+            {
+                if (setLegacySwitch != null)
+                {
+                    ctx = new TestAppContextSwitch(IdentityCompatSwitches.EnableLegacyDefaultCredentialCachingSwitchName, setLegacySwitch.Value.ToString());
+                }
+                if (setLegacyEnvVar != null)
+                {
+                    env = new TestEnvVar(IdentityCompatSwitches.EnableLegacyDefaultCredentialCachingEnvVar, setLegacyEnvVar.Value.ToString());
+                }
+
+                var dac1 = new DefaultAzureCredential();
+
+                var dac2 = new DefaultAzureCredential();
+
+                bool chainReused = dac1.Sources == dac2.Sources;
+
+                if (setLegacySwitch.HasValue)
+                {
+                    Assert.AreEqual(setLegacySwitch.Value, chainReused);
+                }
+                else
+                {
+                    Assert.AreEqual(setLegacyEnvVar.HasValue && setLegacyEnvVar.Value, chainReused);
+                }
+            }
+            finally
+            {
+                ctx?.Dispose();
+                env?.Dispose();
+            }
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/TestAccessorExtensions.cs
+++ b/sdk/identity/Azure.Identity/tests/TestAccessorExtensions.cs
@@ -31,10 +31,5 @@ namespace Azure.Identity.Tests
         {
             typeof(InteractiveBrowserCredential).GetField("_client", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(credential, client);
         }
-
-        public static TokenCredential[] _sources(this DefaultAzureCredential credential)
-        {
-            return typeof(DefaultAzureCredential).GetField("_sources", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(credential) as TokenCredential[];
-        }
     }
 }


### PR DESCRIPTION
`DefaultAzureCredential` was using a statically cached credential chain, but *only* in the case that the `DefaultAzureCredential` was constructed *without* any options.  This lead to very confusing behavior in many cases where new instances of `DefaultAzureCredential` did not respond to changes in the environment, but only in specific cases. This PR removes the use of this statically cached chain by default, to make the behavior more consistent with expectations. 

Also the PR adds a compatibility switch, `Azure.Identity.EnableLegacyDefaultCredentialCaching` or `AZURE_IDENTITY_ENABLE_LEGACYDEFAULTCREDENTIALCACHING`, to opt in to the legacy behavior if any applications are intentionally or unintentionally dependent upon the statically cached chain.