### PR TITLE
Fix live Key Vault tests

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/KeyVaultTestEnvironment.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/KeyVaultTestEnvironment.cs
@@ -77,7 +77,8 @@ namespace Azure.Security.KeyVault.Tests
         /// </summary>
         public Uri AttestationUri => Uri.TryCreate(GetRecordedOptionalVariable("AZURE_KEYVAULT_ATTESTATION_URL"), UriKind.Absolute, out Uri attestationUri)
             ? attestationUri
-            : throw new InvalidOperationException("Attestation service not deployed");
+            // BUGBUG: Make required when https://github.com/Azure/azure-sdk-for-net/issues/22750 is resolved.
+            : throw new IgnoreException($"Required variable 'AZURE_KEYVAULT_ATTESTATION_URL' is not defined");
 
         /// <summary>
         /// Throws an <see cref="IgnoreException"/> if <see cref="ManagedHsmUrl"/> is not defined.

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/KeyVaultTestEnvironment.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/KeyVaultTestEnvironment.cs
@@ -75,7 +75,9 @@ namespace Azure.Security.KeyVault.Tests
         /// <summary>
         /// Gets the value of the "AZURE_KEYVAULT_ATTESTATION_URL" variable.
         /// </summary>
-        public Uri AttestationUri => new(GetRecordedVariable("AZURE_KEYVAULT_ATTESTATION_URL"), UriKind.Absolute);
+        public Uri AttestationUri => Uri.TryCreate(GetRecordedOptionalVariable("AZURE_KEYVAULT_ATTESTATION_URL"), UriKind.Absolute, out Uri attestationUri)
+            ? attestationUri
+            : throw new InvalidOperationException("Attestation service not deployed");
 
         /// <summary>
         /// Throws an <see cref="IgnoreException"/> if <see cref="ManagedHsmUrl"/> is not defined.

--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -324,6 +324,7 @@
         },
         "AZURE_KEYVAULT_ATTESTATION_URL": {
             "type": "string",
+            "condition": "[parameters('enableHsm')]",
             "value": "[format('https://{0}/', reference(variables('attestationSite')).defaultHostName)]"
         }
     }


### PR DESCRIPTION
The services for the attestation mock service container were
conditioned, which required the `output` parameter to be conditioned and
it wasn't. Initially testing locally with enableHsm=true so didn't catch
it.
