### PR TITLE
Expand spatial types supported by MicrosoftSpatialGeoJsonConverter.

### DIFF
--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/GeoJsonConstants.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/GeoJsonConstants.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Core.Serialization
+{
+    internal static class GeoJsonConstants
+    {
+        public const string PointTypeName = "Point";
+        public const string LineStringTypeName = "LineString";
+        public const string PolygonTypeName = "Polygon";
+        public const string MultiPointTypeName = "MultiPoint";
+        public const string MultiLineStringTypeName = "MultiLineString";
+        public const string MultiPolygonTypeName = "MultiPolygon";
+        public const string GeometryCollectionTypeName = "GeometryCollection";
+        public const string CoordinatesPropertyName = "coordinates";
+        public const string TypePropertyName = "type";
+        public const string GeometriesPropertyName = "geometries";
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/GeoJsonCoordinateReader.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/GeoJsonCoordinateReader.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Spatial;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Azure.Core.Serialization
+{
+    internal abstract class GeoJsonCoordinateReader
+    {
+        public abstract void Process(ref Utf8JsonReader reader);
+
+        public static GeoJsonCoordinateReader Create(ref Utf8JsonReader reader)
+        {
+            GeoJsonCoordinateReader result;
+
+            reader.Expect(JsonTokenType.StartArray);
+
+            int detectedLevel = 0;
+
+            for (; reader.SkipComments() && reader.TokenType == JsonTokenType.StartArray; detectedLevel++)
+            {
+                if (detectedLevel == 4)
+                {
+                    throw new JsonException($"Deserialization failed. GeoJson property '{GeoJsonConstants.CoordinatesPropertyName}' does not contain recognizable GeoJson.");
+                }
+            }
+
+            reader.Expect(JsonTokenType.Number);
+
+            switch (detectedLevel)
+            {
+                case 0:
+                    result = new LevelZeroGeoJsonCoordinateReader();
+                    break;
+
+                case 1:
+                    result = new LevelOneGeoJsonCoordinateReader();
+                    break;
+
+                case 2:
+                    result = new LevelTwoGeoJsonCoordinateReader();
+                    break;
+
+                default:
+                    result = new LevelThreeGeoJsonCoordinateReader();
+                    break;
+            }
+
+            result.Process(ref reader);
+
+            return result;
+        }
+
+        protected static List<GeographyPoint> ReadPoints(ref Utf8JsonReader reader)
+        {
+            List<GeographyPoint> result = new List<GeographyPoint>();
+
+            reader.Expect(JsonTokenType.Number);
+
+            while (true)
+            {
+                GeographyPoint geographyPoint = ReadPoint(ref reader);
+
+                result.Add(geographyPoint);
+
+                reader.SkipComments();
+
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+
+                reader.SkipComments();
+
+                reader.Expect(JsonTokenType.Number);
+            }
+
+            return result;
+        }
+
+        protected static GeographyPoint ReadPoint(ref Utf8JsonReader reader)
+        {
+            double longitude = reader.GetDouble();
+
+            reader.SkipComments();
+
+            reader.Expect(JsonTokenType.Number);
+
+            double latitude = reader.GetDouble();
+
+            //TODO perhaps read M and / or Z??? Gotta check the spec
+
+            do
+            {
+                reader.SkipComments();
+            } while (reader.TokenType != JsonTokenType.EndArray);
+
+            return GeographyPoint.Create(latitude, longitude);
+        }
+
+        public abstract Geography GetGeography(string type);
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/GeographyFactoryExtensions.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/GeographyFactoryExtensions.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Spatial;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace Azure.Core.Serialization
+{
+    internal static class GeographyFactoryExtensions
+    {
+        public static GeographyFactory<GeographyCollection> Add(this GeographyFactory<GeographyCollection> factory, Geography geography)
+        {
+            if (geography is GeographyPoint point)
+            {
+                factory = factory.Add(point);
+            }
+
+            else if (geography is GeographyLineString lineString)
+            {
+                factory = factory.Add(lineString);
+            }
+
+            else if (geography is GeographyPolygon polygon)
+            {
+                factory = factory.Add(polygon);
+            }
+
+            else if (geography is GeographyMultiPoint multiPoint)
+            {
+                factory = factory.Add(multiPoint);
+            }
+
+            else if (geography is GeographyMultiLineString multiLineString)
+            {
+                factory = factory.Add(multiLineString);
+            }
+
+            else if (geography is GeographyMultiPolygon multiPolygon)
+            {
+                factory = factory.Add(multiPolygon);
+            }
+
+            else if (geography is GeographyCollection geographyCollection)
+            {
+                factory = factory.Add(geographyCollection);
+            }
+
+            return factory;
+        }
+
+        private static GeographyFactory<GeographyCollection> Add(this GeographyFactory<GeographyCollection> factory, GeographyPoint point)
+        {
+            factory = factory.Point(point.Latitude, point.Longitude);
+
+            return factory;
+        }
+
+        private static GeographyFactory<GeographyCollection> Add(this GeographyFactory<GeographyCollection> factory, GeographyLineString lineString)
+        {
+            factory = factory.LineString();
+
+            foreach (GeographyPoint point in lineString.Points)
+            {
+                factory = factory.LineTo(point.Latitude, point.Longitude);
+            }
+
+            return factory;
+        }
+
+        private static GeographyFactory<GeographyCollection> Add(this GeographyFactory<GeographyCollection> factory, GeographyPolygon polygon)
+        {
+            factory = factory.Polygon();
+
+            foreach (GeographyLineString ring in polygon.Rings)
+            {
+                factory = factory.Ring(ring.Points[0].Latitude, ring.Points[0].Longitude);
+
+                for (int i = 1; i < ring.Points.Count; i++)
+                {
+                    factory = factory.LineTo(ring.Points[i].Latitude, ring.Points[i].Longitude);
+                }
+            }
+
+            return factory;
+        }
+
+        private static GeographyFactory<GeographyCollection> Add(this GeographyFactory<GeographyCollection> factory, GeographyMultiPoint multiPoint)
+        {
+            foreach (GeographyPoint point in multiPoint.Points)
+            {
+                factory = factory.Add(point);
+            }
+
+            return factory;
+        }
+
+        private static GeographyFactory<GeographyCollection> Add(this GeographyFactory<GeographyCollection> factory, GeographyMultiLineString multiLineString)
+        {
+            foreach (GeographyLineString lineString in multiLineString.LineStrings)
+            {
+                factory = factory.Add(lineString);
+            }
+
+            return factory;
+        }
+
+        private static GeographyFactory<GeographyCollection> Add(this GeographyFactory<GeographyCollection> factory, GeographyMultiPolygon multiPolygon)
+        {
+            foreach (GeographyPolygon polygon in multiPolygon.Polygons)
+            {
+                factory = factory.Add(polygon);
+            }
+
+            return factory;
+        }
+
+        private static GeographyFactory<GeographyCollection> Add(this GeographyFactory<GeographyCollection> factory, GeographyCollection geographyCollection)
+        {
+            factory = factory.Collection();
+
+            foreach (Geography geography in geographyCollection.Geographies)
+            {
+                factory = factory.Add(geography);
+            }
+
+            return factory;
+        }
+
+        public static GeographyLineString Create(this GeographyFactory<GeographyLineString> factory, List<GeographyPoint> points)
+        {
+            if (points.Count < 2)
+            {
+                throw new JsonException($"Deserialization of {nameof(GeographyLineString)} failed. {GeoJsonConstants.LineStringTypeName} must contain at least two points.");
+            }
+
+            foreach (GeographyPoint point in points)
+            {
+                factory = factory.LineTo(point.Latitude, point.Longitude);
+            }
+
+            GeographyLineString result = factory.Build();
+
+            return result;
+        }
+
+        public static GeographyPolygon Create(this GeographyFactory<GeographyPolygon> factory, List<List<GeographyPoint>> listOfPointList)
+        {
+            foreach (List<GeographyPoint> pointList in listOfPointList)
+            {
+                if (pointList.Count < 4)
+                {
+                    throw new JsonException($"Deserialization of {nameof(GeographyPolygon)} failed. {GeoJsonConstants.PolygonTypeName} must have at least four points.");
+                }
+
+                else if (!pointList.First().Equals(pointList.Last()))
+                {
+                    throw new JsonException($"Deserialization of {nameof(GeographyPolygon)} failed. {GeoJsonConstants.PolygonTypeName} first and last point must be the same.");
+                }
+
+                factory = factory.Ring(pointList[0].Latitude, pointList[0].Longitude);
+
+                for (int i = 1; i < pointList.Count - 1; i++)
+                {
+                    factory = factory.LineTo(pointList[i].Latitude, pointList[i].Longitude);
+                }
+            }
+
+            var result = factory.Build();
+
+            return result;
+        }
+
+        public static GeographyMultiPoint Create(this GeographyFactory<GeographyMultiPoint> factory, List<GeographyPoint> points)
+        {
+            foreach (GeographyPoint point in points)
+            {
+                factory = factory.Point(point.Latitude, point.Longitude);
+            }
+
+            GeographyMultiPoint result = factory.Build();
+
+            return result;
+        }
+
+        public static GeographyMultiLineString Create(this GeographyFactory<GeographyMultiLineString> factory, List<List<GeographyPoint>> listOfPointList)
+        {
+            foreach (List<GeographyPoint> points in listOfPointList)
+            {
+                if (points.Count < 2)
+                {
+                    throw new JsonException($"Deserialization of {nameof(GeographyMultiLineString)} failed. {GeoJsonConstants.MultiLineStringTypeName} must contain at least two points.");
+                }
+
+                factory = factory.LineString();
+
+                foreach (GeographyPoint point in points)
+                {
+                    factory = factory.LineTo(point.Latitude, point.Longitude);
+                }
+            }
+
+            GeographyMultiLineString result = factory.Build();
+
+            return result;
+        }
+
+        public static GeographyMultiPolygon Create(this GeographyFactory<GeographyMultiPolygon> factory, List<GeographyPolygon> polygons)
+        {
+            foreach (var polygon in polygons)
+            {
+                factory = factory.Polygon();
+
+                foreach (GeographyLineString li in polygon.Rings)
+                {
+                    factory = factory.Ring(li.Points[0].Latitude, li.Points[0].Longitude);
+
+                    for (int i = 1; i < li.Points.Count - 1; i++)
+                    {
+                        factory = factory.LineTo(li.Points[i].Latitude, li.Points[i].Longitude);
+                    }
+                }
+            }
+
+            GeographyMultiPolygon result = factory.Build();
+
+            return result;
+        }
+
+        public static GeographyCollection Create(this GeographyFactory<GeographyCollection> factory, List<Geography> geographies)
+        {
+            foreach (Geography geography in geographies)
+            {
+                factory.Add(geography);
+            }
+
+            return factory.Build();
+        }
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/JsonExtensions.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/JsonExtensions.cs
@@ -25,5 +25,23 @@ namespace Azure.Core.Serialization
                 throw new JsonException($"Deserialization failed. Expected token: '{expectedTokenType}'.");
             }
         }
+
+        /// <summary>
+        /// Skips comments in reader
+        /// </summary>
+        /// <param name="reader">The Utf8JsonReader to advance</param>
+        /// <returns>True if TokenType other than Comment is found, or false when reader is at end</returns>
+        public static bool SkipComments(this ref Utf8JsonReader reader)
+        {
+            while (reader.Read())
+            {
+                if (reader.TokenType != JsonTokenType.Comment)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/LevelOneGeoJsonCoordinateReader.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/LevelOneGeoJsonCoordinateReader.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Spatial;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Azure.Core.Serialization
+{
+    internal class LevelOneGeoJsonCoordinateReader : GeoJsonCoordinateReader
+    {
+        protected List<GeographyPoint> Points { get; set; }
+
+        public override Geography GetGeography(string type)
+        {
+            if (type == GeoJsonConstants.LineStringTypeName)
+            {
+                return GeographyFactory.LineString().Create(Points);
+            }
+
+            else if (type == GeoJsonConstants.MultiPointTypeName)
+            {
+                return GeographyFactory.MultiPoint().Create(Points);
+            }
+
+            else
+            {
+                throw new JsonException($"Invalid GeoJson. type: {type} does not match coordinates provided");
+            }
+        }
+
+        public override void Process(ref Utf8JsonReader reader)
+        {
+            Points = ReadPoints(ref reader);
+        }
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/LevelThreeGeoJsonCoordinateReader.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/LevelThreeGeoJsonCoordinateReader.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Spatial;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Azure.Core.Serialization
+{
+    internal class LevelThreeGeoJsonCoordinateReader : GeoJsonCoordinateReader
+    {
+        protected List<GeographyPolygon> Polygons { get; set; }
+
+        public override Geography GetGeography(string type)
+        {
+            if (type == GeoJsonConstants.MultiPolygonTypeName)
+            {
+                return GeographyFactory.MultiPolygon().Create(Polygons);
+            }
+
+            else
+            {
+                throw new JsonException($"Invalid GeoJson. type: {type} does not match coordinates provided");
+            }
+        }
+
+        public override void Process(ref Utf8JsonReader reader)
+        {
+            Polygons = new List<GeographyPolygon>();
+
+            while (true)
+            {
+                GeographyPolygon polygon = ReadPolygon(ref reader);
+
+                Polygons.Add(polygon);
+
+                reader.SkipComments();
+
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+
+                reader.SkipComments();
+
+                reader.SkipComments();
+
+                reader.SkipComments();
+            }
+        }
+
+        private static GeographyPolygon ReadPolygon(ref Utf8JsonReader reader)
+        {
+            List<List<GeographyPoint>> geographyPoints = new List<List<GeographyPoint>>();
+
+            reader.Expect(JsonTokenType.Number);
+
+            while (true)
+            {
+                List<GeographyPoint> points = ReadPoints(ref reader);
+
+                geographyPoints.Add(points);
+
+                reader.SkipComments();
+
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+
+                reader.SkipComments();
+
+                reader.SkipComments();
+            }
+
+            GeographyPolygon result = GeographyFactory.Polygon().Create(geographyPoints);
+
+            return result;
+        }
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/LevelTwoGeoJsonCoordinateReader.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/LevelTwoGeoJsonCoordinateReader.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Spatial;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Azure.Core.Serialization
+{
+    internal class LevelTwoGeoJsonCoordinateReader : GeoJsonCoordinateReader
+    {
+        protected List<List<GeographyPoint>> Points { get; set; }
+
+        public override Geography GetGeography(string type)
+        {
+            if (type == GeoJsonConstants.PolygonTypeName)
+            {
+                return GeographyFactory.Polygon().Create(Points);
+            }
+
+            else if (type == GeoJsonConstants.MultiLineStringTypeName)
+            {
+                return GeographyFactory.MultiLineString().Create(Points);
+            }
+
+            else
+            {
+                throw new JsonException($"Invalid GeoJson. type: {type} does not match coordinates provided");
+            }
+        }
+
+        public override void Process(ref Utf8JsonReader reader)
+        {
+            Points = new List<List<GeographyPoint>>();
+
+            while (true)
+            {
+                List<GeographyPoint> points = ReadPoints(ref reader);
+
+                Points.Add(points);
+
+                reader.SkipComments();
+
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+
+                reader.SkipComments();
+
+                reader.SkipComments();
+            }
+        }
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/LevelZeroGeoJsonCoordinateReader.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/LevelZeroGeoJsonCoordinateReader.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Spatial;
+using System.Text.Json;
+
+namespace Azure.Core.Serialization
+{
+    internal class LevelZeroGeoJsonCoordinateReader : GeoJsonCoordinateReader
+    {
+        protected GeographyPoint GeographyPoint { get; set; }
+
+        public override Geography GetGeography(string type)
+        {
+            if (type == GeoJsonConstants.PointTypeName)
+            {
+                return GeographyPoint;
+            }
+
+            throw new JsonException($"Invalid GeoJson. type: {type} does not match coordinates provided");
+        }
+
+        public override void Process(ref Utf8JsonReader reader)
+        {
+            GeographyPoint = ReadPoint(ref reader);
+        }
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/MicrosoftSpatialGeoJsonConverter.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/MicrosoftSpatialGeoJsonConverter.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Spatial;
@@ -13,18 +15,33 @@ namespace Azure.Core.Serialization
     /// </summary>
     public class MicrosoftSpatialGeoJsonConverter : JsonConverter<object>
     {
-        // TODO: Consider reading and writing more of a GeographicPoint, but for now we only read and write what we support in OData currently.
-        private const string CoordinatesPropertyName = "coordinates";
-        private const string PointTypeName = "Point";
-        private const string TypePropertyName = "type";
+        private static readonly string[] TypeNames = new string[]
+        {
+            GeoJsonConstants.PointTypeName,
+            GeoJsonConstants.LineStringTypeName,
+            GeoJsonConstants.PolygonTypeName,
+            GeoJsonConstants.MultiPointTypeName,
+            GeoJsonConstants.MultiLineStringTypeName,
+            GeoJsonConstants.MultiPolygonTypeName,
+            GeoJsonConstants.GeometryCollectionTypeName
+        };
 
-        private static readonly JsonEncodedText s_CoordinatesPropertyNameBytes = JsonEncodedText.Encode(CoordinatesPropertyName);
-        private static readonly JsonEncodedText s_TypePropertyNameBytes = JsonEncodedText.Encode(TypePropertyName);
+        private static readonly Type[] SupportedTypes = new Type[]
+        {
+            typeof(GeographyPoint),
+            typeof(GeographyLineString),
+            typeof(GeographyPolygon),
+            typeof(GeographyMultiPoint),
+            typeof(GeographyMultiLineString),
+            typeof(GeographyMultiPolygon),
+            typeof(GeographyCollection),
+        };
 
         /// <inheritdoc/>
-        public override bool CanConvert(Type typeToConvert) =>
-            // BUGBUG #15506: Check for all Geography derivatives.
-            typeof(GeographyPoint).IsAssignableFrom(typeToConvert);
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return SupportedTypes.Any(z => typeToConvert.IsAssignableFrom(z));
+        }
 
         /// <inheritdoc/>
         public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -34,73 +51,119 @@ namespace Azure.Core.Serialization
                 return null;
             }
 
-            string type = default;
-            double? longitude = default;
-            double? latitude = default;
+            Geography result = ProcessSingleGeography(ref reader);
+
+            Type resultType = result.GetType();
+
+            if (!typeToConvert.IsAssignableFrom(resultType))
+            {
+                throw new JsonException($"Deserialization failed. Discovered GeoJson of Type {resultType.Name}, expected {typeToConvert.Name}.");
+            }
+
+            return result;
+        }
+
+        private Geography ProcessSingleGeography(ref Utf8JsonReader reader)
+        {
+            string type = null;
+            GeoJsonCoordinateReader geoJsonCoordinateReader = null;
+            List<Geography> geographies = null;
 
             reader.Expect(JsonTokenType.StartObject);
-            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+
+            while (reader.SkipComments() && reader.TokenType != JsonTokenType.EndObject)
             {
                 reader.Expect(JsonTokenType.PropertyName);
+
                 string propertyName = reader.GetString();
 
-                reader.Read();
-                if (string.Equals(TypePropertyName, propertyName, StringComparison.Ordinal))
+                reader.SkipComments();
+
+                if (string.Equals(GeoJsonConstants.TypePropertyName, propertyName, StringComparison.Ordinal))
                 {
                     reader.Expect(JsonTokenType.String);
                     type = reader.GetString();
                 }
-                else if (string.Equals(CoordinatesPropertyName, propertyName, StringComparison.Ordinal))
+
+                else if (string.Equals(GeoJsonConstants.CoordinatesPropertyName, propertyName, StringComparison.Ordinal))
                 {
-                    reader.Expect(JsonTokenType.StartArray);
-
-                    // Longitude
-                    reader.Read();
-                    reader.Expect(JsonTokenType.Number);
-                    longitude = reader.GetDouble();
-
-                    // Latitude
-                    reader.Read();
-                    reader.Expect(JsonTokenType.Number);
-                    latitude = reader.GetDouble();
-
-                    // Skip the rest.
-                    do
-                    {
-                        reader.Read();
-                    } while (reader.TokenType != JsonTokenType.EndArray);
+                    geoJsonCoordinateReader = GeoJsonCoordinateReader.Create(ref reader);
                 }
+
+                else if (string.Equals(GeoJsonConstants.GeometriesPropertyName, propertyName, StringComparison.Ordinal))
+                {
+                    geographies = ProcessGeometryCollection(ref reader);
+                }
+
                 else
                 {
                     reader.Skip();
                 }
             }
 
-            if (!string.Equals(PointTypeName, type, StringComparison.Ordinal))
+            if (type == null)
             {
-                throw new JsonException($"Deserialization of {nameof(GeographyPoint)} failed. Expected geographic type: '{PointTypeName}'.");
+                throw new JsonException($"Deserialization failed. Required GeoJson property '{GeoJsonConstants.TypePropertyName}' not found.");
             }
 
-            if (!longitude.HasValue || !latitude.HasValue)
+            if (!TypeNames.Contains(type))
             {
-                throw new JsonException($"Deserialization of {nameof(GeographyPoint)} failed. Expected both longitude and latitude.");
+                string valid = TypeNames.FirstOrDefault(z => z.Equals(type, StringComparison.OrdinalIgnoreCase));
+
+                if (valid != null)
+                {
+                    throw new JsonException($"Deserialization failed. GeoJson property '{GeoJsonConstants.TypePropertyName}' values are case sensitive. Use '{valid}' instead.");
+                }
+
+                throw new JsonException($"Deserialization failed. GeoJson property '{GeoJsonConstants.TypePropertyName}' contains an invalid value: {type}.");
             }
 
-            return GeographyPoint.Create(latitude.Value, longitude.Value);
+            if (geoJsonCoordinateReader != null)
+            {
+                return geoJsonCoordinateReader.GetGeography(type);
+            }
+
+            else if (geographies != null)
+            {
+                return GeographyFactory.Collection().Create(geographies);
+            }
+
+            else
+            {
+                if (type == GeoJsonConstants.GeometryCollectionTypeName)
+                {
+                    throw new JsonException($"Deserialization failed. Required GeoJson property '{GeoJsonConstants.GeometriesPropertyName}' not found.");
+                }
+
+                else
+                {
+                    throw new JsonException($"Deserialization failed. Required GeoJson property '{GeoJsonConstants.CoordinatesPropertyName}' not found.");
+                }
+            }
+        }
+
+        private List<Geography> ProcessGeometryCollection(ref Utf8JsonReader reader)
+        {
+            List<Geography> result = new List<Geography>();
+
+            reader.Expect(JsonTokenType.StartArray);
+
+            while (reader.SkipComments() && reader.TokenType != JsonTokenType.EndArray)
+            {
+                Geography geography = ProcessSingleGeography(ref reader);
+
+                result.Add(geography);
+            }
+
+            return result;
         }
 
         /// <inheritdoc/>
         public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
         {
-            if (value is GeographyPoint point)
+            if (value is Geography geography)
             {
-                writer.WriteStartObject();
-                writer.WriteString(s_TypePropertyNameBytes, PointTypeName);
-                writer.WriteStartArray(s_CoordinatesPropertyNameBytes);
-                writer.WriteNumberValue(point.Longitude);
-                writer.WriteNumberValue(point.Latitude);
-                writer.WriteEndArray();
-                writer.WriteEndObject();
+                writer.WriteGeography(geography);
             }
         }
     }

--- a/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/Utf8JsonWriterExtensions.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/src/Serialization/Utf8JsonWriterExtensions.cs
@@ -1,0 +1,208 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Spatial;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Azure.Core.Serialization
+{
+    internal static class Utf8JsonWriterExtensions
+    {
+        private static readonly JsonEncodedText s_CoordinatesPropertyNameBytes = JsonEncodedText.Encode(GeoJsonConstants.CoordinatesPropertyName);
+        private static readonly JsonEncodedText s_TypePropertyNameBytes = JsonEncodedText.Encode(GeoJsonConstants.TypePropertyName);
+        private static readonly JsonEncodedText s_GeometriesPropertyNameBytes = JsonEncodedText.Encode(GeoJsonConstants.GeometriesPropertyName);
+
+        public static void WriteGeography(
+            this Utf8JsonWriter writer,
+            Geography geography)
+        {
+            if (geography is GeographyPoint point)
+            {
+                WriteGeography(writer, point);
+            }
+
+            else if (geography is GeographyLineString lineString)
+            {
+                WriteGeography(writer, lineString);
+            }
+
+            else if (geography is GeographyPolygon polygon)
+            {
+                WriteGeography(writer, polygon);
+            }
+
+            else if (geography is GeographyMultiPoint multiPoint)
+            {
+                WriteGeography(writer, multiPoint);
+            }
+
+            else if (geography is GeographyMultiLineString multiLineString)
+            {
+                WriteGeography(writer, multiLineString);
+            }
+
+            else if (geography is GeographyMultiPolygon multiPolygon)
+            {
+                WriteGeography(writer, multiPolygon);
+            }
+
+            else if (geography is GeographyCollection collection)
+            {
+                WriteGeography(writer, collection);
+            }
+        }
+
+        private static void WriteGeography(
+            this Utf8JsonWriter writer,
+            GeographyPoint geography)
+        {
+            writer.WriteStartObject();
+            writer.WriteString(s_TypePropertyNameBytes, GeoJsonConstants.PointTypeName);
+            writer.WriteStartArray(s_CoordinatesPropertyNameBytes);
+            writer.WriteNumberValue(geography.Longitude);
+            writer.WriteNumberValue(geography.Latitude);
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private static void WriteGeography(
+            this Utf8JsonWriter writer,
+            GeographyLineString geography)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString(s_TypePropertyNameBytes, GeoJsonConstants.LineStringTypeName);
+
+            WritePointArray(writer, geography.Points, s_CoordinatesPropertyNameBytes);
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteGeography(
+            this Utf8JsonWriter writer,
+            GeographyPolygon geography)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString(s_TypePropertyNameBytes, GeoJsonConstants.PolygonTypeName);
+
+            writer.WriteStartArray(s_CoordinatesPropertyNameBytes);
+
+            foreach (GeographyLineString ring in geography.Rings)
+            {
+                WritePointArray(writer, ring.Points);
+            }
+
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteGeography(
+            this Utf8JsonWriter writer,
+            GeographyMultiPoint geography)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString(s_TypePropertyNameBytes, GeoJsonConstants.MultiPointTypeName);
+
+            WritePointArray(writer, geography.Points, s_CoordinatesPropertyNameBytes);
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteGeography(
+            this Utf8JsonWriter writer,
+            GeographyMultiLineString geography)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString(s_TypePropertyNameBytes, GeoJsonConstants.MultiLineStringTypeName);
+
+            writer.WriteStartArray(s_CoordinatesPropertyNameBytes);
+
+            foreach (GeographyLineString lineString in geography.LineStrings)
+            {
+                WritePointArray(writer, lineString.Points);
+            }
+
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteGeography(
+            this Utf8JsonWriter writer,
+            GeographyMultiPolygon geography)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString(s_TypePropertyNameBytes, GeoJsonConstants.MultiPolygonTypeName);
+
+            writer.WriteStartArray(s_CoordinatesPropertyNameBytes);
+
+            foreach (GeographyPolygon polygon in geography.Polygons)
+            {
+                writer.WriteStartArray();
+
+                foreach (var item in polygon.Rings)
+                {
+                    WritePointArray(writer, item.Points);
+                }
+
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteGeography(
+            Utf8JsonWriter writer,
+            GeographyCollection geography)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString(s_TypePropertyNameBytes, GeoJsonConstants.GeometryCollectionTypeName);
+
+            writer.WriteStartArray(s_GeometriesPropertyNameBytes);
+
+            foreach (Geography child in geography.Geographies)
+            {
+                WriteGeography(writer, child);
+            }
+
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+
+        private static void WritePointArray(
+            Utf8JsonWriter writer,
+            IEnumerable<GeographyPoint> points,
+            JsonEncodedText? propertyName = null)
+        {
+            if (propertyName == null)
+            {
+                writer.WriteStartArray();
+            }
+
+            else
+            {
+                writer.WriteStartArray(s_CoordinatesPropertyNameBytes);
+            }
+
+            foreach (GeographyPoint point in points)
+            {
+                writer.WriteStartArray();
+                writer.WriteNumberValue(point.Longitude);
+                writer.WriteNumberValue(point.Latitude);
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndArray();
+        }
+    }
+}


### PR DESCRIPTION
# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
