### PR TITLE
[TA] Stabilized flaky test "RecognizeHealthcareEntitiesBatchWithCancellation"

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeHealthcareEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeHealthcareEntitiesTests.cs
@@ -385,9 +385,9 @@ namespace Azure.AI.TextAnalytics.Tests
                 }
 
                 // If we get here, that means that the operation completed successfully and didn't cancel.
-                throw new InvalidOperationException("StartAnalyzeHealthcareEntitiesAsync did not cancel operation");
+                throw new InvalidOperationException("StartAnalyzeHealthcareEntitiesAsync operation did not get cancelled.");
             },
-            maxIterations: 15, delay: TimeSpan.FromSeconds(0));
+            maxIterations: 15, delay: TimeSpan.FromSeconds(1));
 
             Assert.IsTrue(operation.HasCompleted);
             Assert.IsFalse(operation.HasValue);


### PR DESCRIPTION
This PR addresses and closes #24052. After some debugging, I came to the conclusion that this test fails sporadically because there are instances where the operation completes before being cancelled, which causes the following assertion to fail:

`RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => awaitoperation.WaitForCompletionAsync());`

The solution provided in this PR is to wrap the API calls in a loop and only break once an exception is thrown.

This doesn't feel like a perfect solution, but I couldn't see any other way to deal with the cancellation race condition.  Other ideas would be much appreciated!  