### PR TITLE
Update text analytics to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Constants.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Constants.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.AI.TextAnalytics.Models;
 
 namespace Azure.AI.TextAnalytics
@@ -8,7 +9,15 @@ namespace Azure.AI.TextAnalytics
     internal static class Constants
     {
         public static readonly StringIndexType DefaultStringIndexType = StringIndexType.Utf16CodeUnit;
-        public const string DefaultCognitiveScope = "https://cognitiveservices.azure.com/.default";
+        public static string CognitiveServicesEndpointSuffix => Environment.GetEnvironmentVariable("TEXT_ANALYTICS_DEFAULT_SCOPE");
         public const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
+
+        public static string getDefaultCognitiveScope()
+        {
+            string cognitiveServicesEndpointSuffix = CognitiveServicesEndpointSuffix;
+            cognitiveServicesEndpointSuffix = cognitiveServicesEndpointSuffix.Substring(1);
+            string defaultCognitiveScope = $"https://{cognitiveServicesEndpointSuffix}/.default";
+            return defaultCognitiveScope;
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Constants.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Constants.cs
@@ -9,7 +9,7 @@ namespace Azure.AI.TextAnalytics
     internal static class Constants
     {
         public static readonly StringIndexType DefaultStringIndexType = StringIndexType.Utf16CodeUnit;
-        public static string CognitiveServicesEndpointSuffix => Environment.GetEnvironmentVariable("TEXT_ANALYTICS_DEFAULT_SCOPE");
+        public static string CognitiveServicesEndpointSuffix => Environment.GetEnvironmentVariable("TEXT_ANALYTICS_DEFAULT_SCOPE") ?? ".cognitiveservices.azure.com";
         public const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
 
         public static string getDefaultCognitiveScope()

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -63,7 +63,7 @@ namespace Azure.AI.TextAnalytics
             _clientDiagnostics = new TextAnalyticsClientDiagnostics(options);
             _options = options;
 
-            var pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, Constants.DefaultCognitiveScope));
+            var pipeline = HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, Constants.getDefaultCognitiveScope()));
             _serviceRestClient = new TextAnalyticsRestClient(_clientDiagnostics, pipeline, endpoint.AbsoluteUri, TextAnalyticsClientOptions.GetVersionString(options.Version));
         }
 

--- a/sdk/textanalytics/test-resources.json
+++ b/sdk/textanalytics/test-resources.json
@@ -59,11 +59,11 @@
             }
         }
     },
-  "variables": {
-    "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
-    "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
-    "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('cognitiveServicesEndpointSuffix'))]"
-  },
+    "variables": {
+        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
+        "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
+        "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('cognitiveServicesEndpointSuffix'))]"
+    },
     "resources": [
         {
             "type": "Microsoft.CognitiveServices/accounts",

--- a/sdk/textanalytics/test-resources.json
+++ b/sdk/textanalytics/test-resources.json
@@ -44,16 +44,26 @@
             "defaultValue": "textanalytics",
             "type": "string"
         },
-        "endpointSuffix": {
+        "cognitiveServicesEndpointSuffix": {
             "defaultValue": ".cognitiveservices.azure.com",
-            "type": "string"
+            "type": "string",
+            "metadata": {
+                "description": "Endpoint suffix for sovereign clouds, requies the preceeding '.'. The default uses the public Azure Cloud (.cognitiveservices.azure.com)"
+            }
+        },
+        "textAnalyticsSku": {
+            "type": "string",
+            "defaultValue": "S",
+            "metadata": {
+                "description": "Text Analytics SKU to deploy. The default is 'S'"
+            }
         }
     },
-    "variables": {
-        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
-        "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
-        "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('endpointSuffix'))]"
-    },
+  "variables": {
+    "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
+    "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
+    "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('cognitiveServicesEndpointSuffix'))]"
+  },
     "resources": [
         {
             "type": "Microsoft.CognitiveServices/accounts",
@@ -61,7 +71,7 @@
             "name": "[variables('uniqueSubDomainName')]",
             "location":"[parameters('location')]",
             "sku": {
-                "name": "S"
+                "name": "[parameters('textAnalyticsSku')]"
             },
             "kind": "TextAnalytics",
             "properties": {
@@ -86,6 +96,10 @@
         "TEXT_ANALYTICS_ENDPOINT": {
             "type": "string",
             "value": "[variables('endpointValue')]"
+        },
+        "TEXT_ANALYTICS_DEFAULT_SCOPE": {
+            "type": "string",
+            "value": "[parameters('cognitiveServicesEndpointSuffix')]"
         }
     }
 }

--- a/sdk/textanalytics/tests.yml
+++ b/sdk/textanalytics/tests.yml
@@ -10,3 +10,8 @@ extends:
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'
+      UsGov:
+        SubscriptionConfiguration: $(sub-config-gov-test-resources)
+      China:
+        SubscriptionConfiguration: $(sub-config-cn-test-resources)
+    SupportedClouds: 'Public,Canary,UsGov,China'


### PR DESCRIPTION
1. These changes contain fixes for the text analytics to be able to run live tests against AzureUsGovernment and AzureChina clouds. The sovereign cloud live tests will be green with the changes.

2. Update file : test-resources.json 
Add an output : "TEXT_ANALYTICS_DEFAULT_SCOPE" to switch different endpoint suffix for different clouds. 

3. Update file : Constants.cs 
Use getDefaultCognitiveScope() method to set cognitive scope for different clouds.

Pipeline result : https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1133435&view=results

@benbp , @meeraharidasa , @mayurid for notification.