### PR TITLE
Make TokenCacheData.CacheBytes readonly per API review feedback

### DIFF
--- a/sdk/identity/Azure.Identity/Azure.Identity.sln
+++ b/sdk/identity/Azure.Identity/Azure.Identity.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.352
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Identity", "src\Azure.Identity.csproj", "{8A856C05-8CC7-4A1A-A3DC-DD628ECD3E2A}"
 EndProject
@@ -19,7 +19,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{DBE8A141-33F2-489A-A228-B2C919E10C03}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Identity.Perf", "perf\Azure.Identity.Perf.csproj", "{94123C93-FB92-4D05-AA7B-45E1896696FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Identity.Perf", "perf\Azure.Identity.Perf.csproj", "{94123C93-FB92-4D05-AA7B-45E1896696FC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{D181301A-2FA4-420D-963F-529445E61409}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,6 +49,10 @@ Global
 		{94123C93-FB92-4D05-AA7B-45E1896696FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{94123C93-FB92-4D05-AA7B-45E1896696FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{94123C93-FB92-4D05-AA7B-45E1896696FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D181301A-2FA4-420D-963F-529445E61409}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D181301A-2FA4-420D-963F-529445E61409}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D181301A-2FA4-420D-963F-529445E61409}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D181301A-2FA4-420D-963F-529445E61409}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Removed `RegionalAuthority` from `ClientCertificateCredentialOptions` and `ClientSecretCredentialOptions`, along with the `RegionalAuthority` type. This feature will stay in preview, and these APIs will be added back in `1.6.0-beta.1`.
 - Renamed struct `TokenCacheDetails` to `TokenCacheData`.
 - Renamed class `TokenCacheNotificationDetails` to `TokenCacheRefreshArgs`.
+- Updated `CacheBytes` property on `TokenCacheData` to be readonly and a required constructor parameter.
 
 ### Bugs Fixed
 - Fixed issue with `AuthorizationCodeCredential` not specifying correct redirectUrl (Issue [#24183](https://github.com/Azure/azure-sdk-for-net/issues/24183))

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -266,7 +266,8 @@ namespace Azure.Identity
     {
         private object _dummy;
         private int _dummyPrimitive;
-        public System.ReadOnlyMemory<byte> CacheBytes { get { throw null; } set { } }
+        public TokenCacheData(System.ReadOnlyMemory<byte> cacheBytes) { throw null; }
+        public System.ReadOnlyMemory<byte> CacheBytes { get { throw null; } }
     }
     public partial class TokenCachePersistenceOptions
     {

--- a/sdk/identity/Azure.Identity/src/TokenCacheData.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCacheData.cs
@@ -11,8 +11,17 @@ namespace Azure.Identity
     public struct TokenCacheData
     {
         /// <summary>
+        /// Constructs a new <see cref="TokenCacheData"/> instance with the specified cache bytes.
+        /// </summary>
+        /// <param name="cacheBytes">The serialized content of the token cache.</param>
+        public TokenCacheData(ReadOnlyMemory<byte> cacheBytes)
+        {
+            CacheBytes = cacheBytes;
+        }
+
+        /// <summary>
         /// The bytes representing the state of the token cache.
         /// </summary>
-        public ReadOnlyMemory<byte> CacheBytes { get; set; }
+        public ReadOnlyMemory<byte> CacheBytes { get; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/UnsafeTokenCacheOptions.cs
+++ b/sdk/identity/Azure.Identity/src/UnsafeTokenCacheOptions.cs
@@ -31,6 +31,6 @@ namespace Azure.Identity
         /// <param name="args">The <see cref="TokenCacheRefreshArgs"/> containing information about the current state of the cache.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> controlling the lifetime of this operation.</param>
         protected internal virtual async Task<TokenCacheData> RefreshCacheAsync(TokenCacheRefreshArgs args, CancellationToken cancellationToken = default) =>
-             new() {CacheBytes =  await RefreshCacheAsync().ConfigureAwait(false)};
+             new TokenCacheData(await RefreshCacheAsync().ConfigureAwait(false));
     }
 }


### PR DESCRIPTION
Making `CacheBytes` read-only and adding it as a required constructor parameter.