### PR TITLE
Support multi-tenant authentication in Key Vault

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -85,7 +85,7 @@
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.7.0" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.4.0" />
     <PackageReference Update="Azure.Messaging.WebPubSub" Version="1.0.0-beta.2" />
-    <PackageReference Update="Azure.Identity" Version="1.4.0" />
+    <PackageReference Update="Azure.Identity" Version="1.5.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.2.0" />
     <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.2.0" />

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Support multi-tenant authentication against Managed HSM when using Azure.Identity 1.5.0 or newer. ([#18359](https://github.com/Azure/azure-sdk-for-net/issues/18359))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added `KeyVaultCertificateIdentifier.TryCreate` to parse certificate URIs without throwing an exception when invalid. ([#23146](https://github.com/Azure/azure-sdk-for-net/issues/23146))
+- Support multi-tenant authentication against Key Vault and Managed HSM when using Azure.Identity 1.5.0 or newer. ([#18359](https://github.com/Azure/azure-sdk-for-net/issues/18359))
 
 ### Breaking Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `KeyClient.GetCryptographyClient` to get a `CryptographyClient` that uses the same options, policies, and pipeline as the `KeyClient` that created it. ([#23786](https://github.com/Azure/azure-sdk-for-net/issues/23786))
 - Added `KeyRotationPolicy` class and new methods including `KeyClient.GetKeyRotationPolicy`, `KeyClient.RotateKey`, and `KeyClient.UpdateKeyRotationPolicy`.
 - Added `KeyVaultKeyIdentifier.TryCreate` to parse key URIs without throwing an exception when invalid. ([#23146](https://github.com/Azure/azure-sdk-for-net/issues/23146))
+- Support multi-tenant authentication against Key Vault and Managed HSM when using Azure.Identity 1.5.0 or newer. ([#18359](https://github.com/Azure/azure-sdk-for-net/issues/18359))
 
 ### Breaking Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added `KeyVaultSecretIdentifier.TryCreate` to parse secret URIs without throwing an exception when invalid. ([#23146](https://github.com/Azure/azure-sdk-for-net/issues/23146))
+- Support multi-tenant authentication against Key Vault and Managed HSM when using Azure.Identity 1.5.0 or newer. ([#18359](https://github.com/Azure/azure-sdk-for-net/issues/18359))
 
 ### Breaking Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -25,6 +25,11 @@
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <!-- TODO: Remove once Azure.Identity 1.5.0 ships. -->
+    <ProjectReference Include="..\..\..\identity\Azure.Identity\src\Azure.Identity.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -27,11 +27,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <!-- TODO: Remove once Azure.Identity 1.5.0 ships. -->
-    <ProjectReference Include="..\..\..\identity\Azure.Identity\src\Azure.Identity.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/Azure.Security.KeyVault.Secrets.Tests.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/Azure.Security.KeyVault.Secrets.Tests.csproj
@@ -17,9 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />
     <ProjectReference Include="..\src\Azure.Security.KeyVault.Secrets.csproj" />
-
-    <!-- TODO: Remove once Azure.Identity 1.5.0 ships. -->
-    <ProjectReference Include="..\..\..\identity\Azure.Identity\src\Azure.Identity.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/Azure.Security.KeyVault.Secrets.Tests.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/Azure.Security.KeyVault.Secrets.Tests.csproj
@@ -17,5 +17,9 @@
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />
     <ProjectReference Include="..\src\Azure.Security.KeyVault.Secrets.csproj" />
+
+    <!-- TODO: Remove once Azure.Identity 1.5.0 ships. -->
+    <ProjectReference Include="..\..\..\identity\Azure.Identity\src\Azure.Identity.csproj" />
   </ItemGroup>
+
 </Project>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Azure.Core;
 using Azure.Core.TestFramework;
-using System.Text;
 using NUnit.Framework.Constraints;
 
 namespace Azure.Security.KeyVault.Secrets.Tests
@@ -459,6 +460,20 @@ namespace Azure.Security.KeyVault.Secrets.Tests
                 KeyVaultSecret returnedSecret = allSecrets.Single(s => s.Name == deletedSecret.Name);
                 AssertSecretPropertiesEqual(deletedSecret.Properties, returnedSecret.Properties, compareId: false);
             }
+        }
+
+        [Test]
+        public async Task AuthenticateCrossTenant()
+        {
+            TokenCredential credential = GetCredential(Recording.Random.NewGuid().ToString());
+            SecretClient client = GetClient(credential);
+
+            string secretName = Recording.GenerateId();
+
+            Response<KeyVaultSecret> response = await client.SetSecretAsync(secretName, "secret");
+            RegisterForCleanup(secretName);
+
+            Assert.AreEqual(200, response.GetRawResponse().Status);
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/AuthenticateCrossTenant.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/AuthenticateCrossTenant.json
@@ -1,0 +1,98 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1976825381?api-version=7.3-preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-4ccf898de50d824686a88d142ae3949b-942c9ef9409b7f48-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Secrets/4.3.0-alpha.20211006.1",
+          "(.NET 5.0.10; Microsoft Windows 10.0.22000)"
+        ],
+        "x-ms-client-request-id": "3ffda9192896abb52c556d714ba4f0f5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 07 Oct 2021 00:58:44 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3ffda9192896abb52c556d714ba4f0f5",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.132.3",
+        "x-ms-request-id": "22a7e4d6-d334-4870-b379-ef40c2c01df4",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1976825381?api-version=7.3-preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "18",
+        "Content-Type": "application/json",
+        "traceparent": "00-4ccf898de50d824686a88d142ae3949b-942c9ef9409b7f48-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Secrets/4.3.0-alpha.20211006.1",
+          "(.NET 5.0.10; Microsoft Windows 10.0.22000)"
+        ],
+        "x-ms-client-request-id": "3ffda9192896abb52c556d714ba4f0f5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "value": "secret"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "258",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 07 Oct 2021 00:58:47 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "3ffda9192896abb52c556d714ba4f0f5",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.132.3",
+        "x-ms-request-id": "585c4eeb-c666-4760-9150-9a2d31a97bbf",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "secret",
+        "id": "https://heathskeyvault.vault.azure.net/secrets/1976825381/7f9f6a57d81f4997aa71365da5923a7c",
+        "attributes": {
+          "enabled": true,
+          "created": 1633568327,
+          "updated": 1633568327,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
+    "RandomSeed": "914486277"
+  }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/AuthenticateCrossTenantAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/AuthenticateCrossTenantAsync.json
@@ -1,0 +1,98 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1361693861?api-version=7.3-preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "traceparent": "00-68a7ae7bababd243a4177c95c8a17a84-adf102b50b9e4549-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Secrets/4.3.0-alpha.20211006.1",
+          "(.NET 5.0.10; Microsoft Windows 10.0.22000)"
+        ],
+        "x-ms-client-request-id": "e871c4ae36cf4c9ba7851ef729df4ae2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 401,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 07 Oct 2021 00:58:49 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "WWW-Authenticate": "Bearer authorization=\u0022https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\u0022, resource=\u0022https://vault.azure.net\u0022",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e871c4ae36cf4c9ba7851ef729df4ae2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.132.3",
+        "x-ms-request-id": "459be702-5cea-4e8f-bf20-40a0ba829746",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "Unauthorized",
+          "message": "AKV10000: Request is missing a Bearer or PoP token."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://heathskeyvault.vault.azure.net/secrets/1361693861?api-version=7.3-preview",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "18",
+        "Content-Type": "application/json",
+        "traceparent": "00-68a7ae7bababd243a4177c95c8a17a84-adf102b50b9e4549-00",
+        "User-Agent": [
+          "azsdk-net-Security.KeyVault.Secrets/4.3.0-alpha.20211006.1",
+          "(.NET 5.0.10; Microsoft Windows 10.0.22000)"
+        ],
+        "x-ms-client-request-id": "e871c4ae36cf4c9ba7851ef729df4ae2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "value": "secret"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "258",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 07 Oct 2021 00:58:50 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000;includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "e871c4ae36cf4c9ba7851ef729df4ae2",
+        "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=67.171.12.239;act_addr_fam=InterNetwork;",
+        "x-ms-keyvault-region": "westus2",
+        "x-ms-keyvault-service-version": "1.9.132.3",
+        "x-ms-request-id": "4413f9d6-d556-452e-b579-ca7a96b7c477",
+        "X-Powered-By": "ASP.NET"
+      },
+      "ResponseBody": {
+        "value": "secret",
+        "id": "https://heathskeyvault.vault.azure.net/secrets/1361693861/2bbf7785b5444a07850ed04d2bbd19b1",
+        "attributes": {
+          "enabled": true,
+          "created": 1633568330,
+          "updated": 1633568330,
+          "recoveryLevel": "CustomizedRecoverable\u002BPurgeable",
+          "recoverableDays": 7
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "AZURE_AUTHORITY_HOST": "https://login.microsoftonline.com/",
+    "AZURE_KEYVAULT_URL": "https://heathskeyvault.vault.azure.net/",
+    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
+    "RandomSeed": "1322165825"
+  }
+}


### PR DESCRIPTION
Resolves #18359. Some refactoring / renaming to avoid confusion mainly with the name "authority" e.g., URI authority vs. authentication authority.