### PR TITLE
Test improvements for Queues/ServiceBus DynamicConcurrency (#24426)

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusEndToEndTests.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -420,8 +419,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
                 await WriteQueueMessages(messages);
 
-                // start the host and wait for all messages to be processed
+                // start the host
                 await host.StartAsync();
+
+                // wait for all messages to be processed
                 await TestHelpers.Await(() =>
                 {
                     return DynamicConcurrencyTestJob.InvocationCount >= numMessages;
@@ -429,7 +430,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
 
                 // ensure we've dynamically increased concurrency
                 concurrencyStatus = concurrencyManager.GetStatus(functionId);
-                Assert.GreaterOrEqual(concurrencyStatus.CurrentConcurrency, 10);
+                Assert.GreaterOrEqual(concurrencyStatus.CurrentConcurrency, 5);
 
                 // check a few of the concurrency logs
                 var concurrencyLogs = host.GetTestLoggerProvider().GetAllLogMessages().Where(p => p.Category == LogCategories.Concurrency).Select(p => p.FormattedMessage).ToList();
@@ -503,10 +504,6 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         {
             await TestMultiple<ServiceBusSingleMessageTestJob_BindMultipleFunctionsToSameEntity>();
         }
-
-        /*
-         * Helper functions
-         */
 
         private async Task TestSingleDrainMode<T>(bool sendToQueue)
         {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/ServiceBusSessionsEndToEndTests.cs
@@ -81,8 +81,10 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                 }
                 await WriteQueueMessages(messages, sessionIds);
 
-                // start the host and wait for all messages to be processed
+                // start the host
                 await host.StartAsync();
+
+                // wait for all messages to be processed
                 await TestHelpers.Await(() =>
                 {
                     return DynamicConcurrencyTestJob.InvocationCount >= numMessages;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/AzureStorageEndToEndTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/AzureStorageEndToEndTests.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.ScenarioTests
             Assert.AreEqual(1, concurrencyStatus.CurrentConcurrency);
 
             // write a bunch of queue messages
-            int numMessages = 300;
+            int numMessages = 500;
             string queueName = _resolver.ResolveInString(DynamicConcurrencyQueueName);
             await WriteQueueMessages(queueName, numMessages);
 
@@ -279,14 +279,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.ScenarioTests
             Assert.AreEqual(1, concurrencyStatus.CurrentConcurrency);
 
             // write some blobs
-            int numBlobs = 50;
+            int numBlobs = 100;
             string blobContainerName = _resolver.ResolveInString(DynamicConcurrencyBlobContainerName);
             await WriteBlobs(blobContainerName, numBlobs);
 
             // start the host
             await host.StartAsync();
 
-            // wait for all messages to be processed
+            // wait for all blobs to be processed
             await TestHelpers.Await(() =>
             {
                 return DynamicConcurrencyTestJob.InvocationCount >= numBlobs;


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-for-net/issues/24426 and https://github.com/Azure/azure-sdk-for-net/issues/24745. Initially I was considering a larger overhaul of the tests, e.g. having a message writer that continued to write messages until concurrency increased by a certain amount. However, I think If we just adjust the message numbers and test conditions we should be able to arrive at a stable configuration.