### PR TITLE
[Event Hubs] Processor Release Prep for v5.6.2

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -79,7 +79,7 @@
     <PackageReference Update="Azure.Core" Version="1.20.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.2.0" />
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.17" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.6.1" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.6.2" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.6.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.3.0" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.0.0-beta.2" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 5.7.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 5.6.2 (2021-10-05)
 
 ### Bugs Fixed
 
-### Other Changes
+- Dependencies have been updated to resolve an error when creating `EventSource` instances when used with Xamarin.
 
 ## 5.6.1 (2021-09-08)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.7.0-beta.1</Version>
+    <Version>5.6.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>5.6.1</ApiCompatVersion>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare for the 5.6.2 patch release.