### PR TITLE
Prevent ObjectDisposedException if Key Vault config provider disposed twice

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationProvider.cs
@@ -23,6 +23,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         private Dictionary<string, KeyVaultSecret> _loadedSecrets;
         private Task _pollingTask;
         private readonly CancellationTokenSource _cancellationToken;
+        private bool _disposed;
 
         /// <summary>
         /// Creates a new instance of <see cref="AzureKeyVaultConfigurationProvider"/>.
@@ -148,8 +149,13 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets
         {
             if (disposing)
             {
-                _cancellationToken.Cancel();
-                _cancellationToken.Dispose();
+                if (!_disposed)
+                {
+                    _cancellationToken.Cancel();
+                    _cancellationToken.Dispose();
+                }
+
+                _disposed = true;
             }
         }
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -628,6 +628,21 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => new AzureKeyVaultConfigurationProvider(Mock.Of<SecretClient>(),  new AzureKeyVaultConfigurationOptions() { ReloadInterval = TimeSpan.FromMilliseconds(-1) }));
         }
 
+        [Test]
+        public void DisposeCanBeCalledMultipleTimes()
+        {
+            // Arrange
+            var client = new Mock<SecretClient>();
+
+            using (var provider = new AzureKeyVaultConfigurationProvider(client.Object, new AzureKeyVaultConfigurationOptions() { Manager = new KeyVaultSecretManager() }))
+            {
+                provider.Dispose();
+
+                // Act & Assert
+                Assert.DoesNotThrow(() => provider.Dispose());
+            }
+        }
+
         private class EndsWithOneKeyVaultSecretManager : KeyVaultSecretManager
         {
             public override bool Load(SecretProperties secret)


### PR DESCRIPTION
Prevent `ObjectDisposeException` if `AzureKeyVaultConfigurationProvider` is disposed of more than once.

See dotnet/aspnetcore#37631.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.
