### PR TITLE
Avoid filename or extension is too long error

### DIFF
--- a/sdk/core/Azure.Core/generate_solution.ps1
+++ b/sdk/core/Azure.Core/generate_solution.ps1
@@ -35,7 +35,10 @@ try
         }
     }
 
-    dotnet sln $slnName add $projects
+    foreach ($project in $projects)
+    {
+       dotnet sln $slnName add $project 
+    }
 }
 finally
 {

--- a/sdk/core/Azure.Core/generate_solution.ps1
+++ b/sdk/core/Azure.Core/generate_solution.ps1
@@ -35,10 +35,9 @@ try
         }
     }
 
-    foreach ($project in $projects)
-    {
-       dotnet sln $slnName add $project 
-    }
+    $len = $projects.Length
+    dotnet sln $slnName add $projects[0..($len/2)]
+    dotnet sln $slnName add $projects[($len/2 + 1)..($len-1)]
 }
 finally
 {


### PR DESCRIPTION
Avoids the following error when generating the sln

```
Line |
  38 |      dotnet sln $slnName add $projects
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Program 'dotnet.exe' failed to run: The filename or extension is too long.At
     | C:\src\azure-sdk-for-net\sdk\core\Azure.Core\generate_solution.ps1:38 char:5 +     dotnet sln $slnName add $projects +
     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~.
```