### PR TITLE
[WebPubSub] Generate code using '2021-10-01' version of the swagger

### DIFF
--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.netstandard2.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.netstandard2.0.cs
@@ -33,10 +33,10 @@ namespace Azure.Messaging.WebPubSub
         public virtual System.Threading.Tasks.Task<Azure.Response> CloseUserConnectionsAsync(string userId, System.Collections.Generic.IEnumerable<string> excluded = null, string reason = null, Azure.RequestOptions options = null) { throw null; }
         public virtual Azure.Response<bool> ConnectionExists(string connectionId, Azure.RequestOptions options = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<bool>> ConnectionExistsAsync(string connectionId, Azure.RequestOptions options = null) { throw null; }
-        public virtual System.Uri GenerateClientAccessUri(System.DateTimeOffset expiresAt, string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Uri GenerateClientAccessUri(System.TimeSpan expiresAfter = default(System.TimeSpan), string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Uri> GenerateClientAccessUriAsync(System.DateTimeOffset expiresAt, string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Uri> GenerateClientAccessUriAsync(System.TimeSpan expiresAfter = default(System.TimeSpan), string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Uri GetClientAccessUri(System.DateTimeOffset expiresAt, string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Uri GetClientAccessUri(System.TimeSpan expiresAfter = default(System.TimeSpan), string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Uri> GetClientAccessUriAsync(System.DateTimeOffset expiresAt, string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Uri> GetClientAccessUriAsync(System.TimeSpan expiresAfter = default(System.TimeSpan), string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response GrantPermission(Azure.Messaging.WebPubSub.WebPubSubPermission permission, string connectionId, string targetName = null, Azure.RequestOptions options = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> GrantPermissionAsync(Azure.Messaging.WebPubSub.WebPubSubPermission permission, string connectionId, string targetName = null, Azure.RequestOptions options = null) { throw null; }
         public virtual Azure.Response<bool> GroupExists(string group, Azure.RequestOptions options = null) { throw null; }
@@ -74,8 +74,7 @@ namespace Azure.Messaging.WebPubSub
         public System.Uri ReverseProxyEndpoint { get { throw null; } set { } }
         public enum ServiceVersion
         {
-            V2021_08_01_preview = 1,
-            V2021_10_01 = 2,
+            V2021_10_01 = 1,
         }
     }
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.netstandard2.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/api/Azure.Messaging.WebPubSub.netstandard2.0.cs
@@ -23,8 +23,14 @@ namespace Azure.Messaging.WebPubSub
         public virtual System.Threading.Tasks.Task<Azure.Response> AddUserToGroupAsync(string group, string userId, Azure.RequestOptions options = null) { throw null; }
         public virtual Azure.Response<bool> CheckPermission(Azure.Messaging.WebPubSub.WebPubSubPermission permission, string connectionId, string targetName = null, Azure.RequestOptions options = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<bool>> CheckPermissionAsync(Azure.Messaging.WebPubSub.WebPubSubPermission permission, string connectionId, string targetName = null, Azure.RequestOptions options = null) { throw null; }
+        public virtual Azure.Response CloseAllConnections(System.Collections.Generic.IEnumerable<string> excluded = null, string reason = null, Azure.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> CloseAllConnectionsAsync(System.Collections.Generic.IEnumerable<string> excluded = null, string reason = null, Azure.RequestOptions options = null) { throw null; }
         public virtual Azure.Response CloseConnection(string connectionId, string reason = null, Azure.RequestOptions options = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> CloseConnectionAsync(string connectionId, string reason = null, Azure.RequestOptions options = null) { throw null; }
+        public virtual Azure.Response CloseGroupConnections(string group, System.Collections.Generic.IEnumerable<string> excluded = null, string reason = null, Azure.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> CloseGroupConnectionsAsync(string group, System.Collections.Generic.IEnumerable<string> excluded = null, string reason = null, Azure.RequestOptions options = null) { throw null; }
+        public virtual Azure.Response CloseUserConnections(string userId, System.Collections.Generic.IEnumerable<string> excluded = null, string reason = null, Azure.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> CloseUserConnectionsAsync(string userId, System.Collections.Generic.IEnumerable<string> excluded = null, string reason = null, Azure.RequestOptions options = null) { throw null; }
         public virtual Azure.Response<bool> ConnectionExists(string connectionId, Azure.RequestOptions options = null) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<bool>> ConnectionExistsAsync(string connectionId, Azure.RequestOptions options = null) { throw null; }
         public virtual System.Uri GenerateClientAccessUri(System.DateTimeOffset expiresAt, string userId = null, System.Collections.Generic.IEnumerable<string> roles = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -64,12 +70,12 @@ namespace Azure.Messaging.WebPubSub
     }
     public partial class WebPubSubServiceClientOptions : Azure.Core.ClientOptions
     {
-        public WebPubSubServiceClientOptions(Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion version = Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion.V2021_08_01_preview) { }
+        public WebPubSubServiceClientOptions(Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion version = Azure.Messaging.WebPubSub.WebPubSubServiceClientOptions.ServiceVersion.V2021_10_01) { }
         public System.Uri ReverseProxyEndpoint { get { throw null; } set { } }
         public enum ServiceVersion
         {
-            V2021_05_01_preview = 1,
-            V2021_08_01_preview = 2,
+            V2021_08_01_preview = 1,
+            V2021_10_01 = 2,
         }
     }
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Generated/HealthApiClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Generated/HealthApiClient.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.WebPubSub
     {
         private readonly HttpPipeline _pipeline;
         private readonly ClientDiagnostics _clientDiagnostics;
-        private readonly Uri _endpoint;
+        private readonly string _endpoint;
         private readonly string _apiVersion;
 
         /// <summary> The HTTP pipeline for sending and receiving REST requests and responses. </summary>
@@ -30,11 +30,15 @@ namespace Azure.Messaging.WebPubSub
         }
 
         /// <summary> Initializes a new instance of HealthApiClient. </summary>
-        /// <param name="endpoint"> server parameter. </param>
+        /// <param name="endpoint"> HTTP or HTTPS endpoint for the Web PubSub service instance. </param>
         /// <param name="options"> The options for configuring the client. </param>
-        public HealthApiClient(Uri endpoint = null, WebPubSubServiceClientOptions options = null)
+        /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> is null. </exception>
+        public HealthApiClient(string endpoint, WebPubSubServiceClientOptions options = null)
         {
-            endpoint ??= new Uri("");
+            if (endpoint == null)
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
 
             options ??= new WebPubSubServiceClientOptions();
 
@@ -90,12 +94,9 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Head;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/health", false);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             message.ResponseClassifier = ResponseClassifier200.Instance;
             return message;

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Generated/WebPubSubServiceClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Generated/WebPubSubServiceClient.cs
@@ -19,8 +19,8 @@ namespace Azure.Messaging.WebPubSub
     {
         private readonly HttpPipeline _pipeline;
         private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly string _endpoint;
         private readonly string _hub;
-        private readonly Uri _endpoint;
         private readonly string _apiVersion;
 
         /// <summary> The HTTP pipeline for sending and receiving REST requests and responses. </summary>
@@ -40,6 +40,18 @@ namespace Azure.Messaging.WebPubSub
         /// Schema for <c>Response Body</c>:
         /// <code>{
         ///   token: string
+        /// }
+        /// </code>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
         /// }
         /// </code>
         /// 
@@ -73,6 +85,18 @@ namespace Azure.Messaging.WebPubSub
         ///   token: string
         /// }
         /// </code>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
         /// 
         /// </remarks>
 #pragma warning disable AZC0002
@@ -93,12 +117,101 @@ namespace Azure.Messaging.WebPubSub
             }
         }
 
+        /// <summary> Close the connections in the hub. </summary>
+        /// <param name="excluded"> Exclude these connectionIds when closing the connections in the hub. </param>
+        /// <param name="reason"> The reason closing the client connection. </param>
+        /// <param name="options"> The request options. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+#pragma warning disable AZC0002
+        public virtual async Task<Response> CloseAllConnectionsAsync(IEnumerable<string> excluded = null, string reason = null, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            using var scope = _clientDiagnostics.CreateScope("WebPubSubServiceClient.CloseAllConnections");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateCloseAllConnectionsRequest(excluded, reason);
+                return await _pipeline.ProcessMessageAsync(message, _clientDiagnostics, options).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Close the connections in the hub. </summary>
+        /// <param name="excluded"> Exclude these connectionIds when closing the connections in the hub. </param>
+        /// <param name="reason"> The reason closing the client connection. </param>
+        /// <param name="options"> The request options. </param>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+#pragma warning disable AZC0002
+        public virtual Response CloseAllConnections(IEnumerable<string> excluded = null, string reason = null, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            using var scope = _clientDiagnostics.CreateScope("WebPubSubServiceClient.CloseAllConnections");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateCloseAllConnectionsRequest(excluded, reason);
+                return _pipeline.ProcessMessage(message, _clientDiagnostics, options);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
         /// <summary> Broadcast content inside request body to all the connected client connections. </summary>
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="contentType"> Upload file type. Allowed values: &quot;application/json&quot; | &quot;application/octet-stream&quot;. </param>
         /// <param name="excluded"> Excluded connection Ids. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> SendToAllAsync(RequestContent content, ContentType contentType, IEnumerable<string> excluded = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -123,6 +236,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="excluded"> Excluded connection Ids. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="content"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response SendToAll(RequestContent content, ContentType contentType, IEnumerable<string> excluded = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -145,6 +273,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="connectionId"> The connection Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual async Task<Response> ConnectionExistsImplAsync(string connectionId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -167,6 +310,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="connectionId"> The connection Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual Response ConnectionExistsImpl(string connectionId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -190,6 +348,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="reason"> The reason closing the client connection. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> CloseConnectionAsync(string connectionId, string reason = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -213,6 +386,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="reason"> The reason closing the client connection. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response CloseConnection(string connectionId, string reason = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -237,6 +425,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="contentType"> Upload file type. Allowed values: &quot;application/json&quot; | &quot;application/octet-stream&quot;. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="connectionId"/> or <paramref name="content"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> SendToConnectionAsync(string connectionId, RequestContent content, ContentType contentType, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -261,6 +464,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="contentType"> Upload file type. Allowed values: &quot;application/json&quot; | &quot;application/octet-stream&quot;. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="connectionId"/> or <paramref name="content"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response SendToConnection(string connectionId, RequestContent content, ContentType contentType, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -283,6 +501,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual async Task<Response> GroupExistsImplAsync(string group, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -305,6 +538,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual Response GroupExistsImpl(string group, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -323,6 +571,84 @@ namespace Azure.Messaging.WebPubSub
             }
         }
 
+        /// <summary> Close connections in the specific group. </summary>
+        /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
+        /// <param name="excluded"> Exclude these connectionIds when closing the connections in the group. </param>
+        /// <param name="reason"> The reason closing the client connection. </param>
+        /// <param name="options"> The request options. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+#pragma warning disable AZC0002
+        public virtual async Task<Response> CloseGroupConnectionsAsync(string group, IEnumerable<string> excluded = null, string reason = null, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            using var scope = _clientDiagnostics.CreateScope("WebPubSubServiceClient.CloseGroupConnections");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateCloseGroupConnectionsRequest(group, excluded, reason);
+                return await _pipeline.ProcessMessageAsync(message, _clientDiagnostics, options).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Close connections in the specific group. </summary>
+        /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
+        /// <param name="excluded"> Exclude these connectionIds when closing the connections in the group. </param>
+        /// <param name="reason"> The reason closing the client connection. </param>
+        /// <param name="options"> The request options. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="group"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+#pragma warning disable AZC0002
+        public virtual Response CloseGroupConnections(string group, IEnumerable<string> excluded = null, string reason = null, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            using var scope = _clientDiagnostics.CreateScope("WebPubSubServiceClient.CloseGroupConnections");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateCloseGroupConnectionsRequest(group, excluded, reason);
+                return _pipeline.ProcessMessage(message, _clientDiagnostics, options);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
         /// <summary> Send content inside request body to a group of connections. </summary>
         /// <param name="group"> Target group name, which length should be greater than 0 and less than 1025. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
@@ -330,6 +656,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="excluded"> Excluded connection Ids. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="content"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> SendToGroupAsync(string group, RequestContent content, ContentType contentType, IEnumerable<string> excluded = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -355,6 +696,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="excluded"> Excluded connection Ids. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="content"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response SendToGroup(string group, RequestContent content, ContentType contentType, IEnumerable<string> excluded = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -378,6 +734,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="connectionId"> Target connection Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> AddConnectionToGroupAsync(string group, string connectionId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -401,6 +772,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="connectionId"> Target connection Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response AddConnectionToGroup(string group, string connectionId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -424,6 +810,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="connectionId"> Target connection Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> RemoveConnectionFromGroupAsync(string group, string connectionId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -447,6 +848,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="connectionId"> Target connection Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response RemoveConnectionFromGroup(string group, string connectionId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -469,6 +885,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="userId"> Target user Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual async Task<Response> UserExistsImplAsync(string userId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -491,6 +922,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="userId"> Target user Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual Response UserExistsImpl(string userId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -509,12 +955,105 @@ namespace Azure.Messaging.WebPubSub
             }
         }
 
+        /// <summary> Close connections for the specific user. </summary>
+        /// <param name="userId"> The user Id. </param>
+        /// <param name="excluded"> Exclude these connectionIds when closing the connections for the user. </param>
+        /// <param name="reason"> The reason closing the client connection. </param>
+        /// <param name="options"> The request options. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+#pragma warning disable AZC0002
+        public virtual async Task<Response> CloseUserConnectionsAsync(string userId, IEnumerable<string> excluded = null, string reason = null, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            using var scope = _clientDiagnostics.CreateScope("WebPubSubServiceClient.CloseUserConnections");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateCloseUserConnectionsRequest(userId, excluded, reason);
+                return await _pipeline.ProcessMessageAsync(message, _clientDiagnostics, options).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+        /// <summary> Close connections for the specific user. </summary>
+        /// <param name="userId"> The user Id. </param>
+        /// <param name="excluded"> Exclude these connectionIds when closing the connections for the user. </param>
+        /// <param name="reason"> The reason closing the client connection. </param>
+        /// <param name="options"> The request options. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
+#pragma warning disable AZC0002
+        public virtual Response CloseUserConnections(string userId, IEnumerable<string> excluded = null, string reason = null, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            using var scope = _clientDiagnostics.CreateScope("WebPubSubServiceClient.CloseUserConnections");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateCloseUserConnectionsRequest(userId, excluded, reason);
+                return _pipeline.ProcessMessage(message, _clientDiagnostics, options);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
         /// <summary> Send content inside request body to the specific user. </summary>
         /// <param name="userId"> The user Id. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="contentType"> Upload file type. Allowed values: &quot;application/json&quot; | &quot;application/octet-stream&quot;. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="userId"/> or <paramref name="content"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> SendToUserAsync(string userId, RequestContent content, ContentType contentType, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -539,6 +1078,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="contentType"> Upload file type. Allowed values: &quot;application/json&quot; | &quot;application/octet-stream&quot;. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="userId"/> or <paramref name="content"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response SendToUser(string userId, RequestContent content, ContentType contentType, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -562,6 +1116,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="userId"> Target user Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> AddUserToGroupAsync(string group, string userId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -585,6 +1154,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="userId"> Target user Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response AddUserToGroup(string group, string userId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -608,6 +1192,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="userId"> Target user Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> RemoveUserFromGroupAsync(string group, string userId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -631,6 +1230,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="userId"> Target user Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="group"/> or <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response RemoveUserFromGroup(string group, string userId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -653,6 +1267,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="userId"> Target user Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual async Task<Response> RemoveUserFromAllGroupsAsync(string userId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -675,6 +1304,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="userId"> Target user Id. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="userId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         public virtual Response RemoveUserFromAllGroups(string userId, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -699,6 +1343,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="targetName"> Optional. If not set, grant the permission to all the targets. If set, grant the permission to the specific target. The meaning of the target depends on the specific permission. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="permission"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual async Task<Response> GrantPermissionAsync(string permission, string connectionId, string targetName = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -723,6 +1382,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="targetName"> Optional. If not set, grant the permission to all the targets. If set, grant the permission to the specific target. The meaning of the target depends on the specific permission. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="permission"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual Response GrantPermission(string permission, string connectionId, string targetName = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -747,6 +1421,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="targetName"> Optional. If not set, revoke the permission for all targets. If set, revoke the permission for the specific target. The meaning of the target depends on the specific permission. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="permission"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual async Task<Response> RevokePermissionAsync(string permission, string connectionId, string targetName = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -771,6 +1460,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="targetName"> Optional. If not set, revoke the permission for all targets. If set, revoke the permission for the specific target. The meaning of the target depends on the specific permission. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="permission"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual Response RevokePermission(string permission, string connectionId, string targetName = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -795,6 +1499,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="targetName"> Optional. If not set, get the permission for all targets. If set, get the permission for the specific target. The meaning of the target depends on the specific permission. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="permission"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual async Task<Response> CheckPermissionAsync(string permission, string connectionId, string targetName = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -819,6 +1538,21 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="targetName"> Optional. If not set, get the permission for all targets. If set, get the permission for the specific target. The meaning of the target depends on the specific permission. </param>
         /// <param name="options"> The request options. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="permission"/> or <paramref name="connectionId"/> is null. </exception>
+        /// <remarks>
+        /// Schema for <c>Response Error</c>:
+        /// <code>{
+        ///   code: string,
+        ///   message: string,
+        ///   target: string,
+        ///   details: [ErrorDetail],
+        ///   inner: {
+        ///     code: string,
+        ///     inner: InnerError
+        ///   }
+        /// }
+        /// </code>
+        /// 
+        /// </remarks>
 #pragma warning disable AZC0002
         internal virtual Response CheckPermission(string permission, string connectionId, string targetName = null, RequestOptions options = null)
 #pragma warning restore AZC0002
@@ -843,7 +1577,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/:generateToken", false);
@@ -862,13 +1596,38 @@ namespace Azure.Messaging.WebPubSub
             {
                 uri.AppendQuery("minutesToExpire", minutesToExpire.Value, true);
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
             message.ResponseClassifier = ResponseClassifier200.Instance;
+            return message;
+        }
+
+        internal HttpMessage CreateCloseAllConnectionsRequest(IEnumerable<string> excluded, string reason)
+        {
+            var message = _pipeline.CreateMessage();
+            var request = message.Request;
+            request.Method = RequestMethod.Post;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendPath("/api/hubs/", false);
+            uri.AppendPath(_hub, true);
+            uri.AppendPath("/:closeConnections", false);
+            if (excluded != null)
+            {
+                foreach (var param in excluded)
+                {
+                    uri.AppendQuery("excluded", param, true);
+                }
+            }
+            if (reason != null)
+            {
+                uri.AppendQuery("reason", reason, true);
+            }
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = ResponseClassifier204.Instance;
             return message;
         }
 
@@ -878,7 +1637,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/:send", false);
@@ -889,11 +1648,9 @@ namespace Azure.Messaging.WebPubSub
                     uri.AppendQuery("excluded", param, true);
                 }
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             request.Headers.Add("Content-Type", contentType.ToString());
             request.Content = content;
             message.ResponseClassifier = ResponseClassifier202.Instance;
@@ -906,7 +1663,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/:send", false);
@@ -917,11 +1674,9 @@ namespace Azure.Messaging.WebPubSub
                     uri.AppendQuery("excluded", param, true);
                 }
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             request.Headers.Add("Content-Type", "text/plain");
             request.Content = content;
             message.ResponseClassifier = ResponseClassifier202.Instance;
@@ -934,16 +1689,14 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Head;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/connections/", false);
             uri.AppendPath(connectionId, true);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             message.ResponseClassifier = ResponseClassifier200404.Instance;
             return message;
         }
@@ -954,7 +1707,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/connections/", false);
@@ -963,12 +1716,10 @@ namespace Azure.Messaging.WebPubSub
             {
                 uri.AppendQuery("reason", reason, true);
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
-            message.ResponseClassifier = ResponseClassifier200.Instance;
+            request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = ResponseClassifier204.Instance;
             return message;
         }
 
@@ -978,17 +1729,15 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/connections/", false);
             uri.AppendPath(connectionId, true);
             uri.AppendPath("/:send", false);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             request.Headers.Add("Content-Type", contentType.ToString());
             request.Content = content;
             message.ResponseClassifier = ResponseClassifier202.Instance;
@@ -1001,17 +1750,15 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/connections/", false);
             uri.AppendPath(connectionId, true);
             uri.AppendPath("/:send", false);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             request.Headers.Add("Content-Type", "text/plain");
             request.Content = content;
             message.ResponseClassifier = ResponseClassifier202.Instance;
@@ -1024,17 +1771,45 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Head;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/groups/", false);
             uri.AppendPath(group, true);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             message.ResponseClassifier = ResponseClassifier200404.Instance;
+            return message;
+        }
+
+        internal HttpMessage CreateCloseGroupConnectionsRequest(string group, IEnumerable<string> excluded, string reason)
+        {
+            var message = _pipeline.CreateMessage();
+            var request = message.Request;
+            request.Method = RequestMethod.Post;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendPath("/api/hubs/", false);
+            uri.AppendPath(_hub, true);
+            uri.AppendPath("/groups/", false);
+            uri.AppendPath(group, true);
+            uri.AppendPath("/:closeConnections", false);
+            if (excluded != null)
+            {
+                foreach (var param in excluded)
+                {
+                    uri.AppendQuery("excluded", param, true);
+                }
+            }
+            if (reason != null)
+            {
+                uri.AppendQuery("reason", reason, true);
+            }
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = ResponseClassifier204.Instance;
             return message;
         }
 
@@ -1044,7 +1819,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/groups/", false);
@@ -1057,11 +1832,9 @@ namespace Azure.Messaging.WebPubSub
                     uri.AppendQuery("excluded", param, true);
                 }
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             request.Headers.Add("Content-Type", contentType.ToString());
             request.Content = content;
             message.ResponseClassifier = ResponseClassifier202.Instance;
@@ -1074,7 +1847,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/groups/", false);
@@ -1087,11 +1860,9 @@ namespace Azure.Messaging.WebPubSub
                     uri.AppendQuery("excluded", param, true);
                 }
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             request.Headers.Add("Content-Type", "text/plain");
             request.Content = content;
             message.ResponseClassifier = ResponseClassifier202.Instance;
@@ -1104,18 +1875,16 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/groups/", false);
             uri.AppendPath(group, true);
             uri.AppendPath("/connections/", false);
             uri.AppendPath(connectionId, true);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             message.ResponseClassifier = ResponseClassifier200404.Instance;
             return message;
         }
@@ -1126,19 +1895,17 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/groups/", false);
             uri.AppendPath(group, true);
             uri.AppendPath("/connections/", false);
             uri.AppendPath(connectionId, true);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
-            message.ResponseClassifier = ResponseClassifier200.Instance;
+            request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = ResponseClassifier204.Instance;
             return message;
         }
 
@@ -1148,17 +1915,45 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Head;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/users/", false);
             uri.AppendPath(userId, true);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             message.ResponseClassifier = ResponseClassifier200404.Instance;
+            return message;
+        }
+
+        internal HttpMessage CreateCloseUserConnectionsRequest(string userId, IEnumerable<string> excluded, string reason)
+        {
+            var message = _pipeline.CreateMessage();
+            var request = message.Request;
+            request.Method = RequestMethod.Post;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(_endpoint, false);
+            uri.AppendPath("/api/hubs/", false);
+            uri.AppendPath(_hub, true);
+            uri.AppendPath("/users/", false);
+            uri.AppendPath(userId, true);
+            uri.AppendPath("/:closeConnections", false);
+            if (excluded != null)
+            {
+                foreach (var param in excluded)
+                {
+                    uri.AppendQuery("excluded", param, true);
+                }
+            }
+            if (reason != null)
+            {
+                uri.AppendQuery("reason", reason, true);
+            }
+            uri.AppendQuery("api-version", _apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = ResponseClassifier204.Instance;
             return message;
         }
 
@@ -1168,17 +1963,15 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/users/", false);
             uri.AppendPath(userId, true);
             uri.AppendPath("/:send", false);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             request.Headers.Add("Content-Type", contentType.ToString());
             request.Content = content;
             message.ResponseClassifier = ResponseClassifier202.Instance;
@@ -1191,17 +1984,15 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/users/", false);
             uri.AppendPath(userId, true);
             uri.AppendPath("/:send", false);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             request.Headers.Add("Content-Type", "text/plain");
             request.Content = content;
             message.ResponseClassifier = ResponseClassifier202.Instance;
@@ -1214,18 +2005,16 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/users/", false);
             uri.AppendPath(userId, true);
             uri.AppendPath("/groups/", false);
             uri.AppendPath(group, true);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             message.ResponseClassifier = ResponseClassifier200404.Instance;
             return message;
         }
@@ -1236,19 +2025,17 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/users/", false);
             uri.AppendPath(userId, true);
             uri.AppendPath("/groups/", false);
             uri.AppendPath(group, true);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
-            message.ResponseClassifier = ResponseClassifier200.Instance;
+            request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = ResponseClassifier204.Instance;
             return message;
         }
 
@@ -1258,18 +2045,16 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/users/", false);
             uri.AppendPath(userId, true);
             uri.AppendPath("/groups", false);
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
-            message.ResponseClassifier = ResponseClassifier200.Instance;
+            request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = ResponseClassifier204.Instance;
             return message;
         }
 
@@ -1279,7 +2064,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/permissions/", false);
@@ -1290,11 +2075,9 @@ namespace Azure.Messaging.WebPubSub
             {
                 uri.AppendQuery("targetName", targetName, true);
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             message.ResponseClassifier = ResponseClassifier200.Instance;
             return message;
         }
@@ -1305,7 +2088,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/permissions/", false);
@@ -1316,12 +2099,10 @@ namespace Azure.Messaging.WebPubSub
             {
                 uri.AppendQuery("targetName", targetName, true);
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
-            message.ResponseClassifier = ResponseClassifier200.Instance;
+            request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = ResponseClassifier204.Instance;
             return message;
         }
 
@@ -1331,7 +2112,7 @@ namespace Azure.Messaging.WebPubSub
             var request = message.Request;
             request.Method = RequestMethod.Head;
             var uri = new RawRequestUriBuilder();
-            uri.Reset(_endpoint);
+            uri.AppendRaw(_endpoint, false);
             uri.AppendPath("/api/hubs/", false);
             uri.AppendPath(_hub, true);
             uri.AppendPath("/permissions/", false);
@@ -1342,11 +2123,9 @@ namespace Azure.Messaging.WebPubSub
             {
                 uri.AppendQuery("targetName", targetName, true);
             }
-            if (_apiVersion != null)
-            {
-                uri.AppendQuery("api-version", _apiVersion, true);
-            }
+            uri.AppendQuery("api-version", _apiVersion, true);
             request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
             message.ResponseClassifier = ResponseClassifier200404.Instance;
             return message;
         }
@@ -1360,6 +2139,19 @@ namespace Azure.Messaging.WebPubSub
                 return message.Response.Status switch
                 {
                     200 => false,
+                    _ => true
+                };
+            }
+        }
+        private sealed class ResponseClassifier204 : ResponseClassifier
+        {
+            private static ResponseClassifier _instance;
+            public static ResponseClassifier Instance => _instance ??= new ResponseClassifier204();
+            public override bool IsErrorResponse(HttpMessage message)
+            {
+                return message.Response.Status switch
+                {
+                    204 => false,
                     _ => true
                 };
             }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClientOptions.ServiceVersion.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClientOptions.ServiceVersion.cs
@@ -24,12 +24,8 @@ namespace Azure.Messaging.WebPubSub
         public enum ServiceVersion
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-#pragma warning disable AZC0016 // Invalid ServiceVersion member name.
-            /// <summary> The 2021_08_01_preview version of the Azure WebPubSub service. </summary>
-            V2021_08_01_preview = 1,
             /// <summary> The 2021_10_01_stable version of the Azure WebPubSub service. </summary>
-            V2021_10_01 = 2,
-#pragma warning restore AZC0016 // Invalid ServiceVersion member name.
+            V2021_10_01 = 1,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -77,7 +73,6 @@ namespace Azure.Messaging.WebPubSub
         public static string ToVersionString(this WebPubSubServiceClientOptions.ServiceVersion version) =>
             version switch
             {
-                WebPubSubServiceClientOptions.ServiceVersion.V2021_08_01_preview => "2021-08-01-preview",
                 WebPubSubServiceClientOptions.ServiceVersion.V2021_10_01 => "2021-10-01",
                 _ => throw CreateInvalidVersionException(version)
             };

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClientOptions.ServiceVersion.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClientOptions.ServiceVersion.cs
@@ -25,10 +25,10 @@ namespace Azure.Messaging.WebPubSub
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
 #pragma warning disable AZC0016 // Invalid ServiceVersion member name.
-            /// <summary> The 2021_05_01_preview version of the Azure WebPubSub service. </summary>
-            V2021_05_01_preview = 1,
             /// <summary> The 2021_08_01_preview version of the Azure WebPubSub service. </summary>
-            V2021_08_01_preview = 2,
+            V2021_08_01_preview = 1,
+            /// <summary> The 2021_10_01_stable version of the Azure WebPubSub service. </summary>
+            V2021_10_01 = 2,
 #pragma warning restore AZC0016 // Invalid ServiceVersion member name.
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
@@ -36,7 +36,7 @@ namespace Azure.Messaging.WebPubSub
         /// <summary>
         /// The Latest <see cref="ServiceVersion"/> supported by this client library.
         /// </summary>
-        private const ServiceVersion LatestVersion = ServiceVersion.V2021_08_01_preview;
+        private const ServiceVersion LatestVersion = ServiceVersion.V2021_10_01;
 
         /// <summary>
         /// Gets the version of the service API used when making requests.
@@ -77,8 +77,8 @@ namespace Azure.Messaging.WebPubSub
         public static string ToVersionString(this WebPubSubServiceClientOptions.ServiceVersion version) =>
             version switch
             {
-                WebPubSubServiceClientOptions.ServiceVersion.V2021_05_01_preview => "2021-05-01-preview",
                 WebPubSubServiceClientOptions.ServiceVersion.V2021_08_01_preview => "2021-08-01-preview",
+                WebPubSubServiceClientOptions.ServiceVersion.V2021_10_01 => "2021-10-01",
                 _ => throw CreateInvalidVersionException(version)
             };
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClient_extensions.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClient_extensions.cs
@@ -34,7 +34,7 @@ namespace Azure.Messaging.WebPubSub
         /// <summary>
         /// The service endpoint.
         /// </summary>
-        public virtual Uri Endpoint => _endpoint;
+        public virtual Uri Endpoint { get; }
 
         /// <summary> Initializes a new instance of WebPubSubServiceClient. </summary>
         /// <param name="endpoint"> server parameter. </param>
@@ -150,7 +150,8 @@ namespace Azure.Messaging.WebPubSub
             Argument.AssertNotNull(hub, nameof(hub));
 
             _hub = hub;
-            _endpoint = endpoint;
+            _endpoint = endpoint.AbsoluteUri;
+            Endpoint = endpoint;
 
             options ??= new WebPubSubServiceClientOptions();
             _clientDiagnostics = new ClientDiagnostics(options);

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClient_helpers.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClient_helpers.cs
@@ -36,9 +36,9 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="roles">Roles that the connection with the generated token will have.</param>
         /// <returns></returns>
 #pragma warning disable AZC0015 // Unexpected client method return type.
-        public virtual Uri GenerateClientAccessUri(DateTimeOffset expiresAt, string userId = default, IEnumerable<string> roles = default, CancellationToken cancellationToken = default)
+        public virtual Uri GetClientAccessUri(DateTimeOffset expiresAt, string userId = default, IEnumerable<string> roles = default, CancellationToken cancellationToken = default)
 #pragma warning restore AZC0015 // Unexpected client method return type.
-            => GenerateClientAccessUriInternal(expiresAt, userId, roles, async: false, cancellationToken).EnsureCompleted();
+            => GetClientAccessUriInternal(expiresAt, userId, roles, async: false, cancellationToken).EnsureCompleted();
 
         /// <summary>
         /// Creates a URI with authentication token.
@@ -49,8 +49,8 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="roles">Roles that the connection with the generated token will have.</param>
         /// <returns></returns>
 #pragma warning disable AZC0015 // Unexpected client method return type.
-        public virtual async Task<Uri> GenerateClientAccessUriAsync(DateTimeOffset expiresAt, string userId = default, IEnumerable<string> roles = default, CancellationToken cancellationToken = default)
-            => await GenerateClientAccessUriInternal(expiresAt, userId, roles, async: true, cancellationToken).ConfigureAwait(false);
+        public virtual async Task<Uri> GetClientAccessUriAsync(DateTimeOffset expiresAt, string userId = default, IEnumerable<string> roles = default, CancellationToken cancellationToken = default)
+            => await GetClientAccessUriInternal(expiresAt, userId, roles, async: true, cancellationToken).ConfigureAwait(false);
 #pragma warning restore AZC0015 // Unexpected client method return type.
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns></returns>
 #pragma warning disable AZC0015 // Unexpected client method return type.
-        public virtual Uri GenerateClientAccessUri(
+        public virtual Uri GetClientAccessUri(
             TimeSpan expiresAfter = default,
             string userId = default,
             IEnumerable<string> roles = default,
@@ -71,7 +71,7 @@ namespace Azure.Messaging.WebPubSub
         {
             DateTimeOffset expiresAt = GetExpiryTimeFromTimeSpan(expiresAfter);
 
-            return GenerateClientAccessUri(expiresAt, userId, roles, cancellationToken);
+            return GetClientAccessUri(expiresAt, userId, roles, cancellationToken);
         }
 
         /// <summary>
@@ -83,15 +83,15 @@ namespace Azure.Messaging.WebPubSub
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns></returns>
 #pragma warning disable AZC0015 // Unexpected client method return type.
-        public virtual async Task<Uri> GenerateClientAccessUriAsync(TimeSpan expiresAfter = default, string userId = default, IEnumerable<string> roles = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Uri> GetClientAccessUriAsync(TimeSpan expiresAfter = default, string userId = default, IEnumerable<string> roles = default, CancellationToken cancellationToken = default)
 #pragma warning restore AZC0015 // Unexpected client method return type.
         {
             DateTimeOffset expiresAt = GetExpiryTimeFromTimeSpan(expiresAfter);
 
-            return await GenerateClientAccessUriAsync(expiresAt, userId, roles, cancellationToken).ConfigureAwait(false);
+            return await GetClientAccessUriAsync(expiresAt, userId, roles, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<Uri> GenerateClientAccessUriInternal(
+        private async Task<Uri> GetClientAccessUriInternal(
             DateTimeOffset expiresAt,
             string userId = default,
             IEnumerable<string> roles = default,

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClient_helpers.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/WebPubSubServiceClient_helpers.cs
@@ -118,9 +118,9 @@ namespace Azure.Messaging.WebPubSub
                 throw new InvalidOperationException($"{nameof(WebPubSubServiceClient)} must be constructed with either a {typeof(TokenCredential)} or {typeof(AzureKeyCredential)} to generate client access URIs.");
             }
 
-            UriBuilder clientEndpoint = new(_endpoint)
+            UriBuilder clientEndpoint = new(Endpoint)
             {
-                Scheme = _endpoint.Scheme == "http" ? "ws" : "wss"
+                Scheme = Endpoint.Scheme == "http" ? "ws" : "wss"
             };
 
             return new Uri($"{clientEndpoint}client/hubs/{_hub}?access_token={token}");
@@ -231,7 +231,7 @@ namespace Azure.Messaging.WebPubSub
             var jwt = new JwtBuilder(keyBytes);
             var now = DateTimeOffset.UtcNow;
 
-            string endpoint = _endpoint.AbsoluteUri;
+            string endpoint = Endpoint.AbsoluteUri;
             if (!endpoint.EndsWith("/", StringComparison.Ordinal))
             {
                 endpoint += "/";

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/autorest.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/autorest.md
@@ -9,7 +9,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 ``` yaml
 title: WebPubSubServiceClient
 input-file:
-- https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d241e05b224891ddc0147544213d8edccf53f7d9/specification/webpubsub/data-plane/WebPubSub/preview/2021-08-01-preview/webpubsub.json
+- https://github.com/Azure/azure-rest-api-specs/blob/39c7d63c21b9a29efe3907d9b949d1c77b021907/specification/webpubsub/data-plane/WebPubSub/stable/2021-10-01/webpubsub.json
 low-level-client: true
 credential-types: AzureKeyCredential
 credential-header-name: Ocp-Apim-Subscription-Key
@@ -238,4 +238,37 @@ directive:
 - from: swagger-document
   where: $.paths["/api/hubs/{hub}/permissions/{permission}/connections/{connectionId}"].head
   transform: $["x-accessibility"] = "internal"
+```
+
+### CloseAllConnections
+``` yaml
+directive:
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/:closeConnections"].post.operationId
+  transform: return "WebPubSubService_CloseAllConnections";
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/:closeConnections"].post.parameters["0"]
+  transform: $["x-ms-parameter-location"] = "client"
+```
+
+### CloseGroupConnections
+``` yaml
+directive:
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/groups/{group}/:closeConnections"].post.operationId
+  transform: return "WebPubSubService_CloseGroupConnections";
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/groups/{group}/:closeConnections"].post.parameters["0"]
+  transform: $["x-ms-parameter-location"] = "client"
+```
+
+### CloseUserConnections
+``` yaml
+directive:
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/users/{userId}/:closeConnections"].post.operationId
+  transform: return "WebPubSubService_CloseUserConnections";
+- from: swagger-document
+  where: $.paths["/api/hubs/{hub}/users/{userId}/:closeConnections"].post.parameters["0"]
+  transform: $["x-ms-parameter-location"] = "client"
 ```

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubParseConnectionStringTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubParseConnectionStringTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Messaging.WebPubSub.Tests
         {
             var serviceClient = new WebPubSubServiceClient(string.Format("Endpoint=http://localhost;Port=8080;AccessKey={0};Version=1.0;", FakeAccessKey), "hub");
             var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(5);
-            var uri = serviceClient.GenerateClientAccessUri(expiresAt, userId, roles);
+            var uri = serviceClient.GetClientAccessUri(expiresAt, userId, roles);
             var token = HttpUtility.ParseQueryString(uri.Query).Get("access_token");
             Assert.NotNull(token);
             var jwt = JwtTokenHandler.ReadJwtToken(token);
@@ -87,7 +87,7 @@ namespace Azure.Messaging.WebPubSub.Tests
         public void TestGenerateUriContainsExpectedPayloads(string userId, string[] roles)
         {
             var serviceClient = new WebPubSubServiceClient(string.Format("Endpoint=http://localhost;Port=8080;AccessKey={0};Version=1.0;", FakeAccessKey), "hub");
-            var uri = serviceClient.GenerateClientAccessUri(TimeSpan.FromMinutes(5), userId, roles);
+            var uri = serviceClient.GetClientAccessUri(TimeSpan.FromMinutes(5), userId, roles);
             var token = HttpUtility.ParseQueryString(uri.Query).Get("access_token");
             Assert.NotNull(token);
             var jwt = JwtTokenHandler.ReadJwtToken(token);
@@ -135,8 +135,8 @@ namespace Azure.Messaging.WebPubSub.Tests
         public void TestGenerateUriUseSameKidWithSameKey(string connectionString, string hub, string expectedUrl)
         {
             var serviceClient = new WebPubSubServiceClient(string.Format(connectionString, FakeAccessKey), hub);
-            var uri1 = serviceClient.GenerateClientAccessUri();
-            var uri2 = serviceClient.GenerateClientAccessUri();
+            var uri1 = serviceClient.GetClientAccessUri();
+            var uri2 = serviceClient.GetClientAccessUri();
             var urlBuilder = new UriBuilder(uri1);
             urlBuilder.Query = string.Empty;
             Assert.AreEqual(expectedUrl, urlBuilder.Uri.ToString());


### PR DESCRIPTION
- Add transforms to put methods in the public client
- Add service version 'V2021_10_01' and remove all preview service versions
- Fix code because generated member `_endpoint` is `String` and not `Uri`
