### PR TITLE
[FR] Add post response to Operation classes

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeDocumentOperation.cs
@@ -103,11 +103,12 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="serviceClient">The client for communicating with the Form Recognizer Azure Cognitive Service through its REST API.</param>
         /// <param name="diagnostics">The client diagnostics for exception creation in case of failure.</param>
         /// <param name="operationLocation">The address of the long-running operation. It can be obtained from the response headers upon starting the operation.</param>
-        internal AnalyzeDocumentOperation(DocumentAnalysisRestClient serviceClient, ClientDiagnostics diagnostics, string operationLocation)
+        /// <param name="postResponse">Response from the POSt request that initiated the operation.</param>
+        internal AnalyzeDocumentOperation(DocumentAnalysisRestClient serviceClient, ClientDiagnostics diagnostics, string operationLocation, Response postResponse)
         {
             _serviceClient = serviceClient;
             _diagnostics = diagnostics;
-            _operationInternal = new(_diagnostics, this, rawResponse: null);
+            _operationInternal = new(_diagnostics, this, rawResponse: postResponse);
 
             // TODO: Use regex to parse ids.
             // https://github.com/Azure/azure-sdk-for-net/issues/11505

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/BuildModelOperation.cs
@@ -94,12 +94,13 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
 
         internal BuildModelOperation(
             string location,
+            Response postResponse,
             DocumentAnalysisRestClient allOperations,
             ClientDiagnostics diagnostics)
         {
             _serviceClient = allOperations;
             _diagnostics = diagnostics;
-            _operationInternal = new(_diagnostics, this, rawResponse: null, nameof(BuildModelOperation));
+            _operationInternal = new(_diagnostics, this, rawResponse: postResponse);
 
             Id = location.Split('/').Last().Split('?').FirstOrDefault();
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
@@ -79,11 +79,12 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// <param name="serviceClient">The client for communicating with the Form Recognizer Azure Cognitive Service through its REST API.</param>
         /// <param name="diagnostics">The client diagnostics for exception creation in case of failure.</param>
         /// <param name="operationLocation">The address of the long-running operation. It can be obtained from the response headers upon starting the operation.</param>
-        internal CopyModelOperation(DocumentAnalysisRestClient serviceClient, ClientDiagnostics diagnostics, string operationLocation)
+        /// <param name="postResponse">Response from the POSt request that initiated the operation.</param>
+        internal CopyModelOperation(DocumentAnalysisRestClient serviceClient, ClientDiagnostics diagnostics, string operationLocation, Response postResponse)
         {
             _serviceClient = serviceClient;
             _diagnostics = diagnostics;
-            _operationInternal = new(_diagnostics, this, rawResponse: null);
+            _operationInternal = new(_diagnostics, this, rawResponse: postResponse);
 
             Id = operationLocation.Split('/').Last().Split('?').FirstOrDefault();
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentAnalysisClient.cs
@@ -150,7 +150,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     document,
                     cancellationToken).ConfigureAwait(false);
 
-                return new AnalyzeDocumentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
+                return new AnalyzeDocumentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation, response.GetRawResponse());
             }
             catch (Exception e)
             {
@@ -200,7 +200,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     document,
                     cancellationToken);
 
-                return new AnalyzeDocumentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
+                return new AnalyzeDocumentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation, response.GetRawResponse());
             }
             catch (Exception e)
             {
@@ -250,7 +250,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     request,
                     cancellationToken).ConfigureAwait(false);
 
-                return new AnalyzeDocumentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
+                return new AnalyzeDocumentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation, response.GetRawResponse());
             }
             catch (Exception e)
             {
@@ -300,7 +300,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                     request,
                     cancellationToken);
 
-                return new AnalyzeDocumentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
+                return new AnalyzeDocumentOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation, response.GetRawResponse());
             }
             catch (Exception e)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelAdministrationClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentModelAdministrationClient.cs
@@ -148,7 +148,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                 };
 
                 var response = ServiceClient.DocumentAnalysisBuildDocumentModel(request, cancellationToken);
-                return new BuildModelOperation(response.Headers.OperationLocation, ServiceClient, Diagnostics);
+                return new BuildModelOperation(response.Headers.OperationLocation, response.GetRawResponse(), ServiceClient, Diagnostics);
             }
             catch (Exception e)
             {
@@ -194,7 +194,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                 };
 
                 var response = await ServiceClient.DocumentAnalysisBuildDocumentModelAsync(request, cancellationToken).ConfigureAwait(false);
-                return new BuildModelOperation(response.Headers.OperationLocation, ServiceClient, Diagnostics);
+                return new BuildModelOperation(response.Headers.OperationLocation, response.GetRawResponse(), ServiceClient, Diagnostics);
             }
             catch (Exception e)
             {
@@ -603,7 +603,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             try
             {
                 var response = ServiceClient.DocumentAnalysisCopyDocumentModelTo(modelId, target, cancellationToken);
-                return new CopyModelOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
+                return new CopyModelOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation, response.GetRawResponse());
             }
             catch (Exception e)
             {
@@ -632,7 +632,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             try
             {
                 var response = await ServiceClient.DocumentAnalysisCopyDocumentModelToAsync(modelId, target, cancellationToken).ConfigureAwait(false);
-                return new CopyModelOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
+                return new CopyModelOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation, response.GetRawResponse());
             }
             catch (Exception e)
             {
@@ -739,7 +739,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                 };
 
                 var response = ServiceClient.DocumentAnalysisComposeDocumentModel(composeRequest, cancellationToken);
-                return new BuildModelOperation(response.Headers.OperationLocation, ServiceClient, Diagnostics);
+                return new BuildModelOperation(response.Headers.OperationLocation, response.GetRawResponse(), ServiceClient, Diagnostics);
             }
             catch (Exception e)
             {
@@ -778,7 +778,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
                 };
 
                 var response = await ServiceClient.DocumentAnalysisComposeDocumentModelAsync(composeRequest, cancellationToken).ConfigureAwait(false);
-                return new BuildModelOperation(response.Headers.OperationLocation, ServiceClient, Diagnostics);
+                return new BuildModelOperation(response.Headers.OperationLocation, response.GetRawResponse(), ServiceClient, Diagnostics);
             }
             catch (Exception e)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisModels/OperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentAnalysisModels/OperationsLiveTests.cs
@@ -38,6 +38,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
 
             var uri = DocumentAnalysisTestEnvironment.CreateUri(TestFile.Blank);
             var operation = await client.StartAnalyzeDocumentFromUriAsync(modelId, uri);
+            Assert.IsNotNull(operation.GetRawResponse());
 
             var sameOperation = InstrumentOperation(new AnalyzeDocumentOperation(operation.Id, nonInstrumentedClient));
             await sameOperation.WaitForCompletionAsync();
@@ -54,6 +55,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             var modelId = Recording.GenerateId();
 
             var operation = await client.StartBuildModelAsync(trainingFilesUri, modelId);
+            Assert.IsNotNull(operation.GetRawResponse());
 
             var sameOperation = InstrumentOperation(new BuildModelOperation(operation.Id, nonInstrumentedClient));
             await sameOperation.WaitForCompletionAsync();
@@ -74,6 +76,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
             CopyAuthorization targetAuth = await client.GetCopyAuthorizationAsync(targetModelId);
 
             var operation = await client.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
+            Assert.IsNotNull(operation.GetRawResponse());
 
             var sameOperation = InstrumentOperation(new CopyModelOperation(operation.Id, nonInstrumentedClient));
             await sameOperation.WaitForCompletionAsync();


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/24468

~~Will wait for https://github.com/Azure/azure-sdk-for-net/pull/24555 to take advantage of the Operation Test and add a check there that after creating the operation, the response is not null~~