### PR TITLE
Allow setting nullable AMQP properties to null

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -288,15 +288,14 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         public string CorrelationId
         {
-            get
-            {
-                return AmqpMessage.Properties.CorrelationId.ToString();
-            }
+            get => _correlationIdSet ? AmqpMessage.Properties.CorrelationId?.ToString() : AmqpMessage.Properties.CorrelationId.ToString();
             set
             {
-                AmqpMessage.Properties.CorrelationId = new AmqpMessageId(value);
+                _correlationIdSet = true;
+                AmqpMessage.Properties.CorrelationId = value == null ? null : new AmqpMessageId(value);
             }
         }
+        private bool _correlationIdSet;
 
         /// <summary>Gets or sets an application specific subject.</summary>
         /// <value>The application specific subject.</value>
@@ -326,15 +325,14 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         public string To
         {
-            get
-            {
-                return AmqpMessage.Properties.To.ToString();
-            }
+            get => _toSet ? AmqpMessage.Properties.To?.ToString() : AmqpMessage.Properties.To.ToString();
             set
             {
-                AmqpMessage.Properties.To = new AmqpAddress(value);
+                _toSet = true;
+                AmqpMessage.Properties.To = value == null ? null : new AmqpAddress(value);
             }
         }
+        private bool _toSet;
 
         /// <summary>Gets or sets the content type descriptor.</summary>
         /// <value>RFC2045 Content-Type descriptor.</value>
@@ -364,15 +362,14 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         public string ReplyTo
         {
-            get
-            {
-                return AmqpMessage.Properties.ReplyTo.ToString();
-            }
+            get => _replyToSet ? AmqpMessage.Properties.ReplyTo?.ToString() :  AmqpMessage.Properties.ReplyTo.ToString();
             set
             {
-                AmqpMessage.Properties.ReplyTo = new AmqpAddress(value);
+                _replyToSet = true;
+                AmqpMessage.Properties.ReplyTo = value == null ? null : new AmqpAddress(value);
             }
         }
+        private bool _replyToSet;
 
         /// <summary>
         /// Gets or sets the date and time in UTC at which the message will be enqueued. This

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -1322,6 +1322,50 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             }
         }
 
+        [Test]
+        public async Task NullableAmqpPropertiesRoundTripCorrectly()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                await using var sender = client.CreateSender(scope.QueueName);
+
+                var message = new ServiceBusMessage
+                {
+                    ReplyTo = null,
+                    To = null,
+                    CorrelationId = null
+                };
+
+                Assert.IsNull(message.ReplyTo);
+                Assert.IsNull(message.To);
+                Assert.IsNull(message.CorrelationId);
+
+                await sender.SendMessageAsync(message);
+
+                await using var receiver = client.CreateReceiver(scope.QueueName);
+                ServiceBusReceivedMessage receivedMessage = await receiver.ReceiveMessageAsync();
+                Assert.IsNull(receivedMessage.ReplyTo);
+                Assert.IsNull(receivedMessage.To);
+                Assert.IsNull(receivedMessage.CorrelationId);
+
+                // verify default behavior for backcompat
+
+                message = new ServiceBusMessage();
+
+                Assert.AreEqual("", message.ReplyTo);
+                Assert.AreEqual("", message.To);
+                Assert.AreEqual("", message.CorrelationId);
+
+                await sender.SendMessageAsync(message);
+
+                receivedMessage = await receiver.ReceiveMessageAsync();
+                Assert.AreEqual("", receivedMessage.ReplyTo);
+                Assert.AreEqual("", receivedMessage.To);
+                Assert.AreEqual("", receivedMessage.CorrelationId);
+            }
+        }
+
         private static async Task<List<ServiceBusReceivedMessage>> ReceiveMessagesAsync(
             int messageCount,
             ServiceBusReceiver receiver,


### PR DESCRIPTION
We have to retain the unfortunate behavior of having the properties return an empty string if unset, but we can at least return null if the user explicitly sets to null.