### PR TITLE
[TA] Re-recorded tests excluding AAD tests

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationMockTests.cs
@@ -865,10 +865,10 @@ namespace Azure.AI.TextAnalytics.Tests
             var operation = new AnalyzeActionsOperation("75d521bc-c2aa-4d8a-aabe-713e72d53a2d", client);
             await operation.UpdateStatusAsync();
 
-            Assert.AreEqual(7, operation.ActionsFailed);
+            Assert.AreEqual(9, operation.ActionsFailed);
             Assert.AreEqual(0, operation.ActionsSucceeded);
             Assert.AreEqual(0, operation.ActionsInProgress);
-            Assert.AreEqual(7, operation.ActionsTotal);
+            Assert.AreEqual(9, operation.ActionsTotal);
 
             //Take the first page
             AnalyzeActionsResult resultCollection = operation.Value.ToEnumerableAsync().Result.FirstOrDefault();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationAllActionsAndDisableServiceLogs.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationAllActionsAndDisableServiceLogs.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "657",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-26318d95f2deea42b47860d1b6b8f84f-8ecd4fe02af5564d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b17650d343cc8742b3c5409c5889b084-c82ea0a0b8868c4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "782379accaf823684ab3ddba1b6d3561",
         "x-ms-return-client-request-id": "true"
       },
@@ -72,45 +78,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "577326d8-f2ab-4ec3-bdf0-7260fc13071b",
-        "Date": "Thu, 23 Sep 2021 14:41:58 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+        "apim-request-id": "f0f6d54a-0d09-402c-be45-ee510536d52d",
+        "Date": "Mon, 25 Oct 2021 21:02:27 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "785"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "489"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "31203c82b3d5318a200c000c98fad128",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "44bbc66f-34f2-4b66-b6d9-513e390aa80c",
+        "apim-request-id": "fadd7949-9686-4237-a5de-0456d05f122d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:41:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "118"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:41:59Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
-        "status": "running",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:27Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
+        "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -120,34 +131,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8b23d49428581723bf3cd5f948f9b6f0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bd25e248-03d8-45ef-8ddd-e4a75f9fbc7d",
+        "apim-request-id": "382882b3-cf7a-4321-8611-2a577c3bc69e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:00 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:41:59Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:28Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -157,34 +173,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "987bba592dc9f935eff158ecca5b8b4f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "06b80254-df85-436b-b81e-e4d7dbf71f57",
+        "apim-request-id": "0d9e9bf6-5878-449d-a8b5-2181969101b4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:41:59Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:28Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -194,34 +215,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4725b4e1aa495a0919087199de91e826",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4549c2af-b261-4efe-996a-9b0dcc602dfd",
+        "apim-request-id": "181d6bf3-ecbc-4a2e-8725-6a6be7877df0",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:41:59Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:28Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -231,273 +257,558 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ddb30f55397e675f9e2a9b66d0364c64",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "139a1a71-2581-47d4-aa77-c57b7a454ca2",
+        "apim-request-id": "7aecb9eb-9278-4f78-afdb-48ce18806553",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:03 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "229"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:42:03Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:28Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 3,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 2,
-          "total": 5,
-          "entityRecognitionTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:03.3852926Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Elon Musk",
-                        "category": "Person",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "CEO",
-                        "category": "PersonType",
-                        "offset": 17,
-                        "length": 3,
-                        "confidenceScore": 0.95
-                      },
-                      {
-                        "text": "SpaceX",
-                        "category": "Organization",
-                        "offset": 24,
-                        "length": 6,
-                        "confidenceScore": 0.99
-                      },
-                      {
-                        "text": "Tesla",
-                        "category": "Organization",
-                        "offset": 35,
-                        "length": 5,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Tesla",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 5,
-                        "confidenceScore": 0.98
-                      },
-                      {
-                        "text": "400%",
-                        "category": "Quantity",
-                        "subcategory": "Percentage",
-                        "offset": 21,
-                        "length": 4,
-                        "confidenceScore": 0.8
-                      },
-                      {
-                        "text": "this year",
-                        "category": "DateTime",
-                        "subcategory": "DateRange",
-                        "offset": 26,
-                        "length": 9,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            }
-          ],
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9092414Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* is the *** of ****** and *****.",
-                    "id": "0",
-                    "entities": [
-                      {
-                        "text": "Elon Musk",
-                        "category": "Person",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.99
-                      },
-                      {
-                        "text": "CEO",
-                        "category": "PersonType",
-                        "offset": 17,
-                        "length": 3,
-                        "confidenceScore": 0.96
-                      },
-                      {
-                        "text": "SpaceX",
-                        "category": "Organization",
-                        "offset": 24,
-                        "length": 6,
-                        "confidenceScore": 0.98
-                      },
-                      {
-                        "text": "Tesla",
-                        "category": "Organization",
-                        "offset": 35,
-                        "length": 5,
-                        "confidenceScore": 0.98
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "***** stock is up by 400% *********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Tesla",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 5,
-                        "confidenceScore": 0.95
-                      },
-                      {
-                        "text": "this year",
-                        "category": "DateTime",
-                        "subcategory": "DateRange",
-                        "offset": 26,
-                        "length": 9,
-                        "confidenceScore": 0.8
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9264793Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 41,
-                        "text": "Elon Musk is the CEO of SpaceX and Tesla."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 1.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 1.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 36,
-                        "text": "Tesla stock is up by 400% this year."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
+          "inProgress": 5,
+          "total": 5
         }
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "941785b06fd3afa7b1217fc0bb9c1a5e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c5878215-7299-4ca4-9709-b711010052ae",
+        "apim-request-id": "c3219235-e327-4b10-85ce-988c44052bcb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:04 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "240"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:42:04Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:34Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 5,
+          "total": 5
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "bb973109aea8a8d054bea81f0ea289e2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "349e0b4b-39dc-4482-9aa2-0310aaab9c4d",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:02:34 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
+      },
+      "ResponseBody": {
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:34Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 5,
+          "total": 5
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "58e80dbb5479e65268032b5cb99fab01",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "297c9a9f-3015-4b8b-9878-1867ccb910a3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:02:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:34Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 5,
+          "total": 5
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9e5c3d0f919f02bbb46f3f15c787a00e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8591c3eb-b3f5-4b87-8ecd-fd8813c44a56",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:02:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "132"
+      },
+      "ResponseBody": {
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:37Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 4,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:02:37.5599819Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ad049d97c1b4b5e4deb153a48373eeb5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d3ce7e30-67b3-4ef9-bc04-5db2417348ab",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:02:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "101"
+      },
+      "ResponseBody": {
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:37Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 4,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:02:37.5599819Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d10fa612eb462a4252e6a40a143d1fe0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f4a964bd-5188-4f60-b75f-8089b7535574",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:02:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "241"
+      },
+      "ResponseBody": {
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:37Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 4,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:02:37.5599819Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "1cc41c63fe9a4d4d58a7bfee3d177f40",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1c1a7432-9b3f-4a83-abbf-b50a08b92c4c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:02:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "236"
+      },
+      "ResponseBody": {
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:42Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
+        "status": "running",
+        "errors": [],
         "tasks": {
           "completed": 3,
           "failed": 0,
@@ -505,7 +816,7 @@
           "total": 5,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:03.3852926Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:37.5599819Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -580,7 +891,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9092414Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:41.2945412Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -649,7 +960,7 @@
           ],
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9264793Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:42.4601302Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -709,42 +1020,47 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bb973109aea8a8d054bea81f0ea289e2",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "20028a80cf77acc85bd95bce1ddaa0a1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50b1aa99-8547-49f6-b004-71e3c04b14aa",
+        "apim-request-id": "323d0285-8cde-4451-8539-0154a838f087",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "376"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1517"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:42:05Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:42Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 4,
+          "completed": 3,
           "failed": 0,
-          "inProgress": 1,
+          "inProgress": 2,
           "total": 5,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:03.3852926Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:37.5599819Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -817,97 +1133,9 @@
               }
             }
           ],
-          "entityLinkingTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:05.1246774Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
-                        "name": "Elon Musk",
-                        "matches": [
-                          {
-                            "text": "Elon Musk",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.94
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Elon Musk",
-                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
-                        "dataSource": "Wikipedia"
-                      },
-                      {
-                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
-                        "name": "SpaceX",
-                        "matches": [
-                          {
-                            "text": "SpaceX",
-                            "offset": 24,
-                            "length": 6,
-                            "confidenceScore": 0.63
-                          }
-                        ],
-                        "language": "en",
-                        "id": "SpaceX",
-                        "url": "https://en.wikipedia.org/wiki/SpaceX",
-                        "dataSource": "Wikipedia"
-                      },
-                      {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 35,
-                            "length": 5,
-                            "confidenceScore": 0.47
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 0,
-                            "length": 5,
-                            "confidenceScore": 0.05
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            }
-          ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9092414Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:41.2945412Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -976,7 +1204,7 @@
           ],
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9264793Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:42.4601302Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1036,42 +1264,47 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "58e80dbb5479e65268032b5cb99fab01",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "66417292d2af141a58c2789f2b53ec3a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8846e222-8635-4ad6-b47f-9d055f3ca94e",
+        "apim-request-id": "1e7cf76b-b3a6-4b90-b2ac-d6804746ffbd",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:08 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "276"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "171"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:42:05Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:42Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 4,
+          "completed": 3,
           "failed": 0,
-          "inProgress": 1,
+          "inProgress": 2,
           "total": 5,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:03.3852926Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:37.5599819Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1144,97 +1377,9 @@
               }
             }
           ],
-          "entityLinkingTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:05.1246774Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "entities": [
-                      {
-                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
-                        "name": "Elon Musk",
-                        "matches": [
-                          {
-                            "text": "Elon Musk",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.94
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Elon Musk",
-                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
-                        "dataSource": "Wikipedia"
-                      },
-                      {
-                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
-                        "name": "SpaceX",
-                        "matches": [
-                          {
-                            "text": "SpaceX",
-                            "offset": 24,
-                            "length": 6,
-                            "confidenceScore": 0.63
-                          }
-                        ],
-                        "language": "en",
-                        "id": "SpaceX",
-                        "url": "https://en.wikipedia.org/wiki/SpaceX",
-                        "dataSource": "Wikipedia"
-                      },
-                      {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 35,
-                            "length": 5,
-                            "confidenceScore": 0.47
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 0,
-                            "length": 5,
-                            "confidenceScore": 0.05
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            }
-          ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9092414Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:41.2945412Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1303,7 +1448,7 @@
           ],
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9264793Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:42.4601302Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1363,34 +1508,283 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/04076d3b-729e-42e8-9fef-16f4d7e5c73c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9e5c3d0f919f02bbb46f3f15c787a00e",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "8a8a6366fe3b93695318c0c0a27f307e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "493b5555-1502-49f6-888b-01d0591bf3c5",
+        "apim-request-id": "ec6da102-9cf2-4161-9f03-e534621a08ec",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:09 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "354"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7991"
       },
       "ResponseBody": {
-        "jobId": "04076d3b-729e-42e8-9fef-16f4d7e5c73c",
-        "lastUpdateDateTime": "2021-09-23T14:42:08Z",
-        "createdDateTime": "2021-09-23T14:41:57Z",
-        "expirationDateTime": "2021-09-24T14:41:57Z",
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:42Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:02:37.5599819Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:02:41.2945412Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:02:42.4601302Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 41,
+                        "text": "Elon Musk is the CEO of SpaceX and Tesla."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.0,
+                      "neutral": 1.0,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.0,
+                          "neutral": 1.0,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 36,
+                        "text": "Tesla stock is up by 400% this year."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8ef0011-2e7c-421e-8558-cadcde63f546",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "cb5c1e0618d6ad916fedc8b557298007",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "31bebfb2-2cb0-41c2-9924-18421cba9d0e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:02:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "251"
+      },
+      "ResponseBody": {
+        "jobId": "c8ef0011-2e7c-421e-8558-cadcde63f546",
+        "lastUpdateDateTime": "2021-10-25T21:02:58Z",
+        "createdDateTime": "2021-10-25T21:02:27Z",
+        "expirationDateTime": "2021-10-26T21:02:27Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 5,
           "failed": 0,
@@ -1398,7 +1792,7 @@
           "total": 5,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:03.3852926Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:37.5599819Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1473,7 +1867,7 @@
           ],
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:05.1246774Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:58.0421731Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1561,7 +1955,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9092414Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:41.2945412Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1630,7 +2024,7 @@
           ],
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:08.1113957Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:53.8966586Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1659,7 +2053,7 @@
           ],
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:02.9264793Z",
+              "lastUpdateDateTime": "2021-10-25T21:02:42.4601302Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1722,6 +2116,6 @@
   "Variables": {
     "RandomSeed": "1881715126",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationAllActionsAndDisableServiceLogsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationAllActionsAndDisableServiceLogsAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "657",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8051d00686edf04bbc5ed3e11a79b945-6bf07fe90283a040-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e895acb3eaece244b1bef931049e8f57-aef72f5293ab3546-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cab6db40209658f86d8910a806e31bf5",
         "x-ms-return-client-request-id": "true"
       },
@@ -72,45 +78,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "7179f2fb-8e7d-4f5b-b10b-e9ee22c5e1f1",
-        "Date": "Thu, 23 Sep 2021 14:44:12 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+        "apim-request-id": "aea21175-cd53-4db9-ac97-98dd61eead75",
+        "Date": "Mon, 25 Oct 2021 21:05:40 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "521"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "604"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c47d34012245c090a781ad405351b093",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aca649a0-1a4f-4e8d-81b8-e9659a1bbdfe",
+        "apim-request-id": "78864347-de1c-4474-b400-0c56bdec53b9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:12 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "a7110920-94cd-4f0d-a156-0c5d55c6c52e",
-        "lastUpdateDateTime": "2021-09-23T14:44:13Z",
-        "createdDateTime": "2021-09-23T14:44:13Z",
-        "expirationDateTime": "2021-09-24T14:44:13Z",
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:40Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -120,34 +131,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a9595244f4c07851c15dba6c4a69457a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ed20e71f-47de-4856-9dc5-f523f3c79bce",
+        "apim-request-id": "b4422a16-5bdc-4829-9b83-2d19f57b5af6",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "a7110920-94cd-4f0d-a156-0c5d55c6c52e",
-        "lastUpdateDateTime": "2021-09-23T14:44:14Z",
-        "createdDateTime": "2021-09-23T14:44:13Z",
-        "expirationDateTime": "2021-09-24T14:44:13Z",
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:40Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -157,42 +173,47 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d93f0294486e1eee4bf5221573b8041c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b3debdcf-e0b2-4cc3-bf81-e2e649e7a161",
+        "apim-request-id": "d6686b44-ef90-4a9e-a91c-a6c3f8c2066e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:16 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "157"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "114"
       },
       "ResponseBody": {
-        "jobId": "a7110920-94cd-4f0d-a156-0c5d55c6c52e",
-        "lastUpdateDateTime": "2021-09-23T14:44:15Z",
-        "createdDateTime": "2021-09-23T14:44:13Z",
-        "expirationDateTime": "2021-09-24T14:44:13Z",
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:43Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 1,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 4,
+          "inProgress": 3,
           "total": 5,
-          "entityLinkingTasks": [
+          "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:15.3609686Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -200,52 +221,32 @@
                     "id": "0",
                     "entities": [
                       {
-                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
-                        "name": "Elon Musk",
-                        "matches": [
-                          {
-                            "text": "Elon Musk",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.94
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Elon Musk",
-                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
-                        "dataSource": "Wikipedia"
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
                       },
                       {
-                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
-                        "name": "SpaceX",
-                        "matches": [
-                          {
-                            "text": "SpaceX",
-                            "offset": 24,
-                            "length": 6,
-                            "confidenceScore": 0.63
-                          }
-                        ],
-                        "language": "en",
-                        "id": "SpaceX",
-                        "url": "https://en.wikipedia.org/wiki/SpaceX",
-                        "dataSource": "Wikipedia"
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
                       },
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 35,
-                            "length": 5,
-                            "confidenceScore": 0.47
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
                       }
                     ],
                     "warnings": []
@@ -254,20 +255,27 @@
                     "id": "1",
                     "entities": [
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 0,
-                            "length": 5,
-                            "confidenceScore": 0.05
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
                       }
                     ],
                     "warnings": []
@@ -277,47 +285,121 @@
                 "modelVersion": "2021-06-01"
               }
             }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
           ]
         }
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b3637dd8728a0c34e20502e76723763e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "57816457-494e-46d9-ae8e-a045e45cc75c",
+        "apim-request-id": "2502f5a3-8527-44ea-afeb-166dd722c241",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "219"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "307"
       },
       "ResponseBody": {
-        "jobId": "a7110920-94cd-4f0d-a156-0c5d55c6c52e",
-        "lastUpdateDateTime": "2021-09-23T14:44:17Z",
-        "createdDateTime": "2021-09-23T14:44:13Z",
-        "expirationDateTime": "2021-09-24T14:44:13Z",
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:43Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 2,
+          "inProgress": 3,
           "total": 5,
-          "entityLinkingTasks": [
+          "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:15.3609686Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -325,52 +407,32 @@
                     "id": "0",
                     "entities": [
                       {
-                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
-                        "name": "Elon Musk",
-                        "matches": [
-                          {
-                            "text": "Elon Musk",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.94
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Elon Musk",
-                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
-                        "dataSource": "Wikipedia"
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
                       },
                       {
-                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
-                        "name": "SpaceX",
-                        "matches": [
-                          {
-                            "text": "SpaceX",
-                            "offset": 24,
-                            "length": 6,
-                            "confidenceScore": 0.63
-                          }
-                        ],
-                        "language": "en",
-                        "id": "SpaceX",
-                        "url": "https://en.wikipedia.org/wiki/SpaceX",
-                        "dataSource": "Wikipedia"
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
                       },
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 35,
-                            "length": 5,
-                            "confidenceScore": 0.47
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
                       }
                     ],
                     "warnings": []
@@ -379,20 +441,27 @@
                     "id": "1",
                     "entities": [
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 0,
-                            "length": 5,
-                            "confidenceScore": 0.05
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
                       }
                     ],
                     "warnings": []
@@ -405,7 +474,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:16.7146258Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -471,105 +540,52 @@
                 "modelVersion": "2021-01-15"
               }
             }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:17.0299484Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 41,
-                        "text": "Elon Musk is the CEO of SpaceX and Tesla."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 1.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 1.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 36,
-                        "text": "Tesla stock is up by 400% this year."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
           ]
         }
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "51ab323bd712fc24633a5ecbd13c0509",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1f0f224c-a22e-472b-a41c-6aeaf5524c38",
+        "apim-request-id": "5828cac2-276e-4efd-bf9e-09de59124e4a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "206"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "174"
       },
       "ResponseBody": {
-        "jobId": "a7110920-94cd-4f0d-a156-0c5d55c6c52e",
-        "lastUpdateDateTime": "2021-09-23T14:44:17Z",
-        "createdDateTime": "2021-09-23T14:44:13Z",
-        "expirationDateTime": "2021-09-24T14:44:13Z",
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:46Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 2,
+          "inProgress": 3,
           "total": 5,
-          "entityLinkingTasks": [
+          "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:15.3609686Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -577,52 +593,32 @@
                     "id": "0",
                     "entities": [
                       {
-                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
-                        "name": "Elon Musk",
-                        "matches": [
-                          {
-                            "text": "Elon Musk",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.94
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Elon Musk",
-                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
-                        "dataSource": "Wikipedia"
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
                       },
                       {
-                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
-                        "name": "SpaceX",
-                        "matches": [
-                          {
-                            "text": "SpaceX",
-                            "offset": 24,
-                            "length": 6,
-                            "confidenceScore": 0.63
-                          }
-                        ],
-                        "language": "en",
-                        "id": "SpaceX",
-                        "url": "https://en.wikipedia.org/wiki/SpaceX",
-                        "dataSource": "Wikipedia"
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
                       },
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 35,
-                            "length": 5,
-                            "confidenceScore": 0.47
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
                       }
                     ],
                     "warnings": []
@@ -631,20 +627,27 @@
                     "id": "1",
                     "entities": [
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 0,
-                            "length": 5,
-                            "confidenceScore": 0.05
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
                       }
                     ],
                     "warnings": []
@@ -657,7 +660,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:16.7146258Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -723,105 +726,52 @@
                 "modelVersion": "2021-01-15"
               }
             }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:17.0299484Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 41,
-                        "text": "Elon Musk is the CEO of SpaceX and Tesla."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 1.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 1.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 36,
-                        "text": "Tesla stock is up by 400% this year."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
           ]
         }
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cd939e58910622f0ce32f6694507b627",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa52deea-b4a8-4300-a087-920910329b62",
+        "apim-request-id": "31a9ae4e-5b78-4952-97ea-0800b0a30b22",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "223"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "119"
       },
       "ResponseBody": {
-        "jobId": "a7110920-94cd-4f0d-a156-0c5d55c6c52e",
-        "lastUpdateDateTime": "2021-09-23T14:44:19Z",
-        "createdDateTime": "2021-09-23T14:44:13Z",
-        "expirationDateTime": "2021-09-24T14:44:13Z",
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:46Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 2,
+          "inProgress": 3,
           "total": 5,
-          "entityLinkingTasks": [
+          "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:15.3609686Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -829,52 +779,32 @@
                     "id": "0",
                     "entities": [
                       {
-                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
-                        "name": "Elon Musk",
-                        "matches": [
-                          {
-                            "text": "Elon Musk",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.94
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Elon Musk",
-                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
-                        "dataSource": "Wikipedia"
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
                       },
                       {
-                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
-                        "name": "SpaceX",
-                        "matches": [
-                          {
-                            "text": "SpaceX",
-                            "offset": 24,
-                            "length": 6,
-                            "confidenceScore": 0.63
-                          }
-                        ],
-                        "language": "en",
-                        "id": "SpaceX",
-                        "url": "https://en.wikipedia.org/wiki/SpaceX",
-                        "dataSource": "Wikipedia"
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
                       },
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 35,
-                            "length": 5,
-                            "confidenceScore": 0.47
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
                       }
                     ],
                     "warnings": []
@@ -883,20 +813,27 @@
                     "id": "1",
                     "entities": [
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 0,
-                            "length": 5,
-                            "confidenceScore": 0.05
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
                       }
                     ],
                     "warnings": []
@@ -909,7 +846,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:16.7146258Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -975,105 +912,52 @@
                 "modelVersion": "2021-01-15"
               }
             }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:17.0299484Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 41,
-                        "text": "Elon Musk is the CEO of SpaceX and Tesla."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 1.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 1.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 36,
-                        "text": "Tesla stock is up by 400% this year."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
           ]
         }
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "41d9e47eb30c01095867504f14693aa6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "35f89be1-4adc-4a96-9097-8fbaa007d857",
+        "apim-request-id": "5acba0d3-98ed-4953-b0af-3cf33276eb6e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "215"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "123"
       },
       "ResponseBody": {
-        "jobId": "a7110920-94cd-4f0d-a156-0c5d55c6c52e",
-        "lastUpdateDateTime": "2021-09-23T14:44:19Z",
-        "createdDateTime": "2021-09-23T14:44:13Z",
-        "expirationDateTime": "2021-09-24T14:44:13Z",
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:46Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 3,
+          "completed": 2,
           "failed": 0,
-          "inProgress": 2,
+          "inProgress": 3,
           "total": 5,
-          "entityLinkingTasks": [
+          "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:15.3609686Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1081,52 +965,32 @@
                     "id": "0",
                     "entities": [
                       {
-                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
-                        "name": "Elon Musk",
-                        "matches": [
-                          {
-                            "text": "Elon Musk",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.94
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Elon Musk",
-                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
-                        "dataSource": "Wikipedia"
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
                       },
                       {
-                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
-                        "name": "SpaceX",
-                        "matches": [
-                          {
-                            "text": "SpaceX",
-                            "offset": 24,
-                            "length": 6,
-                            "confidenceScore": 0.63
-                          }
-                        ],
-                        "language": "en",
-                        "id": "SpaceX",
-                        "url": "https://en.wikipedia.org/wiki/SpaceX",
-                        "dataSource": "Wikipedia"
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
                       },
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 35,
-                            "length": 5,
-                            "confidenceScore": 0.47
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
                       }
                     ],
                     "warnings": []
@@ -1135,20 +999,27 @@
                     "id": "1",
                     "entities": [
                       {
-                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
-                        "name": "Tesla, Inc.",
-                        "matches": [
-                          {
-                            "text": "Tesla",
-                            "offset": 0,
-                            "length": 5,
-                            "confidenceScore": 0.05
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Tesla, Inc.",
-                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
-                        "dataSource": "Wikipedia"
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
                       }
                     ],
                     "warnings": []
@@ -1161,7 +1032,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:16.7146258Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1227,62 +1098,190 @@
                 "modelVersion": "2021-01-15"
               }
             }
-          ],
-          "sentimentAnalysisTasks": [
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c98ef900a98fa938418982dfe0bbb65c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e49a2a08-b28f-4cdc-af25-0befd6bba9fd",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:05:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "115"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:46Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 5,
+          "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:17.0299484Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
               "state": "succeeded",
               "results": {
                 "documents": [
                   {
                     "id": "0",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
+                    "entities": [
                       {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
+                        "text": "Elon Musk",
+                        "category": "Person",
                         "offset": 0,
-                        "length": 41,
-                        "text": "Elon Musk is the CEO of SpaceX and Tesla."
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
                       }
                     ],
                     "warnings": []
                   },
                   {
                     "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 1.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
+                    "entities": [
                       {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 1.0,
-                          "negative": 0.0
-                        },
+                        "text": "Tesla",
+                        "category": "Organization",
                         "offset": 0,
-                        "length": 36,
-                        "text": "Tesla stock is up by 400% this year."
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
                       }
                     ],
                     "warnings": []
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2020-04-01"
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
               }
             }
           ]
@@ -1290,42 +1289,47 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a7110920-94cd-4f0d-a156-0c5d55c6c52e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c98ef900a98fa938418982dfe0bbb65c",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ed4c3684c462a5fd9492749f41a10d64",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "42a9dec3-1c16-4615-ae72-56dc24d67d38",
+        "apim-request-id": "84823b8c-e0f1-4729-b99a-8924f12dc040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:22 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "374"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "263"
       },
       "ResponseBody": {
-        "jobId": "a7110920-94cd-4f0d-a156-0c5d55c6c52e",
-        "lastUpdateDateTime": "2021-09-23T14:44:22Z",
-        "createdDateTime": "2021-09-23T14:44:13Z",
-        "expirationDateTime": "2021-09-24T14:44:13Z",
-        "status": "succeeded",
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
-          "completed": 5,
+          "completed": 4,
           "failed": 0,
-          "inProgress": 0,
+          "inProgress": 1,
           "total": 5,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:21.7265143Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1400,7 +1404,7 @@
           ],
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:15.3609686Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1488,7 +1492,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:16.7146258Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1557,7 +1561,2734 @@
           ],
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:22.6197564Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4c6850f8ec78d598ac2fff83312a219d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "98d43f9a-b704-4dbd-bbc2-76258ab3af1f",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:05:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "725"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ddcaf4b04d1d3c43fbe934fd3598689f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "da6a6529-4358-4ddb-9862-412711133904",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:05:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "223"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "90e61d7b6a5298e39e764032c4797369",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3b9938dd-e8a7-4abd-8e2f-0aae3dc33207",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:05:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "312"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4ceed6702fd7aa470c2c508fb79aa013",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f2465131-6735-4b2d-9b6e-f2fab5f1bdf2",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "234"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "130860c79144454b11323fa60d107881",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3929d088-6400-4a65-be72-d27bae7c53b7",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "351"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "5e8ccb751caa4bc8d53c83251953e003",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3920b053-1497-4020-8324-57bce6a17c82",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "249"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "636b2cd66071df258ba93ba4f0a19dfb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f5a67637-2e9a-4e46-bbc5-0597fe75b837",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "254"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ec19ceb4410eab6998bd3d070e252cbd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e3410199-fa2d-441a-8fc4-2da1973c7842",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5461"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:05:53Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e0d03c5214a51510a5add301e0235a34",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "40449f0a-edd4-41fa-9318-258aafe51e00",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "400"
+      },
+      "ResponseBody": {
+        "jobId": "f7dded68-afe6-4a4d-8137-2d1769b2c2ff",
+        "lastUpdateDateTime": "2021-10-25T21:06:12Z",
+        "createdDateTime": "2021-10-25T21:05:39Z",
+        "expirationDateTime": "2021-10-26T21:05:39Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 5,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:42.4358072Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "400%",
+                        "category": "Quantity",
+                        "subcategory": "Percentage",
+                        "offset": 21,
+                        "length": 4,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:52.5953168Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "entities": [
+                      {
+                        "bingId": "ce6414c0-f9f0-b48b-31f9-42a7dab4db59",
+                        "name": "Elon Musk",
+                        "matches": [
+                          {
+                            "text": "Elon Musk",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.94
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Elon Musk",
+                        "url": "https://en.wikipedia.org/wiki/Elon_Musk",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "627fa43a-d963-2c69-46ae-de521d27f9b9",
+                        "name": "SpaceX",
+                        "matches": [
+                          {
+                            "text": "SpaceX",
+                            "offset": 24,
+                            "length": 6,
+                            "confidenceScore": 0.63
+                          }
+                        ],
+                        "language": "en",
+                        "id": "SpaceX",
+                        "url": "https://en.wikipedia.org/wiki/SpaceX",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 35,
+                            "length": 5,
+                            "confidenceScore": 0.47
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "732e1de9-8d5c-15ed-7f0d-7e2169dc9859",
+                        "name": "Tesla, Inc.",
+                        "matches": [
+                          {
+                            "text": "Tesla",
+                            "offset": 0,
+                            "length": 5,
+                            "confidenceScore": 0.05
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Tesla, Inc.",
+                        "url": "https://en.wikipedia.org/wiki/Tesla,_Inc.",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:43.2579704Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* is the *** of ****** and *****.",
+                    "id": "0",
+                    "entities": [
+                      {
+                        "text": "Elon Musk",
+                        "category": "Person",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.99
+                      },
+                      {
+                        "text": "CEO",
+                        "category": "PersonType",
+                        "offset": 17,
+                        "length": 3,
+                        "confidenceScore": 0.96
+                      },
+                      {
+                        "text": "SpaceX",
+                        "category": "Organization",
+                        "offset": 24,
+                        "length": 6,
+                        "confidenceScore": 0.98
+                      },
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 35,
+                        "length": 5,
+                        "confidenceScore": 0.98
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "***** stock is up by 400% *********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Tesla",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 5,
+                        "confidenceScore": 0.95
+                      },
+                      {
+                        "text": "this year",
+                        "category": "DateTime",
+                        "subcategory": "DateRange",
+                        "offset": 26,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:05:53.7823098Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1586,7 +4317,7 @@
           ],
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:17.0299484Z",
+              "lastUpdateDateTime": "2021-10-25T21:06:12.4650464Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1649,6 +4380,6 @@
   "Variables": {
     "RandomSeed": "1499041820",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationAnalyzeSentimentWithOpinionMining.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationAnalyzeSentimentWithOpinionMining.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "304",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a410475800a59d4ab18dd1d5bb37b168-0edf8a49e8ba3441-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b157eecab9155d4a9d722225c52d111c-a4ad3ada562bc047-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "aeed755eebf15dfbf87891ec623be508",
         "x-ms-return-client-request-id": "true"
       },
@@ -37,43 +43,49 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0a917f7c-b9df-4d43-8035-a1afc84b3261",
-        "Date": "Thu, 23 Sep 2021 14:42:09 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
+        "apim-request-id": "66c89bad-0eae-4f7d-97ed-3b5e41594cf9",
+        "Date": "Mon, 25 Oct 2021 21:02:59 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "218"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "163"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b89b687077016fde88c409f18dad86de",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bebcf317-5e49-4ece-890a-42f43a8362c9",
+        "apim-request-id": "fd4a6aa3-7ac7-42d2-8f0f-3d1c6523f18a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:09 GMT",
+        "Date": "Mon, 25 Oct 2021 21:02:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
-        "lastUpdateDateTime": "2021-09-23T14:42:10Z",
-        "createdDateTime": "2021-09-23T14:42:10Z",
-        "expirationDateTime": "2021-09-24T14:42:10Z",
-        "status": "notStarted",
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
         "tasks": {
@@ -85,31 +97,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cd305befd02867efcaa990c232be4a65",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4c52a580-5328-4142-894e-659aacae984e",
+        "apim-request-id": "124d51b0-119c-4c5a-8065-47c50d95888f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:11 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
-        "lastUpdateDateTime": "2021-09-23T14:42:10Z",
-        "createdDateTime": "2021-09-23T14:42:10Z",
-        "expirationDateTime": "2021-09-24T14:42:10Z",
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -122,31 +140,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ddc0b88facc4e772977d262ce109cf4a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "892c3cde-36a9-4a96-a7ee-2c666d4efb8a",
+        "apim-request-id": "d02c15ab-4396-444c-bc24-89287ec3a77f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:12 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
-        "lastUpdateDateTime": "2021-09-23T14:42:10Z",
-        "createdDateTime": "2021-09-23T14:42:10Z",
-        "expirationDateTime": "2021-09-24T14:42:10Z",
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -159,31 +183,768 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "07fdb3f2180b9fe07934ed57e71b3dc9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "51f3821a-8430-4859-9a88-a692e062b1b7",
+        "apim-request-id": "e3ae680f-ae5a-4e20-96aa-9415ff3582ef",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "61"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "6c190067-3de2-4bd4-9132-ae17c1f8e6cb",
-        "lastUpdateDateTime": "2021-09-23T14:42:12Z",
-        "createdDateTime": "2021-09-23T14:42:10Z",
-        "expirationDateTime": "2021-09-24T14:42:10Z",
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d561a47aa8ed421ae84935aaaac286c1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "443e9354-15c6-45dc-88a9-2fa75d763cf6",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7fd045da43c17759d8206490bf1a007b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3686091e-06e2-4f9e-b4bc-aef56428bc0e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3db25c40faa8495d99ba1ec2e235f5b7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e80dcbd5-0b84-46f7-8096-3c1c997dc028",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a17d2badbe4b37084aeafccc448982cd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "39c45ded-7318-43de-8c55-4e045134cc45",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4e6aba484910e019e786e606249794a3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b0a409f4-4da8-4565-b7b1-e9f8124a8865",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:10 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "93e2ac2b5e9d8230537bf2bdfd91050f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c0cefe53-ce54-4d60-b01c-aa0372332346",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "28795137a7ca64a6129dbac4d80112b2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c89d3ae0-c806-49f3-be1e-dfcec4a35fe6",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "97a15955efa6ea3089e8fa95565be256",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3dc03b26-dd6c-40d3-adbe-1676e3234493",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d2ced6816b1e83d8057e80ffa36baa51",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fdafa2c2-2ed6-4471-ba25-e6bcdf5fbcef",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a46840686df04868218e9ee2ac110eb7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "26efce3d-31ce-489b-aa30-7c977eb19a15",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "014264bb4033e993811d91286e30461d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "eeb0af8c-1be2-40b1-89e7-9f606cef6155",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "162da83e3ef314656d86b090ccf5d7f4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9f58a0dc-3f8f-4baf-a312-cbe0f0e6fc97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3f44c970a829281eac7e22d3db40daf1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1ec7bfce-7a0a-47ba-842e-ef75128cceb7",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "04a48148f7e47dc3fe2e93ac8f031d8b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e67024a4-37f4-4436-b72e-8ee2c66bd94b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a4b89d4607ec95f489056a751b92382d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5a850931-92fc-4d8b-8e54-47843b4ba438",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4b47bfacd251780f05c740fb147298a8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b0c19557-9b1a-4d4a-b38d-ce307a5914dc",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:02:59Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ca5c9c48-b73d-4447-9a77-88de15972329",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3e8d9760358740048c0e7adf8d4e616b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "016975f4-cf20-471a-b950-240cfb3ba8eb",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "127"
+      },
+      "ResponseBody": {
+        "jobId": "ca5c9c48-b73d-4447-9a77-88de15972329",
+        "lastUpdateDateTime": "2021-10-25T21:03:24Z",
+        "createdDateTime": "2021-10-25T21:02:59Z",
+        "expirationDateTime": "2021-10-26T21:02:59Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -194,7 +955,7 @@
           "total": 1,
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:12.855788Z",
+              "lastUpdateDateTime": "2021-10-25T21:03:24.3288394Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -338,6 +1099,6 @@
   "Variables": {
     "RandomSeed": "1819362252",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationAnalyzeSentimentWithOpinionMiningAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationAnalyzeSentimentWithOpinionMiningAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "304",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-deec0cced9d59d4aad4d55e145e92dda-a6d03855975c5543-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-cf41d1d32cc44f46b6511f59c949a6dc-312e8c91dc8d9845-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b6927c132680ad8649ac90e19e28d853",
         "x-ms-return-client-request-id": "true"
       },
@@ -37,43 +43,49 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "469cfeb3-b62f-4111-8ee0-1659835861b2",
-        "Date": "Thu, 23 Sep 2021 14:44:22 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+        "apim-request-id": "7af4a17b-dd70-4f1e-afa7-c9e8e0b4d057",
+        "Date": "Mon, 25 Oct 2021 21:06:17 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "190"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "153d4b6951e2c2fd62e262d9e8ed622f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "73301e61-bf54-4af3-9801-c3b9556eca39",
+        "apim-request-id": "e4d6eae8-424e-41cd-b77f-85759d24b592",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:22 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "35f29916-514a-48d2-a52d-bce89830634f",
-        "lastUpdateDateTime": "2021-09-23T14:44:23Z",
-        "createdDateTime": "2021-09-23T14:44:23Z",
-        "expirationDateTime": "2021-09-24T14:44:23Z",
-        "status": "notStarted",
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
         "tasks": {
@@ -85,31 +97,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8d697313a410adabb5c42bae4e0a8799",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "65abdb08-0894-41cd-8d94-42f651d85b01",
+        "apim-request-id": "1d113e78-d743-40d2-982d-a9b350fbd4cc",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:24 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
       },
       "ResponseBody": {
-        "jobId": "35f29916-514a-48d2-a52d-bce89830634f",
-        "lastUpdateDateTime": "2021-09-23T14:44:23Z",
-        "createdDateTime": "2021-09-23T14:44:23Z",
-        "expirationDateTime": "2021-09-24T14:44:23Z",
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -122,31 +140,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4e5bfab8d343c24b7ecf549ec3adc45c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f18db7e7-28f5-4fc4-8a13-3e1c4492f62c",
+        "apim-request-id": "03e6d9b9-716f-43d0-b1db-badeb693101e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "15"
       },
       "ResponseBody": {
-        "jobId": "35f29916-514a-48d2-a52d-bce89830634f",
-        "lastUpdateDateTime": "2021-09-23T14:44:23Z",
-        "createdDateTime": "2021-09-23T14:44:23Z",
-        "expirationDateTime": "2021-09-24T14:44:23Z",
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -159,31 +183,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2ace604a4bbec5429f90601e254f7357",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4293b649-6fa4-4184-94a0-19c8b3591bab",
+        "apim-request-id": "230e253a-1ad2-473a-a381-6376c9efc6c5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "35f29916-514a-48d2-a52d-bce89830634f",
-        "lastUpdateDateTime": "2021-09-23T14:44:23Z",
-        "createdDateTime": "2021-09-23T14:44:23Z",
-        "expirationDateTime": "2021-09-24T14:44:23Z",
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -196,31 +226,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ee21c95b139140eb27a70f40500de907",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fcaed530-203b-4d9a-80a5-1dd952374449",
+        "apim-request-id": "82ec6484-a8d2-4d6e-b28e-f05c2ae2f582",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:28 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "35f29916-514a-48d2-a52d-bce89830634f",
-        "lastUpdateDateTime": "2021-09-23T14:44:23Z",
-        "createdDateTime": "2021-09-23T14:44:23Z",
-        "expirationDateTime": "2021-09-24T14:44:23Z",
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -233,31 +269,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ed63cf005c3c6ddab795afb3722d9d2e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8484044c-fee8-482e-988c-1fa865e4f29b",
+        "apim-request-id": "a828f2fe-0166-4f94-88c7-c7758b66f6e1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "35f29916-514a-48d2-a52d-bce89830634f",
-        "lastUpdateDateTime": "2021-09-23T14:44:23Z",
-        "createdDateTime": "2021-09-23T14:44:23Z",
-        "expirationDateTime": "2021-09-24T14:44:23Z",
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -270,31 +312,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f942fc5cd58b36ca758d02173c027591",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "246596ed-471c-4cb4-8aa3-77909b7e4352",
+        "apim-request-id": "75525fbf-2ee4-4782-9a32-ce478823d1b9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:30 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "35f29916-514a-48d2-a52d-bce89830634f",
-        "lastUpdateDateTime": "2021-09-23T14:44:23Z",
-        "createdDateTime": "2021-09-23T14:44:23Z",
-        "expirationDateTime": "2021-09-24T14:44:23Z",
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -307,31 +355,682 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/35f29916-514a-48d2-a52d-bce89830634f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "551d58a785ebfe1aefb436fb6438cefa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d6787186-d95f-4ec5-8d3a-da56a8933623",
+        "apim-request-id": "6dd4240d-e98d-4171-8611-4c77bc7464e9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:31 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "27"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "53e4e00aefca2a7b052d78ae5ac330b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9563d96b-c726-4cc5-b28b-4f343449a68e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "190c1d20470fd642e1440ad79fced23c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "33c9e497-2e9f-4cb8-9cf3-6a7447ae9e06",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "5b0d08bf221db7c6ddf350be0c6ca42c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0ba29bb2-22c8-4cd6-a9cc-90e1bcb33955",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "49"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "46db8183b42cc2ea9d0e7186e4a48b36",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "baa2d899-c66e-42f3-9230-c2f25632e374",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "51ef3c5ad4b6fe9856543c1cf784c975",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c301948e-617c-447b-8a71-776705854e57",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:34 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "65"
       },
       "ResponseBody": {
-        "jobId": "35f29916-514a-48d2-a52d-bce89830634f",
-        "lastUpdateDateTime": "2021-09-23T14:44:31Z",
-        "createdDateTime": "2021-09-23T14:44:23Z",
-        "expirationDateTime": "2021-09-24T14:44:23Z",
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "1e54de9f8bf30a101e4abe0fb040d239",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cc644c6f-7797-4797-a7a2-84d493212fa3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d0641968537cae75e9ddf0d777ceca19",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ea71f306-2a72-4e46-a578-e57bc01fd8af",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "06e6fc446c4fce422ce4336b16884e16",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d0a655ca-c736-4d91-b800-f3a36be927ec",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ddb30381f81f4cf868a534169b389250",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cace7fc3-48dc-4bb4-a3e6-94c9403dc9ef",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b3cba480cc59fbe9d695a4981f0a9860",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b3e2f33f-3089-410b-99e0-f978d71ae490",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7456da8eec1a4bf903999daa382c33f4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "83e18349-435c-45ee-a980-01f91eb9bc43",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:43 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "71eae3519abdb5bc1ab8078a54602c5e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c8169ed4-8d36-4120-9795-019e3393995c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "37"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c187d40d1ee19335ab7fb0c02e3ec3aa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a3e326f4-c622-488f-b9d8-364a4ce4b5a6",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3c46b061261ff3a31da05a62e56ef7a2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "211d7cbe-04ea-46c7-acff-9082af1cae9e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:18Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithOpinionMining",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/facdfec8-5674-4214-8a21-649b6fb574bc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "639d3f6c71a43212ad56c63deafc86db",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9e346043-7c40-4448-9d9c-61aaa47485d2",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:06:51 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "131"
+      },
+      "ResponseBody": {
+        "jobId": "facdfec8-5674-4214-8a21-649b6fb574bc",
+        "lastUpdateDateTime": "2021-10-25T21:06:50Z",
+        "createdDateTime": "2021-10-25T21:06:17Z",
+        "expirationDateTime": "2021-10-26T21:06:17Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithOpinionMining",
@@ -342,7 +1041,7 @@
           "total": 1,
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:31.1261715Z",
+              "lastUpdateDateTime": "2021-10-25T21:06:50.2473937Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -486,6 +1185,6 @@
   "Variables": {
     "RandomSeed": "333490656",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "241",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-794d3cb128de3d478d2e5205affe2e83-1cd54408047dcd48-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-66584e5a66567e42b22c35e9065e7044-53a7589422512648-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bc10ae4f3809e9b40d4f6b783fc973c7",
         "x-ms-return-client-request-id": "true"
       },
@@ -38,45 +44,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ffa1aff2-73af-4a47-b2ad-49dac695b760",
-        "Date": "Tue, 21 Sep 2021 14:56:17 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6da748c4-8f02-441b-ace2-cedb899300e5",
+        "apim-request-id": "7e7ed2b6-75c4-41b4-b726-449a3f21d2ee",
+        "Date": "Mon, 25 Oct 2021 21:03:25 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "204"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "221"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6da748c4-8f02-441b-ace2-cedb899300e5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e45290396662ad6e1e38f63536f933b4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "026543ec-707e-4e3f-9485-59b63083fdcd",
+        "apim-request-id": "0c4a62c5-4636-4a77-9e38-d34fc8f45b38",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "6da748c4-8f02-441b-ace2-cedb899300e5",
-        "lastUpdateDateTime": "2021-09-21T14:56:17Z",
-        "createdDateTime": "2021-09-21T14:56:17Z",
-        "expirationDateTime": "2021-09-22T14:56:17Z",
+        "jobId": "9ff3bb42-8763-445f-8288-55213f793a6a",
+        "lastUpdateDateTime": "2021-10-25T21:03:26Z",
+        "createdDateTime": "2021-10-25T21:03:26Z",
+        "expirationDateTime": "2021-10-26T21:03:26Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -86,34 +97,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6da748c4-8f02-441b-ace2-cedb899300e5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "026f5447158ee5d664682b08d83e8d91",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "839eb465-6041-4b17-812d-5e4caa1735d3",
+        "apim-request-id": "1b9ac4ab-b2ae-4d4b-b968-36114a750e82",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "6da748c4-8f02-441b-ace2-cedb899300e5",
-        "lastUpdateDateTime": "2021-09-21T14:56:17Z",
-        "createdDateTime": "2021-09-21T14:56:17Z",
-        "expirationDateTime": "2021-09-22T14:56:17Z",
+        "jobId": "9ff3bb42-8763-445f-8288-55213f793a6a",
+        "lastUpdateDateTime": "2021-10-25T21:03:26Z",
+        "createdDateTime": "2021-10-25T21:03:26Z",
+        "expirationDateTime": "2021-10-26T21:03:26Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -123,34 +139,249 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6da748c4-8f02-441b-ace2-cedb899300e5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3f2ab8555934e81b40639ed1417fb313",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a1fc69a4-3bad-4cc7-9234-7aaf978ccb12",
+        "apim-request-id": "efdf4885-8800-4822-8dd4-b1696e4ac276",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "75"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "6da748c4-8f02-441b-ace2-cedb899300e5",
-        "lastUpdateDateTime": "2021-09-21T14:56:19Z",
-        "createdDateTime": "2021-09-21T14:56:17Z",
-        "expirationDateTime": "2021-09-22T14:56:17Z",
+        "jobId": "9ff3bb42-8763-445f-8288-55213f793a6a",
+        "lastUpdateDateTime": "2021-10-25T21:03:26Z",
+        "createdDateTime": "2021-10-25T21:03:26Z",
+        "expirationDateTime": "2021-10-26T21:03:26Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ea31b61c715a2439ba6d7ff93a66d4df",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d11cae18-b5c1-43e6-8abc-b9370c88b418",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "9ff3bb42-8763-445f-8288-55213f793a6a",
+        "lastUpdateDateTime": "2021-10-25T21:03:26Z",
+        "createdDateTime": "2021-10-25T21:03:26Z",
+        "expirationDateTime": "2021-10-26T21:03:26Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7edf65aaf3ceed7f3986c12a7704a3e5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "26ecd374-0431-45e4-9ee6-c03cde7fd3f5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "9ff3bb42-8763-445f-8288-55213f793a6a",
+        "lastUpdateDateTime": "2021-10-25T21:03:26Z",
+        "createdDateTime": "2021-10-25T21:03:26Z",
+        "expirationDateTime": "2021-10-26T21:03:26Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "21ec18b4a30de4377f0685c7d921adda",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "371604f0-3dfc-4149-9c7c-dbe0d843752d",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "9ff3bb42-8763-445f-8288-55213f793a6a",
+        "lastUpdateDateTime": "2021-10-25T21:03:26Z",
+        "createdDateTime": "2021-10-25T21:03:26Z",
+        "expirationDateTime": "2021-10-26T21:03:26Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "dc27be8f359f29443743b1d3af0facb5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d4ef1cd9-f2bc-43eb-ab42-3580076840cf",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "9ff3bb42-8763-445f-8288-55213f793a6a",
+        "lastUpdateDateTime": "2021-10-25T21:03:26Z",
+        "createdDateTime": "2021-10-25T21:03:26Z",
+        "expirationDateTime": "2021-10-26T21:03:26Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9ff3bb42-8763-445f-8288-55213f793a6a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "22449ac9b27907d12dfbffc86db71417",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d0917005-79cd-4bcc-9f8c-15bb4c22a78f",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:03:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1423"
+      },
+      "ResponseBody": {
+        "jobId": "9ff3bb42-8763-445f-8288-55213f793a6a",
+        "lastUpdateDateTime": "2021-10-25T21:03:34Z",
+        "createdDateTime": "2021-10-25T21:03:26Z",
+        "expirationDateTime": "2021-10-26T21:03:26Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -158,7 +389,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-21T14:56:19.9910231Z",
+              "lastUpdateDateTime": "2021-10-25T21:03:34.6774823Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -192,6 +423,6 @@
   "Variables": {
     "RandomSeed": "1233550557",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "241",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9e22de479f26fe4587e0c57a81003ccf-d488cd1acfa60244-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8c8909596499bb42bd7b7df3a799f3a1-36954ded821cb741-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f64d021068f23b47239dc64d32ac0d55",
         "x-ms-return-client-request-id": "true"
       },
@@ -38,45 +44,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b4d4173e-ed7a-4e25-af0f-0034371b8151",
-        "Date": "Tue, 21 Sep 2021 14:56:20 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+        "apim-request-id": "03e83626-f792-4e08-8be7-987fbec819ec",
+        "Date": "Mon, 25 Oct 2021 21:06:55 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "287"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "326f6a53ce870c398bb9ee51f13f5560",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8cc971cb-43cd-4a62-968b-9fbbd20b82b6",
+        "apim-request-id": "bad44bb4-23f3-4572-8718-0a28586c4d99",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:20Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
-        "status": "notStarted",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:06:56Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -86,34 +97,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4d2db5835d6ee56b0a068d1cd4f24286",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "99b2dd77-c936-4230-b175-fe3c258f8ae3",
+        "apim-request-id": "43beb759-21df-479e-8369-3a27a4c718bb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:21Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:06:56Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -123,34 +139,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "84470c68f8b742c6c8406a3979f549e3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "61699814-f5ca-4c79-9d96-e270d4237abb",
+        "apim-request-id": "053746be-715b-4728-8327-6154a73a6d45",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:23 GMT",
+        "Date": "Mon, 25 Oct 2021 21:06:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:21Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:06:56Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -160,34 +181,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7dc96647c07ef5e7fe892880411d3899",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "60bbd7ff-8e77-4bac-8d72-101acffc5b6a",
+        "apim-request-id": "99ea81cc-d49f-488b-a723-1b01e9874b26",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:24 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "78"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:21Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:06:56Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -197,34 +223,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e4e86876d1f78ba8eeeb842df2326c15",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "706f019c-0e0e-4a51-a31b-a2b394901ca4",
+        "apim-request-id": "a3c5cfc2-09db-4187-9b78-08337c1e08b2",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:21Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:06:56Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -234,34 +265,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6ed4aabdc428a8072551852ed04501ab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "282037f7-ea9c-4e88-a1e2-9fbbe12687ee",
+        "apim-request-id": "15671ffa-340d-4889-a615-d917ea516e6c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:21Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:06:56Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -271,34 +307,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "11c2d108650c76ebbd3e8e933bba02cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aa06bd28-d06c-4999-a21a-83d543a73661",
+        "apim-request-id": "728aac35-0d92-4769-addc-79f1526da326",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:21Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:06:56Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -308,34 +349,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "96c3121dca48b1706040bfa64c7abba9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c0182c80-83a1-4ffe-826b-ef2ae7f14941",
+        "apim-request-id": "f7f01de9-26b7-4d71-b49d-dfb3602c01c9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:28 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "333"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:21Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:06:56Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -345,34 +391,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c29ea39b-9a5c-4672-93ee-6f209851c52a",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210921.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2125d8ea5a6f5708be5eb0ea35746c6a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb538db9-63df-4749-9cd4-dd71c2f189e2",
+        "apim-request-id": "7a0ba672-44d1-474a-9c89-4ac9a3609609",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 21 Sep 2021 14:56:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "67"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "176"
       },
       "ResponseBody": {
-        "jobId": "2a573d60-cbf2-44c7-bb55-c8ad0113abfd",
-        "lastUpdateDateTime": "2021-09-21T14:56:29Z",
-        "createdDateTime": "2021-09-21T14:56:20Z",
-        "expirationDateTime": "2021-09-22T14:56:20Z",
+        "jobId": "c29ea39b-9a5c-4672-93ee-6f209851c52a",
+        "lastUpdateDateTime": "2021-10-25T21:07:08Z",
+        "createdDateTime": "2021-10-25T21:06:55Z",
+        "expirationDateTime": "2021-10-26T21:06:55Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -380,7 +431,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-21T14:56:29.0744847Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:08.3952502Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -414,6 +465,6 @@
   "Variables": {
     "RandomSeed": "1355402112",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithErrorTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5202b0960872ee4f8ab4dadb7fb4d148-9e504b97b1168f4b-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-25d41f390b5c314fbb04872ddc526638-4f6a9f8447a22841-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c99cb42a5a82e854b9e5b6d84f7b86ab",
         "x-ms-return-client-request-id": "true"
       },
@@ -36,13 +42,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "b129dfaa-4632-402e-be69-aa3b6ba297a2",
+        "apim-request-id": "ec0097a4-2b2d-437a-aaa0-f72222efb7e0",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4"
       },
       "ResponseBody": {
         "error": {
@@ -59,6 +65,6 @@
   "Variables": {
     "RandomSeed": "776948702",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithErrorTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-97eb6ce5cf38e746a4239146b5463f5c-186841abcf91cd47-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-47ddfa85c8c51a45ac9f5df5e4f33653-d95f982b8c82f947-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ac619f24e6117d0afaa59ef96ef473c7",
         "x-ms-return-client-request-id": "true"
       },
@@ -36,13 +42,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "c5928ab8-a964-4e4f-a25a-f59d1d52acc2",
+        "apim-request-id": "c9f7d7d4-0d90-4a9b-8043-f1b4558602d2",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5"
       },
       "ResponseBody": {
         "error": {
@@ -59,6 +65,6 @@
   "Variables": {
     "RandomSeed": "1285200460",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithErrorsInDocumentTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithErrorsInDocumentTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "212",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b6477f59a7b2a94ba8a6fba1dee93d00-3f9d14a61984234a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f3d68eca2616f3428bbe13e01e1c9474-34f49d820867c541-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5576fa283fd263773849a876efb14577",
         "x-ms-return-client-request-id": "true"
       },
@@ -38,45 +44,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ddbcc497-65bd-404a-81cf-b324147425de",
-        "Date": "Thu, 23 Sep 2021 14:42:16 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
+        "apim-request-id": "6d7484d3-82db-47a6-8009-6f4d6629b56a",
+        "Date": "Mon, 25 Oct 2021 21:03:39 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/74f3411e-5a5b-47ae-8913-98e39dc35e1d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "304"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "179"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/74f3411e-5a5b-47ae-8913-98e39dc35e1d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d15a28e9d4af4ce3e85229bba2a5c170",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "54f64c7b-cabb-4bab-8db1-9ca49432cc59",
+        "apim-request-id": "bc1596de-4142-4f3f-a294-b07b92f025ba",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:16 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
-        "status": "notStarted",
+        "jobId": "74f3411e-5a5b-47ae-8913-98e39dc35e1d",
+        "lastUpdateDateTime": "2021-10-25T21:03:39Z",
+        "createdDateTime": "2021-10-25T21:03:39Z",
+        "expirationDateTime": "2021-10-26T21:03:39Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -86,34 +97,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/74f3411e-5a5b-47ae-8913-98e39dc35e1d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c53291c346adf1e1915603c512bf7f11",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "60c56080-b436-4747-a852-917800ea96b2",
+        "apim-request-id": "e9026c7f-3507-49f3-9d9d-2fc614557465",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
+        "jobId": "74f3411e-5a5b-47ae-8913-98e39dc35e1d",
+        "lastUpdateDateTime": "2021-10-25T21:03:39Z",
+        "createdDateTime": "2021-10-25T21:03:39Z",
+        "expirationDateTime": "2021-10-26T21:03:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -123,34 +139,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/74f3411e-5a5b-47ae-8913-98e39dc35e1d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0d55ac00f984545c172a6c8015bbc092",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b15f44b-14bc-481b-acae-6522011c0d43",
+        "apim-request-id": "465c3079-230b-4136-966b-eecb2b0067fe",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
+        "jobId": "74f3411e-5a5b-47ae-8913-98e39dc35e1d",
+        "lastUpdateDateTime": "2021-10-25T21:03:39Z",
+        "createdDateTime": "2021-10-25T21:03:39Z",
+        "expirationDateTime": "2021-10-26T21:03:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -160,34 +181,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/74f3411e-5a5b-47ae-8913-98e39dc35e1d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5eb238877f7fa2ca46684059d01e3a29",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a02190b0-17bb-4f2b-9c95-147ab3110d44",
+        "apim-request-id": "946ce5d6-3c92-4692-8bd0-a6ed3ae71701",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
       },
       "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
+        "jobId": "74f3411e-5a5b-47ae-8913-98e39dc35e1d",
+        "lastUpdateDateTime": "2021-10-25T21:03:39Z",
+        "createdDateTime": "2021-10-25T21:03:39Z",
+        "expirationDateTime": "2021-10-26T21:03:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -197,34 +223,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/74f3411e-5a5b-47ae-8913-98e39dc35e1d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f5ba18d3b450caeb35ddae83d961dcd5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a00ddc68-25ee-44e1-aa67-015a33803f6d",
+        "apim-request-id": "4cafd7d6-5dbc-410d-ba66-7d4c502f7de8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
+        "jobId": "74f3411e-5a5b-47ae-8913-98e39dc35e1d",
+        "lastUpdateDateTime": "2021-10-25T21:03:39Z",
+        "createdDateTime": "2021-10-25T21:03:39Z",
+        "expirationDateTime": "2021-10-26T21:03:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -234,34 +265,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/74f3411e-5a5b-47ae-8913-98e39dc35e1d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d93d7195200c8191e2b2c61bb80384f8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dd631b6e-b2b0-4be8-bef1-712419917841",
+        "apim-request-id": "5e7de2ec-4655-4f3f-87d9-96a3a7d81eb7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:22 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
+        "jobId": "74f3411e-5a5b-47ae-8913-98e39dc35e1d",
+        "lastUpdateDateTime": "2021-10-25T21:03:39Z",
+        "createdDateTime": "2021-10-25T21:03:39Z",
+        "expirationDateTime": "2021-10-26T21:03:39Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -271,145 +307,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/74f3411e-5a5b-47ae-8913-98e39dc35e1d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "fdac43f0ca00d3414ce829a2d047c9e5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "64d3aaa5-4b4b-4df1-b511-d4a1efdbd6d6",
+        "apim-request-id": "d11cc77f-5a6f-496e-af91-1f1cd2098344",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:23 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8443"
       },
       "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5fc36b8c60e0b21c8639139eedd01131",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "79cadadd-dace-4b59-9ff8-085962af8f12",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:24 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9692b558deb4cad42f698c24f7efb09a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "355690d2-8b71-46e9-8629-d3e6467de95c",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:25 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:16Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4d8fe1e9253f8f1826fa77c7b6a3e67c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a501041c-2f22-4855-bab5-fe4dc37ceb97",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:26 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "88"
-      },
-      "ResponseBody": {
-        "jobId": "2fa790ef-9b19-4020-a1e6-c6133e2245ab",
-        "lastUpdateDateTime": "2021-09-23T14:42:25Z",
-        "createdDateTime": "2021-09-23T14:42:16Z",
-        "expirationDateTime": "2021-09-24T14:42:16Z",
+        "jobId": "74f3411e-5a5b-47ae-8913-98e39dc35e1d",
+        "lastUpdateDateTime": "2021-10-25T21:03:47Z",
+        "createdDateTime": "2021-10-25T21:03:39Z",
+        "expirationDateTime": "2021-10-26T21:03:39Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -417,7 +347,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:25.8653809Z",
+              "lastUpdateDateTime": "2021-10-25T21:03:47.2830644Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -455,6 +385,6 @@
   "Variables": {
     "RandomSeed": "538531571",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithErrorsInDocumentTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithErrorsInDocumentTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "212",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90b521ef25b971499e474b6c3f808780-a40c7ba20ebb904d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-966300cd3a34f94aafa86468c962c79f-5dbc8e6306659140-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f91fef4332cac890575fea1876896219",
         "x-ms-return-client-request-id": "true"
       },
@@ -38,45 +44,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4895c6ec-fb61-47d7-a271-6d578c77b05b",
-        "Date": "Thu, 23 Sep 2021 14:44:32 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dd3d9718-dad5-4453-b01c-7256d181aba3",
+        "apim-request-id": "7ff8c74d-9ff8-42f5-a4b8-1d4807187b34",
+        "Date": "Mon, 25 Oct 2021 21:07:14 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "218"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "427"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dd3d9718-dad5-4453-b01c-7256d181aba3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b963f4a2286260197a4218e5186ef72e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "34bcf6e8-f8e6-4976-988f-d6f167cc9aa1",
+        "apim-request-id": "7fa1d304-e425-4710-be44-efdc6867cea5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
-        "jobId": "dd3d9718-dad5-4453-b01c-7256d181aba3",
-        "lastUpdateDateTime": "2021-09-23T14:44:32Z",
-        "createdDateTime": "2021-09-23T14:44:32Z",
-        "expirationDateTime": "2021-09-24T14:44:32Z",
-        "status": "notStarted",
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -86,34 +97,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dd3d9718-dad5-4453-b01c-7256d181aba3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "46b6de92afb75c6e3d74cefdc9f3e8ea",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "92a49777-6f26-453c-9373-462ccb5ac9ca",
+        "apim-request-id": "0fe940e4-eb2e-4407-a7a2-673f7b80ef77",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "dd3d9718-dad5-4453-b01c-7256d181aba3",
-        "lastUpdateDateTime": "2021-09-23T14:44:33Z",
-        "createdDateTime": "2021-09-23T14:44:32Z",
-        "expirationDateTime": "2021-09-24T14:44:32Z",
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -123,34 +139,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dd3d9718-dad5-4453-b01c-7256d181aba3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "caf5e0e0a8461a36d6be7e881aabb0e9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f7e2361a-2bd1-4a7e-97d6-8e7dc757508e",
+        "apim-request-id": "4335d299-b2d9-4974-befd-4c6448a966a8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "dd3d9718-dad5-4453-b01c-7256d181aba3",
-        "lastUpdateDateTime": "2021-09-23T14:44:33Z",
-        "createdDateTime": "2021-09-23T14:44:32Z",
-        "expirationDateTime": "2021-09-24T14:44:32Z",
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -160,34 +181,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dd3d9718-dad5-4453-b01c-7256d181aba3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9785bb671cd3f26185067bed5a1c9687",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff41cba1-eb78-4979-a54f-10e56cd5a0a4",
+        "apim-request-id": "b36d7690-7a0d-486b-b3fc-4381ac2b1091",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "dd3d9718-dad5-4453-b01c-7256d181aba3",
-        "lastUpdateDateTime": "2021-09-23T14:44:33Z",
-        "createdDateTime": "2021-09-23T14:44:32Z",
-        "expirationDateTime": "2021-09-24T14:44:32Z",
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -197,34 +223,249 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dd3d9718-dad5-4453-b01c-7256d181aba3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "37042e592c78e9e7a79b70f931e64292",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "36c49c7b-a2f3-4881-81fe-1c067bef830e",
+        "apim-request-id": "e8720167-d5b1-429f-bc61-f89c8f4ee0c4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "70"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "dd3d9718-dad5-4453-b01c-7256d181aba3",
-        "lastUpdateDateTime": "2021-09-23T14:44:36Z",
-        "createdDateTime": "2021-09-23T14:44:32Z",
-        "expirationDateTime": "2021-09-24T14:44:32Z",
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0e96e5c4506dc4177f0345402c49c0ba",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "40f5c1dd-ddbe-4764-be07-6e5562ceb66b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:07:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "eb2ef72778a63a70d39bef37ac68c19f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e867c1e2-3d34-4c2c-8ae6-8202daf9b0a9",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:07:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7429e9c3888508191740b775e7a7bc5e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b1d86897-6272-4c59-830d-ed9dd6195409",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:07:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
+      },
+      "ResponseBody": {
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "39d1b6db57b74beb755b3ad261df1717",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d7b18c61-2582-42d3-a2b6-77b2bf892e10",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:07:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "400"
+      },
+      "ResponseBody": {
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:15Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "437ca6414b1f9f34dd26d366c0fa532c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1ad53d8d-394d-4df5-a853-dc780386ca5f",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:07:35 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1218"
+      },
+      "ResponseBody": {
+        "jobId": "9b5b67f6-e9ab-4a11-8a55-a8d006ae324f",
+        "lastUpdateDateTime": "2021-10-25T21:07:32Z",
+        "createdDateTime": "2021-10-25T21:07:14Z",
+        "expirationDateTime": "2021-10-26T21:07:14Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -232,7 +473,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:36.4871731Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:32.9197386Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -270,6 +511,6 @@
   "Variables": {
     "RandomSeed": "1508474165",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithLanguageTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dda4ac409f90b447972896fb194288d6-fe1c1e90c250794a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-46d99d8d44748343ac55710d139d76ab-2715442ba0265a4a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a87cf6cc9d26e81e4ad3c40561433cdc",
         "x-ms-return-client-request-id": "true"
       },
@@ -39,42 +45,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "366cb088-290f-4880-b8e8-f561fd502cbe",
-        "Date": "Thu, 23 Sep 2021 14:42:26 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/1a1291ae-1017-469c-9536-9635178dc751",
+        "apim-request-id": "815f30b5-2337-4223-8efb-b52522958f15",
+        "Date": "Mon, 25 Oct 2021 21:03:56 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d116a2-db18-400e-811b-8d3d371f3995",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "185"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "214"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/1a1291ae-1017-469c-9536-9635178dc751",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d116a2-db18-400e-811b-8d3d371f3995",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "829f189700a91102b7313377687a2cfe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "00a6f758-7247-4623-a6ac-29f978ac2a59",
+        "apim-request-id": "dc6e948c-7f0a-4fce-9c2b-939bf5f89165",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "87"
       },
       "ResponseBody": {
-        "jobId": "1a1291ae-1017-469c-9536-9635178dc751",
-        "lastUpdateDateTime": "2021-09-23T14:42:27Z",
-        "createdDateTime": "2021-09-23T14:42:27Z",
-        "expirationDateTime": "2021-09-24T14:42:27Z",
+        "jobId": "d8d116a2-db18-400e-811b-8d3d371f3995",
+        "lastUpdateDateTime": "2021-10-25T21:03:56Z",
+        "createdDateTime": "2021-10-25T21:03:56Z",
+        "expirationDateTime": "2021-10-26T21:03:56Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "AnalyzeOperationWithLanguageTest",
@@ -87,31 +99,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/1a1291ae-1017-469c-9536-9635178dc751",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d116a2-db18-400e-811b-8d3d371f3995",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "84565c5816eeba49622c1ac1b6d8c94c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8b5488e3-c3f9-4ce0-97e5-4a28f5d94e96",
+        "apim-request-id": "79f49455-c9f8-4e25-b436-873b78d798a3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:28 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "1a1291ae-1017-469c-9536-9635178dc751",
-        "lastUpdateDateTime": "2021-09-23T14:42:27Z",
-        "createdDateTime": "2021-09-23T14:42:27Z",
-        "expirationDateTime": "2021-09-24T14:42:27Z",
+        "jobId": "d8d116a2-db18-400e-811b-8d3d371f3995",
+        "lastUpdateDateTime": "2021-10-25T21:03:57Z",
+        "createdDateTime": "2021-10-25T21:03:56Z",
+        "expirationDateTime": "2021-10-26T21:03:56Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithLanguageTest",
@@ -124,31 +142,80 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/1a1291ae-1017-469c-9536-9635178dc751",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d116a2-db18-400e-811b-8d3d371f3995",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e6dbb519b5b4cb28f46af0f469a680d0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e2faa139-dcfd-4352-8047-05a0314052fa",
+        "apim-request-id": "e41c9b2d-7911-4f9a-bb7f-8320f614238b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:03:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
       },
       "ResponseBody": {
-        "jobId": "1a1291ae-1017-469c-9536-9635178dc751",
-        "lastUpdateDateTime": "2021-09-23T14:42:29Z",
-        "createdDateTime": "2021-09-23T14:42:27Z",
-        "expirationDateTime": "2021-09-24T14:42:27Z",
+        "jobId": "d8d116a2-db18-400e-811b-8d3d371f3995",
+        "lastUpdateDateTime": "2021-10-25T21:03:57Z",
+        "createdDateTime": "2021-10-25T21:03:56Z",
+        "expirationDateTime": "2021-10-26T21:03:56Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithLanguageTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d116a2-db18-400e-811b-8d3d371f3995",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "05acc6a6b8ec80eecfe5207de6405bde",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6066afc6-f42e-4070-837f-af31a3051fe1",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "113"
+      },
+      "ResponseBody": {
+        "jobId": "d8d116a2-db18-400e-811b-8d3d371f3995",
+        "lastUpdateDateTime": "2021-10-25T21:04:00Z",
+        "createdDateTime": "2021-10-25T21:03:56Z",
+        "expirationDateTime": "2021-10-26T21:03:56Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithLanguageTest",
@@ -159,7 +226,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:29.40397Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:00.5088773Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -194,6 +261,6 @@
   "Variables": {
     "RandomSeed": "2064506440",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithLanguageTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "312",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-48449c990a1f97409bba0d804e4d1d57-492ff669f0b7e84a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-fa1c03d9629b00439f0f45b4d8bfce54-52924e2a35594445-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ff1f44cf0b7d52519f4611a53ca09dbe",
         "x-ms-return-client-request-id": "true"
       },
@@ -39,79 +45,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "99253e5d-50ed-41dc-91f4-41c82715f681",
-        "Date": "Thu, 23 Sep 2021 14:44:36 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d3853c88-9d78-47d7-8749-e689249e8ecc",
+        "apim-request-id": "ed98e8e1-d339-439e-b5d1-cef027193c95",
+        "Date": "Mon, 25 Oct 2021 21:07:36 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9f939849-7fbe-405d-a83d-48ebd2bafdbc",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "217"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "228"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d3853c88-9d78-47d7-8749-e689249e8ecc",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9f939849-7fbe-405d-a83d-48ebd2bafdbc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e5fe6af6690f6491194fc0223b355da1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8197f18d-fe96-4722-af2d-dd4d7451b2ac",
+        "apim-request-id": "b662e0bb-15e6-443a-afeb-aa8365a39862",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
       },
       "ResponseBody": {
-        "jobId": "d3853c88-9d78-47d7-8749-e689249e8ecc",
-        "lastUpdateDateTime": "2021-09-23T14:44:37Z",
-        "createdDateTime": "2021-09-23T14:44:37Z",
-        "expirationDateTime": "2021-09-24T14:44:37Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "AnalyzeOperationWithLanguageTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d3853c88-9d78-47d7-8749-e689249e8ecc",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c22721a113540c5c7d4db56795b725e8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "377200f5-f6a4-417e-925e-f75638456b9d",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:38 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "d3853c88-9d78-47d7-8749-e689249e8ecc",
-        "lastUpdateDateTime": "2021-09-23T14:44:38Z",
-        "createdDateTime": "2021-09-23T14:44:37Z",
-        "expirationDateTime": "2021-09-24T14:44:37Z",
+        "jobId": "9f939849-7fbe-405d-a83d-48ebd2bafdbc",
+        "lastUpdateDateTime": "2021-10-25T21:07:36Z",
+        "createdDateTime": "2021-10-25T21:07:36Z",
+        "expirationDateTime": "2021-10-26T21:07:36Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithLanguageTest",
@@ -124,31 +99,166 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d3853c88-9d78-47d7-8749-e689249e8ecc",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9f939849-7fbe-405d-a83d-48ebd2bafdbc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c22721a113540c5c7d4db56795b725e8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "929ec345-c3c2-4c4d-ab9a-2b36f970baf1",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:07:40 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "806"
+      },
+      "ResponseBody": {
+        "jobId": "9f939849-7fbe-405d-a83d-48ebd2bafdbc",
+        "lastUpdateDateTime": "2021-10-25T21:07:36Z",
+        "createdDateTime": "2021-10-25T21:07:36Z",
+        "expirationDateTime": "2021-10-26T21:07:36Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithLanguageTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9f939849-7fbe-405d-a83d-48ebd2bafdbc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c5f8bf9fc78e66c8b2bbe62e4a2e1669",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a2b6e9ad-ba10-40fb-a95d-dc6ed3a1ac0a",
+        "apim-request-id": "be142acd-6c20-4615-9547-f855510c4fe0",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "80"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
       },
       "ResponseBody": {
-        "jobId": "d3853c88-9d78-47d7-8749-e689249e8ecc",
-        "lastUpdateDateTime": "2021-09-23T14:44:40Z",
-        "createdDateTime": "2021-09-23T14:44:37Z",
-        "expirationDateTime": "2021-09-24T14:44:37Z",
+        "jobId": "9f939849-7fbe-405d-a83d-48ebd2bafdbc",
+        "lastUpdateDateTime": "2021-10-25T21:07:36Z",
+        "createdDateTime": "2021-10-25T21:07:36Z",
+        "expirationDateTime": "2021-10-26T21:07:36Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithLanguageTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9f939849-7fbe-405d-a83d-48ebd2bafdbc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "1b036fe8da78e36a0df268c1b329cf61",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cf254d3d-59fc-4efb-8d93-0d6bf356c22a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:07:43 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "9f939849-7fbe-405d-a83d-48ebd2bafdbc",
+        "lastUpdateDateTime": "2021-10-25T21:07:36Z",
+        "createdDateTime": "2021-10-25T21:07:36Z",
+        "expirationDateTime": "2021-10-26T21:07:36Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithLanguageTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9f939849-7fbe-405d-a83d-48ebd2bafdbc",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7c83d729973dd91359c00f992c2ec14e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e9023545-cba6-4529-a1db-864151484291",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:07:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "651"
+      },
+      "ResponseBody": {
+        "jobId": "9f939849-7fbe-405d-a83d-48ebd2bafdbc",
+        "lastUpdateDateTime": "2021-10-25T21:07:46Z",
+        "createdDateTime": "2021-10-25T21:07:36Z",
+        "expirationDateTime": "2021-10-26T21:07:36Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithLanguageTest",
@@ -159,7 +269,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:39.9961088Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:46.000271Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -194,6 +304,6 @@
   "Variables": {
     "RandomSeed": "915431106",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithMultipleActions.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "624",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d282e78742d46a40b0c9940c4adb2c41-1ae253e3ba380f47-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-bfe16c6d6c0cb947bc8e2da5458a5839-4d8cbf68116b1443-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "da9c404f19269b117394a823858b72a9",
         "x-ms-return-client-request-id": "true"
       },
@@ -67,79 +73,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "5692f5f9-10dd-48dd-8dce-1d60bf04d6cd",
-        "Date": "Thu, 23 Sep 2021 14:42:29 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
+        "apim-request-id": "b840630b-7150-4b99-a202-c1fe57c9587d",
+        "Date": "Mon, 25 Oct 2021 21:04:01 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "513"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "711"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9abcf455d5282fa542e4f94ff79d2572",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a9fc6e74-7410-42e1-ae46-cd3a66694066",
+        "apim-request-id": "465bd452-100a-4234-ad12-575874850932",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:04:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:30Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "AnalyzeOperationWithMultipleTasks",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 5,
-          "total": 5
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "38769894a9ad45aa2d9e6112ab005942",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "484034ad-2a4b-4188-bb3e-9df20e364b87",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:31 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:30Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:02Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -152,31 +127,252 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "38769894a9ad45aa2d9e6112ab005942",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a1e881a2-dc62-4b15-ab72-5cc0ddb67847",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "49"
+      },
+      "ResponseBody": {
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:02Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 5,
+          "total": 5
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "95624054e5857ada9b6d97411fc2a4d6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4740cd31-0ee8-4842-8bb1-3d133122319e",
+        "apim-request-id": "0d8117b2-a7f3-4322-bb13-494ae353a946",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:04:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "158"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:32Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:02Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 5,
+          "total": 5
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ec8e366f3914acfc49776d8a73938342",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f2021868-0aec-44dc-a15e-98f2d7df79c5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:02Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 5,
+          "total": 5
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b6fbb78b8f3aaeedbdfc9d401268266b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8e113798-5173-4e11-b13a-299da817087b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:02Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 5,
+          "total": 5
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "75a38bf96c711b2e44b64b0e78500608",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "067c470a-fbdc-4c37-8b19-467937b15153",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
+      },
+      "ResponseBody": {
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:08Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 5,
+          "total": 5
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "68b655e9eec6df9b48df2f189bbc99e0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "df55e4f0-ebad-4ffa-b80c-2af92da29e9a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "144"
+      },
+      "ResponseBody": {
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:09Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -187,7 +383,7 @@
           "total": 5,
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:32.620207Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:09.8480649Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -228,7 +424,7 @@
                         "category": "PersonType",
                         "offset": 36,
                         "length": 11,
-                        "confidenceScore": 0.96
+                        "confidenceScore": 0.95
                       }
                     ],
                     "warnings": []
@@ -243,638 +439,145 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ec8e366f3914acfc49776d8a73938342",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "70eecd98-dce7-4ebe-917e-96c236bc42f0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:34 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "140"
-      },
-      "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:33Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationWithMultipleTasks",
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 5,
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:32.620207Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:33.0657354Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b6fbb78b8f3aaeedbdfc9d401268266b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "321ca412-b608-40bd-9802-ececa35a00a3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:35 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "143"
-      },
-      "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:33Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationWithMultipleTasks",
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 5,
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:32.620207Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:33.0657354Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "75a38bf96c711b2e44b64b0e78500608",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1a34d051-5a5d-4d97-972a-53d4a208bbfd",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:36 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "233"
-      },
-      "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:36Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationWithMultipleTasks",
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 5,
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:32.620207Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:33.0657354Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "68b655e9eec6df9b48df2f189bbc99e0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e5c560f8-d2e4-45ac-9fdf-595bdd6d5001",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150"
-      },
-      "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:36Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationWithMultipleTasks",
-        "tasks": {
-          "completed": 2,
-          "failed": 0,
-          "inProgress": 3,
-          "total": 5,
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:32.620207Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:42:33.0657354Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e89101500eef1ed088e0728344df366d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "326c99e2-9e2e-46d5-a783-ca7b9eeb3a00",
+        "apim-request-id": "7f576bfd-682c-4ed5-9d81-c1f55aa46bea",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:04:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "323"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "91"
       },
       "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:38Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:09Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
         "tasks": {
-          "completed": 4,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 1,
+          "inProgress": 4,
+          "total": 5,
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:04:09.8480649Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* was founded by ********** and **********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.95
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "bc5695f5beb20ba4efc32c913d157f88",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8655beb2-9586-411d-ada7-43b3ce8d0781",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "130"
+      },
+      "ResponseBody": {
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:12Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 3,
           "total": 5,
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:38.2749246Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:12.0321334Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -957,7 +660,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:32.620207Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:09.8480649Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -998,7 +701,7 @@
                         "category": "PersonType",
                         "offset": 36,
                         "length": 11,
-                        "confidenceScore": 0.96
+                        "confidenceScore": 0.95
                       }
                     ],
                     "warnings": []
@@ -1008,28 +711,273 @@
                 "modelVersion": "2021-01-15"
               }
             }
-          ],
-          "keyPhraseExtractionTasks": [
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "77bd6a1c1dbfdb188597dfe67c179b68",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ee5a0f71-99dc-4552-b5cf-c68f13a6f420",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "131"
+      },
+      "ResponseBody": {
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:12Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 2,
+          "failed": 0,
+          "inProgress": 3,
+          "total": 5,
+          "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:38.4546002Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:12.0321334Z",
               "state": "succeeded",
               "results": {
                 "documents": [
                   {
                     "id": "1",
-                    "keyPhrases": [
-                      "Bill Gates",
-                      "Paul Allen",
-                      "Microsoft"
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
                     ],
                     "warnings": []
                   },
                   {
                     "id": "2",
-                    "keyPhrases": [
-                      "perro",
-                      "gato",
-                      "veterinario"
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:04:09.8480649Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* was founded by ********** and **********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.95
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0522c1a9dc65922d5c85f92ce13ee173",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e7b95355-790e-4bac-af68-9d1b3e49c069",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:04:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "21420"
+      },
+      "ResponseBody": {
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:15Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 3,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:04:15.6215953Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
                     ],
                     "warnings": []
                   }
@@ -1039,61 +987,140 @@
               }
             }
           ],
-          "sentimentAnalysisTasks": [
+          "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:33.0657354Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:12.0321334Z",
               "state": "succeeded",
               "results": {
                 "documents": [
                   {
                     "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
+                    "entities": [
                       {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
                       }
                     ],
                     "warnings": []
                   },
                   {
                     "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:04:09.8480649Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* was founded by ********** and **********.",
+                    "id": "1",
+                    "entities": [
                       {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
+                        "text": "Microsoft",
+                        "category": "Organization",
                         "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.95
                       }
                     ],
                     "warnings": []
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2020-04-01"
+                "modelVersion": "2021-01-15"
               }
             }
           ]
@@ -1101,31 +1128,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bc5695f5beb20ba4efc32c913d157f88",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d966e960bf22d7ad7d7b371bdfbe8fd7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "53f7402a-d55e-48a4-9622-ad51f10db330",
+        "apim-request-id": "e39b0c80-2af5-4176-90d3-837f45fd0940",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "353"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "23820"
       },
       "ResponseBody": {
-        "jobId": "8e6be3ec-355d-4438-8c6a-1d7f90180e8c",
-        "lastUpdateDateTime": "2021-09-23T14:42:39Z",
-        "createdDateTime": "2021-09-23T14:42:29Z",
-        "expirationDateTime": "2021-09-24T14:42:29Z",
+        "jobId": "e25b1727-19a3-4be6-8e5b-8e4bc241c8bb",
+        "lastUpdateDateTime": "2021-10-25T21:04:27Z",
+        "createdDateTime": "2021-10-25T21:04:01Z",
+        "expirationDateTime": "2021-10-26T21:04:01Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -1136,7 +1169,7 @@
           "total": 5,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:39.6743383Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:15.6215953Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1175,7 +1208,7 @@
                         "category": "PersonType",
                         "offset": 36,
                         "length": 11,
-                        "confidenceScore": 0.97
+                        "confidenceScore": 0.96
                       }
                     ],
                     "warnings": []
@@ -1188,7 +1221,7 @@
           ],
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:38.2749246Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:12.0321334Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1271,7 +1304,7 @@
           ],
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:32.620207Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:09.8480649Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1312,7 +1345,7 @@
                         "category": "PersonType",
                         "offset": 36,
                         "length": 11,
-                        "confidenceScore": 0.96
+                        "confidenceScore": 0.95
                       }
                     ],
                     "warnings": []
@@ -1325,7 +1358,7 @@
           ],
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:38.4546002Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:21.222138Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1355,7 +1388,7 @@
           ],
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:33.0657354Z",
+              "lastUpdateDateTime": "2021-10-25T21:04:27.7119932Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1418,6 +1451,6 @@
   "Variables": {
     "RandomSeed": "294889338",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithMultipleActionsAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "624",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-06ae1f9d8d1a354ab9500063cadbca58-28249c9df44aa649-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-21391f581e0bfa449aa804ce3e0c4a83-6789a54b020b1a45-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "89d8b003187a4095bbbb24fbfe84af54",
         "x-ms-return-client-request-id": "true"
       },
@@ -67,42 +73,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a5d99aff-92f9-4c8b-a80e-594e2db407bd",
-        "Date": "Thu, 23 Sep 2021 14:44:40 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+        "apim-request-id": "6b1cb275-5e6b-4e8a-bcf2-8e9f6dd03dab",
+        "Date": "Mon, 25 Oct 2021 21:07:46 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "482"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "522"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2855ecc1615ff9546357ae19534c50d8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4e27c89-ba9e-46e7-acd8-2223e492b83e",
+        "apim-request-id": "28f9b83f-1632-4233-9aa4-57bfa7303875",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
       },
       "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:40Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:07:47Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -115,31 +127,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "49705b3bf552a68f1ed902bccb13384a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b1c8c5d2-b364-41d5-b04c-956fba113e00",
+        "apim-request-id": "90a45515-281d-4857-80e9-a7095522de2a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:41 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5385"
       },
       "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:41Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:07:47Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -152,31 +170,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b846e7be8ec5a1535bdf25226a7ced6f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "71889445-8899-4d8d-ac8c-a647364c213e",
+        "apim-request-id": "ec6f0bf6-0856-45ba-a450-a674a944b221",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "67"
       },
       "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:41Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:07:53Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -189,279 +213,95 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a3bf4c6a6514cb015cae0a855f982e50",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a6928f8-4f10-4577-a75c-93a58a84e4a8",
+        "apim-request-id": "a774e1d8-60b2-49f3-b7ce-50b4124eec9c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "136"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:44Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:07:53Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
         "tasks": {
-          "completed": 2,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 3,
-          "total": 5,
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:44.005246Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:43.2697274Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
+          "inProgress": 5,
+          "total": 5
         }
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6b5a641f9805ac1307ceee72d06c3ca1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2afb6a2d-16da-4ada-9703-db0646e9b0b0",
+        "apim-request-id": "9bb6ed7f-6a2c-4d9e-8b66-faaa2094b7e7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:45 GMT",
+        "Date": "Mon, 25 Oct 2021 21:07:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "220"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "72"
       },
       "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:45Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:07:57Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
         "tasks": {
-          "completed": 3,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
+          "inProgress": 4,
           "total": 5,
-          "entityLinkingTasks": [
+          "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:45.3222217Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
               "state": "succeeded",
               "results": {
                 "documents": [
                   {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
-                        "name": "Microsoft",
-                        "matches": [
-                          {
-                            "text": "Microsoft",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.49
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Microsoft",
-                        "url": "https://en.wikipedia.org/wiki/Microsoft",
-                        "dataSource": "Wikipedia"
-                      },
-                      {
-                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
-                        "name": "Bill Gates",
-                        "matches": [
-                          {
-                            "text": "Bill Gates",
-                            "offset": 25,
-                            "length": 10,
-                            "confidenceScore": 0.52
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Bill Gates",
-                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
-                        "dataSource": "Wikipedia"
-                      },
-                      {
-                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
-                        "name": "Paul Allen",
-                        "matches": [
-                          {
-                            "text": "Paul Allen",
-                            "offset": 40,
-                            "length": 10,
-                            "confidenceScore": 0.54
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Paul Allen",
-                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
-                        "dataSource": "Wikipedia"
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            }
-          ],
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:44.005246Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
                     "id": "1",
                     "entities": [
                       {
@@ -469,7 +309,7 @@
                         "category": "Organization",
                         "offset": 0,
                         "length": 9,
-                        "confidenceScore": 0.97
+                        "confidenceScore": 1.0
                       },
                       {
                         "text": "Bill Gates",
@@ -483,13 +323,12 @@
                         "category": "Person",
                         "offset": 40,
                         "length": 10,
-                        "confidenceScore": 0.99
+                        "confidenceScore": 1.0
                       }
                     ],
                     "warnings": []
                   },
                   {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
                     "id": "2",
                     "entities": [
                       {
@@ -504,65 +343,7 @@
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:43.2697274Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
+                "modelVersion": "2021-06-01"
               }
             }
           ]
@@ -570,31 +351,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7e5192ec94535835e57a5b1684cd42c2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2024c75e-ad8d-49dd-85e8-844d9fc3b1d7",
+        "apim-request-id": "7b589a75-8180-4c67-84c8-dc7bf1b3b4b8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "189"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1148"
       },
       "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:46Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:07:59Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -603,9 +390,61 @@
           "failed": 0,
           "inProgress": 2,
           "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:45.3222217Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -686,115 +525,33 @@
               }
             }
           ],
-          "entityRecognitionPiiTasks": [
+          "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:44.005246Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:43.2697274Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
               "state": "succeeded",
               "results": {
                 "documents": [
                   {
                     "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
                     ],
                     "warnings": []
                   },
                   {
                     "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
+                    "keyPhrases": [
+                      "perro",
+                      "gato",
+                      "veterinario"
                     ],
                     "warnings": []
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2020-04-01"
+                "modelVersion": "2021-06-01"
               }
             }
           ]
@@ -802,31 +559,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0603d5b18121d26939129b46778efbf0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca262429-100c-4574-886e-e1f25abd90e7",
+        "apim-request-id": "53a2d36b-d4de-4848-be8a-95c70fa0aaf4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "206"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "551"
       },
       "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:46Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:07:59Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -835,9 +598,61 @@
           "failed": 0,
           "inProgress": 2,
           "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:45.3222217Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -918,115 +733,33 @@
               }
             }
           ],
-          "entityRecognitionPiiTasks": [
+          "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:44.005246Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:43.2697274Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
               "state": "succeeded",
               "results": {
                 "documents": [
                   {
                     "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
                     ],
                     "warnings": []
                   },
                   {
                     "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
+                    "keyPhrases": [
+                      "perro",
+                      "gato",
+                      "veterinario"
                     ],
                     "warnings": []
                   }
                 ],
                 "errors": [],
-                "modelVersion": "2020-04-01"
+                "modelVersion": "2021-06-01"
               }
             }
           ]
@@ -1034,31 +767,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cc996972af478afc2e02868b3dfc283a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "434cbc84-f28f-4fa1-abd6-996f817c659f",
+        "apim-request-id": "32771cb9-7efb-4dde-abbd-57669757a8cf",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "337"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1103"
       },
       "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:48Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:08:04Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithMultipleTasks",
@@ -1069,7 +808,7 @@
           "total": 5,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:48.9681809Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1108,7 +847,7 @@
                         "category": "PersonType",
                         "offset": 36,
                         "length": 11,
-                        "confidenceScore": 0.97
+                        "confidenceScore": 0.96
                       }
                     ],
                     "warnings": []
@@ -1121,7 +860,7 @@
           ],
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:45.3222217Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1199,350 +938,12 @@
                   }
                 ],
                 "modelVersion": "2021-06-01"
-              }
-            }
-          ],
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:44.005246Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
-              }
-            }
-          ],
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:43.2697274Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.01,
-                      "neutral": 0.99,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.01,
-                          "neutral": 0.99,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 51,
-                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentiment": "neutral",
-                    "confidenceScores": {
-                      "positive": 0.13,
-                      "neutral": 0.85,
-                      "negative": 0.02
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.13,
-                          "neutral": 0.85,
-                          "negative": 0.02
-                        },
-                        "offset": 0,
-                        "length": 48,
-                        "text": "Mi perro y mi gato tienen que ir al veterinario."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/b2bf84fd-897b-4b83-9294-26e5265fecc8",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fbc12b8b36696a80287e4541f9efe156",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5c1d2d16-64ac-4d78-a060-bbd010467503",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:51 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "395"
-      },
-      "ResponseBody": {
-        "jobId": "b2bf84fd-897b-4b83-9294-26e5265fecc8",
-        "lastUpdateDateTime": "2021-09-23T14:44:49Z",
-        "createdDateTime": "2021-09-23T14:44:40Z",
-        "expirationDateTime": "2021-09-24T14:44:40Z",
-        "status": "succeeded",
-        "errors": [],
-        "displayName": "AnalyzeOperationWithMultipleTasks",
-        "tasks": {
-          "completed": 5,
-          "failed": 0,
-          "inProgress": 0,
-          "total": 5,
-          "entityRecognitionTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:48.9681809Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.97
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            }
-          ],
-          "entityLinkingTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:45.3222217Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "entities": [
-                      {
-                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
-                        "name": "Microsoft",
-                        "matches": [
-                          {
-                            "text": "Microsoft",
-                            "offset": 0,
-                            "length": 9,
-                            "confidenceScore": 0.49
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Microsoft",
-                        "url": "https://en.wikipedia.org/wiki/Microsoft",
-                        "dataSource": "Wikipedia"
-                      },
-                      {
-                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
-                        "name": "Bill Gates",
-                        "matches": [
-                          {
-                            "text": "Bill Gates",
-                            "offset": 25,
-                            "length": 10,
-                            "confidenceScore": 0.52
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Bill Gates",
-                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
-                        "dataSource": "Wikipedia"
-                      },
-                      {
-                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
-                        "name": "Paul Allen",
-                        "matches": [
-                          {
-                            "text": "Paul Allen",
-                            "offset": 40,
-                            "length": 10,
-                            "confidenceScore": 0.54
-                          }
-                        ],
-                        "language": "en",
-                        "id": "Paul Allen",
-                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
-                        "dataSource": "Wikipedia"
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "entities": [],
-                    "warnings": []
-                  }
-                ],
-                "errors": [
-                  {
-                    "id": "2",
-                    "error": {
-                      "code": "InvalidArgument",
-                      "message": "Invalid Language Code.",
-                      "innererror": {
-                        "code": "UnsupportedLanguageCode",
-                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
-                      }
-                    }
-                  }
-                ],
-                "modelVersion": "2021-06-01"
-              }
-            }
-          ],
-          "entityRecognitionPiiTasks": [
-            {
-              "lastUpdateDateTime": "2021-09-23T14:44:44.005246Z",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "redactedText": "********* was founded by ********** and **********.",
-                    "id": "1",
-                    "entities": [
-                      {
-                        "text": "Microsoft",
-                        "category": "Organization",
-                        "offset": 0,
-                        "length": 9,
-                        "confidenceScore": 0.97
-                      },
-                      {
-                        "text": "Bill Gates",
-                        "category": "Person",
-                        "offset": 25,
-                        "length": 10,
-                        "confidenceScore": 1.0
-                      },
-                      {
-                        "text": "Paul Allen",
-                        "category": "Person",
-                        "offset": 40,
-                        "length": 10,
-                        "confidenceScore": 0.99
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
-                    "id": "2",
-                    "entities": [
-                      {
-                        "text": "veterinario",
-                        "category": "PersonType",
-                        "offset": 36,
-                        "length": 11,
-                        "confidenceScore": 0.96
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-01-15"
               }
             }
           ],
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:49.9444774Z",
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1572,7 +973,1657 @@
           ],
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:43.2697274Z",
+              "lastUpdateDateTime": "2021-10-25T21:08:04.4180726Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 51,
+                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.13,
+                      "neutral": 0.85,
+                      "negative": 0.02
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.13,
+                          "neutral": 0.85,
+                          "negative": 0.02
+                        },
+                        "offset": 0,
+                        "length": 48,
+                        "text": "Mi perro y mi gato tienen que ir al veterinario."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "fbc12b8b36696a80287e4541f9efe156",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0d8e0183-90c1-4972-9876-fcdb2028385a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "271"
+      },
+      "ResponseBody": {
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:08:04Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "perro",
+                      "gato",
+                      "veterinario"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:08:04.4180726Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 51,
+                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.13,
+                      "neutral": 0.85,
+                      "negative": 0.02
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.13,
+                          "neutral": 0.85,
+                          "negative": 0.02
+                        },
+                        "offset": 0,
+                        "length": 48,
+                        "text": "Mi perro y mi gato tienen que ir al veterinario."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "1aa46a7f7634017bd878d71ffade953c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "169cfcdd-1016-4ae9-af7f-5d24ec62c354",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "529"
+      },
+      "ResponseBody": {
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:08:04Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "perro",
+                      "gato",
+                      "veterinario"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:08:04.4180726Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 51,
+                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.13,
+                      "neutral": 0.85,
+                      "negative": 0.02
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.13,
+                          "neutral": 0.85,
+                          "negative": 0.02
+                        },
+                        "offset": 0,
+                        "length": 48,
+                        "text": "Mi perro y mi gato tienen que ir al veterinario."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4bba61eaffcd3c86e82ea4c86abb913e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "609d3d58-0fa9-482a-a7bc-12b356e27a6c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "230"
+      },
+      "ResponseBody": {
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:08:04Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "perro",
+                      "gato",
+                      "veterinario"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:08:04.4180726Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 51,
+                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.13,
+                      "neutral": 0.85,
+                      "negative": 0.02
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.13,
+                          "neutral": 0.85,
+                          "negative": 0.02
+                        },
+                        "offset": 0,
+                        "length": 48,
+                        "text": "Mi perro y mi gato tienen que ir al veterinario."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d20c30200d581505b0c022f05e616f4a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6b3f7428-216c-4bc4-b5c9-9cac608e7555",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "3081"
+      },
+      "ResponseBody": {
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:08:04Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "perro",
+                      "gato",
+                      "veterinario"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:08:04.4180726Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 51,
+                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.13,
+                      "neutral": 0.85,
+                      "negative": 0.02
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.13,
+                          "neutral": 0.85,
+                          "negative": 0.02
+                        },
+                        "offset": 0,
+                        "length": 48,
+                        "text": "Mi perro y mi gato tienen que ir al veterinario."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "975708e996357f89e4673105d1b2971d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e902c074-ac2e-4e66-b725-b7c33d58fc48",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "362"
+      },
+      "ResponseBody": {
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:08:04Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 4,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "perro",
+                      "gato",
+                      "veterinario"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:08:04.4180726Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.01,
+                      "neutral": 0.99,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.01,
+                          "neutral": 0.99,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 51,
+                        "text": "Microsoft was founded by Bill Gates and Paul Allen."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "sentiment": "neutral",
+                    "confidenceScores": {
+                      "positive": 0.13,
+                      "neutral": 0.85,
+                      "negative": 0.02
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.13,
+                          "neutral": 0.85,
+                          "negative": 0.02
+                        },
+                        "offset": 0,
+                        "length": 48,
+                        "text": "Mi perro y mi gato tienen que ir al veterinario."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4acf6cf7-0fed-41bc-b8cd-013001b94864",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "cafe98e7c2d2dce45ba49a0cdd95dd87",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "82f03b89-045d-435c-918d-42ba323ca3ca",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "392"
+      },
+      "ResponseBody": {
+        "jobId": "4acf6cf7-0fed-41bc-b8cd-013001b94864",
+        "lastUpdateDateTime": "2021-10-25T21:08:20Z",
+        "createdDateTime": "2021-10-25T21:07:47Z",
+        "expirationDateTime": "2021-10-26T21:07:47Z",
+        "status": "succeeded",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithMultipleTasks",
+        "tasks": {
+          "completed": 5,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 5,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:57.4943879Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:59.2470203Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "2",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:08:20.140432Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "********* was founded by ********** and **********.",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Mi perro y mi gato tienen que ir al ***********.",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "veterinario",
+                        "category": "PersonType",
+                        "offset": 36,
+                        "length": 11,
+                        "confidenceScore": 0.95
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ],
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:07:58.6764018Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "perro",
+                      "gato",
+                      "veterinario"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ],
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:08:04.4180726Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -1635,6 +2686,6 @@
   "Variables": {
     "RandomSeed": "1928146711",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPHIDomain.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPHIDomain.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "320",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5dfdd19612d99f43a89650b89a5505f8-25e70a4234d18848-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-88b8153950aaa4478246fa9bf9f8fc9d-f73ccd378418cf4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cfe8e2f8ee3911d883f149c5ba708a25",
         "x-ms-return-client-request-id": "true"
       },
@@ -37,43 +43,49 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "71a99ec5-e403-43da-8d87-64aa1b510527",
-        "Date": "Fri, 06 Aug 2021 01:44:46 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/98bc881a-4213-4158-bf03-c8c6ec2fe47d",
+        "apim-request-id": "3912d284-d6de-48f6-a14d-c9d5a77e6edc",
+        "Date": "Mon, 25 Oct 2021 21:05:17 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/135a4a1e-ea37-43a7-a95a-4ff2805d304c",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "219"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "230"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/98bc881a-4213-4158-bf03-c8c6ec2fe47d",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/135a4a1e-ea37-43a7-a95a-4ff2805d304c",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0af6547e6d21f99df5e133f9fb1abff6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "74836995-bbcc-4d12-aabc-d2596b99b943",
+        "apim-request-id": "f60b00cf-6cdd-4ec5-8a68-b3bf93ff504f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "98bc881a-4213-4158-bf03-c8c6ec2fe47d",
-        "lastUpdateDateTime": "2021-08-06T01:44:46Z",
-        "createdDateTime": "2021-08-06T01:44:46Z",
-        "expirationDateTime": "2021-08-07T01:44:46Z",
-        "status": "notStarted",
+        "jobId": "135a4a1e-ea37-43a7-a95a-4ff2805d304c",
+        "lastUpdateDateTime": "2021-10-25T21:05:18Z",
+        "createdDateTime": "2021-10-25T21:05:17Z",
+        "expirationDateTime": "2021-10-26T21:05:17Z",
+        "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
         "tasks": {
@@ -85,31 +97,37 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/98bc881a-4213-4158-bf03-c8c6ec2fe47d",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/135a4a1e-ea37-43a7-a95a-4ff2805d304c",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1ffe04ae50f965a11f4bc1da8e14f022",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b3645fd6-f12f-4162-bde5-bfb34f6918b7",
+        "apim-request-id": "672d37f1-c9fe-45fb-99f2-0f2f6ad8b0c1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "98bc881a-4213-4158-bf03-c8c6ec2fe47d",
-        "lastUpdateDateTime": "2021-08-06T01:44:47Z",
-        "createdDateTime": "2021-08-06T01:44:46Z",
-        "expirationDateTime": "2021-08-07T01:44:46Z",
+        "jobId": "135a4a1e-ea37-43a7-a95a-4ff2805d304c",
+        "lastUpdateDateTime": "2021-10-25T21:05:18Z",
+        "createdDateTime": "2021-10-25T21:05:17Z",
+        "expirationDateTime": "2021-10-26T21:05:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -122,31 +140,37 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/98bc881a-4213-4158-bf03-c8c6ec2fe47d",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/135a4a1e-ea37-43a7-a95a-4ff2805d304c",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1647a062e0a88b5844efda57badf1569",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "291af48b-6b92-4ff1-a4f9-82ac3e41d0f2",
+        "apim-request-id": "cbd16663-122b-4e99-8df7-8795f0792cf8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "98bc881a-4213-4158-bf03-c8c6ec2fe47d",
-        "lastUpdateDateTime": "2021-08-06T01:44:47Z",
-        "createdDateTime": "2021-08-06T01:44:46Z",
-        "expirationDateTime": "2021-08-07T01:44:46Z",
+        "jobId": "135a4a1e-ea37-43a7-a95a-4ff2805d304c",
+        "lastUpdateDateTime": "2021-10-25T21:05:18Z",
+        "createdDateTime": "2021-10-25T21:05:17Z",
+        "expirationDateTime": "2021-10-26T21:05:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -159,31 +183,37 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/98bc881a-4213-4158-bf03-c8c6ec2fe47d",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/135a4a1e-ea37-43a7-a95a-4ff2805d304c",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b61653316b722e2cb391ead5abc26ae0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2854c496-b11c-444c-8ced-a8e6e4f10045",
+        "apim-request-id": "3458fadf-c3e3-4f4d-856b-df3f6b2614a3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "22"
       },
       "ResponseBody": {
-        "jobId": "98bc881a-4213-4158-bf03-c8c6ec2fe47d",
-        "lastUpdateDateTime": "2021-08-06T01:44:47Z",
-        "createdDateTime": "2021-08-06T01:44:46Z",
-        "expirationDateTime": "2021-08-07T01:44:46Z",
+        "jobId": "135a4a1e-ea37-43a7-a95a-4ff2805d304c",
+        "lastUpdateDateTime": "2021-10-25T21:05:18Z",
+        "createdDateTime": "2021-10-25T21:05:17Z",
+        "expirationDateTime": "2021-10-26T21:05:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -196,31 +226,37 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/98bc881a-4213-4158-bf03-c8c6ec2fe47d",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/135a4a1e-ea37-43a7-a95a-4ff2805d304c",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5a9611f1a9d2cd4dab72da09754aaa40",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7c72f209-81bd-4f21-872a-0cb2067b7f46",
+        "apim-request-id": "7023435e-7605-48fc-a765-0211a2e98a83",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "98bc881a-4213-4158-bf03-c8c6ec2fe47d",
-        "lastUpdateDateTime": "2021-08-06T01:44:47Z",
-        "createdDateTime": "2021-08-06T01:44:46Z",
-        "expirationDateTime": "2021-08-07T01:44:46Z",
+        "jobId": "135a4a1e-ea37-43a7-a95a-4ff2805d304c",
+        "lastUpdateDateTime": "2021-10-25T21:05:18Z",
+        "createdDateTime": "2021-10-25T21:05:17Z",
+        "expirationDateTime": "2021-10-26T21:05:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -233,31 +269,37 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/98bc881a-4213-4158-bf03-c8c6ec2fe47d",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/135a4a1e-ea37-43a7-a95a-4ff2805d304c",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3ba9583539fdf7af74196317f682e081",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d5985879-fac9-4750-91d2-cb2139995984",
+        "apim-request-id": "b19fb477-a295-4be2-b1ab-1605e80bf718",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "98bc881a-4213-4158-bf03-c8c6ec2fe47d",
-        "lastUpdateDateTime": "2021-08-06T01:44:47Z",
-        "createdDateTime": "2021-08-06T01:44:46Z",
-        "expirationDateTime": "2021-08-07T01:44:46Z",
+        "jobId": "135a4a1e-ea37-43a7-a95a-4ff2805d304c",
+        "lastUpdateDateTime": "2021-10-25T21:05:18Z",
+        "createdDateTime": "2021-10-25T21:05:17Z",
+        "expirationDateTime": "2021-10-26T21:05:17Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -270,31 +312,37 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/98bc881a-4213-4158-bf03-c8c6ec2fe47d",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/135a4a1e-ea37-43a7-a95a-4ff2805d304c",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a966f984bb48889605490aff9122b869",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7134ad29-3a6c-4d0a-888f-078f32cc89dd",
+        "apim-request-id": "beff3319-8f79-413b-8b22-a970f67b38e4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "65"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "67"
       },
       "ResponseBody": {
-        "jobId": "98bc881a-4213-4158-bf03-c8c6ec2fe47d",
-        "lastUpdateDateTime": "2021-08-06T01:44:52Z",
-        "createdDateTime": "2021-08-06T01:44:46Z",
-        "expirationDateTime": "2021-08-07T01:44:46Z",
+        "jobId": "135a4a1e-ea37-43a7-a95a-4ff2805d304c",
+        "lastUpdateDateTime": "2021-10-25T21:05:25Z",
+        "createdDateTime": "2021-10-25T21:05:17Z",
+        "expirationDateTime": "2021-10-26T21:05:17Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -305,7 +353,7 @@
           "total": 1,
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-08-06T01:44:52.7901475Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:25.0899804Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -343,6 +391,6 @@
   "Variables": {
     "RandomSeed": "390387714",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPHIDomainAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPHIDomainAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "320",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ed1720388ae7bd4599cea57e97377651-9c524b563b1c204b-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-272a04cce40de4478a382dc7c67094a3-be5f72dabd350842-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "dbcf75b1d6cb24fdb41d742a5d142b0a",
         "x-ms-return-client-request-id": "true"
       },
@@ -37,42 +43,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "c8f3c347-0bdf-490f-9fbd-1ca410ce8bf2",
-        "Date": "Thu, 23 Sep 2021 14:45:02 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+        "apim-request-id": "6fddb1b7-2080-4a21-9a50-f8cac3370784",
+        "Date": "Mon, 25 Oct 2021 21:09:46 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "187"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1888"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4c8042efa9b72511ebff89e389aea38e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "74a4f217-9280-4b58-b42c-00a4fdcb3b2c",
+        "apim-request-id": "af0c4d13-b7d9-4f2a-9f16-a18776e82e22",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:02Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
+        "jobId": "88d2f819-f4dc-4374-b246-113e9fa96784",
+        "lastUpdateDateTime": "2021-10-25T21:09:46Z",
+        "createdDateTime": "2021-10-25T21:09:44Z",
+        "expirationDateTime": "2021-10-26T21:09:44Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -85,32 +97,38 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d874985d95266ebb9878278edaa670b9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "65bb8b9e-e9f1-47f1-a540-3289d0a5f3d0",
+        "apim-request-id": "12f89f3c-96e6-410e-b914-c62695167370",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:03 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:03Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
-        "status": "running",
+        "jobId": "88d2f819-f4dc-4374-b246-113e9fa96784",
+        "lastUpdateDateTime": "2021-10-25T21:09:46Z",
+        "createdDateTime": "2021-10-25T21:09:44Z",
+        "expirationDateTime": "2021-10-26T21:09:44Z",
+        "status": "notStarted",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
         "tasks": {
@@ -122,32 +140,38 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "75458861a56107e864a9f0cb4c199a06",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5fad487d-fb05-43f6-944c-ca3f41c65af7",
+        "apim-request-id": "75eabc37-1707-4920-8add-9455d7a6841a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:03Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
-        "status": "running",
+        "jobId": "88d2f819-f4dc-4374-b246-113e9fa96784",
+        "lastUpdateDateTime": "2021-10-25T21:09:46Z",
+        "createdDateTime": "2021-10-25T21:09:44Z",
+        "expirationDateTime": "2021-10-26T21:09:44Z",
+        "status": "notStarted",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
         "tasks": {
@@ -159,32 +183,38 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c4cce67952a059e38711b33f82834b45",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2568b744-ea85-4411-ae5f-717f040e8d6d",
+        "apim-request-id": "f55d4bfb-cf26-4cb5-8542-f091022ff2fe",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:06 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:03Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
-        "status": "running",
+        "jobId": "88d2f819-f4dc-4374-b246-113e9fa96784",
+        "lastUpdateDateTime": "2021-10-25T21:09:46Z",
+        "createdDateTime": "2021-10-25T21:09:44Z",
+        "expirationDateTime": "2021-10-26T21:09:44Z",
+        "status": "notStarted",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
         "tasks": {
@@ -196,31 +226,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0182d08f2e68b82daf6c747ca5ef217e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "886e9346-f737-4271-a376-a21f072ce485",
+        "apim-request-id": "37636412-2024-43bf-9e79-fc4859a3c1d5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:07 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:03Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
+        "jobId": "88d2f819-f4dc-4374-b246-113e9fa96784",
+        "lastUpdateDateTime": "2021-10-25T21:09:53Z",
+        "createdDateTime": "2021-10-25T21:09:44Z",
+        "expirationDateTime": "2021-10-26T21:09:44Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -233,31 +269,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f31420deabd90f18a4ecee4ff1a985e1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "798341db-fe85-47c5-8906-63db2abb0e63",
+        "apim-request-id": "bc7bbc94-dcb3-4ccc-8b28-ebe74f53b7cb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:08 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:03Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
+        "jobId": "88d2f819-f4dc-4374-b246-113e9fa96784",
+        "lastUpdateDateTime": "2021-10-25T21:09:53Z",
+        "createdDateTime": "2021-10-25T21:09:44Z",
+        "expirationDateTime": "2021-10-26T21:09:44Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -270,31 +312,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7c3cab5e99974b9db9141433dd67b397",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "65542b75-770a-4810-bc84-f87fe224c0a0",
+        "apim-request-id": "0d275f4f-68e5-4f61-bbea-dce9f072ca48",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:09 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:03Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
+        "jobId": "88d2f819-f4dc-4374-b246-113e9fa96784",
+        "lastUpdateDateTime": "2021-10-25T21:09:53Z",
+        "createdDateTime": "2021-10-25T21:09:44Z",
+        "expirationDateTime": "2021-10-26T21:09:44Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -307,68 +355,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88d2f819-f4dc-4374-b246-113e9fa96784",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "616034ef576ee36bb7725c7c40ddc605",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "76a0188d-2b82-4138-bd8b-f414f580d47c",
+        "apim-request-id": "fab77027-1190-4f3e-86be-a93feedaa21b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:10 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2331"
       },
       "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:03Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationWithPHIDomain",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fa1e93e7a5b345e782c93ac496e4323d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "32a7c1de-420f-4fed-8900-e72e66095374",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:11 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "56"
-      },
-      "ResponseBody": {
-        "jobId": "a3c3e034-69b6-4075-8cb4-e1a93519fcdd",
-        "lastUpdateDateTime": "2021-09-23T14:45:11Z",
-        "createdDateTime": "2021-09-23T14:45:02Z",
-        "expirationDateTime": "2021-09-24T14:45:02Z",
+        "jobId": "88d2f819-f4dc-4374-b246-113e9fa96784",
+        "lastUpdateDateTime": "2021-10-25T21:09:57Z",
+        "createdDateTime": "2021-10-25T21:09:44Z",
+        "expirationDateTime": "2021-10-26T21:09:44Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithPHIDomain",
@@ -379,7 +396,7 @@
           "total": 1,
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:11.2083524Z",
+              "lastUpdateDateTime": "2021-10-25T21:09:57.356919Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -417,6 +434,6 @@
   "Variables": {
     "RandomSeed": "1544755028",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPagination.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPagination.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "1944",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-84f19ad590ead144885e9963348646fa-7d8e82b6c2b8e545-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-90f73da668f70745859314793139d577-561013c0d2008d45-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5a3d6c2348d829c15de122829c1d2254",
         "x-ms-return-client-request-id": "true"
       },
@@ -144,43 +150,49 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e23672ce-0cc8-4c16-8b55-a6e7cec55565",
-        "Date": "Thu, 23 Sep 2021 14:42:41 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+        "apim-request-id": "8cf160ec-5410-46b8-951f-6da0f33574a9",
+        "Date": "Mon, 25 Oct 2021 21:05:03 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "699"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "641"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4d5c3f1f260ea429f32258bc15d3c165",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "65fb61fe-6deb-4165-ae05-b6f117a97add",
+        "apim-request-id": "c16ad2dd-ea7d-4a02-a21a-33b8b62aa32f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:41 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:41Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
-        "status": "notStarted",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:04Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
+        "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
         "tasks": {
@@ -192,31 +204,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0814b8f9ff4d9a0118a1c7a3b4ca2d52",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "57d7aff5-0696-4d06-b079-d189bf1dcbb4",
+        "apim-request-id": "97ae0bcf-4393-4bb8-9ad8-fb71d74cd548",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:42Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:04Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -229,31 +247,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e5bd681a9611fd57429866b6f0041489",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "17c74696-b4a2-46ff-802b-00fa6ffa53c8",
+        "apim-request-id": "5e59f5b1-86f1-43e7-a931-5235e1a15084",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:42Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:04Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -266,31 +290,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e389bc1f1a0820073dc2346c5e86f029",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ec1d4218-e09f-4b5e-bb5b-fe0e29095049",
+        "apim-request-id": "31027f7b-3f18-4a37-a47f-cec7fc3bdb23",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:45 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:42Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:04Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -303,31 +333,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "aca106f5dc1663546016c5b4984baa13",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7bfd1f81-fda6-4f33-8691-a22c1374f1e1",
+        "apim-request-id": "7244b04d-d97e-423e-8794-e71ea1bbff86",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:42Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:04Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -340,31 +376,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f7833e8d4940ff49619da74f61ea9fbc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "32b370bf-cb54-4c44-8d06-3c33f39235fd",
+        "apim-request-id": "1f9aa084-bccb-4ff4-84ee-d71d04c644a3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:42Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:04Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -377,31 +419,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "eac03ca867624373682682f2555287f2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b65afa5b-73b4-4873-b6e7-bd23affe0dd1",
+        "apim-request-id": "02c23b46-bcf5-4c22-abf9-07ca082692b3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "23"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:48Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:04Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -414,31 +462,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "20de2017f802ace8bda24b7834050176",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b9664f07-c672-49f7-90f4-1100c0f5af71",
+        "apim-request-id": "b3a9f465-0443-4138-b74d-8348672c7a36",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:48Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:13Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -451,31 +505,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5b0b0877bf8a26b0ca408f1ac657aa0e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a329a453-a72a-480a-b2cb-e956218ffc52",
+        "apim-request-id": "3fbcf2e4-ec02-47cd-9296-7e9605f61531",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "357"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "245"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:50Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:14Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -486,7 +546,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:50.3741302Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:14.8692042Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -697,35 +757,41 @@
             }
           ]
         },
-        "@nextLink": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4?$skip=20\u0026$top=3\u0026showStats=False"
+        "@nextLink": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189?$skip=20\u0026$top=3\u0026showStats=False"
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4?$skip=20\u0026$top=3\u0026showStats=False",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189?$skip=20\u0026$top=3\u0026showStats=False",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4037b5167f0cafba54142dc01cfa0e62",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cccdf73b-eb6e-468d-b67f-c61c79e78487",
+        "apim-request-id": "5fb3e752-b25b-46c4-8da0-c2b7e32b4f3e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "104"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "191"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:50Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:14Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -736,7 +802,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:50.3741302Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:14.8692042Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -780,31 +846,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e3a9b19e-814a-41fe-ab07-14c57a42f2e4?$skip=20\u0026$top=3\u0026showStats=False",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/88a3d31e-e85e-4fd6-99cb-afbe664d8189?$skip=20\u0026$top=3\u0026showStats=False",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4c7a0c252b4757676fb855c169cee566",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e6f50a1-8404-4806-97ed-7a3ee4e4fc6b",
+        "apim-request-id": "7e96f202-4df1-4438-af73-bfdd1526fdb9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:42:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "89"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "273"
       },
       "ResponseBody": {
-        "jobId": "e3a9b19e-814a-41fe-ab07-14c57a42f2e4",
-        "lastUpdateDateTime": "2021-09-23T14:42:50Z",
-        "createdDateTime": "2021-09-23T14:42:41Z",
-        "expirationDateTime": "2021-09-24T14:42:41Z",
+        "jobId": "88a3d31e-e85e-4fd6-99cb-afbe664d8189",
+        "lastUpdateDateTime": "2021-10-25T21:05:14Z",
+        "createdDateTime": "2021-10-25T21:05:03Z",
+        "expirationDateTime": "2021-10-26T21:05:03Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -815,7 +887,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:42:50.3741302Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:14.8692042Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -862,6 +934,6 @@
   "Variables": {
     "RandomSeed": "275027038",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPaginationAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPaginationAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "1944",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b1cdff457d471548b372786babbe4964-32e06affb5ff784e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8b64539bf10ce249a9b5864b0c50d169-10721064c2e35d41-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "21ac64e10f1baa75d580bbe74a8c1d32",
         "x-ms-return-client-request-id": "true"
       },
@@ -144,42 +150,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3d81dfe4-7098-4209-9b5d-844332302987",
-        "Date": "Thu, 23 Sep 2021 14:44:52 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+        "apim-request-id": "793359ca-9392-4bc9-901e-3d58cf2e3b9d",
+        "Date": "Mon, 25 Oct 2021 21:08:30 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "868"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9358"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b6309a59d4cb441b6d3a8ce20237d04a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3a3011c2-79a3-49a5-ab7f-bed185d1dd76",
+        "apim-request-id": "d4e96416-cba0-4717-9804-0f2f7bab80a0",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "214"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:44:52Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:30Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "notStarted",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -192,31 +204,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e3d0a275ac6660be41af3fd3bf957141",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cbee276e-ea19-4df9-bb27-ecd7f53f2378",
+        "apim-request-id": "1446ff5c-38f2-479d-afd6-ad877845901e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "15"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:44:52Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -229,31 +247,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2d059a9f02910c864867b4e18393a89d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "21e30c4d-5222-40f4-8bc4-0d62effe0280",
+        "apim-request-id": "a0522310-70d8-466d-8754-464da75ce1b7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "93"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:44:52Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -266,31 +290,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a87271af3abbaccbdbd0751c954884d8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "37662a9e-9e53-4dd2-972d-aebfdea14a6a",
+        "apim-request-id": "e1ff2a74-8e61-486e-8e7a-b345a50b67fa",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "57"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:44:52Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -303,31 +333,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "68424ac8a23173b91bc49bfef8dddcae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7cac43d7-1713-4a46-adc9-0e1a85935759",
+        "apim-request-id": "deda65ca-9260-4a05-ad66-63d29d9fa7c7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:44:52Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -340,31 +376,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4e23a107c9226585ce5851c08c6a7600",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "400094ad-5e6c-4d70-ae62-c690e6076fa0",
+        "apim-request-id": "171ad52b-923b-4f51-9681-97f668d9ee42",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "35"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:44:52Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -377,31 +419,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3818dce33f500d6cb8ff8cf79eccb4fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aac629ff-e787-49b0-b8b2-01d2bc5ef291",
+        "apim-request-id": "8e60e1b3-4bf1-4398-89cd-735834c71905",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:44:58Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -414,31 +462,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f414c7f33524ffb5c4dc9ad850f8e6b0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "36f63de7-d4b7-40af-87c6-a25b20674fb4",
+        "apim-request-id": "66b62b77-a109-4cf8-b9e9-421aa45883ed",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:00 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:45:00Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -451,31 +505,854 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1b1b9a4da3c4c85d341696233c8dc601",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5718e723-66d5-4a67-b913-e431d338319c",
+        "apim-request-id": "de38b6f9-87fd-42d0-8ad9-0386568e4230",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:08:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "384"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:45:01Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c5cc53a48255addc27197474a593bcbf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "db7c6d0a-1032-4c81-a8d0-264141ba4e51",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2840"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "04aadb1998b14f3a694cbf0d9f91c336",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5fd52b93-8f71-4953-b89e-ade277fbf003",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "276"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "fd349816202cca5bbe6df4ab2fe922a0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "84523c89-2b0f-4549-996b-3f9678be23b4",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "600ad659c2e30b50187c5c09c2ce0d95",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "618bc948-b688-4c0c-885d-e13fb19324d6",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0c5d3d56bf5ff89380df4543a48f1f80",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "eee70039-c96f-463e-901a-d3a8b0e5e9ee",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c8b31e29628753534728e4afc45107ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d8262630-35cf-4d00-b487-2fd9f0d436ba",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "131"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f2555e5f158b9a404311e0037c0d6788",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "66aa08b2-66c7-4145-b412-f40a284a0b62",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:08:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "92"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a4dfdc5c451af30ee90ac537dae4342f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8df4df20-f1eb-4ebb-b97d-0c072c96f317",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "109"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "45e355d82d3a13f4dd1985758250d63a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0420d8a1-8b08-407e-8cde-002de44166c4",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e8525cc063721ad5506108815009bf5f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a3c79920-fe49-409b-9547-3dffe3ac260d",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "313"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "272bb0dd22292f4ee7cbc601c0997199",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cf588029-e5b9-498d-a072-00026f38003f",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "41"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7e768a334c9174bc80c9f5d82473c3d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "de9954bc-0ff9-4730-84ee-2614d9ba6530",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d1982559af249e110d2200a69dd35ab7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "86f16353-261f-4446-979b-f1ac00013d23",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2250"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c64d6ff0419290cdf4b6a65f2c750a73",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "aeff1d40-2772-4462-ad98-5113a0bea8d5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "41"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:08:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9aa7f1089f00847479d7716e4b16d7ac",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e669c8b6-899d-44bf-9e6b-aeb9b9dcc2ba",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:09:20Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b5e83e6ffd2618415707dd6e08b17197",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f0e140f3-41aa-4af3-ae37-bc460f220335",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:34 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5879"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:09:32Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ab9d8d17bf2c50b6fac94cbacf5e45dd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bd25dfc9-a479-4a83-94c6-65d1f085a2d9",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:09:36Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "eef0fadf558d0b4db08e43f9c2067bc7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "56ad956c-ab73-4385-a398-93a178f52a17",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "182"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:09:36Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationWithPagination",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "bd57d9662b78af7f8797bb5cb08648f8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "46420c13-1f70-4429-9032-486638b59271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:09:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "451"
+      },
+      "ResponseBody": {
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:09:39Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -486,7 +1363,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:01.0504897Z",
+              "lastUpdateDateTime": "2021-10-25T21:09:39.7113958Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -697,35 +1574,41 @@
             }
           ]
         },
-        "@nextLink": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449?$skip=20\u0026$top=3\u0026showStats=False"
+        "@nextLink": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7?$skip=20\u0026$top=3\u0026showStats=False"
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449?$skip=20\u0026$top=3\u0026showStats=False",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7?$skip=20\u0026$top=3\u0026showStats=False",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c5cc53a48255addc27197474a593bcbf",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0e8fffc283c0c20a3f92fb9e7cbd8ef3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "566d56f3-7158-4244-a08d-f24a824052ad",
+        "apim-request-id": "d015f892-f8f9-4c96-b1b5-e4a5cb9c94e5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "111"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "89"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:45:01Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:09:39Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -736,7 +1619,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:01.0504897Z",
+              "lastUpdateDateTime": "2021-10-25T21:09:39.7113958Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -780,31 +1663,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/2c091aff-a5d6-49cf-a6cb-f2aaba7ab449?$skip=20\u0026$top=3\u0026showStats=False",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e457d46e-2e88-439f-9b20-f16aef5b7ce7?$skip=20\u0026$top=3\u0026showStats=False",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "04aadb1998b14f3a694cbf0d9f91c336",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f654844d8707b3647a4167f59af15a29",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e062b191-a85c-439f-b8ad-a72faf68f4f9",
+        "apim-request-id": "602f49a7-0d48-4a46-9b08-c887b370d7e3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:09:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "96"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "246"
       },
       "ResponseBody": {
-        "jobId": "2c091aff-a5d6-49cf-a6cb-f2aaba7ab449",
-        "lastUpdateDateTime": "2021-09-23T14:45:01Z",
-        "createdDateTime": "2021-09-23T14:44:51Z",
-        "expirationDateTime": "2021-09-24T14:44:51Z",
+        "jobId": "e457d46e-2e88-439f-9b20-f16aef5b7ce7",
+        "lastUpdateDateTime": "2021-10-25T21:09:39Z",
+        "createdDateTime": "2021-10-25T21:08:21Z",
+        "expirationDateTime": "2021-10-26T21:08:21Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationWithPagination",
@@ -815,7 +1704,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:01.0504897Z",
+              "lastUpdateDateTime": "2021-10-25T21:09:39.7113958Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -862,6 +1751,6 @@
   "Variables": {
     "RandomSeed": "24609339",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPiiCategories.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPiiCategories.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "328",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b63691be70268c45bf70daff4ce9f453-50452f6b53517444-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-549a27ffb71f4047aaedb32978da2232-c8c95c2de5005a43-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1945c414c8d0214218f422447fc26906",
         "x-ms-return-client-request-id": "true"
       },
@@ -38,45 +44,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "9cbb6ae3-d73d-473a-9d1a-b2bcc75b7f35",
-        "Date": "Fri, 06 Aug 2021 01:44:52 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
+        "apim-request-id": "84c2b290-799f-464d-9645-e951430579f0",
+        "Date": "Mon, 25 Oct 2021 21:05:26 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/415076cc-83c7-4174-8781-8c99f6edad48",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "232"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/415076cc-83c7-4174-8781-8c99f6edad48",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d5ed9f7c29b99e5a59c9017ada6e4b30",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e3b16eff-d6d9-4fa9-afc6-12d025d81017",
+        "apim-request-id": "8dab8292-3bd1-456e-a319-0710ad9ae60f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-        "lastUpdateDateTime": "2021-08-06T01:44:53Z",
-        "createdDateTime": "2021-08-06T01:44:53Z",
-        "expirationDateTime": "2021-08-07T01:44:53Z",
-        "status": "notStarted",
+        "jobId": "415076cc-83c7-4174-8781-8c99f6edad48",
+        "lastUpdateDateTime": "2021-10-25T21:05:27Z",
+        "createdDateTime": "2021-10-25T21:05:26Z",
+        "expirationDateTime": "2021-10-26T21:05:26Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -86,34 +97,39 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/415076cc-83c7-4174-8781-8c99f6edad48",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0deca93c3e3c1d92798cfe90bfcfa237",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "42239396-484e-46ff-8b85-19c2a13fa429",
+        "apim-request-id": "677f9a01-2823-4d40-a279-87af0f38a343",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "23"
       },
       "ResponseBody": {
-        "jobId": "e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-        "lastUpdateDateTime": "2021-08-06T01:44:53Z",
-        "createdDateTime": "2021-08-06T01:44:53Z",
-        "expirationDateTime": "2021-08-07T01:44:53Z",
+        "jobId": "415076cc-83c7-4174-8781-8c99f6edad48",
+        "lastUpdateDateTime": "2021-10-25T21:05:28Z",
+        "createdDateTime": "2021-10-25T21:05:26Z",
+        "expirationDateTime": "2021-10-26T21:05:26Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -123,219 +139,39 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/415076cc-83c7-4174-8781-8c99f6edad48",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "dec0a3dfed6cea0b69a7bf06c7c746aa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6d796592-89ea-4428-acca-055f837551e8",
+        "apim-request-id": "4d912925-49c4-44b1-a76e-a1f85577eac2",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:55 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "68"
       },
       "ResponseBody": {
-        "jobId": "e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-        "lastUpdateDateTime": "2021-08-06T01:44:53Z",
-        "createdDateTime": "2021-08-06T01:44:53Z",
-        "expirationDateTime": "2021-08-07T01:44:53Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d507f2a85bd63ec90cd05c2d2ac9de8a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "92007716-2ca4-4ad0-aea6-e706ccfd1381",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:56 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-        "lastUpdateDateTime": "2021-08-06T01:44:53Z",
-        "createdDateTime": "2021-08-06T01:44:53Z",
-        "expirationDateTime": "2021-08-07T01:44:53Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "369bc9276dad4ec49d01a4947e8c55b1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e4ea8fdd-c94d-4153-8927-dfd250bbc061",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:57 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-        "lastUpdateDateTime": "2021-08-06T01:44:53Z",
-        "createdDateTime": "2021-08-06T01:44:53Z",
-        "expirationDateTime": "2021-08-07T01:44:53Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cde85445ccc78460d982d19b91debf9f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0f62ddf2-a9c5-418a-9ae7-89f7a3707769",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:58 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-        "lastUpdateDateTime": "2021-08-06T01:44:53Z",
-        "createdDateTime": "2021-08-06T01:44:53Z",
-        "expirationDateTime": "2021-08-07T01:44:53Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fddf35c9102b3bfc2eb937d5b734bf80",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "055b469a-b9a9-4957-9aca-5deffc4c2d70",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:44:59 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-        "lastUpdateDateTime": "2021-08-06T01:44:53Z",
-        "createdDateTime": "2021-08-06T01:44:53Z",
-        "expirationDateTime": "2021-08-07T01:44:53Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/analyze/jobs/e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d6e7aa7b11e15ac269175c2a9b28bcbf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b7c4ec86-d4cc-4499-8262-35e7e97543a6",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:45:00 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "85"
-      },
-      "ResponseBody": {
-        "jobId": "e6f08afd-2116-49ad-ab8e-a4e9bd020bc6",
-        "lastUpdateDateTime": "2021-08-06T01:45:00Z",
-        "createdDateTime": "2021-08-06T01:44:53Z",
-        "expirationDateTime": "2021-08-07T01:44:53Z",
+        "jobId": "415076cc-83c7-4174-8781-8c99f6edad48",
+        "lastUpdateDateTime": "2021-10-25T21:05:28Z",
+        "createdDateTime": "2021-10-25T21:05:26Z",
+        "expirationDateTime": "2021-10-26T21:05:26Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -343,8 +179,7 @@
           "total": 1,
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-08-06T01:45:00.340659Z",
-              "taskName": "PersonallyIdentifiableInformation_latest",
+              "lastUpdateDateTime": "2021-10-25T21:05:28.9494864Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -375,6 +210,6 @@
   "Variables": {
     "RandomSeed": "1156890369",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPiiCategoriesAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithPiiCategoriesAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "328",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-138fe4d70a6d794bb65b1a1e37c09ff6-f476787fb4be4341-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-76f4982a2b963e43b8655244edf99ade-cf1091cd8b781b4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "32c323d944ebc101cfef406c61f44cba",
         "x-ms-return-client-request-id": "true"
       },
@@ -38,45 +44,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "09d01f91-a9fc-4975-b881-9b37700034aa",
-        "Date": "Thu, 23 Sep 2021 14:45:11 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/518f3c7a-8373-4ca4-afd3-b005457e145e",
+        "apim-request-id": "48cc5244-dfac-417e-8150-46d4f04f0e5a",
+        "Date": "Mon, 25 Oct 2021 21:10:01 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/629fc9ee-0233-4ecb-8811-5cc2f7f00860",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "180"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "574"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/518f3c7a-8373-4ca4-afd3-b005457e145e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/629fc9ee-0233-4ecb-8811-5cc2f7f00860",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5b7957cdb9c168af0199370dfb7f5028",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f8643251-5186-4039-a957-06b6638b70ef",
+        "apim-request-id": "2a1b590f-162c-46ef-94ad-c0f734e3faae",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:11 GMT",
+        "Date": "Mon, 25 Oct 2021 21:10:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "518f3c7a-8373-4ca4-afd3-b005457e145e",
-        "lastUpdateDateTime": "2021-09-23T14:45:12Z",
-        "createdDateTime": "2021-09-23T14:45:12Z",
-        "expirationDateTime": "2021-09-24T14:45:12Z",
-        "status": "notStarted",
+        "jobId": "629fc9ee-0233-4ecb-8811-5cc2f7f00860",
+        "lastUpdateDateTime": "2021-10-25T21:10:01Z",
+        "createdDateTime": "2021-10-25T21:10:00Z",
+        "expirationDateTime": "2021-10-26T21:10:00Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -86,34 +97,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/518f3c7a-8373-4ca4-afd3-b005457e145e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/629fc9ee-0233-4ecb-8811-5cc2f7f00860",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4004f81507632899cee58f8d15635040",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "37159c63-eadf-4639-a2f3-cb9437982b76",
+        "apim-request-id": "1a831c19-8aca-40c7-87fd-898d6238e7c5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:10:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "518f3c7a-8373-4ca4-afd3-b005457e145e",
-        "lastUpdateDateTime": "2021-09-23T14:45:13Z",
-        "createdDateTime": "2021-09-23T14:45:12Z",
-        "expirationDateTime": "2021-09-24T14:45:12Z",
+        "jobId": "629fc9ee-0233-4ecb-8811-5cc2f7f00860",
+        "lastUpdateDateTime": "2021-10-25T21:10:01Z",
+        "createdDateTime": "2021-10-25T21:10:00Z",
+        "expirationDateTime": "2021-10-26T21:10:00Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -123,34 +139,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/518f3c7a-8373-4ca4-afd3-b005457e145e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/629fc9ee-0233-4ecb-8811-5cc2f7f00860",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "46900fccd3641ff8735a31510df3c64f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8d5ff34c-fd15-4bc7-a39d-5ccb00bdd8b6",
+        "apim-request-id": "1003bebb-f883-492f-8d3a-b9da89387ba2",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:10:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "113"
       },
       "ResponseBody": {
-        "jobId": "518f3c7a-8373-4ca4-afd3-b005457e145e",
-        "lastUpdateDateTime": "2021-09-23T14:45:13Z",
-        "createdDateTime": "2021-09-23T14:45:12Z",
-        "expirationDateTime": "2021-09-24T14:45:12Z",
+        "jobId": "629fc9ee-0233-4ecb-8811-5cc2f7f00860",
+        "lastUpdateDateTime": "2021-10-25T21:10:01Z",
+        "createdDateTime": "2021-10-25T21:10:00Z",
+        "expirationDateTime": "2021-10-26T21:10:00Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -160,34 +181,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/518f3c7a-8373-4ca4-afd3-b005457e145e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/629fc9ee-0233-4ecb-8811-5cc2f7f00860",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6957179f0bf0c557bd518ddc2a22539e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0cead53c-6107-485c-aea3-217eca18cfdb",
+        "apim-request-id": "e9f2c556-0b23-432d-a279-1a378d8462ef",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:15 GMT",
+        "Date": "Mon, 25 Oct 2021 21:10:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "63"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "459"
       },
       "ResponseBody": {
-        "jobId": "518f3c7a-8373-4ca4-afd3-b005457e145e",
-        "lastUpdateDateTime": "2021-09-23T14:45:15Z",
-        "createdDateTime": "2021-09-23T14:45:12Z",
-        "expirationDateTime": "2021-09-24T14:45:12Z",
+        "jobId": "629fc9ee-0233-4ecb-8811-5cc2f7f00860",
+        "lastUpdateDateTime": "2021-10-25T21:10:05Z",
+        "createdDateTime": "2021-10-25T21:10:00Z",
+        "expirationDateTime": "2021-10-26T21:10:00Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -195,7 +221,7 @@
           "total": 1,
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:15.1898509Z",
+              "lastUpdateDateTime": "2021-10-25T21:10:05.4785563Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -226,6 +252,6 @@
   "Variables": {
     "RandomSeed": "1393333091",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithStatisticsTest.json
@@ -1,77 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "337",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2a7cd6b83526104981bfd9e9809df1c5-62fafb1976663f44-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7113589c3007a78af3272be840001637",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "analysisInput": {
-          "documents": [
-            {
-              "id": "1",
-              "text": "Microsoft was founded by Bill Gates and Paul Allen.",
-              "language": "en"
-            },
-            {
-              "id": "2",
-              "text": "Mi perro y mi gato tienen que ir al veterinario.",
-              "language": "es"
-            },
-            {
-              "id": "3",
-              "text": "",
-              "language": "es"
-            }
-          ]
-        },
-        "tasks": {
-          "keyPhraseExtractionTasks": [
-            {
-              "parameters": {}
-            }
-          ]
-        },
-        "displayName": "AnalyzeOperationTest"
-      },
-      "StatusCode": 500,
-      "ResponseHeaders": {
-        "apim-request-id": "5b94d3e1-fe06-4054-8f35-2d9d0a6b4128",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:46 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "555"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "InternalServerError",
-          "innerError": {
-            "requestId": "5b94d3e1-fe06-4054-8f35-2d9d0a6b4128"
-          },
-          "message": "Internal server error"
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Content-Length": "337",
-        "Content-Type": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2a7cd6b83526104981bfd9e9809df1c5-62fafb1976663f44-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-bbf26565acd497449d9653e0d8fce0a2-9b54d72d6ee59844-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7113589c3007a78af3272be840001637",
         "x-ms-return-client-request-id": "true"
       },
@@ -106,42 +50,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4cf204b2-a9e4-4d7f-9109-64d15acc43e3",
-        "Date": "Thu, 23 Sep 2021 14:43:47 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438",
+        "apim-request-id": "6d4ee155-7c53-47f7-80b2-04352f9fdcf4",
+        "Date": "Mon, 25 Oct 2021 21:05:30 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a45b9092-465c-45e5-8d8c-b6f0ed9a8815",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "293"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "191"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a45b9092-465c-45e5-8d8c-b6f0ed9a8815?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "144d8fd0fea1ffdadc949dbbddaecf18",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4bf3b9cf-a187-42da-bf1d-5c91ee65b9cd",
+        "apim-request-id": "c5b6a40e-06b6-4719-9d6e-2c639235bced",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "26"
       },
       "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
+        "jobId": "a45b9092-465c-45e5-8d8c-b6f0ed9a8815",
+        "lastUpdateDateTime": "2021-10-25T21:05:30Z",
+        "createdDateTime": "2021-10-25T21:05:30Z",
+        "expirationDateTime": "2021-10-26T21:05:30Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -154,31 +104,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a45b9092-465c-45e5-8d8c-b6f0ed9a8815?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "451e25c95048143288e779fc762b7962",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1afd276e-68ef-4092-b5c2-e306d1d5abe2",
+        "apim-request-id": "5a906cdd-1e47-4fdc-b07c-e814b0a9099e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
+        "jobId": "a45b9092-465c-45e5-8d8c-b6f0ed9a8815",
+        "lastUpdateDateTime": "2021-10-25T21:05:30Z",
+        "createdDateTime": "2021-10-25T21:05:30Z",
+        "expirationDateTime": "2021-10-26T21:05:30Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -191,31 +147,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a45b9092-465c-45e5-8d8c-b6f0ed9a8815?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f329f0ff21bb9efb7e13957393cfc944",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f0a9cade-c525-410c-b650-857815ff2c04",
+        "apim-request-id": "6db39f86-e3b0-4153-8446-b702a1b7b663",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
+        "jobId": "a45b9092-465c-45e5-8d8c-b6f0ed9a8815",
+        "lastUpdateDateTime": "2021-10-25T21:05:30Z",
+        "createdDateTime": "2021-10-25T21:05:30Z",
+        "expirationDateTime": "2021-10-26T21:05:30Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -228,31 +190,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a45b9092-465c-45e5-8d8c-b6f0ed9a8815?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1b1f1358d0e27fee5d388bb985dd89b1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b66a3134-33a0-4c05-b447-8a98cde5a2c8",
+        "apim-request-id": "4ca602c2-0fc2-470f-af53-9e522df4f6bb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "26"
       },
       "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
+        "jobId": "a45b9092-465c-45e5-8d8c-b6f0ed9a8815",
+        "lastUpdateDateTime": "2021-10-25T21:05:30Z",
+        "createdDateTime": "2021-10-25T21:05:30Z",
+        "expirationDateTime": "2021-10-26T21:05:30Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -265,31 +233,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a45b9092-465c-45e5-8d8c-b6f0ed9a8815?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "edbc3b1bdb85a75d2980c735bbbe81b9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc2ab3b3-392a-4137-84a4-934784741c40",
+        "apim-request-id": "20ce8a1c-8a6e-4313-b995-6450f1842a40",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
+        "jobId": "a45b9092-465c-45e5-8d8c-b6f0ed9a8815",
+        "lastUpdateDateTime": "2021-10-25T21:05:30Z",
+        "createdDateTime": "2021-10-25T21:05:30Z",
+        "expirationDateTime": "2021-10-26T21:05:30Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -302,31 +276,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a45b9092-465c-45e5-8d8c-b6f0ed9a8815?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "63a4341e5d0b2f8001a99582954218a0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a02a225a-9e11-44e6-8c56-8197c896960e",
+        "apim-request-id": "5f5a0603-e094-489c-be62-c6c3eec0d70d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "265"
       },
       "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
+        "jobId": "a45b9092-465c-45e5-8d8c-b6f0ed9a8815",
+        "lastUpdateDateTime": "2021-10-25T21:05:30Z",
+        "createdDateTime": "2021-10-25T21:05:30Z",
+        "expirationDateTime": "2021-10-26T21:05:30Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -339,623 +319,37 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a45b9092-465c-45e5-8d8c-b6f0ed9a8815?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5758e38adc137cbfb678f16108b9c49e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "945d3af7-7253-49b8-b972-bbf67f09a999",
+        "apim-request-id": "3a4b59e2-8403-424e-922f-3d8803e2671d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:05:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "290"
       },
       "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "519bd2b72539bda5ba8debdc46da12e7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "cf250995-72a4-4aa1-8086-fd73c5f070fd",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:55 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d7aa2668296641a57527ad936b1f2648",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "bd0ed38e-b27f-40da-9377-c72b5c2cce06",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:56 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c3caf6e4c7a664663e9a9c86f0e336db",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7c005a4b-501d-41ca-ba44-1cc70005e1e0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:57 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e1f90a66ed0e8e382c5adc117812519b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0758834a-9e01-488d-a293-22690b95a074",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:43:59 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4ff7a3664e10a041c04599cb8c1f5191",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5d57d0c9-ad8b-4a3e-b121-e9eb5c0977cd",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:00 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "612dd1f14425f739be3c964ceb54ec2b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a7b3064b-86d2-47e8-af96-fed894567f0c",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:01 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4d1f0048e7eb17cbc95821c8546c010d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "24e162ac-3bcb-477c-afde-3fdf6e41c1b3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:02 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a7204a08f0e5227669ff90d3b8f4b56b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "545f382c-d1ec-4d0b-a425-d6fe7bd248a2",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:03 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8b826d5903000aa5061698cd2371a351",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0d85bee6-8b76-4b10-b264-6d0759e8bd0a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:04 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a043893a443458468afde3eb56f75ed4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "595bd249-6f87-4929-8069-502e30586f83",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:05 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e66fb6a275ea050da415a0cf57a8fef8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f3b32844-98fd-41ab-a847-f379898877a1",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:07 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2f993f5c15b11436272a00021fb9b40e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "fb0a6f42-2591-4666-b77d-dd5244997976",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:08 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6d2bc3b7bc02c4677b3efc1ea47600e2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "cd69b30f-5aea-4b40-a951-85c90173a54a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:09 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "168febfe2f5e8d227f5abfc0750ae5ea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "47113b9f-6aaf-491d-b479-ff89c725878f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:10 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "93179161917ca0f6d8d4b373181770b0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "cc16807a-be0b-4e0b-8f08-52b86a15aef1",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:11 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:43:47Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d784706f-c7da-41e8-87a2-94d25b68a438?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "34041e299e2a88b0a09eeda7fda74f71",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d0ed26b2-02bf-45b1-b942-fe292ab579af",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:44:12 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "95"
-      },
-      "ResponseBody": {
-        "jobId": "d784706f-c7da-41e8-87a2-94d25b68a438",
-        "lastUpdateDateTime": "2021-09-23T14:44:12Z",
-        "createdDateTime": "2021-09-23T14:43:47Z",
-        "expirationDateTime": "2021-09-24T14:43:47Z",
+        "jobId": "a45b9092-465c-45e5-8d8c-b6f0ed9a8815",
+        "lastUpdateDateTime": "2021-10-25T21:05:38Z",
+        "createdDateTime": "2021-10-25T21:05:30Z",
+        "expirationDateTime": "2021-10-26T21:05:30Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -966,7 +360,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:44:12.338983Z",
+              "lastUpdateDateTime": "2021-10-25T21:05:38.2161918Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -1027,6 +421,6 @@
   "Variables": {
     "RandomSeed": "267372785",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeOperationTests/AnalyzeOperationWithStatisticsTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "337",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-08cb777ec459c14582e0ba46654b8206-7e934784a5da4c49-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-d4a186a207726247b654be2f8f10f8cd-5aad172f3218c04e-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2542d8e9f699af8c456bc28823041414",
         "x-ms-return-client-request-id": "true"
       },
@@ -44,79 +50,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "92c09074-88c3-4700-9523-007020d474c5",
-        "Date": "Thu, 23 Sep 2021 14:45:15 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/45269a5e-a75c-4026-bcba-e6450227aaaf",
+        "apim-request-id": "8a450ca0-b071-4599-9f5f-eca9d7bc4f38",
+        "Date": "Mon, 25 Oct 2021 21:12:57 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "215"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "208"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/45269a5e-a75c-4026-bcba-e6450227aaaf?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ed9d01e6f22a03f27d82800089c0a199",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d59e850c-6a9f-4bd0-8c7f-0d07a3208fad",
+        "apim-request-id": "85492115-cef8-4cf2-b0d6-aef05804e445",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:15 GMT",
+        "Date": "Mon, 25 Oct 2021 21:12:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "69"
       },
       "ResponseBody": {
-        "jobId": "45269a5e-a75c-4026-bcba-e6450227aaaf",
-        "lastUpdateDateTime": "2021-09-23T14:45:16Z",
-        "createdDateTime": "2021-09-23T14:45:16Z",
-        "expirationDateTime": "2021-09-24T14:45:16Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "AnalyzeOperationTest",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/45269a5e-a75c-4026-bcba-e6450227aaaf?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "90b6c8c3c1a1af318c24ffc2d4d26635",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "485d1e1c-18b5-4d88-ad3f-e87baabc425a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:16 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "45269a5e-a75c-4026-bcba-e6450227aaaf",
-        "lastUpdateDateTime": "2021-09-23T14:45:16Z",
-        "createdDateTime": "2021-09-23T14:45:16Z",
-        "expirationDateTime": "2021-09-24T14:45:16Z",
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
         "status": "running",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -129,31 +104,596 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/45269a5e-a75c-4026-bcba-e6450227aaaf?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "90b6c8c3c1a1af318c24ffc2d4d26635",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "321c2b77-eff9-4b1a-899b-0c4e6a8ea362",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:12:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "26"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7d35e0d1c2bff7dee53fa717758b2584",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0673c48f-4175-4d38-87b8-5b1c0046d422",
+        "apim-request-id": "302fcdfb-23ff-4221-ab00-7a877f9b908e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "88"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "45269a5e-a75c-4026-bcba-e6450227aaaf",
-        "lastUpdateDateTime": "2021-09-23T14:45:18Z",
-        "createdDateTime": "2021-09-23T14:45:16Z",
-        "expirationDateTime": "2021-09-24T14:45:16Z",
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "5ac529c9844e2473cfee6106f2302eaa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cf8f2c4a-4339-4b4b-a7ef-0c071a6ecc4e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a82f4b1b238a00d9eabeaa62191a3900",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3f9bac55-3a01-42fd-bcc3-d0a006c83c7a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "abf87bfe0c0d4ce66d10add060d805b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "513e0264-7e84-4244-b92d-b4c10ec43be7",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "29fbfd107d5ca6f950c46f90da110bb5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "59cc44d2-5609-48dd-9d10-78557c3bea39",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "760760b583380f9d64e23b797508a012",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "34e1f9ff-3e89-4540-a9e6-160ec2c8bc2a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "1c51f5b90f1f81a481515b489c56725b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cbbba335-0210-4c94-a99a-e70faae88a98",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ff1bf8058ed08c7c60ecc57a417f3147",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a0fc7d56-f533-4f43-9570-1ebd74531ec8",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e5d65d23efbfa595bc85f4e62754720e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "22504a6e-6c94-4a6e-b906-8393554212ee",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7c74e06fa0ec2a4178c5bb324a2a3f02",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ecd841b6-e584-4974-95b1-22a62fb8ce16",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3f2414208c7f169b6275434a9a95650c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d05a6d15-7760-49bd-a3b1-2c244e625a0d",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "610ab67ab40b835a1bac6cfa33625b92",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d9bd510b-1f4b-4800-a86a-e6781c527239",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:12:58Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
+        "status": "running",
+        "errors": [],
+        "displayName": "AnalyzeOperationTest",
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e2a734cd-802a-4622-a17c-7bf9e5ce0a4a?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "13c6f246322fe38f445e19775cf690e2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ef271d65-06c8-47ca-ab48-0a3fb3ffc259",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:13:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "69"
+      },
+      "ResponseBody": {
+        "jobId": "e2a734cd-802a-4622-a17c-7bf9e5ce0a4a",
+        "lastUpdateDateTime": "2021-10-25T21:13:15Z",
+        "createdDateTime": "2021-10-25T21:12:57Z",
+        "expirationDateTime": "2021-10-26T21:12:57Z",
         "status": "succeeded",
         "errors": [],
         "displayName": "AnalyzeOperationTest",
@@ -164,7 +704,7 @@
           "total": 1,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:18.4850851Z",
+              "lastUpdateDateTime": "2021-10-25T21:13:15.3628347Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -225,6 +765,6 @@
   "Variables": {
     "RandomSeed": "1456992479",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceFullTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceFullTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-abad52dddb7b0f4190d9c879a933af85-c66f925e44b8a041-00",
+        "traceparent": "00-aaf989ab2b8c5d46aad5ae14001600bc-3718e0352079d340-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "7fbb9dea32b8080ffdad856789b2330d",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "316c9dd8-8930-4196-91a0-daa89d42656e",
+        "apim-request-id": "e95be2c4-9e3b-4dc4-9cf4-c62c0116acd3",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "119"
+        "x-envoy-upstream-service-time": "76"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "508530765",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceFullTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceFullTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c7e80ee54217804da9e6fc66c24a93a8-714c965f0b1f1541-00",
+        "traceparent": "00-f789def9a1480340934f6d9e03071c3c-4a183c9a373f9841-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9ce6282fe98018f1ea732ad3ecd9e59c",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f419396a-4af3-4e8a-9f31-f9db8b772760",
+        "apim-request-id": "bf37077e-2863-4814-9fab-3ba931314269",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "90"
+        "x-envoy-upstream-service-time": "85"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "172625245",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-517bc91b1072e940ab5fba994268bde0-4c9864349b422248-00",
+        "traceparent": "00-d514bdb893fd9f4aa4c73eab34258563-6b214688849c2f43-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "119c99db1e02c34777426e77d5c75cb6",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cea80b0d-4b06-41ed-aab1-a549342d17c8",
+        "apim-request-id": "39bb0bcf-ac09-4e9b-8216-218c586420c3",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "124"
+        "x-envoy-upstream-service-time": "95"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "1081025872",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c11b967f1efdc643b6abbb6626734114-4ac0d2480f73614f-00",
+        "traceparent": "00-0e66cc57e6e43b49a7db8737f545c655-f8d725e3aba59c42-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9d1067da67ede0f99771b2c8070f5079",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "616b0ca7-f3cc-4337-9cc0-ce8b8f653a80",
+        "apim-request-id": "0751fa01-73fa-438d-bd7f-2fb75c3e991f",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "103"
+        "x-envoy-upstream-service-time": "84"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "353364953",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithCancellationTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithCancellationTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c69f213aeb7c2c4789b7420a24da4a76-3bf896166833cc43-00",
+        "traceparent": "00-7c225805ee007140a23269ad678c73b7-4ceca83be90bdf47-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "86b79e2f0559eb97f25b1c5b233a68dd",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca033168-e66d-40e8-9d77-4e310ac553ef",
+        "apim-request-id": "36266a57-b409-480f-8940-be52fb38e6a1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "127"
+        "x-envoy-upstream-service-time": "108"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "1844243829",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithCancellationTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithCancellationTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bf532a8ad0290649a5240be5fbafd9d8-0d7820127bb8a74b-00",
+        "traceparent": "00-7a46c63bf55edc48a2d2780a9f95499a-bd05a256f821d44c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "300adb4a8ab9aa03c50b104c35b7e035",
         "x-ms-return-client-request-id": "true"
@@ -35,10 +35,10 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b46b1b2c-8215-4602-9f64-03f4fca39420",
+        "apim-request-id": "0f7609d9-9c3c-40ba-98f5-f4a41cc8da11",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "413540855",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageAndCancellationTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageAndCancellationTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ae7452d4a5425348b8829c213e199234-4220d06a45b7ae46-00",
+        "traceparent": "00-56c3cb10f5134a468f6891897ed2f6c9-74eb059ed8604947-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "abe848a0b41107615847f9d88e292402",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e81656e8-68d6-41b1-85eb-704551ad68a7",
+        "apim-request-id": "15096d6e-315b-4414-93db-32350656d6fb",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "115"
+        "x-envoy-upstream-service-time": "121"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "1867949087",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageAndCancellationTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageAndCancellationTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-757833adb63e68408ad8726a5d172fd0-2bfee98cd043c249-00",
+        "traceparent": "00-ec93a7eba2bd5645a67a155347e9abec-bf20a9e4bd1dc045-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "e76a4622dec6c96d7ae12bfd307d2c70",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "86ec949e-e24e-46b4-b04f-c0c8506050b6",
+        "apim-request-id": "4ae93926-be50-4881-b761-866ed789f7a8",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "88"
+        "x-envoy-upstream-service-time": "94"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "1600068101",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageAndStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageAndStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cc751e532e60be44b901141e7a7625b7-5b764ae7ce04f341-00",
+        "traceparent": "00-23655f7fe809054db8b3ed24c1e9713a-ebe282a53dca0045-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ddaaf35e96b9dae8e520d1e25db41ef1",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5ea4fa29-dcde-4af1-bfa1-755c138d5ae9",
+        "apim-request-id": "b5d2053e-4f71-4dd0-bcab-df27f00e50eb",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "121"
+        "x-envoy-upstream-service-time": "171"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "1265629352",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageAndStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageAndStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-97efbcc65b9d644eb67b591a76534030-19144c4eaf801045-00",
+        "traceparent": "00-24ca083358aa5346806bb5d89270706f-df76e07bb5f4ed4d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a461009a7ec465a3d8be1a54c58e3575",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6923040d-92c7-42a2-a38b-7dd18c84bc5d",
+        "apim-request-id": "d85cf8f7-7c02-416e-9db4-62b75fc3bc6e",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "90"
+        "x-envoy-upstream-service-time": "91"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "598481068",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1471887b41988e47a872fb60919067df-fa7ca133b516f444-00",
+        "traceparent": "00-4473b389d5ade54abe498823a982574b-e41dcb38a22ca245-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f4f79420d55186c560e783cd65904498",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae3a1713-b339-49a1-af93-bec0d0b08886",
+        "apim-request-id": "26b96413-3e5f-4c71-a2eb-96f90803f2a5",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "115"
+        "x-envoy-upstream-service-time": "101"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "843042242",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithLanguageTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-502ddd8792591a44a98acc8ae99be0ee-5171ccc1814e6b4e-00",
+        "traceparent": "00-0375cf6784e48f4287b929db133b1ab5-cb08eb2a0a6d2c49-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a82300e8850457b9e1ddd84e5e66ebf5",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eb0384b3-97a5-46fb-8fbf-8dece8504b0b",
+        "apim-request-id": "b3377677-e6ad-4dc7-ab53-a4c77baa1c99",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "104"
+        "x-envoy-upstream-service-time": "113"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "1612151291",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithOpinionMiningTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithOpinionMiningTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "197",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ac52e6cd0932c54689dd9ddc3a067cae-88a0e06a759e2b48-00",
+        "traceparent": "00-e30e3ee559537e4a80d35f89d31cb6cc-2f33e4aa3158564a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d0c9faccbe22f6229408f2811c507283",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "20916abd-fcab-4818-87c9-0a2bb4e32547",
+        "apim-request-id": "03955672-2385-4564-a4e9-d60596c69855",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "104"
+        "x-envoy-upstream-service-time": "115"
       },
       "ResponseBody": {
         "documents": [
@@ -252,6 +252,6 @@
   "Variables": {
     "RandomSeed": "1558892529",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithOpinionMiningTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithOpinionMiningTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "197",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f62b3b897680b243879de1d8ce6b90b0-536147222e97504e-00",
+        "traceparent": "00-b454d66bf266dc48ae55b7b0d32674c6-5f416378b113574a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "99f36dc03d5b69cad15ff682fb68e8a9",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "672c5879-cd86-4576-9aab-664a4ddf37a8",
+        "apim-request-id": "a3533a3a-168e-483d-a47d-561b830b9563",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "98"
       },
       "ResponseBody": {
         "documents": [
@@ -252,6 +252,6 @@
   "Variables": {
     "RandomSeed": "1809635661",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithStatisticsAndCancellationTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithStatisticsAndCancellationTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4a4a97414c918d4ea01c2a388d532a5f-757d8f22d68e2e43-00",
+        "traceparent": "00-61c045d0074e2043ae0b40c1b2bef64b-91213c77181b0f40-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ea37c4c5b43ade506c055e9d1167082c",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4b872324-e58c-4c51-88e1-117c50d671ed",
+        "apim-request-id": "1b754942-2768-4b5a-9868-3f24907fd18c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "103"
+        "x-envoy-upstream-service-time": "99"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "1646397317",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithStatisticsAndCancellationTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithStatisticsAndCancellationTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a73c1cce6e754146abb0ad5f10bc8ab9-e318dc43e3319d4c-00",
+        "traceparent": "00-0cec4807443ef6479d41dc2109bf116e-a89b6300b076f04d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d297a709781eea07c58dac26eba5fefd",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d290e134-2582-4c0b-88ac-962d7e52f577",
+        "apim-request-id": "d3559e40-c6c2-4a8f-ba8a-82ccb1a0a601",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "96"
+        "x-envoy-upstream-service-time": "80"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "1063573528",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9178f2a29f17da488e1881a2ea5cd268-befb0a6e30f5e64b-00",
+        "traceparent": "00-f409015bf639d54fbb28304113deb94b-6ed124df7cc33a48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "b93a282865c5e574aa1703755dff0595",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "68918e5c-e333-48da-a246-c9ddc0e6c76e",
+        "apim-request-id": "7ebf05bc-50d9-4638-b974-82ddc730454d",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "99"
+        "x-envoy-upstream-service-time": "135"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "1108552328",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchConvenienceWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "222",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8338e84c0e3c604e853b282cb6d53647-377ee542094c714b-00",
+        "traceparent": "00-2afb6216b8b0fe4784552097a097a45c-3a3c281a56253246-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "896aa869bee9e15710e9b281353ff7e1",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa88cae6-4e3f-43c9-a717-b5450bfa7179",
+        "apim-request-id": "142eed70-1fd9-4b6a-9861-c9744fa2e371",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "91"
+        "x-envoy-upstream-service-time": "106"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "1480611001",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "224",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b4a247f4e0d1ef47ab122117a0666916-c4917e3c5420cc49-00",
+        "traceparent": "00-8632120c2bafb145be6853290dc936e2-d87d673c1a121d45-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f4c1d2e666ddf215fcefdfedc5dd71c8",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9dadaf60-841f-4939-af65-774efc39abc2",
+        "apim-request-id": "3a35d0eb-d944-41c7-b16d-95d13be9ce5a",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "120"
+        "x-envoy-upstream-service-time": "93"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "876796289",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "224",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c7d0c2f6c860f54cad3563fa5ba02910-0691f7f879ad0540-00",
+        "traceparent": "00-b1ecaf635d2bd846b7e2130c702a4f82-d6905ee4c2fb1d49-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "26baa46075d446ba158f6fd6eeae447a",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "68025f36-8264-428c-8868-93793a558360",
+        "apim-request-id": "39d9656b-aff2-4100-9720-33e5056ddc50",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "115"
+        "x-envoy-upstream-service-time": "111"
       },
       "ResponseBody": {
         "documents": [
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "539665015",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithErrorTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "207",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5d32ea627420804285fd8619f2786eaa-d18dde1717c5c243-00",
+        "traceparent": "00-d653579a37b83546b998df7e3f76cffc-3f56ab72ef2f314f-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "381e2b63f2088d45202cae7fd25e5042",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0ec8d363-9490-49d3-a603-fac764d1b252",
+        "apim-request-id": "9441356e-17b4-45a9-bd7a-d63ef1b5d90d",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "119"
+        "x-envoy-upstream-service-time": "95"
       },
       "ResponseBody": {
         "documents": [
@@ -118,6 +118,6 @@
   "Variables": {
     "RandomSeed": "1934874503",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithErrorTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "207",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cab3ee4e69df514a9a9ad7b731e7db77-30948c55c61b8740-00",
+        "traceparent": "00-5af747ab2dea23429d9bc355f4bd51a9-cf1baba8f3d1b649-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "29ac615e7a25f0506bd8c86ac7133e14",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50e596e9-0c8a-4652-9cb6-3b676fd5ab5e",
+        "apim-request-id": "cbbc1b2c-a430-4452-9f13-357bfc14ded8",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:37 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "109"
+        "x-envoy-upstream-service-time": "93"
       },
       "ResponseBody": {
         "documents": [
@@ -118,6 +118,6 @@
   "Variables": {
     "RandomSeed": "951483506",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithNullIdTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithNullIdTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "64",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3b089ef4dee43d4fab79c4c7bd08fefa-94625e9faac8aa43-00",
+        "traceparent": "00-af2eb65bcd16ab4ea8a3ae68fac5a854-c23a45364890af48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "e97c715478efd2b509099d562415356f",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "7b7275e5-1f8d-4581-bada-003787e62cdb",
+        "apim-request-id": "0e18206f-a34a-466e-a2e3-509e1a4329f0",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "627709314",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithNullIdTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithNullIdTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "64",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5a0a80fc01e8714e8bb4e10f74eb2241-9f863d8a970e8942-00",
+        "traceparent": "00-c33d74f312828c4b9b05e6736531703d-d3d2fb8a514b3241-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "7d28785fafea6a705989dd511c352058",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "79b02b22-67da-4071-902f-9e23cd741df3",
+        "apim-request-id": "60e8e574-0b78-4204-97c3-ca8b6a5321b3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:37 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "1350287540",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithNullTextTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithNullTextTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4f469848cbfe444f8cfb65dba25cd13e-f96404d21e01e84f-00",
+        "traceparent": "00-1c4106a0118ddb4da6d0990f95356922-c2c1ed584f36624e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a82047bc1e56521f19fee095619725e3",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "40bab834-b3a2-466d-a702-3d3473e96ee9",
+        "apim-request-id": "45550c43-510f-4fae-a8b0-661c9c0c909e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "3"
       },
       "ResponseBody": {
         "documents": [],
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "847855095",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithNullTextTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithNullTextTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4d5533e671ae1340985c9e8f5ddd5e10-91b032617c6dc44f-00",
+        "traceparent": "00-eb6722abf08cf64eaec63e456abd3a84-5f2c8f107324b94d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "e4b5e1c573e3bc3fc5137a6a90633740",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7ed37283-9254-400b-b2f2-32168c4f11ae",
+        "apim-request-id": "0977bdc9-f2bd-4d33-a079-e0de64547681",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:37 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "3"
       },
       "ResponseBody": {
         "documents": [],
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "256924080",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithOpinionMiningTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithOpinionMiningTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "197",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-11815660d390fa4ea7eea0f1e39fdecd-a6d50618bb783b4a-00",
+        "traceparent": "00-f95ae180df07824199f274fecfc3dbad-15079917ff58ef42-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "4bb052b32c66958101e8bfb2d70a96bf",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e15718b1-2b3c-4db3-89c6-7caf600ee83e",
+        "apim-request-id": "c21b2a4e-f19b-493b-99f6-2a7596df25c8",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "136"
+        "x-envoy-upstream-service-time": "93"
       },
       "ResponseBody": {
         "documents": [
@@ -252,6 +252,6 @@
   "Variables": {
     "RandomSeed": "1053489488",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithOpinionMiningTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithOpinionMiningTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "197",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f1d8e48e7207694eb669e730f9ca45b6-013cb39e11bdf84f-00",
+        "traceparent": "00-18447de64d697c43b97c088ae68cffe9-152d82cdad871444-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "10469efe411909195ef72681bf249b22",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2121da6a-07a8-4161-9ff1-1e92a107820e",
+        "apim-request-id": "7cf53492-c76a-4a01-bd4d-67b3f8e125ae",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:37 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "90"
+        "x-envoy-upstream-service-time": "105"
       },
       "ResponseBody": {
         "documents": [
@@ -252,6 +252,6 @@
   "Variables": {
     "RandomSeed": "1224561162",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "224",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9838435553e91b46870aa47c270fe0ca-7a703e044f0dbe41-00",
+        "traceparent": "00-4f31ca769f7737469d42d147d12cf17f-31bfcb44d3916048-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "380d3332cec3ce7a5b0d21c20c2f8b8d",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a7c35cd8-af3d-4e8f-b137-7ef124599c23",
+        "apim-request-id": "c97db10c-0912-4fb2-935f-98cc3e769dc1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "126"
+        "x-envoy-upstream-service-time": "97"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "2080433243",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentBatchWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "224",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2305eb05bff2bd458e522386ba61678c-0c7b389b6818904f-00",
+        "traceparent": "00-6f6dcdfa7e37e34a9c258d08ab0e8599-f25ac05322e9754f-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f794f0733bb3c43d680189f109278930",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "333dc669-e03a-46d9-9d61-84bb1f542030",
+        "apim-request-id": "ff83e65b-286c-49d3-b817-c312acee3526",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:38 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "110"
+        "x-envoy-upstream-service-time": "92"
       },
       "ResponseBody": {
         "statistics": {
@@ -137,6 +137,6 @@
   "Variables": {
     "RandomSeed": "1104601644",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "85",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a0fff56c80274d4c906f457a02ef25fc-c90e19e32b0c544d-00",
+        "traceparent": "00-96128033ff04594a8db2296a74cd3d12-52b64b4125b39147-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "4e5bdbe5820d38723d195b24082e286d",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "60dc90e1-10ca-402e-bd54-9299a7b35765",
+        "apim-request-id": "aa588299-0f7a-4506-b08c-0989319418ad",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "100"
+        "x-envoy-upstream-service-time": "96"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "2146668003",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "85",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0cec24e38939ee4184b7797a2fbf3f11-cbd9f33a1d0e594b-00",
+        "traceparent": "00-3d4795baed62ea4a9d90a76f850ab8ca-e3d11541cfed7549-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "03ba29d245db7d4660e70538d783a159",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0c51c7c1-c776-4cb1-b240-586cdf32453d",
+        "apim-request-id": "6083da4b-a727-4a86-8567-dff6e29d7636",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:38 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "101"
+        "x-envoy-upstream-service-time": "96"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "9060464",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithCancellationTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithCancellationTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "76",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-00d890f14226b14485df7fa7dfda1a9f-a0c1f33a3ab5a546-00",
+        "traceparent": "00-368890d794e6354e8f780a04fb8e2519-4b12fa586958904e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "1cd519dfbccdba31b1f719f550932df6",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "771d9360-78f1-410b-95ec-1b24d8ce9d3d",
+        "apim-request-id": "337d2d40-85e7-43f5-81bb-7e865b769be1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "101"
+        "x-envoy-upstream-service-time": "94"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "673624529",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithCancellationTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithCancellationTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "76",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cefdf451a1fec84ba3c276566e56e6fa-fb34619f7c66204d-00",
+        "traceparent": "00-05acc539bb74224284b7b353a8b177e1-c95eb879dba34647-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "e4628ff9d75e35fa30a2a74d75b5d054",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f2b7ec2e-066e-497e-997f-e98ba8430584",
+        "apim-request-id": "636df9cb-9e45-40c8-8520-2fd0a1a0ad6e",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:38 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "86"
+        "x-envoy-upstream-service-time": "75"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "486778307",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithLanguageAndCancellationTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithLanguageAndCancellationTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "76",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5b9e51873fea94499513a990a19f310c-0e02fd85648a8844-00",
+        "traceparent": "00-232986cc67173f44925e07ba4db875b4-e13f76fc758f9042-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "0226741a4a3852fb661facf15a20cdfc",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d43058c5-92d5-4ea9-97a3-0df300b14de1",
+        "apim-request-id": "5ab81097-02d4-4450-9610-ce047d285a3f",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "124"
+        "x-envoy-upstream-service-time": "131"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "735963321",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithLanguageAndCancellationTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithLanguageAndCancellationTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "76",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5b5ae0e4e743ea439c57bf296d42e521-ee48bdf52d268940-00",
+        "traceparent": "00-ead18c2fa1df3d479846a212b1e79cdc-9ab849dcad702c4d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "1d19c9bc741aeaae2a3044500760d7de",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "30254ee5-9c53-48d7-a70f-02c750469f0d",
+        "apim-request-id": "4d034cca-217f-48b6-ade1-a154efe253a7",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "108"
+        "x-envoy-upstream-service-time": "127"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "1305725402",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithLanguageTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "76",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-28f1a563938341498b0804bbad3b2b08-ceed3180bd483f45-00",
+        "traceparent": "00-ceeff2a79d48ea468274dc728a7ca47a-7f2f1b3c9fbe1645-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "b1c263e328066fc8dce532b649cbfd03",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "296a50e2-e204-4c3d-80ac-00e8998bc660",
+        "apim-request-id": "c05ff7cc-a1f2-491b-9d21-17e80c9b509c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "124"
+        "x-envoy-upstream-service-time": "85"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "137641087",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithLanguageTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "76",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8f28bc6e8a8e084fb99e57552bfe1749-777858ffe0511c43-00",
+        "traceparent": "00-2b4f53567a7abe4fb4d8017cd673b935-c5567780555ebe48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "61e4104888cde5cbe34786063a0401dd",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "706c37c6-ab2f-4c64-8c43-6657b72cc4f2",
+        "apim-request-id": "06de130c-cea9-449b-84f0-a7fdf8a1927c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "120"
+        "x-envoy-upstream-service-time": "121"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "537807865",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "483",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-98a99792a32f0644aade1778ad28c9e0-fc4d3760b1cb6840-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-eed830d287dff84d9ce8f79b2c839a42-b7566b33aed37c48-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d7ef8fc8067a039e9bfba18b79c28111",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,42 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "90f72759-b227-48a2-8796-9841d90b9643",
-        "Date": "Mon, 25 Oct 2021 18:47:48 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+        "apim-request-id": "e7020528-b99b-4652-9ada-3f4400498362",
+        "Date": "Mon, 25 Oct 2021 21:13:25 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "319"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "294"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b6f57274c91eff72e05ebd5651122253",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f9775494-d3e8-4739-a592-a5301b5dd17d",
+        "apim-request-id": "3218850b-9bdb-44fd-aa53-69455244dddc",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "112"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -95,31 +107,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "75457876211446db86ac360fe02e91f3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "08efe465-8840-41a3-98fd-ef47579d6866",
+        "apim-request-id": "a70d2064-4287-4883-b486-2b5fd5807302",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "133"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -131,31 +149,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d257cbd43ff1fe741deff71b4947b288",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "27b7cacf-1fba-4c5b-b5d3-58d1d93e40b7",
+        "apim-request-id": "73b47b72-7ea1-4787-a7b7-a5c5b7f57dc1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -167,31 +191,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "00154dd80c7c53fc96af2f7292631fb2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80378e20-a102-4baf-9698-a79d5c9e63cb",
+        "apim-request-id": "e202c122-7c90-4ff4-a235-47dcf6960b22",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "112"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -203,31 +233,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8681cacd50bb36610446582529c0fc3f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "59ac958b-bcc8-41ea-854f-8d3c395bd369",
+        "apim-request-id": "6f674058-8c04-4def-8507-d907e2bcb989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -239,31 +275,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9236adfa9018c876ce043c4210016bb9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a7017225-647d-4c3b-b164-7044df8ac599",
+        "apim-request-id": "0501bd45-725d-4e8f-b4bb-36bfe1a92d05",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "49"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -275,31 +317,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7e4d45d02bc588cdebdefc36b3d729d5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ca2fc40-fa7e-419a-9d48-f141db55f026",
+        "apim-request-id": "800bb641-b272-4979-817c-31c21b817636",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "66"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "47"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -311,31 +359,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e578f0b28c2c3d9953b8b8b6131f2602",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4d2d9c36-b2e9-4f56-aa10-dcbf83a8dbdc",
+        "apim-request-id": "97f2af36-f855-4ea5-bfa7-06bb9c1d2d1a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "41"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -347,31 +401,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e4549eda7e73ce79e0aea73a934015f6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "669fa388-4ff7-4b17-93f0-b4691810db1c",
+        "apim-request-id": "d29fc86d-ad97-4a10-9015-e9abf767f64f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "94"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:47:48Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -383,382 +443,163 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1f8f66db8689438dac0f2b0c731774cb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "766d4e19-9845-40b4-9ee5-aa2d5308b9a8",
+        "apim-request-id": "3c5ff22c-44a6-4a9c-beb2-a063fe6eadb7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:47:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "64"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:48:00Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:00.3990299Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
+          "inProgress": 2,
+          "total": 2
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "145bfab84482346277aa057de55faa12",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "35f0aca3-57ca-41b9-a92d-200eca02de45",
+        "apim-request-id": "b3ef0f3b-6b10-4b5c-96d1-5fb8f9b3f852",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "165"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:48:00Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:00.3990299Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
+          "inProgress": 2,
+          "total": 2
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "addac1a30690537911113863526c5ac8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d6a98ac3-7351-4ab6-b99a-8cd6a5f89af5",
+        "apim-request-id": "d35e040e-fe94-419a-8d6d-85e7e5053e50",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "71"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "33"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:48:00Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:26Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:00.3990299Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
+          "inProgress": 2,
+          "total": 2
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9981db3a00e49673035aa8de810f5d4d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb686314-cfcb-472e-a030-56f982d0eb61",
+        "apim-request-id": "f3ef9ed8-ffb9-46a8-89d5-3c0ad558c67b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:03 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "70"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:48:00Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:41Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -768,7 +609,7 @@
           "total": 2,
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-10-25T18:48:00.3990299Z",
+              "lastUpdateDateTime": "2021-10-25T21:13:41.2632841Z",
               "taskName": "AnalyzeSentiment",
               "state": "succeeded",
               "results": {
@@ -851,265 +692,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f406e1c1-83f3-49fd-8a29-7fcb59195602",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b2681865c63cb23b800703710cfee10a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "429c96a1-3c20-45b4-a65d-4dff63c76bc7",
+        "apim-request-id": "b3dfdbf7-2d8d-4be5-b75b-97f0c3b3c445",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "106"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4142"
       },
       "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:48:00Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:00.3990299Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0a433c5010dda32e4d44a9355d9ad202",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ebb3ff1e-0e4e-40d9-8f19-55e8b2a11ad6",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:06 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "228"
-      },
-      "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:48:00Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:00.3990299Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3afeeab3a703738c9fcf18ddfc028905",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9b8deae9-4c7e-4f05-90c1-cdb1776e306e",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:09 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "322"
-      },
-      "ResponseBody": {
-        "jobId": "a6c06233-04c8-4662-84c7-c6d3cfa72e3e",
-        "lastUpdateDateTime": "2021-10-25T18:48:08Z",
-        "createdDateTime": "2021-10-25T18:47:47Z",
-        "expirationDateTime": "2021-10-26T18:47:47Z",
+        "jobId": "f406e1c1-83f3-49fd-8a29-7fcb59195602",
+        "lastUpdateDateTime": "2021-10-25T21:13:42Z",
+        "createdDateTime": "2021-10-25T21:13:26Z",
+        "expirationDateTime": "2021-10-26T21:13:26Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1119,7 +732,7 @@
           "total": 2,
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-10-25T18:48:08.5864845Z",
+              "lastUpdateDateTime": "2021-10-25T21:13:42.8824223Z",
               "taskName": "AnalyzeSentimentWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -1198,7 +811,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-25T18:48:00.3990299Z",
+              "lastUpdateDateTime": "2021-10-25T21:13:41.2632841Z",
               "taskName": "AnalyzeSentiment",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "483",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b71dd92abb6c974988e29ea8b66ed4e1-c06ce9743d8ecd48-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-9fe4faec76064442a7335062829b226a-f8cc5fab7cdb5645-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "af7a81d59f0d0662a00424cc54613f1a",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,42 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "775ed3f1-1949-45de-bacf-d17850a25a4f",
-        "Date": "Mon, 25 Oct 2021 18:48:10 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+        "apim-request-id": "26aef809-f448-4f9d-b660-597aa9547085",
+        "Date": "Mon, 25 Oct 2021 21:13:56 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "233"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "395"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8a1d031a54c087c9bc81023a09f79e72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "816ab4df-66a2-482b-bdf1-729dca862edc",
+        "apim-request-id": "acfa2402-a481-4ac3-bc63-e8d8d1003adf",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:10 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "218"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:13:57Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -95,31 +107,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d4e02b8ed8bf01c6e4d74fd8018e92e2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "64f91c3a-d7fe-4a34-bcc5-52d522ede5ae",
+        "apim-request-id": "fd3d2a88-901c-4c6c-b4cd-3178eeaf9fe3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:12 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:13:57Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -131,31 +149,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d947ee9db44a81ddb8f3f38b9c28fda9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5a8d9224-2701-4ec3-b5dc-0f2f5a058c3a",
+        "apim-request-id": "3604f99e-2ef2-451a-9d1c-4cc2301892f9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:13:57Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -167,31 +191,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "283db1666b81415b3d1ca6e805f1852d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e79c3eec-6bdb-4d56-bca6-9f5ab489f5b6",
+        "apim-request-id": "3dcd70ff-943b-4a62-bdc6-d6a1c831432f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:13:57Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -203,31 +233,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1a9c1feec4afda284e5e1bcce43a64bc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1bd527a2-d147-4783-9520-9955dc2833b8",
+        "apim-request-id": "26c0d765-ba2a-46fa-a524-43191235ab83",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:16 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:13:57Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -239,31 +275,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5071a5da6a51326193059c2e0df57cc6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "55419670-4cef-4ed6-96cd-6b734d1716ee",
+        "apim-request-id": "4d75708a-638a-4b50-a55b-db93ef7e8e05",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "47"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:03Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -275,31 +317,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7c9cc66de28ba1f98862da224f8f5d02",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3c68ab15-28c9-47ca-9940-0b48100fab7b",
+        "apim-request-id": "f84caac1-c7a2-48b6-8d76-7fa644fd7e25",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:03Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -311,31 +359,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5f0ee9b7357f84dcbe6a87aa28facc58",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7ec469e4-83e2-4a6c-a030-2dbb53c1a191",
+        "apim-request-id": "ea7da722-e87e-4cef-9dc9-47b68b1f0686",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:19 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "49"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:03Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -347,31 +401,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1e5e55e2e79df730abcfc7ee903ee304",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f9a07537-6d64-4fa4-9394-430d7a700fa9",
+        "apim-request-id": "c573d4d2-b136-474c-bcea-f055f4e5e839",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:03Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -383,31 +443,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "23769aa81ce63746ea18be215b4f798e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b8802ea-7b7d-41ac-9881-74c768265823",
+        "apim-request-id": "2fc50f1f-27a4-4322-b540-e2bc9a251c76",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:22 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:03Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -419,31 +485,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "fa3f81963f30d064b917b3af6dedf47f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "af240eea-aa11-44a2-9932-e2560e7638d8",
+        "apim-request-id": "41c95361-8060-4c25-ad3c-e32d6a2be0cb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:23 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:03Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -455,31 +527,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8e028386a884c6720e263485290f9c5c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5d4fde38-d929-4e8f-a493-7090e148a13a",
+        "apim-request-id": "5f62fcfa-2507-4192-9374-645ea46acc89",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:24 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:03Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -491,1381 +569,529 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0e583956e9fe69d335a66acf6896cafc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "249bc21f-65c9-4935-96a7-d60f417bf286",
+        "apim-request-id": "aa88c833-a13f-4588-bb6f-74c3f9362eb3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "89"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:12Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:12.4728014Z",
+              "taskName": "AnalyzeSentiment",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "sentiment": "positive",
+                    "confidenceScores": {
+                      "positive": 1.0,
+                      "neutral": 0.0,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "positive",
+                        "confidenceScores": {
+                          "positive": 1.0,
+                          "neutral": 0.0,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 34,
+                        "text": "That was the best day of my life!."
+                      },
+                      {
+                        "sentiment": "positive",
+                        "confidenceScores": {
+                          "positive": 1.0,
+                          "neutral": 0.0,
+                          "negative": 0.0
+                        },
+                        "offset": 35,
+                        "length": 31,
+                        "text": "I had a lot of fun at the park."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "sentiment": "negative",
+                    "confidenceScores": {
+                      "positive": 0.0,
+                      "neutral": 0.0,
+                      "negative": 1.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.02,
+                          "neutral": 0.85,
+                          "negative": 0.13
+                        },
+                        "offset": 0,
+                        "length": 43,
+                        "text": "I\u0027m not sure how I feel about this product."
+                      },
+                      {
+                        "sentiment": "negative",
+                        "confidenceScores": {
+                          "positive": 0.0,
+                          "neutral": 0.0,
+                          "negative": 1.0
+                        },
+                        "offset": 44,
+                        "length": 18,
+                        "text": "It is complicated."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d89a3e24eb4ded0a0f79eb090bdfa7a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c14730b1-fb2a-4382-8d1f-8c26f2dafbbd",
+        "apim-request-id": "fe1a1eca-7082-4720-a0f4-eb75a2c59452",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "831"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:12Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:12.4728014Z",
+              "taskName": "AnalyzeSentiment",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "sentiment": "positive",
+                    "confidenceScores": {
+                      "positive": 1.0,
+                      "neutral": 0.0,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "positive",
+                        "confidenceScores": {
+                          "positive": 1.0,
+                          "neutral": 0.0,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 34,
+                        "text": "That was the best day of my life!."
+                      },
+                      {
+                        "sentiment": "positive",
+                        "confidenceScores": {
+                          "positive": 1.0,
+                          "neutral": 0.0,
+                          "negative": 0.0
+                        },
+                        "offset": 35,
+                        "length": 31,
+                        "text": "I had a lot of fun at the park."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "sentiment": "negative",
+                    "confidenceScores": {
+                      "positive": 0.0,
+                      "neutral": 0.0,
+                      "negative": 1.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.02,
+                          "neutral": 0.85,
+                          "negative": 0.13
+                        },
+                        "offset": 0,
+                        "length": 43,
+                        "text": "I\u0027m not sure how I feel about this product."
+                      },
+                      {
+                        "sentiment": "negative",
+                        "confidenceScores": {
+                          "positive": 0.0,
+                          "neutral": 0.0,
+                          "negative": 1.0
+                        },
+                        "offset": 44,
+                        "length": 18,
+                        "text": "It is complicated."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3459577ae5959d80af9958dd3da25d77",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6ba24a9b-25c6-4e8a-9176-72b60220ac5e",
+        "apim-request-id": "6205e006-d182-4ebb-a34d-0749909a0b97",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:28 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "725"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:12Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:12.4728014Z",
+              "taskName": "AnalyzeSentiment",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "sentiment": "positive",
+                    "confidenceScores": {
+                      "positive": 1.0,
+                      "neutral": 0.0,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "positive",
+                        "confidenceScores": {
+                          "positive": 1.0,
+                          "neutral": 0.0,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 34,
+                        "text": "That was the best day of my life!."
+                      },
+                      {
+                        "sentiment": "positive",
+                        "confidenceScores": {
+                          "positive": 1.0,
+                          "neutral": 0.0,
+                          "negative": 0.0
+                        },
+                        "offset": 35,
+                        "length": 31,
+                        "text": "I had a lot of fun at the park."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "sentiment": "negative",
+                    "confidenceScores": {
+                      "positive": 0.0,
+                      "neutral": 0.0,
+                      "negative": 1.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.02,
+                          "neutral": 0.85,
+                          "negative": 0.13
+                        },
+                        "offset": 0,
+                        "length": 43,
+                        "text": "I\u0027m not sure how I feel about this product."
+                      },
+                      {
+                        "sentiment": "negative",
+                        "confidenceScores": {
+                          "positive": 0.0,
+                          "neutral": 0.0,
+                          "negative": 1.0
+                        },
+                        "offset": 44,
+                        "length": 18,
+                        "text": "It is complicated."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ea60385cc3746a0f2e6aff85fdc95e55",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a271b3f2-406b-45af-9d45-5e4bcc6bfa13",
+        "apim-request-id": "f2b0f9a6-fcb0-4529-b7b5-a052b5c570c2",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "16"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "96"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:12Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "sentimentAnalysisTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:12.4728014Z",
+              "taskName": "AnalyzeSentiment",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "sentiment": "positive",
+                    "confidenceScores": {
+                      "positive": 1.0,
+                      "neutral": 0.0,
+                      "negative": 0.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "positive",
+                        "confidenceScores": {
+                          "positive": 1.0,
+                          "neutral": 0.0,
+                          "negative": 0.0
+                        },
+                        "offset": 0,
+                        "length": 34,
+                        "text": "That was the best day of my life!."
+                      },
+                      {
+                        "sentiment": "positive",
+                        "confidenceScores": {
+                          "positive": 1.0,
+                          "neutral": 0.0,
+                          "negative": 0.0
+                        },
+                        "offset": 35,
+                        "length": 31,
+                        "text": "I had a lot of fun at the park."
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "sentiment": "negative",
+                    "confidenceScores": {
+                      "positive": 0.0,
+                      "neutral": 0.0,
+                      "negative": 1.0
+                    },
+                    "sentences": [
+                      {
+                        "sentiment": "neutral",
+                        "confidenceScores": {
+                          "positive": 0.02,
+                          "neutral": 0.85,
+                          "negative": 0.13
+                        },
+                        "offset": 0,
+                        "length": 43,
+                        "text": "I\u0027m not sure how I feel about this product."
+                      },
+                      {
+                        "sentiment": "negative",
+                        "confidenceScores": {
+                          "positive": 0.0,
+                          "neutral": 0.0,
+                          "negative": 1.0
+                        },
+                        "offset": 44,
+                        "length": 18,
+                        "text": "It is complicated."
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2020-04-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1154c1fe953d3f66bdfc28b3922caf6c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "522bc42a-4499-4e6f-a107-639731e10097",
+        "apim-request-id": "946c4c20-e987-4841-a803-7a269ffa3f4e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:30 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "332"
       },
       "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:10Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d3ac731cbc7eb73448ee052ae5fba0e5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "90745660-0623-4c7d-aaa2-1a1904a238c9",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:31 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "71"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7cde023b4c4ec73ad1212c789b5bd702",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "def26118-0b41-45a6-8420-b633007feecd",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:33 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "73"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "896893bb8b1d42d78c9dc94e8f3b59c2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "07a47f5c-47f6-4945-a1a5-b8711690454e",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:34 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "103"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9078435c324dd01e39e5015d8fbc1cec",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "22ea5420-8e3d-4f45-b909-65df2e8e4bba",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:35 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "81"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "526f03171693afc82b9cf0b082ec3796",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e849d28e-ad52-492a-a04d-243a4b8b9123",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "78"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "571b6ac747e288b4759850388979b2cf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3c3324f5-8f15-4a55-8620-0a0dd9b0e49b",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:38 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "243"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8c37dc8107cb462f7ac864b0426d4d4d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "af0730de-8147-469a-bbdd-60cd025b5960",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:39 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "67"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "25956badc4a0cf0a4ee6dcfac59026b1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e68aad60-f67b-4b7f-97e3-4daa39a51c7c",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:41 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "62"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a62f20eaaab5c0ca3bd5dc19e3044607",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ca4efcf4-d784-4276-9d3f-1b08c2e50d37",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:42 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1e8a034a8ce4bc2fd2673ee42a3480ea",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a95b5eeb-58d3-4350-9913-27b86cf302da",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "111"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:32Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 1,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "sentimentAnalysisTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
-              "taskName": "AnalyzeSentiment",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "sentiment": "positive",
-                    "confidenceScores": {
-                      "positive": 1.0,
-                      "neutral": 0.0,
-                      "negative": 0.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 0,
-                        "length": 34,
-                        "text": "That was the best day of my life!."
-                      },
-                      {
-                        "sentiment": "positive",
-                        "confidenceScores": {
-                          "positive": 1.0,
-                          "neutral": 0.0,
-                          "negative": 0.0
-                        },
-                        "offset": 35,
-                        "length": 31,
-                        "text": "I had a lot of fun at the park."
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "sentiment": "negative",
-                    "confidenceScores": {
-                      "positive": 0.0,
-                      "neutral": 0.0,
-                      "negative": 1.0
-                    },
-                    "sentences": [
-                      {
-                        "sentiment": "neutral",
-                        "confidenceScores": {
-                          "positive": 0.02,
-                          "neutral": 0.85,
-                          "negative": 0.13
-                        },
-                        "offset": 0,
-                        "length": 43,
-                        "text": "I\u0027m not sure how I feel about this product."
-                      },
-                      {
-                        "sentiment": "negative",
-                        "confidenceScores": {
-                          "positive": 0.0,
-                          "neutral": 0.0,
-                          "negative": 1.0
-                        },
-                        "offset": 44,
-                        "length": 18,
-                        "text": "It is complicated."
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2020-04-01"
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "21c6b2a2a73e0298a0d5e9cbe7f0ec4a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4c5959b1-c56b-49f2-8893-4b9b82431809",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 25 Oct 2021 18:48:46 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "116"
-      },
-      "ResponseBody": {
-        "jobId": "572c463d-0478-42d0-9ef8-a8d3c2f4ca73",
-        "lastUpdateDateTime": "2021-10-25T18:48:45Z",
-        "createdDateTime": "2021-10-25T18:48:10Z",
-        "expirationDateTime": "2021-10-26T18:48:10Z",
+        "jobId": "a8ee49b8-7c7b-48b3-bba9-685e823dfb09",
+        "lastUpdateDateTime": "2021-10-25T21:14:19Z",
+        "createdDateTime": "2021-10-25T21:13:57Z",
+        "expirationDateTime": "2021-10-26T21:13:57Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -1875,7 +1101,7 @@
           "total": 2,
           "sentimentAnalysisTasks": [
             {
-              "lastUpdateDateTime": "2021-10-25T18:48:45.6924975Z",
+              "lastUpdateDateTime": "2021-10-25T21:14:19.7887848Z",
               "taskName": "AnalyzeSentimentWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -1954,7 +1180,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-25T18:48:32.2923129Z",
+              "lastUpdateDateTime": "2021-10-25T21:14:12.4728014Z",
               "taskName": "AnalyzeSentiment",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMining.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMining.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "127",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d452cdec9634574fbea5ea6a06dd81b1-c5756f756f9a9d4b-00",
+        "traceparent": "00-1046ff9a6462754d8cf704d60cdaa359-b1de3273b8f17243-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "1e33ed24967d42087f8188a6111ef9b0",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c29a7bbd-23d1-4b00-bef4-b00c2e3b604f",
+        "apim-request-id": "c6fe1b98-9140-4162-992f-5f6eefaa52e1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "114"
+        "x-envoy-upstream-service-time": "75"
       },
       "ResponseBody": {
         "documents": [
@@ -177,6 +177,6 @@
   "Variables": {
     "RandomSeed": "4400155",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "127",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5cf074c7a80fd643817a8b470f7444ef-116746e87cb6084f-00",
+        "traceparent": "00-7924c4d203007f4db38e2ecdc660fd25-815236c2582fab4a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "504a9c53bf1eca7814bfce867e01718a",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "86d7f69b-d01a-45da-a40c-f8582cac32fd",
+        "apim-request-id": "913e6e98-583d-4d68-9cc9-53839242e955",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "124"
+        "x-envoy-upstream-service-time": "131"
       },
       "ResponseBody": {
         "documents": [
@@ -177,6 +177,6 @@
   "Variables": {
     "RandomSeed": "1364359232",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningEmpty.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningEmpty.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "85",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bfeec9f8f7ac6445913896a0e9f8fd65-3c38e11d1e993941-00",
+        "traceparent": "00-08c678312eee38488e520b40f818a5b1-b3c87ff6f3ae2442-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "558a7442c3b1c5137141db1dd8ca6858",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9882e4a7-8e1b-4ef7-8f0d-d17458ab82d1",
+        "apim-request-id": "732e9863-ff39-40aa-80b9-e1dbc74622cc",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "97"
+        "x-envoy-upstream-service-time": "114"
       },
       "ResponseBody": {
         "documents": [
@@ -75,6 +75,6 @@
   "Variables": {
     "RandomSeed": "1727170942",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningEmptyAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningEmptyAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "85",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-779a4df1746c87499be029c6445c9a96-2949dc26c9f0a447-00",
+        "traceparent": "00-611b092c326aa648a7ee790739250ac6-b1cfc1db8e2f1946-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f6867f38d810d57a89dad763eab07a05",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc9ba73e-efeb-4551-a926-5fd68c30a379",
+        "apim-request-id": "2ffdcf88-e707-4680-9f0e-8ab54ab038bb",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "107"
+        "x-envoy-upstream-service-time": "87"
       },
       "ResponseBody": {
         "documents": [
@@ -75,6 +75,6 @@
   "Variables": {
     "RandomSeed": "167361615",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningNegated.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningNegated.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "80",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9b47814fbb1de74fb5d7ae08f1035218-719ac8c2407ce54c-00",
+        "traceparent": "00-86675bd77ae22f4ab8d4bd3342505e82-b522e4ea33228f45-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "8d0590d28394353aadd5df7e697ac312",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e29d2385-d37f-448d-95c4-ad7f13dc975f",
+        "apim-request-id": "e57b83da-b803-4796-9a07-c55f5c205670",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:13:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "98"
+        "x-envoy-upstream-service-time": "80"
       },
       "ResponseBody": {
         "documents": [
@@ -104,6 +104,6 @@
   "Variables": {
     "RandomSeed": "825040414",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningNegatedAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/AnalyzeSentimentTests/AnalyzeSentimentWithOpinionMiningNegatedAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/sentiment?showStats=false\u0026opinionMining=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "80",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-16d49bb96512444d93816394bf9c19b4-3bfa373d08f3a545-00",
+        "traceparent": "00-bedf395038e44247b937e0e794dd3b30-d86a26ff4f910041-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "94ab183ce7dcf7c7f3beeb119ae08867",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1106987b-0f94-4486-a693-23502b3de969",
+        "apim-request-id": "7d442144-e303-4e73-93db-2f9ce199b37d",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "89"
+        "x-envoy-upstream-service-time": "90"
       },
       "ResponseBody": {
         "documents": [
@@ -104,6 +104,6 @@
   "Variables": {
     "RandomSeed": "1263606711",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchConvenienceTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "177",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-39b3f03430d35843a48a9bf6ddfb11c1-2a1700a9adb36645-00",
+        "traceparent": "00-7836a90f32b6ce4f9d81c3b6d758961b-49bf448ba9587d4c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5005f5e8a08b47218215f19574b370f6",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "56b09dba-c21b-4159-9f18-fe1848a3b4a1",
+        "apim-request-id": "c9da7c4f-4d7b-4ca3-adac-926e3538c272",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=3,CognitiveServices.TextAnalytics.TextRecords=3",
-        "Date": "Tue, 03 Aug 2021 18:39:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "22"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -87,6 +87,6 @@
   "Variables": {
     "RandomSeed": "2925177",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchConvenienceTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "177",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3eecb74eb951a2428f837626330b2dfe-e3082534112df744-00",
+        "traceparent": "00-0b59308d0b8fba41a9fc40b617a59f55-81ee680878f36c4d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "3574863b78b3d4b99962ee1a8b7bbd89",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc5d4e8e-a319-4eb7-b67e-25cc62278ace",
+        "apim-request-id": "ddac0f01-6fc2-413b-b3ab-87c9dd3a9216",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=3,CognitiveServices.TextAnalytics.TextRecords=3",
-        "Date": "Tue, 03 Aug 2021 18:39:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "16"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -87,6 +87,6 @@
   "Variables": {
     "RandomSeed": "1287375904",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchConvenienceWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=true",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "177",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f68f9d26ebeaaf41ba2928a24b016b43-e1a410f3d7ca0947-00",
+        "traceparent": "00-e9612cb16ad7a64d9034256fe473bef3-a4e6424693534e43-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "738db85ac016be284349434968e4adff",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "db8ebd0e-d553-4b4e-ac51-3d06c64c5b52",
+        "apim-request-id": "3eb35aa0-841a-4543-a9ce-db83e63c431b",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=3,CognitiveServices.TextAnalytics.TextRecords=3",
-        "Date": "Tue, 03 Aug 2021 18:39:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
         "statistics": {
@@ -105,6 +105,6 @@
   "Variables": {
     "RandomSeed": "211607003",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchConvenienceWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=true",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "177",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4b9efa99d20d5e41b9822476e350863c-01518bdadcbe7547-00",
+        "traceparent": "00-fb0632c0f6a3f245855cb13234a03ec1-bc3b7b0099b27443-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "6246079b8393935bca52b813124b2ad7",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "35c920eb-e99c-441b-836a-245a8ffba07b",
+        "apim-request-id": "d4749c00-3a08-463b-94ed-ae659dcadba6",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=3,CognitiveServices.TextAnalytics.TextRecords=3",
-        "Date": "Tue, 03 Aug 2021 18:39:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
         "statistics": {
@@ -105,6 +105,6 @@
   "Variables": {
     "RandomSeed": "293475495",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "225",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f85b0b1af4ce224d9561985015b6f04a-29c742a905bcde41-00",
+        "traceparent": "00-9e29ca1fb76d35448c1a57e1903c29dd-3edaa384a33ebb4f-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9ed49d935379ea824d7c2153a1e6e6e4",
         "x-ms-return-client-request-id": "true"
@@ -45,14 +45,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c006bf76-fe17-429d-bf2b-cee56b463688",
+        "apim-request-id": "aa437704-2467-4b57-83fd-915988041d1b",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Tue, 03 Aug 2021 18:39:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "20"
       },
       "ResponseBody": {
         "documents": [
@@ -101,6 +101,6 @@
   "Variables": {
     "RandomSeed": "1725013070",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "225",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-477c1e27a8557040b26e641e9c8123f2-78991b11e65b9445-00",
+        "traceparent": "00-5e389c6fe2c5c44b882ce520827d1b3b-081846240884b741-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "da5f41d41140dce5b95983493bb999e3",
         "x-ms-return-client-request-id": "true"
@@ -45,14 +45,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae4087d8-894b-4503-b632-47ca288a917c",
+        "apim-request-id": "cb51dbf9-8e0e-4e04-ac17-8b7b75e8c6c4",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Tue, 03 Aug 2021 18:39:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "16"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -101,6 +101,6 @@
   "Variables": {
     "RandomSeed": "1564753879",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithErrorTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "156",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ec9c285b3954c84fb5ee39d5e1c8e06a-096188e250583242-00",
+        "traceparent": "00-48e23d0c29da5b49b0980500a4f87249-6116176be8bc2e45-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "3ce40d8d4db949068b12a56808d1cfa5",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fef0db58-ccad-4884-8c30-f58c22267264",
+        "apim-request-id": "63d9c478-71e2-47f5-b161-7c97c44cabd8",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "22"
       },
       "ResponseBody": {
         "documents": [
@@ -90,6 +90,6 @@
   "Variables": {
     "RandomSeed": "1998787501",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithErrorTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "156",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-91428c5de2bfb24aafc584f429365b12-8ffae9bfab3b524b-00",
+        "traceparent": "00-99e43a8c87c7d3449021cbb09f5181d8-ca805695ea8f8b4a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "51807d44b190171f3639086e14582723",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "64f85d7c-5c94-4eb2-b9be-7ed8f01adb82",
+        "apim-request-id": "0ce78f8d-c911-4af6-a5f8-f3dadbbebcff",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -90,6 +90,6 @@
   "Variables": {
     "RandomSeed": "1902435763",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithNullIdTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithNullIdTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "67",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-75bd4101a43c2040b6fc7360c48ddee5-f9e77bfb1c0e5645-00",
+        "traceparent": "00-995f9b53f69d4842b7c9be3a5fcda01d-17c5b521b9055246-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "1a3b3f53b2eb19e83bb91b78bee10b95",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "8904e4ef-e1a2-4549-83c6-b3c082f6fb3e",
+        "apim-request-id": "8ff1052b-62f4-4ad4-bc01-f0ce1fd82fcd",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
         "error": {
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "1842668100",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithNullIdTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithNullIdTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "67",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dd72b0ded3dd9145929c653a14298009-3b03a58fdfff944f-00",
+        "traceparent": "00-ee0456df3d2bc9419cc5c1da6f07bdbb-419eb3d1463ae847-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "b23c80179f571f450cf30413f8966972",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "47860001-e355-4cce-95a4-8cebb38d3ccd",
+        "apim-request-id": "9924b14d-c525-4e8c-9304-18f40275011c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "5"
       },
       "ResponseBody": {
         "error": {
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "1421275547",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithNullTextTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithNullTextTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "57",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f3a716126e5556438498ff81669182ae-2718a92971048948-00",
+        "traceparent": "00-325438ad9a88684cbb795904fa268a97-6bff12ba5fc83b49-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ed66d74da14036cde144d6235dacd6d3",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ceb51cc1-b895-4afd-b86a-8c65ef1c6130",
+        "apim-request-id": "331760fe-b665-4c8f-a2af-ff1f3cb61cac",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:41 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2"
+        "x-envoy-upstream-service-time": "3"
       },
       "ResponseBody": {
         "documents": [],
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "1472278800",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithNullTextTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithNullTextTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "57",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-286b2362dbb5ea4b92d5101a7b637c78-cab149f9c0179640-00",
+        "traceparent": "00-251bcf06a9bfc243bbf08b9ba319af6c-f20819edbfadcc4e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "46af5eece4595e8658920ddb272bdb42",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b3d24dfb-c4bd-48ef-83bf-ea4dffa2bd53",
+        "apim-request-id": "aea89b14-1b3f-4493-a48c-de527dffd759",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "1379897499",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=true",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "225",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-08c62cb125f13740a5749cc628fce9ac-f59e79217f85d94d-00",
+        "traceparent": "00-e8b75bac63419048b041ff7bb609dd81-2e3999016983b84a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "acad3cc12aa10a7667d1533045b0a321",
         "x-ms-return-client-request-id": "true"
@@ -45,14 +45,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2f8c6670-15c6-4f6f-96cd-671452cf7fc5",
+        "apim-request-id": "c8951fe4-87ea-4690-92ac-425fc556625e",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Tue, 03 Aug 2021 18:39:41 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
         "statistics": {
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "1441514523",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageBatchWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages?model-version=2019-10-01\u0026showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages?model-version=2019-10-01\u0026showStats=true",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "225",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c971fa9d931a7e479b58df663feca78a-b39099e15f363b4f-00",
+        "traceparent": "00-8e8e866108bc614bb756d919109ab988-90e91eb291187e45-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "50a7683e77aad92fe53b41b770dfa6fb",
         "x-ms-return-client-request-id": "true"
@@ -45,14 +45,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2069b970-2948-4d44-8781-20c37a6583d7",
+        "apim-request-id": "3c7e5b43-fd35-428c-9852-d0341ee5f4ea",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4,CognitiveServices.TextAnalytics.TextRecords=4",
-        "Date": "Tue, 03 Aug 2021 18:39:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "statistics": {
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "1925146009",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "82",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8e945308f85bd74c97fd16d5938c14b5-502b5ae9de700a49-00",
+        "traceparent": "00-388564516f627f4c987a6065e5eb8451-4c1bffef3aa89646-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "7aaab163ed1d982c319bbad40483549a",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "be03ae11-32e4-4d23-b910-557cad5801b0",
+        "apim-request-id": "c47011ae-a099-4910-bbeb-20abf6759478",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:41 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -59,6 +59,6 @@
   "Variables": {
     "RandomSeed": "1945127661",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "82",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f604c9d86f633f45bd18e357e545e068-23085ac0482bd34f-00",
+        "traceparent": "00-5c7763813f0117409fc336d92409e108-08acfee9c5884c42-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d4cc6357ff58c85240bd64c6445c1d0f",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1c15e5f3-d8ea-4488-bc2b-8f2a83d764af",
+        "apim-request-id": "bc201a75-1948-4731-9f12-32a03076f892",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
         "documents": [
@@ -59,6 +59,6 @@
   "Variables": {
     "RandomSeed": "2124897013",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithCountryHintTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithCountryHintTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "95",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7bbbc1c68d69434ea06f63dd0f4a3221-5cb4bbf6dce54f4b-00",
+        "traceparent": "00-51b97d8c75c38d468dc3bcbcaeed2ded-09a18ff4aea6dc42-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "98a2a27e9082d475805aa932800b5cf6",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0c96d1bb-65b2-4664-b1af-d9eb72568f58",
+        "apim-request-id": "211aa00e-418a-49db-b2d7-860e59a5937f",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "19"
+        "x-envoy-upstream-service-time": "29"
       },
       "ResponseBody": {
         "documents": [
@@ -59,6 +59,6 @@
   "Variables": {
     "RandomSeed": "1745096315",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithCountryHintTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithCountryHintTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "95",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2bb94162c44f884a82fa6b2f300602bf-da8bd928a35fe44e-00",
+        "traceparent": "00-d6f8be02873a0d45a4af19ef60e30af2-c490a94ced308549-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f0760fc68cadb07ff1c89a4d1612c056",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "91b9c91b-3549-405d-a4b9-3aa455e9c7fa",
+        "apim-request-id": "a733d54e-58c9-4f63-a49f-cd9eaa8de72e",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
+        "x-envoy-upstream-service-time": "18"
       },
       "ResponseBody": {
         "documents": [
@@ -59,6 +59,6 @@
   "Variables": {
     "RandomSeed": "2142485753",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithErrorCountryHintTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithErrorCountryHintTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "101",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-79785ff455eefb4ba054f3f9d58a40ec-0d37da7d900e1f44-00",
+        "traceparent": "00-deae7a07d7f4c74e99ee3cd43a15c226-baf955c3af9d8d43-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d6d037d3997433f0d1d408295081d2b0",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e5ca421e-0615-4344-9e01-3514e01b3f9d",
+        "apim-request-id": "302049a1-6da9-47f3-8a6d-849f8775e7cd",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "467349083",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithErrorCountryHintTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithErrorCountryHintTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "101",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bc721c7c95e75144a0487e3dfaef54be-5fda2d4d8b7c1d46-00",
+        "traceparent": "00-df7bfb9adeaa4a42be44907acfa08f90-18aabb92c3a7e94e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9d92baec240d7c0e78b80d24d8752359",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1941123b-17c3-4d21-9948-28331594d7be",
+        "apim-request-id": "798c4a68-6289-490d-b92f-3ade3af98dec",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "1987537636",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithNoneCountryHintTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithNoneCountryHintTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "93",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5aad8f3737dac242b17a0e9cb233b68f-9ec3099cef734147-00",
+        "traceparent": "00-0a7af13f994f104b92c38b67f11314c8-592923331fd22e49-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9cded6f43daa9a1f5be8cb3934e1c44c",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "071432db-ce78-4998-97aa-b887f9a9aef7",
+        "apim-request-id": "524e42e6-d81f-4edc-b565-ec5fa861827e",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -59,6 +59,6 @@
   "Variables": {
     "RandomSeed": "1940049365",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithNoneCountryHintTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithNoneCountryHintTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "93",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-174ed3ae743f30408a432610a4bf17a6-6e8f837fda27cf4c-00",
+        "traceparent": "00-0e140b4dad0277439125b34c8b42180b-5d75210466d3fd4b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "6124b40a04621bbacc815e287718638c",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7a346cc1-d84f-4ba7-8ef1-d8a2997f935e",
+        "apim-request-id": "33a09438-5d27-4aa7-be16-3e203bee04f1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -59,6 +59,6 @@
   "Variables": {
     "RandomSeed": "1328135102",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithNoneDefaultCountryHintTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithNoneDefaultCountryHintTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "93",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b6044d1a04663a4192c9378bf658bc9b-6ac036e4af180242-00",
+        "traceparent": "00-e794d41a456b0545b333f66f0672a240-d7ef9cac73c9bf4a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "dda057b9e217d2ba6e5090c17d8fd607",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6fc7946a-2f00-48d5-b599-e4fdfe75d8e4",
+        "apim-request-id": "b97db36b-6ad8-40b1-bc9a-91dcd7952fd5",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -59,6 +59,6 @@
   "Variables": {
     "RandomSeed": "397710028",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithNoneDefaultCountryHintTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/DetectLanguageTests/DetectLanguageWithNoneDefaultCountryHintTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "93",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e33013c39401a748becc5a564a26e285-27d4ec9f277f7443-00",
+        "traceparent": "00-26dd75bf8f1bbe42830d2c5331783177-098886bacca72d44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "bfed051a0d9b7fe81f8b58b8ccb397c0",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1339155b-08d2-4ab4-99a1-09eedfd1b58e",
+        "apim-request-id": "80943738-a5dd-48f5-91b4-b94534ca418c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -59,6 +59,6 @@
   "Variables": {
     "RandomSeed": "691922193",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchConvenienceTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-efed9baedd60c04f9ff90cc991a953b0-4433fdd4fdbec14a-00",
+        "traceparent": "00-6ae227de4a0fef4aab18959ea951591b-a06d755ef9424e4b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "632e1038e2d2bd9cdcf3dd442e79c63c",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7567d243-90f3-4cbe-baf1-53358c0937f0",
+        "apim-request-id": "89d43d42-5971-4c56-a343-08a3e4cd2497",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "45"
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "2011102001",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchConvenienceTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0ba7658d5071f46b9be0d425a1311ec-8d599bab583d0749-00",
+        "traceparent": "00-38543614ba80e14ba2a0ff4ac9c024b0-b13e295250437b4a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "bb6bf08839909e0e578d5bc1b428bcd2",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "83d75bdd-df17-4eeb-9260-c8a64cde9613",
+        "apim-request-id": "2900ec78-1d93-4bcf-bc90-229f5d3c7451",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "47"
+        "x-envoy-upstream-service-time": "141"
       },
       "ResponseBody": {
         "documents": [
@@ -73,6 +73,6 @@
   "Variables": {
     "RandomSeed": "1790351005",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchConvenienceWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=true",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5fee5bbe55b0184ab26fee8c0cc36dbd-8cb21fa322797e43-00",
+        "traceparent": "00-519170d8fb7840418acbc220be817522-15a11bc23090e44e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "4dfa2958a1568d79bc14e1b570d63d15",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9d121136-3d88-4b01-8fe4-d95248c64e4f",
+        "apim-request-id": "d4952316-0d35-41bd-868e-5507cd33409b",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
         "statistics": {
@@ -87,6 +87,6 @@
   "Variables": {
     "RandomSeed": "1074286074",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchConvenienceWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=true",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3f05edf1e33cf64ca7a1aacc6b833727-444da63aa0878444-00",
+        "traceparent": "00-0abcd4aa9bed494bae8a073a83609c6f-c02321aa68d2104e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f8f1e114d697e804255315d1c7e9b6ab",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f7b6934-b1ad-4882-bdcc-0edfba3b2c6e",
+        "apim-request-id": "867fe77e-4b05-488e-84ed-5d4608f7e300",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "x-envoy-upstream-service-time": "29"
       },
       "ResponseBody": {
         "statistics": {
@@ -87,6 +87,6 @@
   "Variables": {
     "RandomSeed": "1602869274",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "188",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8813a07ffdf3564299aa04a9c461349e-fcd3dacd43d53045-00",
+        "traceparent": "00-2143bfacecae5b4dbe4a2991b54f7396-ba79c82089b2ed4c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f8376358e18a19e0b7e6f893926ac745",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93b3c448-e07b-4e9f-bed7-5e2ec392a379",
+        "apim-request-id": "f4ed489c-7200-49e0-8635-1fec477bd41e",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "42"
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
         "documents": [
@@ -58,7 +58,6 @@
           {
             "id": "2",
             "keyPhrases": [
-              "Mi",
               "perro",
               "gato",
               "veterinario"
@@ -74,6 +73,6 @@
   "Variables": {
     "RandomSeed": "979539460",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "188",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e326c5e14d442b4aacf2bdecde162f89-f01b10079318db43-00",
+        "traceparent": "00-0d5ad3a6aed34743af3960747339334c-289662570defd84b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "272edb015782fb6dbcae1cc2967deed3",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ec40330-8957-4bb2-aecb-838a52f7125c",
+        "apim-request-id": "cea26595-4b66-459d-aafb-c8da8e8c91b1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "25"
       },
       "ResponseBody": {
         "documents": [
@@ -58,7 +58,6 @@
           {
             "id": "2",
             "keyPhrases": [
-              "Mi",
               "perro",
               "gato",
               "veterinario"
@@ -74,6 +73,6 @@
   "Variables": {
     "RandomSeed": "349892618",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithErrorTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "217",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c616cd655b2f4344b210747a4af9fc39-c42cc1cda4e42046-00",
+        "traceparent": "00-d233872a4fa3d74192a7b8ef3edb537d-3296073a7583104b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "dd92af13693d6c6d10f5b45092a05fbe",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "61bc678f-5424-4825-b4e6-a9790904bead",
+        "apim-request-id": "fd10ba1c-0173-4462-84aa-b15a4e878881",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "x-envoy-upstream-service-time": "127"
       },
       "ResponseBody": {
         "documents": [
@@ -89,6 +89,6 @@
   "Variables": {
     "RandomSeed": "1310930461",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithErrorTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "217",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d5681c8e58aa504db9be3866bdb230c5-446ca69c21a2ff48-00",
+        "traceparent": "00-a4bef67d7605ce41bbcbab0d9c973978-b56853db65b05e49-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "161fb623980eba163f1211744629e747",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5ee5138b-a2c8-47b0-98fb-905bd91becf7",
+        "apim-request-id": "938b640e-a194-43aa-8b85-b40490be23b6",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "30"
       },
       "ResponseBody": {
         "documents": [
@@ -89,6 +89,6 @@
   "Variables": {
     "RandomSeed": "2016817382",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithNullIdTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithNullIdTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "64",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-79e9b2ca0054e64eb09b14bd93d1a61d-8b6f55a6be8d4949-00",
+        "traceparent": "00-6cdcea9c280ff54ba14e3adf73e40a3f-71342d1a07bcbc4f-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "02233abc1a851f8d7b73c3a9864f0660",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "20f6f2b3-e8b5-4db4-95a8-9529fb7c6670",
+        "apim-request-id": "e0069030-488b-4e22-8f5a-0e41878bd118",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "4"
       },
       "ResponseBody": {
         "error": {
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "39669393",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithNullIdTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithNullIdTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "64",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21f7aaec6766d340afdd55751dd614ac-a5baf32e2df1fe49-00",
+        "traceparent": "00-7183a50b25555a4180fb00a884d0e94c-2f79b29e020f594f-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d3ffef96a22198e4e5a15a93f55c6a25",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "c338059f-dae5-463f-8c40-952c825426fa",
+        "apim-request-id": "0d9da6cd-0dca-4a58-a384-15617deb2be4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
         "error": {
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "356416899",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithNullTextTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithNullTextTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d7fb5ce578a3348ae1185b1967abb22-ed1bcc26b6f1d548-00",
+        "traceparent": "00-236e7e9433e0dd429c44831582dfafc4-b12b70aa280ce64b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5bf1e93674612a2cd70f69188e2d39f7",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c943b7bb-07f5-48eb-8a14-3449820fd188",
+        "apim-request-id": "0e69d68d-6978-40a3-9339-59bb860f7bf3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "593241093",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithNullTextTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithNullTextTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8077068f264bec49abf174a629d605f9-9147883e2accea47-00",
+        "traceparent": "00-a8e28fb8c7fdb3439b889e62f84bf29e-3fd5b1860d63cd4a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5dbd36794559c388c50dd26e725f8f67",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "77c8dc1b-e154-43b5-aa29-1e2ad2c91631",
+        "apim-request-id": "2a6e9d66-7fd0-479a-b909-2e8825b3eec3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "872837413",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithSatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithSatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=true",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "188",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3ee95dd0ff17ad4c8b0e1ff6529c3aee-bf14dea363e2ff40-00",
+        "traceparent": "00-cd6bb5f6eed08f42a0c68433ac356d7a-1ac259a9f094b941-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "481340828d769a0d6f19ecfe6b0d9666",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a05f8fa7-2953-4612-b341-cf2075d9b989",
+        "apim-request-id": "cf3de862-6a1e-43a5-9ea0-04dda12353fe",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
         "statistics": {
@@ -68,7 +68,6 @@
           {
             "id": "2",
             "keyPhrases": [
-              "Mi",
               "perro",
               "gato",
               "veterinario"
@@ -88,6 +87,6 @@
   "Variables": {
     "RandomSeed": "1134123605",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithSatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesBatchWithSatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?showStats=true",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "188",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0f0906489aa4ea4297b533ba72d95750-aba4cf824276b14d-00",
+        "traceparent": "00-da64a9ed674aa443840a6f4113c6cff9-ce46d4f85889af42-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "fcabdefd3d51a89852601fc0d61f3468",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3ad37721-9535-45ae-8ebc-481b12d2547f",
+        "apim-request-id": "1699ad5e-1137-4c81-8f38-e9832b886dcb",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "41"
+        "x-envoy-upstream-service-time": "23"
       },
       "ResponseBody": {
         "statistics": {
@@ -68,7 +68,6 @@
           {
             "id": "2",
             "keyPhrases": [
-              "Mi",
               "perro",
               "gato",
               "veterinario"
@@ -88,6 +87,6 @@
   "Variables": {
     "RandomSeed": "1658669752",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6a1147457f9a02488f1f0690c9fb5d9b-158328b2f358c447-00",
+        "traceparent": "00-2453585e8a84644987ee0b5b733fa224-90cdd51501d84c4f-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "b86575e1b38857965c8495535ac2b899",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "76dd94e5-3361-4815-8777-3f15aa9c503f",
+        "apim-request-id": "d02cddfa-5857-4e53-8b46-d41e5c0981e7",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
         "documents": [
@@ -58,6 +58,6 @@
   "Variables": {
     "RandomSeed": "4209270",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "92",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6c82a42fbdde0542b3ef1772c45a7662-9c8e6b41a9fc3b41-00",
+        "traceparent": "00-2e2fc87ad9b06d42b69f370e7c4e6d16-abf768398fd97d45-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f80f56a1c735d323972d5c2c674aed06",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "21696a04-e756-4821-9255-247b6eebc7b8",
+        "apim-request-id": "30257b62-0850-43bc-8629-c5270af70544",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "30"
       },
       "ResponseBody": {
         "documents": [
@@ -58,6 +58,6 @@
   "Variables": {
     "RandomSeed": "1076673025",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithLanguageTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "88",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b25a37c3f6fd794c92c43bbd8b81f649-3a80433a53348942-00",
+        "traceparent": "00-b55608a95d792e44b34b1746bf12ac31-4c52f13432f06842-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "fee09dae9a1670151c1a3a802afd3e61",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "17495d8d-7c62-4c16-aa53-ed58d2e43dc8",
+        "apim-request-id": "bf619d8e-5fda-4050-a461-d41865ca040b",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
         "documents": [
@@ -58,6 +58,6 @@
   "Variables": {
     "RandomSeed": "462050848",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithLanguageTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "88",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-74c39412b94a92499b217406eb809203-a9b207a175590a4f-00",
+        "traceparent": "00-f72aa1f5cb9e194e9b080034ace0bb71-1cde42ce0dc46940-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "3bfc775f82d23a381e7a3b00a0305c6c",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d7e9f2b6-aa26-4388-ac1f-858377a01c39",
+        "apim-request-id": "8cf92c82-cf1b-494c-b8e4-1bffb3f3387e",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
         "documents": [
@@ -58,6 +58,6 @@
   "Variables": {
     "RandomSeed": "1676133981",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "389",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6cd7e6fc88ac914e8fac000d7f24a97a-eb2afb2ead770f40-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-aef8291fbcd1a04d9bcc179b5d6c6d75-e2a5ca9f6a785a42-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f9fe92c25cc9e332abb31e6d62f326f5",
         "x-ms-return-client-request-id": "true"
       },
@@ -45,42 +51,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "c1b05b96-36a1-48d7-83a5-f84e41ca27fa",
-        "Date": "Wed, 20 Oct 2021 15:00:13 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
+        "apim-request-id": "a7c43bc5-0e93-466b-a911-5e169ae8cbf7",
+        "Date": "Mon, 25 Oct 2021 21:14:34 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "468"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "226"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "593e8a3c12521d4f48bb2223352ad499",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "081f63b9-cd56-44ea-b3c9-e72b00fbc422",
+        "apim-request-id": "169df323-265f-4540-beb6-7da1219e285f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
-        "lastUpdateDateTime": "2021-10-20T15:00:14Z",
-        "createdDateTime": "2021-10-20T15:00:13Z",
-        "expirationDateTime": "2021-10-21T15:00:13Z",
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:35Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -92,31 +104,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c7d6b6a6ce18aa9ea29c4fb7398199cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9100d407-6d21-458d-b53e-1e9952fb6aa3",
+        "apim-request-id": "b7158a1d-4f6a-4ccf-84ad-65eefe957eb8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:15 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
-        "lastUpdateDateTime": "2021-10-20T15:00:14Z",
-        "createdDateTime": "2021-10-20T15:00:13Z",
-        "expirationDateTime": "2021-10-21T15:00:13Z",
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:35Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -128,31 +146,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0db008fa0f80b0ec42e1b00d390ead81",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e888d3b2-c00f-4c10-8c51-de1109ef4bc0",
+        "apim-request-id": "c0b9878a-afd3-446d-ae2b-f6b00332525c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:16 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
-        "lastUpdateDateTime": "2021-10-20T15:00:14Z",
-        "createdDateTime": "2021-10-20T15:00:13Z",
-        "expirationDateTime": "2021-10-21T15:00:13Z",
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:35Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -164,31 +188,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "abc785df5e1d6dddec93b6b6c298e3c7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0d92e39c-8cf6-4b2c-848b-19ae7c0d5595",
+        "apim-request-id": "5402a06a-bb60-4f04-8d21-e50cf2c89d82",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
-        "lastUpdateDateTime": "2021-10-20T15:00:14Z",
-        "createdDateTime": "2021-10-20T15:00:13Z",
-        "expirationDateTime": "2021-10-21T15:00:13Z",
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:35Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -200,31 +230,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2d285621c6799618ca2585361e907193",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6d08436b-9dc2-43b6-961f-504f3a9953df",
+        "apim-request-id": "e4307037-2446-4d4b-b3c2-0b568732f224",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
-        "lastUpdateDateTime": "2021-10-20T15:00:14Z",
-        "createdDateTime": "2021-10-20T15:00:13Z",
-        "expirationDateTime": "2021-10-21T15:00:13Z",
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:35Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -236,31 +272,79 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b4d8ceeeedb99caf2b4321ed5836eeaa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "efa477f4-8dad-44cf-aac6-b57b2a5cec01",
+        "apim-request-id": "f31ac488-8fa9-4072-8bbf-657d55e04950",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "201"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
-        "lastUpdateDateTime": "2021-10-20T15:00:19Z",
-        "createdDateTime": "2021-10-20T15:00:13Z",
-        "expirationDateTime": "2021-10-21T15:00:13Z",
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:41Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e3ebe9fd80e618076c31e1f7d8a64f5b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c1feafe9-4d59-46d8-991b-bc22931df57b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:14:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "224"
+      },
+      "ResponseBody": {
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:43Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -270,8 +354,8 @@
           "total": 2,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:00:19.81358Z",
-              "taskName": "ExtractKeyPhrases",
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -303,31 +387,548 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e3ebe9fd80e618076c31e1f7d8a64f5b",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f3c723212ebf340ea78b0136a52b3d94",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e33aaba1-ec38-4fed-831a-4f3d2c444c38",
+        "apim-request-id": "27fc7055-b7cf-4424-beed-41eddde4368f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "194"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "218"
       },
       "ResponseBody": {
-        "jobId": "6ae1ab6b-e446-470d-b9f5-58b86a85a92e",
-        "lastUpdateDateTime": "2021-10-20T15:00:22Z",
-        "createdDateTime": "2021-10-20T15:00:13Z",
-        "expirationDateTime": "2021-10-21T15:00:13Z",
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:43Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3439db378da46eacc6bf48880cb7c385",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "92603ed4-9575-4324-ae28-f5718fb47eb8",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:14:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "70"
+      },
+      "ResponseBody": {
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:43Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "35cbc5f4fa6eceeadbb73c5a7ed17341",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0a8e381d-4a7f-40a9-ab85-7ffe3ffbd5bd",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:14:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "856"
+      },
+      "ResponseBody": {
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:43Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "fdc04cf31a6c94b776582d00e68527ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a41eed41-d0b5-4168-8022-96810d460573",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:14:49 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "73"
+      },
+      "ResponseBody": {
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:43Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "df427cc8085f3c26f16a59ec5152f0f5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f752aa6e-69b9-46c9-add0-4bd58838e125",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:14:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "64"
+      },
+      "ResponseBody": {
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:43Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c094064bc6f6d9180e37be16cde9e855",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6b1e854b-09bd-4616-9682-00cff388b888",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:14:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "72"
+      },
+      "ResponseBody": {
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:43Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "02924c90938eebe226840c02c0ca4224",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4f3ccf4f-bb42-4e07-892b-23c2471b49df",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:14:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "86"
+      },
+      "ResponseBody": {
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:43Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/492a9471-a8a6-402d-9853-126dfbba234d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "dfb4376867f002f96368d127490f6f07",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b04bba97-48ca-428d-b211-0093143559fe",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:14:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "3979"
+      },
+      "ResponseBody": {
+        "jobId": "492a9471-a8a6-402d-9853-126dfbba234d",
+        "lastUpdateDateTime": "2021-10-25T21:14:54Z",
+        "createdDateTime": "2021-10-25T21:14:35Z",
+        "expirationDateTime": "2021-10-26T21:14:35Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -337,7 +938,7 @@
           "total": 2,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:00:22.1399452Z",
+              "lastUpdateDateTime": "2021-10-25T21:14:43.0013783Z",
               "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -366,7 +967,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:00:19.81358Z",
+              "lastUpdateDateTime": "2021-10-25T21:14:54.1629129Z",
               "taskName": "ExtractKeyPhrases",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "389",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e5099e7612b9d947b1b8024a4c10b5f5-a0ae805d20b0c24c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-c9f68bc07d50df49a6a7fd5ec31d67a4-1c60f26fc11a9c49-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3e804ae24ddafd4e332414fdc826fccc",
         "x-ms-return-client-request-id": "true"
       },
@@ -45,42 +51,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a292fabf-49bc-4ea0-98f0-64e2383bc1fe",
-        "Date": "Wed, 20 Oct 2021 15:00:22 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+        "apim-request-id": "d057e92d-78df-49b3-ab33-8429d3f7760b",
+        "Date": "Mon, 25 Oct 2021 21:15:02 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "328"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "353"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ed609702e874cbd93fd246e6fa53645a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93f3b086-7a54-46c2-baea-8cd799d2b126",
+        "apim-request-id": "c4bded90-f82c-4bb9-b793-05cbfdbd66e0",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:24 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:23Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:03Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -92,31 +104,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bb70e0500624b1179876a86fb55e7e34",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aedf3ce5-54de-47ea-8474-11ff566afe93",
+        "apim-request-id": "ea725baa-58dc-4a79-94e5-2b597e766abf",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:23Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:04Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -128,31 +146,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b58f67e5092afa6870b5ff08076802e0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "32e15325-7332-46b1-985f-fa0cc6b6cb86",
+        "apim-request-id": "6be6e9ef-dd5e-4e53-9697-e00984c8849a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:23Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:04Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -164,31 +188,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e7adbac041b5fca880ae54fd406916e0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca76417c-d0be-46f4-86d9-7af23be994e5",
+        "apim-request-id": "176c535d-d47e-4088-a27d-6e71772f6292",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "45"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:23Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:04Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -200,31 +230,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "93001153afc3463077764a6f060faa30",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ad7deba0-2157-4949-af3d-d98d6f523888",
+        "apim-request-id": "e14d0dc2-f984-4c17-ad83-d56ab1672cf5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "53"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:23Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:04Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -236,31 +272,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "faafc77396b1a47ebf93347bb46bb906",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9d2f9857-4c8f-41f2-a2e6-b23f3c53424c",
+        "apim-request-id": "45b3462c-cf5b-4156-acda-abded1ede303",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:30 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:29Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:04Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -272,98 +314,121 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f5b41f9f6f67101c8966703ff638f571",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "34de2bf2-bed5-44e7-ada2-27cae0e4463d",
+        "apim-request-id": "a05b6154-44c5-486a-9f73-479d2ad916ad",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:31 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "182"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:31Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:04Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "keyPhraseExtractionTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-20T15:00:31.1340971Z",
-              "taskName": "ExtractKeyPhrases",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "0",
-                    "keyPhrases": [
-                      "Bill Gates",
-                      "Paul Allen",
-                      "Microsoft"
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "1",
-                    "keyPhrases": [
-                      "cat",
-                      "dog",
-                      "veterinarian"
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-06-01"
-              }
-            }
-          ]
+          "inProgress": 2,
+          "total": 2
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "788924031bbabd2f925bd3307ab4920c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "99eb075a-dc31-44c9-98b1-24abb78fbbb4",
+        "apim-request-id": "dcd48649-7017-4902-8aa7-2f0c11bbf5f1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "83"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "26"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:31Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:04Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e7d044bcb55a03c8aa9f704a263fae86",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5a7a0c8d-e542-481f-a123-31d4a55bb9de",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "72"
+      },
+      "ResponseBody": {
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:12Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -373,8 +438,8 @@
           "total": 2,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:00:31.1340971Z",
-              "taskName": "ExtractKeyPhrases",
+              "lastUpdateDateTime": "2021-10-25T21:15:12.5745517Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -406,31 +471,329 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/77e3608d-e370-4a66-9141-10f142fe7cd5",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e7d044bcb55a03c8aa9f704a263fae86",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9078c39e41e1834cf0f7620c9cec95d5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ebb41e92-7caa-4a8d-8772-000a7de0f84e",
+        "apim-request-id": "51ea373f-2443-4c13-a2d6-0e16b91b4210",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:00:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "143"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "62"
       },
       "ResponseBody": {
-        "jobId": "77e3608d-e370-4a66-9141-10f142fe7cd5",
-        "lastUpdateDateTime": "2021-10-20T15:00:33Z",
-        "createdDateTime": "2021-10-20T15:00:23Z",
-        "expirationDateTime": "2021-10-21T15:00:23Z",
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:12Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:15:12.5745517Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b28263d40d684e165b85ce1baae49653",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8fdb82e3-c65d-4035-ada2-b2aa4b3ab229",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "70"
+      },
+      "ResponseBody": {
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:12Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:15:12.5745517Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b6914cad023b7b2af74cf76352bc67bd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bcfe0cfd-26e9-42a3-96be-3ed3f9120ecc",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "435"
+      },
+      "ResponseBody": {
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:12Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:15:12.5745517Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c2769b09fcbc901ead2a345c7230d90b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1e891bf5-88c2-4a99-8836-b696a864e4c7",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "61"
+      },
+      "ResponseBody": {
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:12Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:15:12.5745517Z",
+              "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Bill Gates",
+                      "Paul Allen",
+                      "Microsoft"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "cat",
+                      "dog",
+                      "veterinarian"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4f5e0e60de5ad1993907ba1b16b3fb9e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2e0f2180-bd3e-4fed-bca6-4a44001ec5a5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "115"
+      },
+      "ResponseBody": {
+        "jobId": "5b7451fb-7ebc-4c30-9cde-24dd16e03de5",
+        "lastUpdateDateTime": "2021-10-25T21:15:19Z",
+        "createdDateTime": "2021-10-25T21:15:02Z",
+        "expirationDateTime": "2021-10-26T21:15:02Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -440,7 +803,7 @@
           "total": 2,
           "keyPhraseExtractionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:00:33.8561031Z",
+              "lastUpdateDateTime": "2021-10-25T21:15:12.5745517Z",
               "taskName": "ExtractKeyPhrasesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -469,7 +832,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:00:31.1340971Z",
+              "lastUpdateDateTime": "2021-10-25T21:15:19.3298461Z",
               "taskName": "ExtractKeyPhrases",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithWarningTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithWarningTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?model-version=2020-07-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?model-version=2020-07-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "180",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-62f390a31cb0194aa03a166b1db4d7c7-377abfe5a55f6146-00",
+        "traceparent": "00-75f9fe5bc683c24ca7ae90e4f590c7d2-32d940a3087d4f44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "7a99e78b28bbdc34334c788be87edcb8",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "60ae679a-88fe-400e-bbb0-278752bccb72",
+        "apim-request-id": "3d0b1a24-1d4e-41b2-8b00-d3575dd98a8b",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:14:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
         "documents": [
@@ -64,6 +64,6 @@
   "Variables": {
     "RandomSeed": "591698428",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithWarningTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractKeyPhrasesTests/ExtractKeyPhrasesWithWarningTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/keyPhrases?model-version=2020-07-01\u0026showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/keyPhrases?model-version=2020-07-01\u0026showStats=false",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "180",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8805839acd67244fa6b604c65b8685d9-b866aa1e4abee648-00",
+        "traceparent": "00-6c4416cdb366ac4aaf9b3f2f61d4e293-976b91f4f709fe48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d687a16b6a26ea445556f8b3c125785e",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e8022320-afa1-4aeb-bed2-95b32c93c20d",
+        "apim-request-id": "e5ecec31-e472-4537-b365-e8f5462ab2e2",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
         "documents": [
@@ -64,6 +64,6 @@
   "Variables": {
     "RandomSeed": "1154109326",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchConvenienceTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10906",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-722a2322b91221418dc8c5aeef0a510e-2bb5ae2f0cecce4e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b6e7824dbadbb2499874ec6084077573-ccbea9543a714c48-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a87d416d7cb808934968999aecf2d457",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e4e7f9d0-d9f9-46f4-92f3-92b3028c7521",
-        "Date": "Thu, 23 Sep 2021 14:45:39 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
+        "apim-request-id": "d947d75b-0b51-496f-bb26-aa5e4fc549ca",
+        "Date": "Mon, 25 Oct 2021 21:15:20 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "181"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "210"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d0aff37bc9b173e79cb77d81c11e5345",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2af446d7-32ee-4d7b-97d0-f7004b5d0272",
+        "apim-request-id": "14eeea2e-9518-4545-83e7-4f40e8bbdbdf",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
-        "lastUpdateDateTime": "2021-09-23T14:45:39Z",
-        "createdDateTime": "2021-09-23T14:45:39Z",
-        "expirationDateTime": "2021-09-24T14:45:39Z",
-        "status": "notStarted",
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cb3f8bbc1ebf4cdee0fe8767ea0d5e4d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9f995694-c0e0-4cd8-8754-bfaa2ce18799",
+        "apim-request-id": "0764fe7e-b815-4231-af0d-7f3feb909aa8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:41 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
-        "jobId": "ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
-        "lastUpdateDateTime": "2021-09-23T14:45:40Z",
-        "createdDateTime": "2021-09-23T14:45:39Z",
-        "expirationDateTime": "2021-09-24T14:45:39Z",
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,34 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ec8bf51a4a4fa3ed5a0a0c01fe11462a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5ea73d9e-e0bb-44e0-bd55-338992c34768",
+        "apim-request-id": "104b91af-68fa-4326-9fea-332f0290c36a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
       },
       "ResponseBody": {
-        "jobId": "ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
-        "lastUpdateDateTime": "2021-09-23T14:45:40Z",
-        "createdDateTime": "2021-09-23T14:45:39Z",
-        "expirationDateTime": "2021-09-24T14:45:39Z",
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -163,34 +184,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "60de531408b35d981562efb24180888e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "162d209e-d885-437d-bda0-ff7c8c8f97a9",
+        "apim-request-id": "5f2006ef-ce94-42a0-83d1-34ab7ce8cce6",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "26"
       },
       "ResponseBody": {
-        "jobId": "ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
-        "lastUpdateDateTime": "2021-09-23T14:45:40Z",
-        "createdDateTime": "2021-09-23T14:45:39Z",
-        "expirationDateTime": "2021-09-24T14:45:39Z",
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -200,34 +226,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cc673058669272f59d9b71b411dc4ecf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2dac0c25-2ce6-43f8-a464-89b8b1df86a6",
+        "apim-request-id": "bf093de5-d044-42a9-a74f-2474f00d3b1f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
-        "lastUpdateDateTime": "2021-09-23T14:45:40Z",
-        "createdDateTime": "2021-09-23T14:45:39Z",
-        "expirationDateTime": "2021-09-24T14:45:39Z",
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -237,34 +268,291 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "96525db8fd2f119a5d2ed7ed5a3a61d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ad1abe22-d192-4b9b-b262-447153a8c7c4",
+        "apim-request-id": "69ecd48d-c0be-485d-a6fa-8e43d9d8976f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:45 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "84"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "ae06559b-8aff-4f54-94c0-e29f0ebc6e52",
-        "lastUpdateDateTime": "2021-09-23T14:45:44Z",
-        "createdDateTime": "2021-09-23T14:45:39Z",
-        "expirationDateTime": "2021-09-24T14:45:39Z",
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "cea87d817aaaae975e6cc21897e34b38",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f4881f9d-c207-4f68-91d5-b55b97374fb6",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e4fa2014f12d5a5f96556f648f071762",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e1000bc9-a45b-42dc-bf6a-12da24ff431e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "943397397f343d24c5a438c33a817a79",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b786e3b9-b583-45b0-9697-914f18a6feb7",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "39d99fe37d4090ac1d4d38550a331f57",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "14777886-d622-474d-acba-598f2fdaf397",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ffdf5f54b7b09403fcbc1f89b99c2014",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "15c6a1ef-e8ee-4da3-a4e8-bca106fa3fdf",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:34 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:21Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ef80f5dade2dbc22eba276e646cf3391",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a2046e59-63c8-428b-a8a6-c8acceff55df",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:35 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "324"
+      },
+      "ResponseBody": {
+        "jobId": "8f9b4aec-8bf2-4ea7-b46e-919c7cd8f580",
+        "lastUpdateDateTime": "2021-10-25T21:15:35Z",
+        "createdDateTime": "2021-10-25T21:15:21Z",
+        "expirationDateTime": "2021-10-26T21:15:21Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -272,7 +560,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:44.551995Z",
+              "lastUpdateDateTime": "2021-10-25T21:15:35.4226149Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -361,6 +649,6 @@
   "Variables": {
     "RandomSeed": "721611658",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchConvenienceTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10906",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9a30a9aa668d614ba53ef5b3bd4a543c-095e2f1bfc95aa42-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-93ca9e6d14ac64418b6f1fa7be6220be-3736ba7028e6064b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6d5f2ae36c2f32a28821252a0ee4c14c",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8cda4262-ba09-45ad-b609-57e237eac7f4",
-        "Date": "Thu, 23 Sep 2021 14:46:13 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
+        "apim-request-id": "b4384b6b-584a-46cd-87e8-c13769657389",
+        "Date": "Mon, 25 Oct 2021 21:17:05 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "181"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "212"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "527d763ade69ecabff5c3ba7f9ce1a12",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d526e8ba-a1db-44b9-ad5b-d3f8ec83be69",
+        "apim-request-id": "87264bf8-823b-4371-9e9b-0b47678acbc9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
-        "lastUpdateDateTime": "2021-09-23T14:46:14Z",
-        "createdDateTime": "2021-09-23T14:46:14Z",
-        "expirationDateTime": "2021-09-24T14:46:14Z",
-        "status": "notStarted",
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "49cea572b2dcc4e613981d27af531c4b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "53e3e51e-d812-41c2-9a9c-b9ef970be47a",
+        "apim-request-id": "f5c79528-636c-4801-96c9-a42ed0543399",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
-        "lastUpdateDateTime": "2021-09-23T14:46:14Z",
-        "createdDateTime": "2021-09-23T14:46:14Z",
-        "expirationDateTime": "2021-09-24T14:46:14Z",
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,34 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ff172f6780c105077e726dd230fa39b9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "96667ec7-9929-469d-9e8e-705edc0eac7d",
+        "apim-request-id": "a98a3fbb-7a75-4ff2-80f5-fc2e142bd8f9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:16 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
-        "lastUpdateDateTime": "2021-09-23T14:46:14Z",
-        "createdDateTime": "2021-09-23T14:46:14Z",
-        "expirationDateTime": "2021-09-24T14:46:14Z",
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -163,34 +184,459 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "68b81206771588708fb93fd1c1843dac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f156c871-3d2d-49c7-b249-299831fc92be",
+        "apim-request-id": "f187e8de-c36c-43c5-bddc-1eff454328f6",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "161"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "102"
       },
       "ResponseBody": {
-        "jobId": "3b1d7c03-3d5b-4a69-b607-1e6081e0434a",
-        "lastUpdateDateTime": "2021-09-23T14:46:17Z",
-        "createdDateTime": "2021-09-23T14:46:14Z",
-        "expirationDateTime": "2021-09-24T14:46:14Z",
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ca3ff0401ab6f1509dc9cb6944139318",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "22458c58-2169-4571-a5dd-a588045bed00",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:10 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9d20635eb39af035be8f6f08413644f9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "63214c4c-2cf6-42b7-9a9a-65fd1f47e95b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4092c1356fbaeb03c1c6ca4cac06437c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c7115d9e-4910-4a05-b9c0-8d40eadaaddd",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "5d7226259f648d11ba4f0b26aa48b067",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7aa84dc5-2bb6-4d65-a6ec-54271cdd6744",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "8334d1845381ef5e6034dcd3e8e944b7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5467d660-bfd2-43ff-8ed6-67dd212c6f8a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "53"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "1be3f34ce6c49595b004856a63dc4179",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c53d53dc-042e-467e-b718-7a05abd2c701",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "dac76316c0d2d2fac782fd2fc33da4d1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f0970768-5ee1-4abd-a384-a1cffd0d21b5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b6da540b95659ea23c9ed27dcdf38c83",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "27ecc01c-db77-4d23-9d2f-3b4d84adbecc",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "84bd63f36a218be4f9105341e966d272",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "518f0160-883a-4f0a-b4e1-d06bd3ea5870",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:06Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0e5fb4608a028114c0299d34ed7d05d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "750b2b0f-531a-4ae4-8d3f-7baf6939fff7",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "67"
+      },
+      "ResponseBody": {
+        "jobId": "b3328b65-8b3a-4e4e-8bcb-a0f71af403ab",
+        "lastUpdateDateTime": "2021-10-25T21:17:23Z",
+        "createdDateTime": "2021-10-25T21:17:05Z",
+        "expirationDateTime": "2021-10-26T21:17:05Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -198,7 +644,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:17.3079585Z",
+              "lastUpdateDateTime": "2021-10-25T21:17:23.2618747Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -287,6 +733,6 @@
   "Variables": {
     "RandomSeed": "1033345447",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchConvenienceWithStatisticsTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10906",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ffd6e8e1bd1dd44db893688099f29eef-45a742c9665a0241-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-27e44e10a41c7745a9c5b9102882796f-1d24b07f227a174b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bfc113963668fe26b5d07e43e5ef9a18",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "340191b3-9d00-4ff0-99cc-9d22af33d3e7",
-        "Date": "Thu, 23 Sep 2021 14:45:45 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/86d88eeb-9ea9-4d89-8596-00fc6e31edf4",
+        "apim-request-id": "0ed1391c-0386-4247-bbb9-309eba1ea1d4",
+        "Date": "Mon, 25 Oct 2021 21:15:36 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "194"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "201"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/86d88eeb-9ea9-4d89-8596-00fc6e31edf4?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7bf84dfe1eab8869d6053557d69142cd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a461882f-d580-4e8d-ad24-dd090b57627e",
+        "apim-request-id": "664a637f-9908-4f62-8d12-516bbd87a000",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:45 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "86d88eeb-9ea9-4d89-8596-00fc6e31edf4",
-        "lastUpdateDateTime": "2021-09-23T14:45:46Z",
-        "createdDateTime": "2021-09-23T14:45:45Z",
-        "expirationDateTime": "2021-09-24T14:45:45Z",
-        "status": "notStarted",
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/86d88eeb-9ea9-4d89-8596-00fc6e31edf4?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "75316a4f49761d6bfa0d0d83fe3a0076",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9ab21dee-8dcb-4f73-b035-d39277cbfa33",
+        "apim-request-id": "f9e24032-1585-4da4-b457-530a669e1a53",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "37"
       },
       "ResponseBody": {
-        "jobId": "86d88eeb-9ea9-4d89-8596-00fc6e31edf4",
-        "lastUpdateDateTime": "2021-09-23T14:45:46Z",
-        "createdDateTime": "2021-09-23T14:45:45Z",
-        "expirationDateTime": "2021-09-24T14:45:45Z",
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,34 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/86d88eeb-9ea9-4d89-8596-00fc6e31edf4?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e70eb2c015287861aa39e96301ce2824",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "51babdbf-fb50-4c2f-82f0-94c65a62dd7b",
+        "apim-request-id": "2fb9d6c8-23f4-4ea7-85c0-819c1eb5edfa",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "86d88eeb-9ea9-4d89-8596-00fc6e31edf4",
-        "lastUpdateDateTime": "2021-09-23T14:45:46Z",
-        "createdDateTime": "2021-09-23T14:45:45Z",
-        "expirationDateTime": "2021-09-24T14:45:45Z",
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -163,34 +184,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/86d88eeb-9ea9-4d89-8596-00fc6e31edf4?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7bf4b08d25bdb4a2e1da809e10e6899b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "73b82a2e-4870-4e40-9b37-617ad8839961",
+        "apim-request-id": "83e46875-e75b-409f-bc5a-4ac82008b6ae",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "86d88eeb-9ea9-4d89-8596-00fc6e31edf4",
-        "lastUpdateDateTime": "2021-09-23T14:45:46Z",
-        "createdDateTime": "2021-09-23T14:45:45Z",
-        "expirationDateTime": "2021-09-24T14:45:45Z",
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -200,34 +226,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/86d88eeb-9ea9-4d89-8596-00fc6e31edf4?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2496bf055a823aa508b9ca3c60081c2c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fb7d8093-808e-48c2-a376-c593f089c1fa",
+        "apim-request-id": "98632c81-7bd5-4332-9ab2-68e7b67c0a23",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "86d88eeb-9ea9-4d89-8596-00fc6e31edf4",
-        "lastUpdateDateTime": "2021-09-23T14:45:46Z",
-        "createdDateTime": "2021-09-23T14:45:45Z",
-        "expirationDateTime": "2021-09-24T14:45:45Z",
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -237,34 +268,543 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/86d88eeb-9ea9-4d89-8596-00fc6e31edf4?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4ef5e9e584469bb80f59054e94c367c4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "436395d0-4d77-4b40-a674-e1ad1490d0a3",
+        "apim-request-id": "fccedac9-a2dc-492e-a3ef-324fd9350502",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "81"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
       },
       "ResponseBody": {
-        "jobId": "86d88eeb-9ea9-4d89-8596-00fc6e31edf4",
-        "lastUpdateDateTime": "2021-09-23T14:45:50Z",
-        "createdDateTime": "2021-09-23T14:45:45Z",
-        "expirationDateTime": "2021-09-24T14:45:45Z",
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "415d4eb0033732a10bba72045a6554d9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0199ce01-e656-46f1-97a1-5924c10526d3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:43 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "27"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "26b854be3af0805407fb14295457a544",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d0f1c9fa-f2ed-4c3a-874d-00ce1c9011e0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "128c0651daaae1f548c2438c11b341a9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e3c4b321-36de-456e-84c0-06891fa4cbc4",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "408f2c04400a75d3f9dd3a3cef78ddb4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3da5beee-ef31-41fa-b141-9008a1e483c5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "53b32e1442d9e32e5fd7de2ef7c76e53",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c18a14cd-0521-4b90-9ea5-2fbb0d209da7",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:49 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "15"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "28246aba64c7103a321718cda0b8f2d0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3da81b1e-d5a6-4fe2-a196-b84591eb86a4",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e3788fe4ed00c2d0feace13362a57d31",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "96912f1a-3f39-4605-af94-c3b0ad39aa5a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:51 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "8481e76eb553afecf4a321c1296043a6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "08ad5201-860e-46e1-9f6f-4e3f3fe8e546",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "68490ee58b4fcc539a62291b8306ae8d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "97c1aab3-4e49-47e4-b928-7f5363519f52",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b85fe69a6d362f7ca2c8ef5ccc0f989d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b9fabfe1-2f09-47ca-a8f7-fd233fe249e2",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "534e3a68145be3e293b5eaf18bd12bed",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f8f066b2-0aac-4579-8748-e0bc156ce052",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:36Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/39ae5835-071f-45d7-a24c-a536f200a4f3?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "422793f58a01776f911ac6879bf6008a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "98a8ffbd-31c6-40fa-ae7b-ff1e610fcdeb",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:15:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "73"
+      },
+      "ResponseBody": {
+        "jobId": "39ae5835-071f-45d7-a24c-a536f200a4f3",
+        "lastUpdateDateTime": "2021-10-25T21:15:57Z",
+        "createdDateTime": "2021-10-25T21:15:36Z",
+        "expirationDateTime": "2021-10-26T21:15:36Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -272,7 +812,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:50.5796424Z",
+              "lastUpdateDateTime": "2021-10-25T21:15:57.7469525Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -375,6 +915,6 @@
   "Variables": {
     "RandomSeed": "1814199441",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchConvenienceWithStatisticsTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10906",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4cf518e783b64e4f9fd0debc11ab3390-3267a9c7a76d3640-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-fb02bd9296e2044e9d5a7c1c324b5a9f-c8d04140e7de564b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "fe1d7a1a6f9ae5a039fc8ef54aff182a",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "10437255-6acf-4ca1-9f79-d66cff5d6b00",
-        "Date": "Thu, 23 Sep 2021 14:46:17 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/56bc8b5f-329c-4326-8d1c-82f0f48935ea",
+        "apim-request-id": "0e9c3c2d-086b-4461-9aff-22d81569b27a",
+        "Date": "Mon, 25 Oct 2021 21:17:24 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "205"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "203"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/56bc8b5f-329c-4326-8d1c-82f0f48935ea?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "08ea3b4ae4e0a673ea7be2927bc61d1b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "76e1ee88-723b-48a5-ba6f-38cdb348c6ff",
+        "apim-request-id": "4b7c8b98-f143-4b3c-a433-0e9c3c7ac506",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
-        "jobId": "56bc8b5f-329c-4326-8d1c-82f0f48935ea",
-        "lastUpdateDateTime": "2021-09-23T14:46:18Z",
-        "createdDateTime": "2021-09-23T14:46:18Z",
-        "expirationDateTime": "2021-09-24T14:46:18Z",
-        "status": "notStarted",
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/56bc8b5f-329c-4326-8d1c-82f0f48935ea?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e3d7c4e5354315e1886b2f32a319b90e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "332ea65e-5f57-441c-bd67-de3778688967",
+        "apim-request-id": "9d32019a-3bf2-4bc7-bb9b-119cc7c8962e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:19 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "20"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "56bc8b5f-329c-4326-8d1c-82f0f48935ea",
-        "lastUpdateDateTime": "2021-09-23T14:46:18Z",
-        "createdDateTime": "2021-09-23T14:46:18Z",
-        "expirationDateTime": "2021-09-24T14:46:18Z",
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,34 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/56bc8b5f-329c-4326-8d1c-82f0f48935ea?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "393298643a6736400676141e8d0d6973",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8bfd1132-0eb0-4c70-9b4b-941d37f8df75",
+        "apim-request-id": "f4709e75-3453-473f-be38-4dee95d1f606",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "56bc8b5f-329c-4326-8d1c-82f0f48935ea",
-        "lastUpdateDateTime": "2021-09-23T14:46:18Z",
-        "createdDateTime": "2021-09-23T14:46:18Z",
-        "expirationDateTime": "2021-09-24T14:46:18Z",
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -163,34 +184,375 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/56bc8b5f-329c-4326-8d1c-82f0f48935ea?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "851072de352815e659d57f74b44003d0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2147f473-617e-4920-a38b-3cfba94c4d4d",
+        "apim-request-id": "5dfe7254-f7a3-43e1-8e42-20ce1977a8c1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "78"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "56bc8b5f-329c-4326-8d1c-82f0f48935ea",
-        "lastUpdateDateTime": "2021-09-23T14:46:21Z",
-        "createdDateTime": "2021-09-23T14:46:18Z",
-        "expirationDateTime": "2021-09-24T14:46:18Z",
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e32ed3c2e494abb483a1dccc21c3887a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1defd636-3415-4c8b-943c-1b88ff7730a3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "120"
+      },
+      "ResponseBody": {
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3154bc0233092fe6b11ddf91bacb81c5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fbd61e68-6689-49de-a00b-9da32059f395",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
+      },
+      "ResponseBody": {
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b95b437385defadfbe6401875819f396",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6f5e9d02-6635-448e-849a-b1d14775c4c4",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f872044cd2ec8fc6ecff32760422f0b8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a90f26f0-499c-4cce-982a-794c370e9230",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "de58161fce687c9bdd5a72a4315fd697",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8473e030-64ae-4897-8d5d-4b62a628ee5d",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:34 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b545492a8859a1d97ccbcddf5368f69c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b199ee7f-9910-43b3-b562-f673af88ac43",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4167497414c17d2d68f51b915f215e8c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "18a84e05-e5ff-4977-9d3c-e931e41099d6",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:24Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/641c1f99-93c1-43e5-bccc-088315ab0d90?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ba4c9a283add965e3cb7619c01bc2874",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e65e4062-2c31-4976-8b49-feb219e79c06",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "777"
+      },
+      "ResponseBody": {
+        "jobId": "641c1f99-93c1-43e5-bccc-088315ab0d90",
+        "lastUpdateDateTime": "2021-10-25T21:17:38Z",
+        "createdDateTime": "2021-10-25T21:17:24Z",
+        "expirationDateTime": "2021-10-26T21:17:24Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -198,7 +560,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:21.332996Z",
+              "lastUpdateDateTime": "2021-10-25T21:17:38.4433717Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -301,6 +663,6 @@
   "Variables": {
     "RandomSeed": "395657227",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10906",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0dcc5ae44c4973419f6f35e5913727f2-985b9a70b059684d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8407c3a78e2973489bd89789b1003efb-e0628f21d159fd4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f3d9198f505e19b3a58d50518164f79d",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "54f183f1-e411-432a-acde-01261b76ee4b",
-        "Date": "Thu, 23 Sep 2021 14:45:51 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/29c828df-cdf5-4473-926b-abddb5e17a82",
+        "apim-request-id": "797d02ac-047b-4d48-85a1-0ebc5578cc57",
+        "Date": "Mon, 25 Oct 2021 21:15:59 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "204"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "405"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/29c828df-cdf5-4473-926b-abddb5e17a82",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cd73043ed1a6b229132eee9711f3380a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93cc9e1b-6a1e-49ca-a9f5-8628b511b62b",
+        "apim-request-id": "1e94a080-57ab-48b3-8201-32e90bac4e41",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:15:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "38"
       },
       "ResponseBody": {
-        "jobId": "29c828df-cdf5-4473-926b-abddb5e17a82",
-        "lastUpdateDateTime": "2021-09-23T14:45:52Z",
-        "createdDateTime": "2021-09-23T14:45:52Z",
-        "expirationDateTime": "2021-09-24T14:45:52Z",
-        "status": "notStarted",
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/29c828df-cdf5-4473-926b-abddb5e17a82",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5986c0a842081108e68e6679d439d993",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7bbbb2d3-2375-406f-b2d5-733592964a01",
+        "apim-request-id": "285c6a00-f2ef-42cf-bea8-ebd9a95cd2d4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "29c828df-cdf5-4473-926b-abddb5e17a82",
-        "lastUpdateDateTime": "2021-09-23T14:45:52Z",
-        "createdDateTime": "2021-09-23T14:45:52Z",
-        "expirationDateTime": "2021-09-24T14:45:52Z",
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,34 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/29c828df-cdf5-4473-926b-abddb5e17a82",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2e009dff5c37bdf8f027df30611b08b1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0366ec55-f7f7-44d7-ab02-049f8eeacbab",
+        "apim-request-id": "78aa48c2-f333-42bc-a8cc-2607f0d00c85",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "29c828df-cdf5-4473-926b-abddb5e17a82",
-        "lastUpdateDateTime": "2021-09-23T14:45:52Z",
-        "createdDateTime": "2021-09-23T14:45:52Z",
-        "expirationDateTime": "2021-09-24T14:45:52Z",
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -163,34 +184,291 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/29c828df-cdf5-4473-926b-abddb5e17a82",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c1a846549dddfc94fb62e6176ab0ded9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4d42e6a9-2dc7-425c-8be6-d6cbe5ca3133",
+        "apim-request-id": "f1f76521-11e6-4553-8190-cc73040dbbfa",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:55 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "156"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "91"
       },
       "ResponseBody": {
-        "jobId": "29c828df-cdf5-4473-926b-abddb5e17a82",
-        "lastUpdateDateTime": "2021-09-23T14:45:55Z",
-        "createdDateTime": "2021-09-23T14:45:52Z",
-        "expirationDateTime": "2021-09-24T14:45:52Z",
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "74985b540af34cd2c8c869e162d7afcb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1b376e0b-6cdb-4d18-9079-923d502710b2",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "183"
+      },
+      "ResponseBody": {
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "8d24b586189061b5080432d575e0533f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e47c1992-623b-4557-9e2d-5fbad8cd5c93",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "05db064894834abd735cf81534b39a23",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "04f341c5-7b1b-4215-a8b4-1e6266e887a1",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b5911bb2508b3c48a5376befd7fcd6e8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a965c24b-83d1-4e5a-87c9-2376a12c8a9e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "5c982975a9fcf147f7da193420a02c54",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9340bb6e-18eb-47f5-8b56-24fd635b9247",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:15:59Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2c7abb9e-3df4-45bf-8710-138181e46b42",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "59230e6a9e4ef8b4bd9f5f4b28ce7276",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c500deb9-cd03-4108-88ea-1763c4f8b423",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "405"
+      },
+      "ResponseBody": {
+        "jobId": "2c7abb9e-3df4-45bf-8710-138181e46b42",
+        "lastUpdateDateTime": "2021-10-25T21:16:11Z",
+        "createdDateTime": "2021-10-25T21:15:59Z",
+        "expirationDateTime": "2021-10-26T21:15:59Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -198,7 +476,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:55.0085048Z",
+              "lastUpdateDateTime": "2021-10-25T21:16:11.1418636Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -287,6 +565,6 @@
   "Variables": {
     "RandomSeed": "1847785475",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10906",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3e16d64642209948a7026c76fb1edf2a-3d88b17aa1d05245-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-79f5ff421b04e44f9ce59bc577d09b97-164aa2cf85530d4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e34ebf5d11d240721fd15b42fd686423",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "bd9bfac2-2326-402b-b52c-94c38302b32b",
-        "Date": "Thu, 23 Sep 2021 14:46:21 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/02580e0d-fa33-47fa-880d-09c855ab1076",
+        "apim-request-id": "2c8bdba2-19e0-4e3b-81b4-1462e3233fe3",
+        "Date": "Mon, 25 Oct 2021 21:17:40 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ce1b1f3f-1f00-4032-8933-b286fadf0aac",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "210"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "168"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/02580e0d-fa33-47fa-880d-09c855ab1076",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ce1b1f3f-1f00-4032-8933-b286fadf0aac",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bc4928ee7d2e5170fdded73aa0582bcf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d4b78b06-8ae5-49cf-962c-6289a1079d96",
+        "apim-request-id": "4146867e-4a87-49e4-88a7-f4a320b7b548",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "02580e0d-fa33-47fa-880d-09c855ab1076",
-        "lastUpdateDateTime": "2021-09-23T14:46:22Z",
-        "createdDateTime": "2021-09-23T14:46:22Z",
-        "expirationDateTime": "2021-09-24T14:46:22Z",
-        "status": "notStarted",
+        "jobId": "ce1b1f3f-1f00-4032-8933-b286fadf0aac",
+        "lastUpdateDateTime": "2021-10-25T21:17:40Z",
+        "createdDateTime": "2021-10-25T21:17:40Z",
+        "expirationDateTime": "2021-10-26T21:17:40Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/02580e0d-fa33-47fa-880d-09c855ab1076",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ce1b1f3f-1f00-4032-8933-b286fadf0aac",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a74afc252d89954d7c18363abc11fb78",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "66a7819b-7b40-4e49-adc5-990fc5a4ee49",
+        "apim-request-id": "dc51b033-f5fb-4140-9f2d-17feea307de7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:23 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "02580e0d-fa33-47fa-880d-09c855ab1076",
-        "lastUpdateDateTime": "2021-09-23T14:46:22Z",
-        "createdDateTime": "2021-09-23T14:46:22Z",
-        "expirationDateTime": "2021-09-24T14:46:22Z",
+        "jobId": "ce1b1f3f-1f00-4032-8933-b286fadf0aac",
+        "lastUpdateDateTime": "2021-10-25T21:17:40Z",
+        "createdDateTime": "2021-10-25T21:17:40Z",
+        "expirationDateTime": "2021-10-26T21:17:40Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,145 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/02580e0d-fa33-47fa-880d-09c855ab1076",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ce1b1f3f-1f00-4032-8933-b286fadf0aac",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a8c5f98b2521df804ffce6f43937a0c7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "06da155f-1302-49d6-a1ff-1f31aa9bc7f5",
+        "apim-request-id": "01054c79-4620-4afe-bbac-0c1eb8db72a6",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:24 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "67"
       },
       "ResponseBody": {
-        "jobId": "02580e0d-fa33-47fa-880d-09c855ab1076",
-        "lastUpdateDateTime": "2021-09-23T14:46:22Z",
-        "createdDateTime": "2021-09-23T14:46:22Z",
-        "expirationDateTime": "2021-09-24T14:46:22Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/02580e0d-fa33-47fa-880d-09c855ab1076",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "011d8ba5bc1dc099dab34016473695ec",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c0db38a5-67d5-4cd5-91b3-1aa41112cec3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:25 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "02580e0d-fa33-47fa-880d-09c855ab1076",
-        "lastUpdateDateTime": "2021-09-23T14:46:22Z",
-        "createdDateTime": "2021-09-23T14:46:22Z",
-        "expirationDateTime": "2021-09-24T14:46:22Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/02580e0d-fa33-47fa-880d-09c855ab1076",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a7ae5fe28392ffae7c6b578d47595c44",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6cd88499-2e3f-4150-b028-c5234f25a2da",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:26 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "02580e0d-fa33-47fa-880d-09c855ab1076",
-        "lastUpdateDateTime": "2021-09-23T14:46:22Z",
-        "createdDateTime": "2021-09-23T14:46:22Z",
-        "expirationDateTime": "2021-09-24T14:46:22Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/02580e0d-fa33-47fa-880d-09c855ab1076",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "30946e78faf4ce5a5f05cd6de5699719",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c03644fe-d707-463f-9018-c7700a5bf236",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:27 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "130"
-      },
-      "ResponseBody": {
-        "jobId": "02580e0d-fa33-47fa-880d-09c855ab1076",
-        "lastUpdateDateTime": "2021-09-23T14:46:26Z",
-        "createdDateTime": "2021-09-23T14:46:22Z",
-        "expirationDateTime": "2021-09-24T14:46:22Z",
+        "jobId": "ce1b1f3f-1f00-4032-8933-b286fadf0aac",
+        "lastUpdateDateTime": "2021-10-25T21:17:43Z",
+        "createdDateTime": "2021-10-25T21:17:40Z",
+        "expirationDateTime": "2021-10-26T21:17:40Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -272,7 +182,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:26.992557Z",
+              "lastUpdateDateTime": "2021-10-25T21:17:43.389166Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -361,6 +271,6 @@
   "Variables": {
     "RandomSeed": "2045006083",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithErrorTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "249",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c58cb04be5d62f4787918367deb9261a-34a81786cbd49c4d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1987e3a714b59c4f9df0aa747cd70bd8-3cfacef505ea1a47-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1a3c29a29ced609c29f6672dabe3c3d2",
         "x-ms-return-client-request-id": "true"
       },
@@ -40,45 +46,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "009f7767-aab3-400f-83d9-756846488b3e",
-        "Date": "Thu, 23 Sep 2021 14:45:55 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
+        "apim-request-id": "cd119c40-39e8-46a4-8426-4cff10c4f42a",
+        "Date": "Mon, 25 Oct 2021 21:16:12 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "202"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "194"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "78b7ab75536d10b830407bacb9b59147",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eb14f3b4-9621-4d66-a344-b383f607d2d3",
+        "apim-request-id": "a4e9ac5d-4181-4a13-a332-251a914ea65b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:55 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
-        "lastUpdateDateTime": "2021-09-23T14:45:56Z",
-        "createdDateTime": "2021-09-23T14:45:56Z",
-        "expirationDateTime": "2021-09-24T14:45:56Z",
-        "status": "notStarted",
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -88,34 +99,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e8b1923c2c75eff83be1622cf51099fa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e8e9da20-6ca0-44c3-8177-a59fefaef712",
+        "apim-request-id": "a61c3a27-8b06-4e2a-a2c6-37cb333794be",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "28"
       },
       "ResponseBody": {
-        "jobId": "fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
-        "lastUpdateDateTime": "2021-09-23T14:45:56Z",
-        "createdDateTime": "2021-09-23T14:45:56Z",
-        "expirationDateTime": "2021-09-24T14:45:56Z",
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -125,34 +141,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "16ae28d521634f29712beaac21efa674",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "03106759-18e1-48e2-b060-791da740fa4d",
+        "apim-request-id": "0eae7ff5-b3fc-4ea0-b43a-7b1104885a5a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
-        "lastUpdateDateTime": "2021-09-23T14:45:56Z",
-        "createdDateTime": "2021-09-23T14:45:56Z",
-        "expirationDateTime": "2021-09-24T14:45:56Z",
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -162,34 +183,459 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "18f11f64db32495db2c73d8cf18b1b20",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "00812a76-fa36-4bae-882f-5a67a26de783",
+        "apim-request-id": "f45939ce-cc73-477d-92f3-bff52d0e133e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "80"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "fc3db6d6-bd16-484b-bd96-4e8a8da52ccc",
-        "lastUpdateDateTime": "2021-09-23T14:45:59Z",
-        "createdDateTime": "2021-09-23T14:45:56Z",
-        "expirationDateTime": "2021-09-24T14:45:56Z",
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "91d681a77a061be468627649414cce4b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ee0d2afc-3e98-4ba7-8132-a98d45108086",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d5c7ed3b801efac7ca65649be49d5de5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d7ad20c1-282f-455d-b854-93bcba6d397b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a004ca0f1419ea6d3ad6afcf64130765",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c6881c5e-3a9c-414c-b167-1edd454c01f6",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0451f2f946c42701b9dcc6a1164937cb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1b3f82ac-74e0-405b-a326-f888ced79411",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "773a91052e47263180dd9a47d0f896b7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b09681f1-4d06-41ab-8489-b3d5be882eb2",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f1a1fe5d594bc921c8dde73d4dccd3f1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "80d7412d-c509-4617-bde3-e83d15295d3e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "197"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d2cae49f8fd8cb1ec02b83e6abba56c1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d6dc684b-de05-4254-ae77-3f38a5485be1",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "18430f4545a7ab7f7071af6a47f4d8b4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c398afad-62c7-4d55-b58d-9098f952fed3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:26 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "eca8a90ac32dcddee0d63120d53a1e0e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "efd1922d-c08a-4ca6-9d72-f13c81da9f2c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:12Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64d851e5-e40f-44a0-86a0-20c823bd51a6",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3ef72587ba885a49641e6267e0b383cb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a44a87d3-0de7-4721-ae47-a844dac78b70",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:16:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "68"
+      },
+      "ResponseBody": {
+        "jobId": "64d851e5-e40f-44a0-86a0-20c823bd51a6",
+        "lastUpdateDateTime": "2021-10-25T21:16:29Z",
+        "createdDateTime": "2021-10-25T21:16:12Z",
+        "expirationDateTime": "2021-10-26T21:16:12Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -197,7 +643,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:45:59.0865337Z",
+              "lastUpdateDateTime": "2021-10-25T21:16:29.2159986Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -238,6 +684,6 @@
   "Variables": {
     "RandomSeed": "596565522",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithErrorTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "249",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e93017284f62fc4e842874880016c6c0-0aecbcd05b8d2a47-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-fbb63113b378ba4b83e994089875e3e5-377e50efa1220440-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "13ce9a1e1dbf3bc912cb12afa6ed6bdc",
         "x-ms-return-client-request-id": "true"
       },
@@ -40,45 +46,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "fac90d80-aff3-4a9a-a277-d4e9a04b6894",
-        "Date": "Thu, 23 Sep 2021 14:46:27 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/73ad1a9a-58d0-4284-9bae-889a40063a5c",
+        "apim-request-id": "bc252ae5-94eb-4ae7-a8a7-b7de81d25a18",
+        "Date": "Mon, 25 Oct 2021 21:17:44 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "206"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "203"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/73ad1a9a-58d0-4284-9bae-889a40063a5c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "194e3733083110b913cefce8b3894ee9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "71dd58e2-fb5c-4173-bd50-d330c74eb980",
+        "apim-request-id": "f32308de-cf60-4ec3-a2fa-bb7f067cc11a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "73ad1a9a-58d0-4284-9bae-889a40063a5c",
-        "lastUpdateDateTime": "2021-09-23T14:46:28Z",
-        "createdDateTime": "2021-09-23T14:46:28Z",
-        "expirationDateTime": "2021-09-24T14:46:28Z",
-        "status": "notStarted",
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -88,34 +99,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/73ad1a9a-58d0-4284-9bae-889a40063a5c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ba4029d3276320bcae0641b48daf3add",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "58a3993a-7c0f-4bfc-aa37-0ffc3dc7d8bb",
+        "apim-request-id": "57b9ee8a-9c3b-4a26-945e-8c8dad7901e7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "73ad1a9a-58d0-4284-9bae-889a40063a5c",
-        "lastUpdateDateTime": "2021-09-23T14:46:28Z",
-        "createdDateTime": "2021-09-23T14:46:28Z",
-        "expirationDateTime": "2021-09-24T14:46:28Z",
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -125,34 +141,543 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/73ad1a9a-58d0-4284-9bae-889a40063a5c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9f048b69d6a816ade0be00f020e08888",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1d744f07-bbeb-4f86-88e9-802272aebb2e",
+        "apim-request-id": "ebc56c66-aeb7-4061-9537-40eb3163d7e4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:30 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "73ad1a9a-58d0-4284-9bae-889a40063a5c",
-        "lastUpdateDateTime": "2021-09-23T14:46:30Z",
-        "createdDateTime": "2021-09-23T14:46:28Z",
-        "expirationDateTime": "2021-09-24T14:46:28Z",
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7cdc297cb1ac0b787b2d6a2ac6048364",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1caf343c-a6a9-4d54-bbc9-ff661a9d5e80",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "277f1e94ae84fd407c2ad9a527ccffcd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "83e83740-d8e1-4d83-9368-a935a183892d",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "40"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "6338b97ebdd3b83113f8247a6b824fdc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "855c57ed-abb9-405f-9511-503b78fd5b97",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:51 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "29"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "025c9b3b6061ce04e8de0082d7d2e4af",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4549dfa0-4e25-434d-89b8-ff00e6cf09fe",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0dac9c2e1fccd691edc6148c89c692fa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "438aca0e-b06b-4bc0-89db-8b3e54534b4f",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "8b6afddbfd6f1d6cb4697bf4bcaee140",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2f692f62-f81f-4bab-960c-6a3d095b8d01",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ce4c751441d61b100a85149b4c774521",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ba232881-5479-422d-b30e-594b578ac785",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "daa7064c5868313f308e5862a49c1a3e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "390288b5-f0ef-4199-b095-037fd2e6af9c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "1378d3e4c37a9924ec4e80eae8d0d13d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4b498ea0-d6de-4474-b736-e91a34e8a18e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:18:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b6a759240707bbd7361a9d47e9ad776d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "326e54ed-0c2e-40f1-99e4-95352fd471e0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:18:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:17:45Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "78b6d66b31ff89a7e20ded19d754485f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "80bd8162-0c98-46b9-94cd-365e23779330",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:18:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:18:02Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4ec1de31-4252-49b3-8e61-f332ff131910",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4a3e1bbd63f5dd36fcbcdd5f25dcb03f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fa94f1fc-bb6d-42f5-9a99-67a4304c129d",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:18:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4950"
+      },
+      "ResponseBody": {
+        "jobId": "4ec1de31-4252-49b3-8e61-f332ff131910",
+        "lastUpdateDateTime": "2021-10-25T21:18:03Z",
+        "createdDateTime": "2021-10-25T21:17:45Z",
+        "expirationDateTime": "2021-10-26T21:17:45Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -160,7 +685,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:30.2859851Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:03.6060747Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -201,6 +726,6 @@
   "Variables": {
     "RandomSeed": "1798314847",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithRankOrderTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithRankOrderTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10922",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-de767c7deeaad14ca8bb75275386a99b-265f3a2575b66249-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e54b86d8bb7af14d8edf4ece301f6474-3ec2a8f2e599c54b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b55900c4efc4ca60da44cc16b7f84b9b",
         "x-ms-return-client-request-id": "true"
       },
@@ -42,45 +48,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "edfd26ec-6955-4a03-a41d-e959a755c886",
-        "Date": "Thu, 23 Sep 2021 14:45:59 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
+        "apim-request-id": "3c582efe-891b-4864-9498-3946b10dbf13",
+        "Date": "Mon, 25 Oct 2021 21:16:30 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ae28a7b2-43a5-4a84-bb4c-425b60a87085",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "260"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "221"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ae28a7b2-43a5-4a84-bb4c-425b60a87085",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5387e54aaf8e0fc156b6266f9825a838",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b8285c7a-1c6c-416c-9f53-06af99f93870",
+        "apim-request-id": "1cc9e542-89b5-40b7-adef-7e66172e720d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:45:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "70"
       },
       "ResponseBody": {
-        "jobId": "c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
-        "lastUpdateDateTime": "2021-09-23T14:46:00Z",
-        "createdDateTime": "2021-09-23T14:45:59Z",
-        "expirationDateTime": "2021-09-24T14:45:59Z",
-        "status": "notStarted",
+        "jobId": "ae28a7b2-43a5-4a84-bb4c-425b60a87085",
+        "lastUpdateDateTime": "2021-10-25T21:16:30Z",
+        "createdDateTime": "2021-10-25T21:16:30Z",
+        "expirationDateTime": "2021-10-26T21:16:30Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -90,34 +101,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ae28a7b2-43a5-4a84-bb4c-425b60a87085",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "87636c7d805386db16c96f5b8936f94b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9174b6c5-256a-4c17-aa40-7f4accce4257",
+        "apim-request-id": "edcef233-9033-4820-9b7f-3c4c12a8de25",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
-        "lastUpdateDateTime": "2021-09-23T14:46:00Z",
-        "createdDateTime": "2021-09-23T14:45:59Z",
-        "expirationDateTime": "2021-09-24T14:45:59Z",
+        "jobId": "ae28a7b2-43a5-4a84-bb4c-425b60a87085",
+        "lastUpdateDateTime": "2021-10-25T21:16:30Z",
+        "createdDateTime": "2021-10-25T21:16:30Z",
+        "expirationDateTime": "2021-10-26T21:16:30Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -127,71 +143,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ae28a7b2-43a5-4a84-bb4c-425b60a87085",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "18b1a8fc52ab14db3e495f0dc9f031b4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "820a25f2-72b2-44db-88c3-34777c6353eb",
+        "apim-request-id": "a27fa0a4-56cd-4698-b560-9ebc64446343",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "189"
       },
       "ResponseBody": {
-        "jobId": "c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
-        "lastUpdateDateTime": "2021-09-23T14:46:00Z",
-        "createdDateTime": "2021-09-23T14:45:59Z",
-        "expirationDateTime": "2021-09-24T14:45:59Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4a99949cc394ca4709013cc44065861f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1aab1a97-f0e9-4b5e-ba4b-2a5ab82e0bb5",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:03 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "73"
-      },
-      "ResponseBody": {
-        "jobId": "c5fee1ee-e43d-4f12-818e-07d0f5bce5d7",
-        "lastUpdateDateTime": "2021-09-23T14:46:03Z",
-        "createdDateTime": "2021-09-23T14:45:59Z",
-        "expirationDateTime": "2021-09-24T14:45:59Z",
+        "jobId": "ae28a7b2-43a5-4a84-bb4c-425b60a87085",
+        "lastUpdateDateTime": "2021-10-25T21:16:32Z",
+        "createdDateTime": "2021-10-25T21:16:30Z",
+        "expirationDateTime": "2021-10-26T21:16:30Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -199,7 +183,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:03.1283478Z",
+              "lastUpdateDateTime": "2021-10-25T21:16:32.9861304Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -288,6 +272,6 @@
   "Variables": {
     "RandomSeed": "2008210683",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithRankOrderTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithRankOrderTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10922",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c1bd12f3749647438ba4e34fa59156ba-ea011be74d145444-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-452e24e319a92d48917577afd44b9ce4-4d4d1ed9088a874c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0293a97699f5d2ec1fba7df50d61fb6e",
         "x-ms-return-client-request-id": "true"
       },
@@ -42,45 +48,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "46f3088c-48ec-4354-9b42-4fc6108285c0",
-        "Date": "Thu, 23 Sep 2021 14:46:30 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/633f6375-5a91-4cae-b9b3-e0fca9d30c65",
+        "apim-request-id": "e9523592-7236-4c13-9a4c-547103a530ed",
+        "Date": "Mon, 25 Oct 2021 21:18:09 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "182"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "289"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/633f6375-5a91-4cae-b9b3-e0fca9d30c65",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ec215ddf4e4925438ec46a95dc1da62a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a318c615-5c61-4898-a621-e41d262e385d",
+        "apim-request-id": "424a43bb-26b4-4966-b4a6-262fd8e08b15",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:30 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "633f6375-5a91-4cae-b9b3-e0fca9d30c65",
-        "lastUpdateDateTime": "2021-09-23T14:46:31Z",
-        "createdDateTime": "2021-09-23T14:46:30Z",
-        "expirationDateTime": "2021-09-24T14:46:30Z",
-        "status": "notStarted",
+        "jobId": "ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
+        "lastUpdateDateTime": "2021-10-25T21:18:10Z",
+        "createdDateTime": "2021-10-25T21:18:10Z",
+        "expirationDateTime": "2021-10-26T21:18:10Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -90,34 +101,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/633f6375-5a91-4cae-b9b3-e0fca9d30c65",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0765e58eea10dffee922566b5cd6200b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff884452-2b6d-41a0-924b-f639b30eea5d",
+        "apim-request-id": "4b979428-2afe-4b4d-b456-39be2768efeb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:31 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "633f6375-5a91-4cae-b9b3-e0fca9d30c65",
-        "lastUpdateDateTime": "2021-09-23T14:46:31Z",
-        "createdDateTime": "2021-09-23T14:46:30Z",
-        "expirationDateTime": "2021-09-24T14:46:30Z",
+        "jobId": "ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
+        "lastUpdateDateTime": "2021-10-25T21:18:10Z",
+        "createdDateTime": "2021-10-25T21:18:10Z",
+        "expirationDateTime": "2021-10-26T21:18:10Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -127,34 +143,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/633f6375-5a91-4cae-b9b3-e0fca9d30c65",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d5e1841f7b5d2880666d74312f57f601",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fccec737-be5e-488b-9daa-a8eee1503628",
+        "apim-request-id": "b5768f0b-2bc9-47b7-afea-1c34d58a1a70",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
       },
       "ResponseBody": {
-        "jobId": "633f6375-5a91-4cae-b9b3-e0fca9d30c65",
-        "lastUpdateDateTime": "2021-09-23T14:46:31Z",
-        "createdDateTime": "2021-09-23T14:46:30Z",
-        "expirationDateTime": "2021-09-24T14:46:30Z",
+        "jobId": "ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
+        "lastUpdateDateTime": "2021-10-25T21:18:13Z",
+        "createdDateTime": "2021-10-25T21:18:10Z",
+        "expirationDateTime": "2021-10-26T21:18:10Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -164,108 +185,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/633f6375-5a91-4cae-b9b3-e0fca9d30c65",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "27665314f3fbf55e5e410326f8d7c9b7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4ff4d081-7465-4436-9a88-eb52642c7bb4",
+        "apim-request-id": "5242ca9a-9548-4394-898c-705eb4533e2c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "236"
       },
       "ResponseBody": {
-        "jobId": "633f6375-5a91-4cae-b9b3-e0fca9d30c65",
-        "lastUpdateDateTime": "2021-09-23T14:46:31Z",
-        "createdDateTime": "2021-09-23T14:46:30Z",
-        "expirationDateTime": "2021-09-24T14:46:30Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/633f6375-5a91-4cae-b9b3-e0fca9d30c65",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "58755fa3d03c13cd653da1a275cdb092",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b310b344-a56f-4051-bb2c-f2452da64010",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:35 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "633f6375-5a91-4cae-b9b3-e0fca9d30c65",
-        "lastUpdateDateTime": "2021-09-23T14:46:31Z",
-        "createdDateTime": "2021-09-23T14:46:30Z",
-        "expirationDateTime": "2021-09-24T14:46:30Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/633f6375-5a91-4cae-b9b3-e0fca9d30c65",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0956542cf96f2b0f25eb761b7859308e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "fc77e943-51c9-4922-89b8-ea3967ad4d88",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:36 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
-      },
-      "ResponseBody": {
-        "jobId": "633f6375-5a91-4cae-b9b3-e0fca9d30c65",
-        "lastUpdateDateTime": "2021-09-23T14:46:36Z",
-        "createdDateTime": "2021-09-23T14:46:30Z",
-        "expirationDateTime": "2021-09-24T14:46:30Z",
+        "jobId": "ddcd0eaa-c0f0-4186-abdf-c72705d6a535",
+        "lastUpdateDateTime": "2021-10-25T21:18:13Z",
+        "createdDateTime": "2021-10-25T21:18:10Z",
+        "expirationDateTime": "2021-10-26T21:18:10Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -273,7 +225,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:36.0950256Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:13.4208595Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -362,6 +314,6 @@
   "Variables": {
     "RandomSeed": "1656487347",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithStatisticsTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10906",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-242fc763400abb4fbed6334e71734b13-6266d1fba2c6c242-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5bbeb010afa1d04791cab464b7bd4f34-1cbba521dedccf44-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b5b7af78030e9fd13422000420f3bfb1",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "aac4a44a-7c5c-4518-b357-b7e1a11600d1",
-        "Date": "Thu, 23 Sep 2021 14:46:03 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f5db0950-1136-40a2-a98b-376b147c3d53",
+        "apim-request-id": "4eba2d83-95c2-4eb3-9e89-22e3c946b244",
+        "Date": "Mon, 25 Oct 2021 21:16:34 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7b9245c4-9022-41c2-b862-e5ca499ec931",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "176"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "172"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f5db0950-1136-40a2-a98b-376b147c3d53?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7b9245c4-9022-41c2-b862-e5ca499ec931?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "787f8a47014084dcb2054b10ebcfc38a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e98053f-47a1-4def-ac99-d825db8e9e11",
+        "apim-request-id": "f7ae1d35-0f25-4272-8b88-5bffebbbb214",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:03 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "f5db0950-1136-40a2-a98b-376b147c3d53",
-        "lastUpdateDateTime": "2021-09-23T14:46:04Z",
-        "createdDateTime": "2021-09-23T14:46:03Z",
-        "expirationDateTime": "2021-09-24T14:46:03Z",
-        "status": "notStarted",
+        "jobId": "7b9245c4-9022-41c2-b862-e5ca499ec931",
+        "lastUpdateDateTime": "2021-10-25T21:16:35Z",
+        "createdDateTime": "2021-10-25T21:16:34Z",
+        "expirationDateTime": "2021-10-26T21:16:34Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f5db0950-1136-40a2-a98b-376b147c3d53?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7b9245c4-9022-41c2-b862-e5ca499ec931?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1ec85caffbf95b7033e56eb80be0b66a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1434e5b5-c63a-425c-be57-572a570afd2c",
+        "apim-request-id": "3439f2ef-4715-4e9b-bdf7-fbd95e058b92",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:04 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
-        "jobId": "f5db0950-1136-40a2-a98b-376b147c3d53",
-        "lastUpdateDateTime": "2021-09-23T14:46:04Z",
-        "createdDateTime": "2021-09-23T14:46:03Z",
-        "expirationDateTime": "2021-09-24T14:46:03Z",
+        "jobId": "7b9245c4-9022-41c2-b862-e5ca499ec931",
+        "lastUpdateDateTime": "2021-10-25T21:16:35Z",
+        "createdDateTime": "2021-10-25T21:16:34Z",
+        "expirationDateTime": "2021-10-26T21:16:34Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,145 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f5db0950-1136-40a2-a98b-376b147c3d53?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7b9245c4-9022-41c2-b862-e5ca499ec931?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bdedae3200527712d3330308b7c1b464",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c52d111b-f40a-4ebc-ac55-0d76eb0ba279",
+        "apim-request-id": "0c4a9ecd-aad1-4f11-b7fa-d2f49dfae93e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "62"
       },
       "ResponseBody": {
-        "jobId": "f5db0950-1136-40a2-a98b-376b147c3d53",
-        "lastUpdateDateTime": "2021-09-23T14:46:04Z",
-        "createdDateTime": "2021-09-23T14:46:03Z",
-        "expirationDateTime": "2021-09-24T14:46:03Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f5db0950-1136-40a2-a98b-376b147c3d53?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c355765fa02b4bb81a23445a932478d2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e730e145-eafb-4e04-b823-416d77f2da59",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:07 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "f5db0950-1136-40a2-a98b-376b147c3d53",
-        "lastUpdateDateTime": "2021-09-23T14:46:04Z",
-        "createdDateTime": "2021-09-23T14:46:03Z",
-        "expirationDateTime": "2021-09-24T14:46:03Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f5db0950-1136-40a2-a98b-376b147c3d53?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3cdde14f05e2af374a504bc5f867a371",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9913b095-bf73-4790-843e-f86f2e3c38db",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:08 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "f5db0950-1136-40a2-a98b-376b147c3d53",
-        "lastUpdateDateTime": "2021-09-23T14:46:04Z",
-        "createdDateTime": "2021-09-23T14:46:03Z",
-        "expirationDateTime": "2021-09-24T14:46:03Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f5db0950-1136-40a2-a98b-376b147c3d53?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "95590931f28a923ff6a1a32fbbb7e4ae",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "dba86eec-d7c6-4973-a720-e6feee4c8bcc",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:09 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "80"
-      },
-      "ResponseBody": {
-        "jobId": "f5db0950-1136-40a2-a98b-376b147c3d53",
-        "lastUpdateDateTime": "2021-09-23T14:46:08Z",
-        "createdDateTime": "2021-09-23T14:46:03Z",
-        "expirationDateTime": "2021-09-24T14:46:03Z",
+        "jobId": "7b9245c4-9022-41c2-b862-e5ca499ec931",
+        "lastUpdateDateTime": "2021-10-25T21:16:37Z",
+        "createdDateTime": "2021-10-25T21:16:34Z",
+        "expirationDateTime": "2021-10-26T21:16:34Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -272,7 +182,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:08.7889607Z",
+              "lastUpdateDateTime": "2021-10-25T21:16:37.7891941Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -375,6 +285,6 @@
   "Variables": {
     "RandomSeed": "1123779693",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryBatchWithStatisticsTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10906",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-eebe7049a0c36a4881f598de711df0bd-773aa6ba971d5744-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-df7a859003a58449bfbc2dd8a5b32650-3a0439d72ea3ce49-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f651d36160d378a599298ba19919e0a7",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b7a959f8-1abc-489a-9a6b-45ce3cf0a4d7",
-        "Date": "Thu, 23 Sep 2021 14:46:36 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d32329f-e1fe-4b11-a29c-a17191df2ba0",
+        "apim-request-id": "d6fecc37-d8c7-4ff1-91ca-e4311ec39333",
+        "Date": "Mon, 25 Oct 2021 21:18:15 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f0012c06-2c20-45af-9d38-b8b8dfb8135e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "231"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "213"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d32329f-e1fe-4b11-a29c-a17191df2ba0?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f0012c06-2c20-45af-9d38-b8b8dfb8135e?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e8f6931be6a336a1f65aba107d159126",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "44dc0550-1ad8-4914-8a04-4b0d0f86d9f6",
+        "apim-request-id": "0067d530-a21a-487a-8389-a44d159c9962",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "9d32329f-e1fe-4b11-a29c-a17191df2ba0",
-        "lastUpdateDateTime": "2021-09-23T14:46:37Z",
-        "createdDateTime": "2021-09-23T14:46:37Z",
-        "expirationDateTime": "2021-09-24T14:46:37Z",
-        "status": "notStarted",
+        "jobId": "f0012c06-2c20-45af-9d38-b8b8dfb8135e",
+        "lastUpdateDateTime": "2021-10-25T21:18:15Z",
+        "createdDateTime": "2021-10-25T21:18:15Z",
+        "expirationDateTime": "2021-10-26T21:18:15Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d32329f-e1fe-4b11-a29c-a17191df2ba0?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f0012c06-2c20-45af-9d38-b8b8dfb8135e?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d87d90c0b572211b8b6294c31d0071e9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0f2bb408-a1d6-41ea-97f6-f2ce580f12b9",
+        "apim-request-id": "935ad808-5bc0-4481-a07d-1d5553d72154",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:38 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "9d32329f-e1fe-4b11-a29c-a17191df2ba0",
-        "lastUpdateDateTime": "2021-09-23T14:46:37Z",
-        "createdDateTime": "2021-09-23T14:46:37Z",
-        "expirationDateTime": "2021-09-24T14:46:37Z",
+        "jobId": "f0012c06-2c20-45af-9d38-b8b8dfb8135e",
+        "lastUpdateDateTime": "2021-10-25T21:18:15Z",
+        "createdDateTime": "2021-10-25T21:18:15Z",
+        "expirationDateTime": "2021-10-26T21:18:15Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,145 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d32329f-e1fe-4b11-a29c-a17191df2ba0?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f0012c06-2c20-45af-9d38-b8b8dfb8135e?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4036edda14fe7ba6321bff78a594fb84",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c011b052-aff0-409f-b4c4-0ef55a96d70c",
+        "apim-request-id": "3112de65-6698-4d2c-9c47-934e59cec50a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "92"
       },
       "ResponseBody": {
-        "jobId": "9d32329f-e1fe-4b11-a29c-a17191df2ba0",
-        "lastUpdateDateTime": "2021-09-23T14:46:37Z",
-        "createdDateTime": "2021-09-23T14:46:37Z",
-        "expirationDateTime": "2021-09-24T14:46:37Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d32329f-e1fe-4b11-a29c-a17191df2ba0?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "09e06498089c653577d55c4051dd19f5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "16232f6d-0992-4923-8c94-f520f66b248b",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:40 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "9d32329f-e1fe-4b11-a29c-a17191df2ba0",
-        "lastUpdateDateTime": "2021-09-23T14:46:37Z",
-        "createdDateTime": "2021-09-23T14:46:37Z",
-        "expirationDateTime": "2021-09-24T14:46:37Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d32329f-e1fe-4b11-a29c-a17191df2ba0?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8f36d0e850deac28e902a556b5a27bf6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0fe5925c-734a-47fb-ba7e-c0da85415105",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:41 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "9d32329f-e1fe-4b11-a29c-a17191df2ba0",
-        "lastUpdateDateTime": "2021-09-23T14:46:37Z",
-        "createdDateTime": "2021-09-23T14:46:37Z",
-        "expirationDateTime": "2021-09-24T14:46:37Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d32329f-e1fe-4b11-a29c-a17191df2ba0?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b82a10676820d14db7d0c929b8652954",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4dd2840b-d23b-4c36-90e3-aff767dc3d90",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "98"
-      },
-      "ResponseBody": {
-        "jobId": "9d32329f-e1fe-4b11-a29c-a17191df2ba0",
-        "lastUpdateDateTime": "2021-09-23T14:46:42Z",
-        "createdDateTime": "2021-09-23T14:46:37Z",
-        "expirationDateTime": "2021-09-24T14:46:37Z",
+        "jobId": "f0012c06-2c20-45af-9d38-b8b8dfb8135e",
+        "lastUpdateDateTime": "2021-10-25T21:18:18Z",
+        "createdDateTime": "2021-10-25T21:18:15Z",
+        "expirationDateTime": "2021-10-26T21:18:15Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -272,7 +182,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:42.1562206Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:18.2654493Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -375,6 +285,6 @@
   "Variables": {
     "RandomSeed": "1098155344",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryWithDisableServiceLogs.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryWithDisableServiceLogs.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10909",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f08b8a3418e3324d8cc3e9253e041f7b-e54b0a05e7d59349-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ad78402d3a0f8f46881b874df246149c-c4f16f4f203eca44-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "461669e10726ac79776bfb5a88ea135b",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0652a455-732d-40e6-a6e8-af8af566adad",
-        "Date": "Thu, 23 Sep 2021 14:46:09 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
+        "apim-request-id": "550fbccf-9a1d-4ab9-8de6-c2484906c3b2",
+        "Date": "Mon, 25 Oct 2021 21:16:37 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7e2272fd-887d-4f06-82d2-bb998907a764",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "244"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "163"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7e2272fd-887d-4f06-82d2-bb998907a764",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ea1be2e22b92a641fbfc7fd0768103d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "52ee0438-dc90-4c8e-8e06-077d6664bb4e",
+        "apim-request-id": "68b92168-00a6-40ed-be3d-d3ba76561eac",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:09 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
-        "lastUpdateDateTime": "2021-09-23T14:46:10Z",
-        "createdDateTime": "2021-09-23T14:46:10Z",
-        "expirationDateTime": "2021-09-24T14:46:10Z",
-        "status": "notStarted",
+        "jobId": "7e2272fd-887d-4f06-82d2-bb998907a764",
+        "lastUpdateDateTime": "2021-10-25T21:16:38Z",
+        "createdDateTime": "2021-10-25T21:16:38Z",
+        "expirationDateTime": "2021-10-26T21:16:38Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7e2272fd-887d-4f06-82d2-bb998907a764",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d6423be8f24bc2a89baaa7c55a787219",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "58a2faad-873b-4414-b9c9-7db3bc7dbf2b",
+        "apim-request-id": "683bea96-54db-44ce-b01c-a4df62f78e3e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:11 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
       },
       "ResponseBody": {
-        "jobId": "47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
-        "lastUpdateDateTime": "2021-09-23T14:46:10Z",
-        "createdDateTime": "2021-09-23T14:46:10Z",
-        "expirationDateTime": "2021-09-24T14:46:10Z",
+        "jobId": "7e2272fd-887d-4f06-82d2-bb998907a764",
+        "lastUpdateDateTime": "2021-10-25T21:16:38Z",
+        "createdDateTime": "2021-10-25T21:16:38Z",
+        "expirationDateTime": "2021-10-26T21:16:38Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,71 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7e2272fd-887d-4f06-82d2-bb998907a764",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7436f0e7c86eb5ce276f4a2988a836f5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ad2bd990-6806-4b9c-875a-ded7b9913355",
+        "apim-request-id": "ecc10bac-26fc-4fba-882c-9911a3109c72",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:12 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "80"
       },
       "ResponseBody": {
-        "jobId": "47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
-        "lastUpdateDateTime": "2021-09-23T14:46:10Z",
-        "createdDateTime": "2021-09-23T14:46:10Z",
-        "expirationDateTime": "2021-09-24T14:46:10Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4c7121673da8ef1039594fe8847b4c83",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4de0f734-b930-47d7-b0b3-535cb58df5fc",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:13 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "72"
-      },
-      "ResponseBody": {
-        "jobId": "47ca515a-2ba2-4663-ad7a-a14ba3fc304e",
-        "lastUpdateDateTime": "2021-09-23T14:46:13Z",
-        "createdDateTime": "2021-09-23T14:46:10Z",
-        "expirationDateTime": "2021-09-24T14:46:10Z",
+        "jobId": "7e2272fd-887d-4f06-82d2-bb998907a764",
+        "lastUpdateDateTime": "2021-10-25T21:16:41Z",
+        "createdDateTime": "2021-10-25T21:16:38Z",
+        "expirationDateTime": "2021-10-26T21:16:38Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -198,7 +182,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:13.2585303Z",
+              "lastUpdateDateTime": "2021-10-25T21:16:41.3721813Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -263,6 +247,6 @@
   "Variables": {
     "RandomSeed": "2018294457",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryWithDisableServiceLogsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryWithDisableServiceLogsAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "10909",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6468c0de9750d54cbb2da31d20313f7e-b5b5d289a4f3cc46-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-caf63e4bfe925b409d728c07ba53e6d8-a71e40eab300af47-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2eb74242851ebe33c7bc432d1c2529bb",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a71684b6-efe6-4ff5-a66a-a8274a7aace8",
-        "Date": "Thu, 23 Sep 2021 14:46:43 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
+        "apim-request-id": "3cc987bc-2cf1-4bb9-b2f9-edcc72d42b70",
+        "Date": "Mon, 25 Oct 2021 21:18:19 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "190"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "206"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7c4e3fc7528ff50a8e682973177c2556",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5129b6c2-ca67-4281-adf4-2110f612d0d2",
+        "apim-request-id": "d99050cb-3521-4976-af16-1ce5e77aa4ac",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
-        "lastUpdateDateTime": "2021-09-23T14:46:43Z",
-        "createdDateTime": "2021-09-23T14:46:43Z",
-        "expirationDateTime": "2021-09-24T14:46:43Z",
-        "status": "notStarted",
+        "jobId": "0c797573-b6bc-45a8-a16e-af9336bbbd49",
+        "lastUpdateDateTime": "2021-10-25T21:18:19Z",
+        "createdDateTime": "2021-10-25T21:18:19Z",
+        "expirationDateTime": "2021-10-26T21:18:19Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4e195ca81f07b27925fb6d81488ce149",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a050796f-f9ed-4c4c-bb46-a3ca459a1355",
+        "apim-request-id": "d6a569f8-f735-4b47-8667-9fead0b2e19c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
-        "lastUpdateDateTime": "2021-09-23T14:46:43Z",
-        "createdDateTime": "2021-09-23T14:46:43Z",
-        "expirationDateTime": "2021-09-24T14:46:43Z",
+        "jobId": "0c797573-b6bc-45a8-a16e-af9336bbbd49",
+        "lastUpdateDateTime": "2021-10-25T21:18:19Z",
+        "createdDateTime": "2021-10-25T21:18:19Z",
+        "expirationDateTime": "2021-10-26T21:18:19Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -126,34 +142,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "56258be4764df0f138c2a0b55cbfa64a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3e74e7fe-f563-43dc-8d72-1dc5d8074afd",
+        "apim-request-id": "67eced0f-4e99-486e-b7f6-ea973cae9e63",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:45 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
-        "lastUpdateDateTime": "2021-09-23T14:46:43Z",
-        "createdDateTime": "2021-09-23T14:46:43Z",
-        "expirationDateTime": "2021-09-24T14:46:43Z",
+        "jobId": "0c797573-b6bc-45a8-a16e-af9336bbbd49",
+        "lastUpdateDateTime": "2021-10-25T21:18:19Z",
+        "createdDateTime": "2021-10-25T21:18:19Z",
+        "expirationDateTime": "2021-10-26T21:18:19Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -163,34 +184,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c084ed96da0ca7b4c59c5694e488ad01",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7a4da148-9b47-4ae8-ba1f-657fd6b39b40",
+        "apim-request-id": "072c968c-55d1-4390-b1c1-8cbcb32570cc",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
-        "lastUpdateDateTime": "2021-09-23T14:46:43Z",
-        "createdDateTime": "2021-09-23T14:46:43Z",
-        "expirationDateTime": "2021-09-24T14:46:43Z",
+        "jobId": "0c797573-b6bc-45a8-a16e-af9336bbbd49",
+        "lastUpdateDateTime": "2021-10-25T21:18:19Z",
+        "createdDateTime": "2021-10-25T21:18:19Z",
+        "expirationDateTime": "2021-10-26T21:18:19Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -200,34 +226,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8b8fe087ce5731086a2816457fc35666",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2dbec1fe-63e4-4fef-bc26-7c001c45752d",
+        "apim-request-id": "5192eda6-1cf1-4096-8a13-c7760222b81d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
-        "lastUpdateDateTime": "2021-09-23T14:46:43Z",
-        "createdDateTime": "2021-09-23T14:46:43Z",
-        "expirationDateTime": "2021-09-24T14:46:43Z",
+        "jobId": "0c797573-b6bc-45a8-a16e-af9336bbbd49",
+        "lastUpdateDateTime": "2021-10-25T21:18:19Z",
+        "createdDateTime": "2021-10-25T21:18:19Z",
+        "expirationDateTime": "2021-10-26T21:18:19Z",
         "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -237,34 +268,123 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210923.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5beb235420080a3dd77d91b1205c0caf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "865b5722-b26d-46b1-a1e8-43f3a88426f9",
+        "apim-request-id": "cfc2693f-bb6a-4c64-8fa6-69ad17a50bb5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 23 Sep 2021 14:46:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "81"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "743b7466-70f4-4a3c-8dc9-6e2a7c5a3efd",
-        "lastUpdateDateTime": "2021-09-23T14:46:48Z",
-        "createdDateTime": "2021-09-23T14:46:43Z",
-        "expirationDateTime": "2021-09-24T14:46:43Z",
+        "jobId": "0c797573-b6bc-45a8-a16e-af9336bbbd49",
+        "lastUpdateDateTime": "2021-10-25T21:18:19Z",
+        "createdDateTime": "2021-10-25T21:18:19Z",
+        "expirationDateTime": "2021-10-26T21:18:19Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7c2e9e141a30c7f2e55355e3c46f2801",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2dff3fc5-b8cc-48f1-9a86-dba231963d31",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:18:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "0c797573-b6bc-45a8-a16e-af9336bbbd49",
+        "lastUpdateDateTime": "2021-10-25T21:18:19Z",
+        "createdDateTime": "2021-10-25T21:18:19Z",
+        "expirationDateTime": "2021-10-26T21:18:19Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0c797573-b6bc-45a8-a16e-af9336bbbd49",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c03ff045519d66f9a384b4d93d56110e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "09c9fd71-ea04-4b29-9201-7c0bb3b710f3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:18:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "174"
+      },
+      "ResponseBody": {
+        "jobId": "0c797573-b6bc-45a8-a16e-af9336bbbd49",
+        "lastUpdateDateTime": "2021-10-25T21:18:28Z",
+        "createdDateTime": "2021-10-25T21:18:19Z",
+        "expirationDateTime": "2021-10-26T21:18:19Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -272,7 +392,7 @@
           "total": 1,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-23T14:46:48.220201Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:28.6656969Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -337,6 +457,6 @@
   "Variables": {
     "RandomSeed": "738228031",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "11039",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-702354d21afb4d40b07a869475488b7d-896187420b2e294f-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-12843e4a9bc78844804a5484810f8413-535b0b7d6f92e74b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2e73b90435cce70b2e4922f1ab54c953",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,42 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0a400b8f-8317-4b89-8a50-3d7f1ebb852b",
-        "Date": "Wed, 20 Oct 2021 15:01:37 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+        "apim-request-id": "692fa813-349f-41ed-a59c-7ba84a2434b2",
+        "Date": "Mon, 25 Oct 2021 21:16:43 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "470"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1319"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4cd81395d120b81ebbcdb6ad5ac9adf7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f8c73564-876c-405e-a12a-d545a8430192",
+        "apim-request-id": "4c117f8b-29ba-49f5-ace5-0e431245232d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:37 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:43Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -95,31 +107,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "806a4f5736b1b5d26cf0ae80e569d85f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "07321b10-dfc0-4385-af82-ee24754bc51a",
+        "apim-request-id": "f9dcd99d-e928-4aa0-9e38-d36b447f538e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:43Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -131,31 +149,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "fce7960ffcea32129aba72fe7f5d8c65",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c688c114-a2be-4d52-aef5-68d282170c6c",
+        "apim-request-id": "cf628801-21f0-4f28-b0d9-df6254fee180",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:41 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:43Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -167,31 +191,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5c9a2a9b48e95fa14123df2f239dd352",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "752f9eb2-5c06-4446-bc29-1a158cd0f95a",
+        "apim-request-id": "17813f83-ef5d-4e29-a8f3-1520a03cc8db",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:43Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -203,31 +233,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c39e56f5b1e15a0d3d38e5f6c3d3350e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4497f842-e462-4abe-a019-1a4c8acf3e93",
+        "apim-request-id": "7d5e2e0f-b534-4066-81fb-3df7eeef9172",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:43Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -239,31 +275,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bbe549647ccfc676f588bac71ce20efc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb87cd20-5819-4b88-8b05-10fcbfa46cd8",
+        "apim-request-id": "5bbafceb-8b79-4dfe-977b-bee95ca5690d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -275,31 +317,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "290820e7c8bfea831d3f1eb162aa9c6d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "429ece2b-7005-42de-bf53-ad003dc453a2",
+        "apim-request-id": "84a9df62-8199-48a5-a1d6-8702a69b6fdb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:45 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -311,31 +359,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "dacbd1ed17b87983e0d7ce58f6453d5b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0436c306-7cfb-438b-9a4b-1335a6977312",
+        "apim-request-id": "e6b7a416-ae7a-4a25-bdbf-084e302e1ab8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -347,31 +401,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a20fe9290ccb9c4fc5fa9e8f5dc4634a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "37be3aed-b8f8-4f0f-8345-9b2dbff83f62",
+        "apim-request-id": "144eb62f-8679-451c-9a07-39fd80e8733c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -383,31 +443,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4bda4dec3317cf449d8f48e8f92bf3d7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e78e453-7969-43fb-bdbc-5d03628e719c",
+        "apim-request-id": "e20be594-3fb7-427a-a6cd-271607d3c79a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "28"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -419,31 +485,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7988c202f99be0a2822f15bd79f31b1b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5bfc24d4-0e45-450e-915b-b5df9b1d75d1",
+        "apim-request-id": "447a0379-6ea5-49f8-a107-04c71239db24",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:38Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -455,322 +527,289 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a96c8473f16bf544a43f053bc366a299",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d3a64cec-f4fe-45f7-a31f-d74e12cf89ea",
+        "apim-request-id": "aaa65005-6408-4583-aea6-7d82df459553",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "213"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:51Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "extractiveSummarizationTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-20T15:01:51.6239495Z",
-              "taskName": "ExtractSummaryWithDisabledServiceLogs",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentences": [
-                      {
-                        "text": "Windows 365 puts Microsoft\u2019s flagship operating system in the cloud.",
-                        "rankScore": 0.42,
-                        "offset": 1687,
-                        "length": 68
-                      },
-                      {
-                        "text": "Windows is already accessible in the cloud via Azure Virtual Desktop, which offers customers flexibility to create and run their own virtualization service.",
-                        "rankScore": 0.8,
-                        "offset": 2262,
-                        "length": 156
-                      },
-                      {
-                        "text": "Windows 365 is a new virtualization technology for Windows that is easy to set up and deploy for today\u2019s login-from-anywhere, mobile and elastic workforces.",
-                        "rankScore": 1.0,
-                        "offset": 2419,
-                        "length": 156
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentences": [
-                      {
-                        "text": "In this new world of Windows 365, remote workers flip the lid on their laptop, bootup the family workstation or clip a keyboard onto a tablet, launch a native app or modern web browser and login to their Windows 365 account.",
-                        "rankScore": 0.9,
-                        "offset": 460,
-                        "length": 224
-                      },
-                      {
-                        "text": "It enables employees accustomed to working from home to continue working from home;",
-                        "rankScore": 1.0,
-                        "offset": 1300,
-                        "length": 83
-                      },
-                      {
-                        "text": "it enables companies to hire interns from halfway around the world;",
-                        "rankScore": 0.71,
-                        "offset": 1384,
-                        "length": 67
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-08-01"
-              }
-            }
-          ]
+          "inProgress": 2,
+          "total": 2
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9b8cc606ea3cf3aeaaf9c9e81e8656a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e646c3eb-0b8a-4222-b3a5-b07503eb14a6",
+        "apim-request-id": "4372021b-d20d-42df-80a0-23576d5e5a12",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "78"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "23"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:51Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "extractiveSummarizationTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-20T15:01:51.6239495Z",
-              "taskName": "ExtractSummaryWithDisabledServiceLogs",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentences": [
-                      {
-                        "text": "Windows 365 puts Microsoft\u2019s flagship operating system in the cloud.",
-                        "rankScore": 0.42,
-                        "offset": 1687,
-                        "length": 68
-                      },
-                      {
-                        "text": "Windows is already accessible in the cloud via Azure Virtual Desktop, which offers customers flexibility to create and run their own virtualization service.",
-                        "rankScore": 0.8,
-                        "offset": 2262,
-                        "length": 156
-                      },
-                      {
-                        "text": "Windows 365 is a new virtualization technology for Windows that is easy to set up and deploy for today\u2019s login-from-anywhere, mobile and elastic workforces.",
-                        "rankScore": 1.0,
-                        "offset": 2419,
-                        "length": 156
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentences": [
-                      {
-                        "text": "In this new world of Windows 365, remote workers flip the lid on their laptop, bootup the family workstation or clip a keyboard onto a tablet, launch a native app or modern web browser and login to their Windows 365 account.",
-                        "rankScore": 0.9,
-                        "offset": 460,
-                        "length": 224
-                      },
-                      {
-                        "text": "It enables employees accustomed to working from home to continue working from home;",
-                        "rankScore": 1.0,
-                        "offset": 1300,
-                        "length": 83
-                      },
-                      {
-                        "text": "it enables companies to hire interns from halfway around the world;",
-                        "rankScore": 0.71,
-                        "offset": 1384,
-                        "length": 67
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-08-01"
-              }
-            }
-          ]
+          "inProgress": 2,
+          "total": 2
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "75742d734abe116c7e92d45cf3661c1b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4c37a5a-c90e-44f9-917b-ac3f99fa1d08",
+        "apim-request-id": "ea012b7c-15ac-489d-822a-6fd72d7c50cf",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:16:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "92"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:51Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 1,
+          "completed": 0,
           "failed": 0,
-          "inProgress": 1,
-          "total": 2,
-          "extractiveSummarizationTasks": [
-            {
-              "lastUpdateDateTime": "2021-10-20T15:01:51.6239495Z",
-              "taskName": "ExtractSummaryWithDisabledServiceLogs",
-              "state": "succeeded",
-              "results": {
-                "documents": [
-                  {
-                    "id": "1",
-                    "sentences": [
-                      {
-                        "text": "Windows 365 puts Microsoft\u2019s flagship operating system in the cloud.",
-                        "rankScore": 0.42,
-                        "offset": 1687,
-                        "length": 68
-                      },
-                      {
-                        "text": "Windows is already accessible in the cloud via Azure Virtual Desktop, which offers customers flexibility to create and run their own virtualization service.",
-                        "rankScore": 0.8,
-                        "offset": 2262,
-                        "length": 156
-                      },
-                      {
-                        "text": "Windows 365 is a new virtualization technology for Windows that is easy to set up and deploy for today\u2019s login-from-anywhere, mobile and elastic workforces.",
-                        "rankScore": 1.0,
-                        "offset": 2419,
-                        "length": 156
-                      }
-                    ],
-                    "warnings": []
-                  },
-                  {
-                    "id": "2",
-                    "sentences": [
-                      {
-                        "text": "In this new world of Windows 365, remote workers flip the lid on their laptop, bootup the family workstation or clip a keyboard onto a tablet, launch a native app or modern web browser and login to their Windows 365 account.",
-                        "rankScore": 0.9,
-                        "offset": 460,
-                        "length": 224
-                      },
-                      {
-                        "text": "It enables employees accustomed to working from home to continue working from home;",
-                        "rankScore": 1.0,
-                        "offset": 1300,
-                        "length": 83
-                      },
-                      {
-                        "text": "it enables companies to hire interns from halfway around the world;",
-                        "rankScore": 0.71,
-                        "offset": 1384,
-                        "length": 67
-                      }
-                    ],
-                    "warnings": []
-                  }
-                ],
-                "errors": [],
-                "modelVersion": "2021-08-01"
-              }
-            }
-          ]
+          "inProgress": 2,
+          "total": 2
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b3b77b8c806689ded579fe71275cd71e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7fe07db6-125c-4d82-9536-8af8460f9e15",
+        "apim-request-id": "3ce2a3c1-36d3-4428-a50a-793c1279f98c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:17:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "0a84b2f1-40f6-4ce5-94eb-63c9f5556f56",
-        "lastUpdateDateTime": "2021-10-20T15:01:55Z",
-        "createdDateTime": "2021-10-20T15:01:37Z",
-        "expirationDateTime": "2021-10-21T15:01:37Z",
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "96c85be82cf2bcdb5a7b1ca91551ff43",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0c766b4a-bc08-4192-8b17-22c81cc66ab8",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a25baedca2cff3424eeba0454bfae922",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9dc9ed2c-6943-4379-b34a-c8d93ed800a5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:16:49Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9773b6bb869e6029a0fb58eb63357383",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "577fef0d-7b7b-46c6-b5e0-001ddfb79a99",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:17:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "167"
+      },
+      "ResponseBody": {
+        "jobId": "ab9cd2bb-dc51-4bb7-bc48-5c99576f26b5",
+        "lastUpdateDateTime": "2021-10-25T21:17:04Z",
+        "createdDateTime": "2021-10-25T21:16:41Z",
+        "expirationDateTime": "2021-10-26T21:16:41Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -780,7 +819,7 @@
           "total": 2,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:01:51.6239495Z",
+              "lastUpdateDateTime": "2021-10-25T21:17:04.2490617Z",
               "taskName": "ExtractSummaryWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -839,7 +878,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:01:55.8851871Z",
+              "lastUpdateDateTime": "2021-10-25T21:17:04.4173873Z",
               "taskName": "ExtractSummary",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/ExtractSummaryTests/ExtractSummaryWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "11039",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-54cad10705aa8e469806739231020794-aee93db63209e34a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e0a375d64b89a946833e3210153d6cc0-7b30d1af25135a4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3eeabf31c120d2f33d02ae39d3314fb9",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,42 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "28aacef8-0551-4b20-9be0-7d5d92607e85",
-        "Date": "Wed, 20 Oct 2021 15:01:58 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+        "apim-request-id": "6426a53a-9cb2-47bc-9daf-bad213a84156",
+        "Date": "Mon, 25 Oct 2021 21:18:29 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "393"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "205"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7b402d050d70addfa2ecfc1d57fa81d7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bda6ad3c-e217-451c-9256-3d3d3a28eb33",
+        "apim-request-id": "dacac91d-76f0-41d7-8bc8-e938636a133d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:01:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "103"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:30Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -95,31 +107,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e12b9bc0e0b1fc9da2d8c680446ccb0c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0c7a302a-544b-44b4-b7ca-7566af4d7e02",
+        "apim-request-id": "d9b455cf-f0e4-47f7-91a3-a80e45f43985",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:00 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:30Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -131,31 +149,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ef77229f6cc324c0df3d9c33c4d57a42",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ab142577-b2b5-459c-a3ab-5e188aa35a41",
+        "apim-request-id": "1077fd79-50ea-4afc-b946-b3a167069fea",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:30Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -167,31 +191,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3778d7816e0525088f44d997475f6936",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "52b5e264-e789-4796-af90-7ba5937d078f",
+        "apim-request-id": "faa2e3aa-72aa-4b59-90b4-39a72b4de533",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:30Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -203,31 +233,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "357ef02191825414db070173446a38cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "006ec95d-a6b7-42af-bfe7-b293c3d21915",
+        "apim-request-id": "903b9de3-1e36-4163-ac41-1f252c7dcbba",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:03 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:30Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -239,31 +275,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6dff835d93f431061a52607e9328dc7f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a6496bbb-9530-4222-90f9-afd0817eb203",
+        "apim-request-id": "f171d2a0-e31b-4881-a73c-4dcf19ccccf4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:36Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -275,31 +317,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d31265d34557efc0c3245cfe6c94e024",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b3e54f1e-de3d-4b4e-8924-e70fe1118988",
+        "apim-request-id": "d1c070a2-0c64-4db4-afde-f32f98230fac",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:06 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:36Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -311,31 +359,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c4390c0bfc608d41e94d1a2f3095c1b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae2873c4-e169-4f92-8b72-dadaf855572b",
+        "apim-request-id": "625ee35b-3509-466b-b4fd-e13f4e25edb4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:08 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:36Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -347,31 +401,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "dea0822a64581774c20faad03608c585",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6ac0e3dd-0771-40bf-bfbc-3de04ef30039",
+        "apim-request-id": "bb2f52f8-43f8-4711-8620-40259b1832b6",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:09 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:36Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -383,31 +443,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "86733c7118eed71f2485ea0a2b90be2d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6ec9f4c8-144d-44db-91dc-fdbd6d008bcb",
+        "apim-request-id": "ad95d85d-f4ac-4136-90c0-7c07e9a9191e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:10 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:36Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -419,31 +485,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e9d3aa6202f4a7cc97220150527156e1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "85a34b32-aa6f-4092-a40d-d0acaacc50fe",
+        "apim-request-id": "cb0d2854-2aaa-4e7d-a630-4c1274331495",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:11 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "23"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:01:59Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:36Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -455,31 +527,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f4be94883b2212c362c9bad37a6aec32",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "347697b7-ea8d-4819-81ac-da3d5fd287d1",
+        "apim-request-id": "996292ab-7e55-4a34-8be6-9bec806fc43e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:12 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "81"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6654"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:02:13Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:43Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -489,8 +567,8 @@
           "total": 2,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:02:13.0863896Z",
-              "taskName": "ExtractSummary",
+              "lastUpdateDateTime": "2021-10-25T21:18:43.1535823Z",
+              "taskName": "ExtractSummaryWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -552,31 +630,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/878a95d9-375b-4cb0-9bc2-c222e759f222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ddf218dd-cf20-40d0-abff-659181797c96",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8c6d7c50db346f916fcceecc16ce84b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e6c0eddd-1e04-48c7-b808-01f4f714eee0",
+        "apim-request-id": "b8727859-164d-4fb1-9587-d17627ac1e89",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:02:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "299"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "144"
       },
       "ResponseBody": {
-        "jobId": "878a95d9-375b-4cb0-9bc2-c222e759f222",
-        "lastUpdateDateTime": "2021-10-20T15:02:13Z",
-        "createdDateTime": "2021-10-20T15:01:58Z",
-        "expirationDateTime": "2021-10-21T15:01:58Z",
+        "jobId": "ddf218dd-cf20-40d0-abff-659181797c96",
+        "lastUpdateDateTime": "2021-10-25T21:18:46Z",
+        "createdDateTime": "2021-10-25T21:18:29Z",
+        "expirationDateTime": "2021-10-26T21:18:29Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -586,7 +670,7 @@
           "total": 2,
           "extractiveSummarizationTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:02:13.4472359Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:43.1535823Z",
               "taskName": "ExtractSummaryWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -645,7 +729,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:02:13.0863896Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:46.923786Z",
               "taskName": "ExtractSummary",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchConvenienceTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "564",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-02d73dabfeb1c24eb4b415c279c5000a-fabdf2988567034a-00",
+        "traceparent": "00-358752bc67ac124ca151550b1898674f-dad6bed7becc8e42-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f239d83ee3161157ec92517fefbbda7e",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ad99d7d4-90ed-4e2f-a4c9-a116eb5ab489",
-        "Date": "Sun, 26 Sep 2021 18:37:39 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
+        "apim-request-id": "c9bba973-8307-4872-9502-e3359f5906e0",
+        "Date": "Mon, 25 Oct 2021 21:18:52 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c813033d-4b9a-402b-b612-53eb13848a17",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "773"
+        "x-envoy-upstream-service-time": "436"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c813033d-4b9a-402b-b612-53eb13848a17",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "7ec04fe460fa3eef35d0d229a390e245",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f9ed40ae-1c75-481e-aee2-56fb5e35c9f1",
+        "apim-request-id": "d2554e62-f42f-4158-829f-e5c5c9f86970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "174"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
-        "lastUpdateDateTime": "2021-09-26T18:37:39Z",
-        "createdDateTime": "2021-09-26T18:37:38Z",
-        "expirationDateTime": "2021-09-27T18:37:38Z",
+        "jobId": "c813033d-4b9a-402b-b612-53eb13848a17",
+        "lastUpdateDateTime": "2021-10-25T21:18:53Z",
+        "createdDateTime": "2021-10-25T21:18:53Z",
+        "expirationDateTime": "2021-10-26T21:18:53Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c813033d-4b9a-402b-b612-53eb13848a17",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "86a67303a3d1040789a52cdc11e926a2",
         "x-ms-return-client-request-id": "true"
@@ -119,108 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3e116eb0-a066-48d0-a0fc-301101585aba",
+        "apim-request-id": "c1712a26-b984-48b6-9d76-7a3e920cb61a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "62"
       },
       "ResponseBody": {
-        "jobId": "e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
-        "lastUpdateDateTime": "2021-09-26T18:37:39Z",
-        "createdDateTime": "2021-09-26T18:37:38Z",
-        "expirationDateTime": "2021-09-27T18:37:38Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "7116e4bdc810de38e9fbbd46102d6d5c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e661af9e-998e-47fc-8228-bdb11a26fb49",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:41 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
-        "lastUpdateDateTime": "2021-09-26T18:37:39Z",
-        "createdDateTime": "2021-09-26T18:37:38Z",
-        "expirationDateTime": "2021-09-27T18:37:38Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "7c7c0caf531441ad47bcf55533122c4c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "19fd3fe8-3e7a-449e-b3ef-9fe44b472ab7",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "220"
-      },
-      "ResponseBody": {
-        "jobId": "e457ede2-ebd1-47ed-88b1-79e2dd68bde2",
-        "lastUpdateDateTime": "2021-09-26T18:37:42Z",
-        "createdDateTime": "2021-09-26T18:37:38Z",
-        "expirationDateTime": "2021-09-27T18:37:38Z",
+        "jobId": "c813033d-4b9a-402b-b612-53eb13848a17",
+        "lastUpdateDateTime": "2021-10-25T21:18:54Z",
+        "createdDateTime": "2021-10-25T21:18:53Z",
+        "expirationDateTime": "2021-10-26T21:18:53Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -228,7 +140,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:37:42.9616602Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:54.3675718Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -261,6 +173,6 @@
   "Variables": {
     "RandomSeed": "306457240",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchConvenienceTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "564",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9263bc8b9cfa464fa16f6fdb1b007b15-0754cd64ae803e41-00",
+        "traceparent": "00-1fe433a2ef862a43b7afc225f4879529-6cca013d962a8d48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "718a5a8721a7c47b28a6d6f40fa42e90",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "2b272e35-5f6a-4852-b14e-615f562e06c4",
-        "Date": "Sun, 26 Sep 2021 18:37:55 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/16eb16dd-9c06-4486-8b5b-68d092b59469",
+        "apim-request-id": "5b94616a-b766-4def-a792-b1831c49da30",
+        "Date": "Mon, 25 Oct 2021 21:19:16 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7720ed7-e60e-4df6-a501-ec8e5e080711",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "261"
+        "x-envoy-upstream-service-time": "559"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/16eb16dd-9c06-4486-8b5b-68d092b59469",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7720ed7-e60e-4df6-a501-ec8e5e080711",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "52d011f3b82af3f309e064b1bf001af7",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "96a8b076-7014-4e8f-9cd1-ea47b30b3c4d",
+        "apim-request-id": "39ce1e2e-7b35-4055-a9ac-7817482b12bc",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:55 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "16eb16dd-9c06-4486-8b5b-68d092b59469",
-        "lastUpdateDateTime": "2021-09-26T18:37:55Z",
-        "createdDateTime": "2021-09-26T18:37:55Z",
-        "expirationDateTime": "2021-09-27T18:37:55Z",
-        "status": "notStarted",
+        "jobId": "f7720ed7-e60e-4df6-a501-ec8e5e080711",
+        "lastUpdateDateTime": "2021-10-25T21:19:16Z",
+        "createdDateTime": "2021-10-25T21:19:16Z",
+        "expirationDateTime": "2021-10-26T21:19:16Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/16eb16dd-9c06-4486-8b5b-68d092b59469",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f7720ed7-e60e-4df6-a501-ec8e5e080711",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "2e9ba3ef2af0771918680395314e3c1c",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b8ece7e7-21f2-4004-8c08-8678d3307cd0",
+        "apim-request-id": "a3d57d70-871d-4d6f-a58e-cdb562175a6d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "73"
+        "x-envoy-upstream-service-time": "4544"
       },
       "ResponseBody": {
-        "jobId": "16eb16dd-9c06-4486-8b5b-68d092b59469",
-        "lastUpdateDateTime": "2021-09-26T18:37:56Z",
-        "createdDateTime": "2021-09-26T18:37:55Z",
-        "expirationDateTime": "2021-09-27T18:37:55Z",
+        "jobId": "f7720ed7-e60e-4df6-a501-ec8e5e080711",
+        "lastUpdateDateTime": "2021-10-25T21:19:16Z",
+        "createdDateTime": "2021-10-25T21:19:16Z",
+        "expirationDateTime": "2021-10-26T21:19:16Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:37:56.2504231Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:16.99886Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -175,6 +173,6 @@
   "Variables": {
     "RandomSeed": "243582775",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchConvenienceWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "564",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d9dad020148efc4696fec3f209283eed-f1f8f7fc5f37ed42-00",
+        "traceparent": "00-45d4e017e0ba3c4fa68b2985706c1891-24fbe81f43cf7d4d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d058597bceb0808d39f520df873cc702",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "dfac3045-3219-4f1a-9a74-63818e55c1ef",
-        "Date": "Sun, 26 Sep 2021 18:37:43 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/0e9780de-de39-44a6-9f2b-b02a5dc30ccf",
+        "apim-request-id": "3d85bfdd-291c-4122-81bb-94a59a8a8ec0",
+        "Date": "Mon, 25 Oct 2021 21:18:56 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/934ff84e-e47b-4147-8788-4e2b57b145b4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "534"
+        "x-envoy-upstream-service-time": "473"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/0e9780de-de39-44a6-9f2b-b02a5dc30ccf?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/934ff84e-e47b-4147-8788-4e2b57b145b4?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9053fcdd622640c445116a104b8599b8",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f20765e5-6d54-4707-89ae-4e1644a9f489",
+        "apim-request-id": "a6a78462-03d1-4f3e-9278-e464f786a304",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "44"
       },
       "ResponseBody": {
-        "jobId": "0e9780de-de39-44a6-9f2b-b02a5dc30ccf",
-        "lastUpdateDateTime": "2021-09-26T18:37:43Z",
-        "createdDateTime": "2021-09-26T18:37:43Z",
-        "expirationDateTime": "2021-09-27T18:37:43Z",
-        "status": "running",
+        "jobId": "934ff84e-e47b-4147-8788-4e2b57b145b4",
+        "lastUpdateDateTime": "2021-10-25T21:18:56Z",
+        "createdDateTime": "2021-10-25T21:18:56Z",
+        "expirationDateTime": "2021-10-26T21:18:56Z",
+        "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/0e9780de-de39-44a6-9f2b-b02a5dc30ccf?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/934ff84e-e47b-4147-8788-4e2b57b145b4?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5bbdb49dd997808e5a9132fc5dcad991",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "00fcf02e-6a8b-4fb7-9e11-f55128c20eea",
+        "apim-request-id": "f68c2b38-0ef5-4cb0-9fd0-94e9ef51f27f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:18:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "79"
+        "x-envoy-upstream-service-time": "80"
       },
       "ResponseBody": {
-        "jobId": "0e9780de-de39-44a6-9f2b-b02a5dc30ccf",
-        "lastUpdateDateTime": "2021-09-26T18:37:44Z",
-        "createdDateTime": "2021-09-26T18:37:43Z",
-        "expirationDateTime": "2021-09-27T18:37:43Z",
+        "jobId": "934ff84e-e47b-4147-8788-4e2b57b145b4",
+        "lastUpdateDateTime": "2021-10-25T21:18:56Z",
+        "createdDateTime": "2021-10-25T21:18:56Z",
+        "expirationDateTime": "2021-10-26T21:18:56Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:37:44.1350634Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:56.8036188Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -189,6 +187,6 @@
   "Variables": {
     "RandomSeed": "1030528731",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchConvenienceWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "564",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-69a6a68e02741a4eab4537b054bbb732-497e0ccf34119345-00",
+        "traceparent": "00-c93da183dad1e14abecae7904f5b76ab-0e853c8478ac084e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d3acc983e1836ddde491f31a2c505a60",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a6db4736-71ee-4e05-a204-b73c532edc7f",
-        "Date": "Sun, 26 Sep 2021 18:37:58 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/84084a9e-ef7d-4060-b1c0-98a382e1d444",
+        "apim-request-id": "863512c2-0432-452f-8813-2a3ab4ced40a",
+        "Date": "Mon, 25 Oct 2021 21:19:23 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2054b963-73c7-4004-8c44-33e0fdb88dad",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2233"
+        "x-envoy-upstream-service-time": "382"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/84084a9e-ef7d-4060-b1c0-98a382e1d444?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2054b963-73c7-4004-8c44-33e0fdb88dad?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "05165df81797b263847ae86c0bea97b4",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b7eb1e97-024f-4421-8fbb-2ff038727151",
+        "apim-request-id": "f66a9b68-a10b-4f48-8db0-92ad651211e8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "84084a9e-ef7d-4060-b1c0-98a382e1d444",
-        "lastUpdateDateTime": "2021-09-26T18:37:59Z",
-        "createdDateTime": "2021-09-26T18:37:56Z",
-        "expirationDateTime": "2021-09-27T18:37:56Z",
+        "jobId": "2054b963-73c7-4004-8c44-33e0fdb88dad",
+        "lastUpdateDateTime": "2021-10-25T21:19:23Z",
+        "createdDateTime": "2021-10-25T21:19:23Z",
+        "expirationDateTime": "2021-10-26T21:19:23Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/84084a9e-ef7d-4060-b1c0-98a382e1d444?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2054b963-73c7-4004-8c44-33e0fdb88dad?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d84eaa6132a7c9bbf0e418f64a0495e9",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dac0d2b9-45f7-485f-8ff8-cc720f8d716b",
+        "apim-request-id": "80e87768-6977-48ca-ad32-effe9b90f253",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:00 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "73"
+        "x-envoy-upstream-service-time": "69"
       },
       "ResponseBody": {
-        "jobId": "84084a9e-ef7d-4060-b1c0-98a382e1d444",
-        "lastUpdateDateTime": "2021-09-26T18:37:59Z",
-        "createdDateTime": "2021-09-26T18:37:56Z",
-        "expirationDateTime": "2021-09-27T18:37:56Z",
+        "jobId": "2054b963-73c7-4004-8c44-33e0fdb88dad",
+        "lastUpdateDateTime": "2021-10-25T21:19:24Z",
+        "createdDateTime": "2021-10-25T21:19:23Z",
+        "expirationDateTime": "2021-10-26T21:19:23Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:37:59.5109722Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:24.1576395Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -189,6 +187,6 @@
   "Variables": {
     "RandomSeed": "249617768",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "564",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-884e725b7c34b64d9d44875d8b56cfe2-51f7c2bf82e7fb41-00",
+        "traceparent": "00-b15d3e72bc0e32489fc91aeae1be1108-563735d6aba21344-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f9a445d1945350412d315d0677481a7f",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8823e990-51ae-47fd-beb4-0c505ee6584a",
-        "Date": "Sun, 26 Sep 2021 18:37:44 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/bcc19ef9-c122-4f6c-8bae-f77f71a3830f",
+        "apim-request-id": "ec0ffc78-a413-42a6-8b0c-b78cdbf6fefa",
+        "Date": "Mon, 25 Oct 2021 21:18:58 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/3e1715ca-e2b4-4ac6-8ede-f2b6b4ed9730",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "169"
+        "x-envoy-upstream-service-time": "446"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/bcc19ef9-c122-4f6c-8bae-f77f71a3830f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/3e1715ca-e2b4-4ac6-8ede-f2b6b4ed9730",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "65613fb5afe0d6dda7bcc933fe40034b",
         "x-ms-return-client-request-id": "true"
@@ -76,65 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bab72ea3-c266-46c1-99cf-f5cd3bf52efd",
+        "apim-request-id": "8821e90c-ebac-4a72-9ba5-f68fca3f6eca",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "4188"
       },
       "ResponseBody": {
-        "jobId": "bcc19ef9-c122-4f6c-8bae-f77f71a3830f",
-        "lastUpdateDateTime": "2021-09-26T18:37:45Z",
-        "createdDateTime": "2021-09-26T18:37:45Z",
-        "expirationDateTime": "2021-09-27T18:37:45Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/bcc19ef9-c122-4f6c-8bae-f77f71a3830f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "90f7abee75aa105484220d8a1c28422b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "91a44607-a742-462c-a94f-31619aa5d8c5",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:46 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "79"
-      },
-      "ResponseBody": {
-        "jobId": "bcc19ef9-c122-4f6c-8bae-f77f71a3830f",
-        "lastUpdateDateTime": "2021-09-26T18:37:46Z",
-        "createdDateTime": "2021-09-26T18:37:45Z",
-        "expirationDateTime": "2021-09-27T18:37:45Z",
+        "jobId": "3e1715ca-e2b4-4ac6-8ede-f2b6b4ed9730",
+        "lastUpdateDateTime": "2021-10-25T21:18:58Z",
+        "createdDateTime": "2021-10-25T21:18:58Z",
+        "expirationDateTime": "2021-10-26T21:18:58Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +98,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:37:46.1831369Z",
+              "lastUpdateDateTime": "2021-10-25T21:18:58.8334312Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -175,6 +131,6 @@
   "Variables": {
     "RandomSeed": "1987453593",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "564",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d83ce7d210e16846a1f3d3bc96945df4-b6c0d583a4f2964c-00",
+        "traceparent": "00-f948448e9f7eaf4a8d4166c2bb1be68c-1f2174e3e603064c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a6386bfba6299a3233a2dfd0f0d681ac",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "623a527a-e13d-4254-953c-c0688c208f4b",
-        "Date": "Sun, 26 Sep 2021 18:38:00 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/22393095-ec98-4a21-9a05-4695868d3bb7",
+        "apim-request-id": "bc4b2ed0-3e19-4729-952e-77f05c97950d",
+        "Date": "Mon, 25 Oct 2021 21:19:24 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b6e0e38e-9f3f-444e-afdd-8f1ef2f5e723",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "154"
+        "x-envoy-upstream-service-time": "166"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/22393095-ec98-4a21-9a05-4695868d3bb7",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b6e0e38e-9f3f-444e-afdd-8f1ef2f5e723",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "99df5d7a9160810d2c4cc6a396618219",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "657f11ff-891e-41bd-97e8-42dbe18b87be",
+        "apim-request-id": "82d22ee6-47b0-45c8-a4e0-dbfd4b8b0f7f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:00 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "22393095-ec98-4a21-9a05-4695868d3bb7",
-        "lastUpdateDateTime": "2021-09-26T18:38:00Z",
-        "createdDateTime": "2021-09-26T18:38:00Z",
-        "expirationDateTime": "2021-09-27T18:38:00Z",
+        "jobId": "b6e0e38e-9f3f-444e-afdd-8f1ef2f5e723",
+        "lastUpdateDateTime": "2021-10-25T21:19:25Z",
+        "createdDateTime": "2021-10-25T21:19:25Z",
+        "expirationDateTime": "2021-10-26T21:19:25Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/22393095-ec98-4a21-9a05-4695868d3bb7",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b6e0e38e-9f3f-444e-afdd-8f1ef2f5e723",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "bee2f736dbdadf841f035712b1c9634d",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "040bc84b-b16d-4648-905b-9583d24d8f2c",
+        "apim-request-id": "35b2325e-a0c1-4a26-976d-b2345d46e620",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "x-envoy-upstream-service-time": "270"
       },
       "ResponseBody": {
-        "jobId": "22393095-ec98-4a21-9a05-4695868d3bb7",
-        "lastUpdateDateTime": "2021-09-26T18:38:01Z",
-        "createdDateTime": "2021-09-26T18:38:00Z",
-        "expirationDateTime": "2021-09-27T18:38:00Z",
+        "jobId": "b6e0e38e-9f3f-444e-afdd-8f1ef2f5e723",
+        "lastUpdateDateTime": "2021-10-25T21:19:26Z",
+        "createdDateTime": "2021-10-25T21:19:25Z",
+        "expirationDateTime": "2021-10-26T21:19:25Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:38:01.3413113Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:26.1356694Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -175,6 +173,6 @@
   "Variables": {
     "RandomSeed": "542519583",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchWithErrorTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "328",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-13a06e1deedf2148b8b798a6251cc0c3-7ab3734356fc9542-00",
+        "traceparent": "00-fb582edb12f94c489525aa6fe2ff2da7-c147b703f2fba14e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "b3f00d59ecdaec71d23ecfd808fcaa3b",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "61a6a2f0-77a8-4241-a585-0734872b315a",
-        "Date": "Sun, 26 Sep 2021 18:37:46 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9580a26d-74d0-4c56-b4c8-57432b6d8da3",
+        "apim-request-id": "e47cf3da-8fe5-4090-b463-3220a57d2fd2",
+        "Date": "Mon, 25 Oct 2021 21:19:03 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6c59e27c-1acd-424f-ad05-271924ea0de0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "230"
+        "x-envoy-upstream-service-time": "523"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9580a26d-74d0-4c56-b4c8-57432b6d8da3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6c59e27c-1acd-424f-ad05-271924ea0de0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "dea2929332df74905c54c3965e08e957",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "53e0ff42-b9d2-4e52-ae6a-238d099f9b8c",
+        "apim-request-id": "cf99d777-c63b-4dce-ad04-3726dd3fe915",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "9580a26d-74d0-4c56-b4c8-57432b6d8da3",
-        "lastUpdateDateTime": "2021-09-26T18:37:47Z",
-        "createdDateTime": "2021-09-26T18:37:46Z",
-        "expirationDateTime": "2021-09-27T18:37:46Z",
+        "jobId": "6c59e27c-1acd-424f-ad05-271924ea0de0",
+        "lastUpdateDateTime": "2021-10-25T21:19:03Z",
+        "createdDateTime": "2021-10-25T21:19:03Z",
+        "expirationDateTime": "2021-10-26T21:19:03Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9580a26d-74d0-4c56-b4c8-57432b6d8da3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/6c59e27c-1acd-424f-ad05-271924ea0de0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "0c7a0cb56d21b31947ac409a90ebc30d",
         "x-ms-return-client-request-id": "true"
@@ -119,151 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4ee221ba-b525-4de3-9b44-cd1c7d97c269",
+        "apim-request-id": "08de1fc4-466b-4f2b-8c1b-a13deb75ffa7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "110"
       },
       "ResponseBody": {
-        "jobId": "9580a26d-74d0-4c56-b4c8-57432b6d8da3",
-        "lastUpdateDateTime": "2021-09-26T18:37:47Z",
-        "createdDateTime": "2021-09-26T18:37:46Z",
-        "expirationDateTime": "2021-09-27T18:37:46Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9580a26d-74d0-4c56-b4c8-57432b6d8da3",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "bdf42c59a9ff26547d7c578529da8dc9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "34c627a9-f5a5-4f93-80d2-20bcee1f798a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:49 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "9580a26d-74d0-4c56-b4c8-57432b6d8da3",
-        "lastUpdateDateTime": "2021-09-26T18:37:47Z",
-        "createdDateTime": "2021-09-26T18:37:46Z",
-        "expirationDateTime": "2021-09-27T18:37:46Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9580a26d-74d0-4c56-b4c8-57432b6d8da3",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "fc2277549d81251978ee9733f2f5e370",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "31a00c55-ee67-4a29-b9f2-64ecc5b42893",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:50 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "9580a26d-74d0-4c56-b4c8-57432b6d8da3",
-        "lastUpdateDateTime": "2021-09-26T18:37:47Z",
-        "createdDateTime": "2021-09-26T18:37:46Z",
-        "expirationDateTime": "2021-09-27T18:37:46Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9580a26d-74d0-4c56-b4c8-57432b6d8da3",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "323db5902c140b58b8548ea515938a6c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "da7b36a3-0312-4129-9368-eb2cf1ac5801",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:51 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "86"
-      },
-      "ResponseBody": {
-        "jobId": "9580a26d-74d0-4c56-b4c8-57432b6d8da3",
-        "lastUpdateDateTime": "2021-09-26T18:37:50Z",
-        "createdDateTime": "2021-09-26T18:37:46Z",
-        "expirationDateTime": "2021-09-27T18:37:46Z",
+        "jobId": "6c59e27c-1acd-424f-ad05-271924ea0de0",
+        "lastUpdateDateTime": "2021-10-25T21:19:04Z",
+        "createdDateTime": "2021-10-25T21:19:03Z",
+        "expirationDateTime": "2021-10-26T21:19:03Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -271,7 +140,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:37:50.7704268Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:04.8725439Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -306,6 +175,6 @@
   "Variables": {
     "RandomSeed": "651258290",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchWithErrorTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "328",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9af02393cc01c544a01af7f480b0768d-2f536da3f9a2cc4b-00",
+        "traceparent": "00-987e421c7a568d48b4266ce629afa8da-f05a22ae754ef341-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "30f3d0aaed959b158d1c03a1c38ed196",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "465345ff-5570-48d1-90fd-b999dc732c45",
-        "Date": "Sun, 26 Sep 2021 18:38:01 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dc370ca0-347e-4326-85a4-343ebd44f701",
+        "apim-request-id": "17ad6d31-e431-42eb-8b5d-9663c45986cc",
+        "Date": "Mon, 25 Oct 2021 21:19:27 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e64677be-cbd5-4444-9a49-213e717bfc3f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "151"
+        "x-envoy-upstream-service-time": "448"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dc370ca0-347e-4326-85a4-343ebd44f701",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e64677be-cbd5-4444-9a49-213e717bfc3f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "c825cb4a1b45c0a38d00c26413634bd4",
         "x-ms-return-client-request-id": "true"
@@ -76,65 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca2baa62-eb40-49e4-8b79-a1181b25ef46",
+        "apim-request-id": "90b0db25-ded3-4f2e-b00a-63840e22f476",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "72"
       },
       "ResponseBody": {
-        "jobId": "dc370ca0-347e-4326-85a4-343ebd44f701",
-        "lastUpdateDateTime": "2021-09-26T18:38:02Z",
-        "createdDateTime": "2021-09-26T18:38:02Z",
-        "expirationDateTime": "2021-09-27T18:38:02Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dc370ca0-347e-4326-85a4-343ebd44f701",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "cbdf5eda5e441b482047cd1f76afb55d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "ec3df33f-724a-47c7-b09e-d55444b9a2a5",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:03 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "77"
-      },
-      "ResponseBody": {
-        "jobId": "dc370ca0-347e-4326-85a4-343ebd44f701",
-        "lastUpdateDateTime": "2021-09-26T18:38:02Z",
-        "createdDateTime": "2021-09-26T18:38:02Z",
-        "expirationDateTime": "2021-09-27T18:38:02Z",
+        "jobId": "e64677be-cbd5-4444-9a49-213e717bfc3f",
+        "lastUpdateDateTime": "2021-10-25T21:19:28Z",
+        "createdDateTime": "2021-10-25T21:19:27Z",
+        "expirationDateTime": "2021-10-26T21:19:27Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +98,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:38:02.4139547Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:28.2817227Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -177,6 +133,6 @@
   "Variables": {
     "RandomSeed": "1364887234",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "564",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a734d594c9d9da4ca366b06a19dcddb1-7216aa4d97934b40-00",
+        "traceparent": "00-d53a45fe1fa8f04292911b5e534c266b-5482156e6cccbf4c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "1d267b1dc6373f818e2ae2b8b6729718",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "619c4219-f366-4c4a-850a-8a40fb12eaf3",
-        "Date": "Sun, 26 Sep 2021 18:37:51 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d17ec2c-7068-4ad1-8a5b-f7aa17ae7fba",
+        "apim-request-id": "e7451f57-acb6-4ea6-8560-1565b9935562",
+        "Date": "Mon, 25 Oct 2021 21:19:06 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/61d51f05-ff00-4dc2-b2a9-2bcf55bf9030",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "154"
+        "x-envoy-upstream-service-time": "459"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d17ec2c-7068-4ad1-8a5b-f7aa17ae7fba?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/61d51f05-ff00-4dc2-b2a9-2bcf55bf9030?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d6a026686d0319ef4fd032da4c5ed795",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0c58573a-522b-4c93-bb36-2b579dc6996f",
+        "apim-request-id": "04d89c67-1db9-4ce1-b3e9-5f7a6817805e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:51 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "9d17ec2c-7068-4ad1-8a5b-f7aa17ae7fba",
-        "lastUpdateDateTime": "2021-09-26T18:37:52Z",
-        "createdDateTime": "2021-09-26T18:37:51Z",
-        "expirationDateTime": "2021-09-27T18:37:51Z",
-        "status": "running",
+        "jobId": "61d51f05-ff00-4dc2-b2a9-2bcf55bf9030",
+        "lastUpdateDateTime": "2021-10-25T21:19:06Z",
+        "createdDateTime": "2021-10-25T21:19:05Z",
+        "expirationDateTime": "2021-10-26T21:19:05Z",
+        "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9d17ec2c-7068-4ad1-8a5b-f7aa17ae7fba?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/61d51f05-ff00-4dc2-b2a9-2bcf55bf9030?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9bd4d20f26905b2abbe44e8557974917",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1f696025-dfc9-4096-93a4-fb1feb077b57",
+        "apim-request-id": "d81af7ab-ad14-49cb-bd11-e5cbeab884b8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "73"
+        "x-envoy-upstream-service-time": "74"
       },
       "ResponseBody": {
-        "jobId": "9d17ec2c-7068-4ad1-8a5b-f7aa17ae7fba",
-        "lastUpdateDateTime": "2021-09-26T18:37:52Z",
-        "createdDateTime": "2021-09-26T18:37:51Z",
-        "expirationDateTime": "2021-09-27T18:37:51Z",
+        "jobId": "61d51f05-ff00-4dc2-b2a9-2bcf55bf9030",
+        "lastUpdateDateTime": "2021-10-25T21:19:07Z",
+        "createdDateTime": "2021-10-25T21:19:05Z",
+        "expirationDateTime": "2021-10-26T21:19:05Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:37:52.207536Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:07.525311Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -189,6 +187,6 @@
   "Variables": {
     "RandomSeed": "1494605637",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyBatchWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "564",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c2714305fbbc544fbdaf8ce12d06cb5a-7af9a8ca7992654e-00",
+        "traceparent": "00-85fc539809bb5a4a8ce7d3db4088a9cf-2de133a1801ba744-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "906b58cad58335a5847440566fdf9175",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b8b9c71d-e20d-4616-924b-9bf33e1f5b80",
-        "Date": "Sun, 26 Sep 2021 18:38:03 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/7d7bc432-9155-4740-b33c-5fd2dafe8789",
+        "apim-request-id": "c4103c9f-85f3-4c78-a446-014626c2d66a",
+        "Date": "Mon, 25 Oct 2021 21:19:28 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ef36989c-1fe6-45f6-a519-68de159b1146",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "179"
+        "x-envoy-upstream-service-time": "171"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/7d7bc432-9155-4740-b33c-5fd2dafe8789?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ef36989c-1fe6-45f6-a519-68de159b1146?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d7bd2b96de4822366676f3e88d30af2c",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b62bd24-ec0e-421e-9087-115b6a7aa365",
+        "apim-request-id": "971531ca-0f15-439d-b1a7-56b0c56dd403",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:03 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "7d7bc432-9155-4740-b33c-5fd2dafe8789",
-        "lastUpdateDateTime": "2021-09-26T18:38:03Z",
-        "createdDateTime": "2021-09-26T18:38:03Z",
-        "expirationDateTime": "2021-09-27T18:38:03Z",
-        "status": "notStarted",
+        "jobId": "ef36989c-1fe6-45f6-a519-68de159b1146",
+        "lastUpdateDateTime": "2021-10-25T21:19:29Z",
+        "createdDateTime": "2021-10-25T21:19:28Z",
+        "expirationDateTime": "2021-10-26T21:19:28Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/7d7bc432-9155-4740-b33c-5fd2dafe8789?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ef36989c-1fe6-45f6-a519-68de159b1146?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "0b245d4008ebad99d3b8e00231144551",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e6fbc09f-e01b-4143-9854-284e2dbad044",
+        "apim-request-id": "e3e88dad-931e-4b1d-b2b0-2f24ecd3af91",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "75"
+        "x-envoy-upstream-service-time": "70"
       },
       "ResponseBody": {
-        "jobId": "7d7bc432-9155-4740-b33c-5fd2dafe8789",
-        "lastUpdateDateTime": "2021-09-26T18:38:04Z",
-        "createdDateTime": "2021-09-26T18:38:03Z",
-        "expirationDateTime": "2021-09-27T18:38:03Z",
+        "jobId": "ef36989c-1fe6-45f6-a519-68de159b1146",
+        "lastUpdateDateTime": "2021-10-25T21:19:29Z",
+        "createdDateTime": "2021-10-25T21:19:28Z",
+        "expirationDateTime": "2021-10-26T21:19:28Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:38:04.438308Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:29.1425845Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -189,6 +187,6 @@
   "Variables": {
     "RandomSeed": "156613535",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyWithDisableServiceLogs.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyWithDisableServiceLogs.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "585",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c5ef0d263be436429b9751876001e38c-519027e4812b7242-00",
+        "traceparent": "00-9100ba48d07bf74b9a5ddfea5c5d8121-f8d8ea9cffbbe745-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "240aa7eee3f5791310c87f0aea43f279",
         "x-ms-return-client-request-id": "true"
@@ -48,18 +48,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "68b8b827-3c95-4012-80d5-07e869d86d7b",
-        "Date": "Sun, 26 Sep 2021 18:37:53 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f1c090c9-e2dd-4a1a-b901-d81d253477af",
+        "apim-request-id": "362df2c6-3ec4-48cb-a874-ecdce538b065",
+        "Date": "Mon, 25 Oct 2021 21:19:08 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b1f7ff43-6d75-454d-b3a2-b8e3a1c45dda",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "188"
+        "x-envoy-upstream-service-time": "406"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f1c090c9-e2dd-4a1a-b901-d81d253477af",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b1f7ff43-6d75-454d-b3a2-b8e3a1c45dda",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -68,8 +68,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "033483e2516ec9aa820c90ec10e84892",
         "x-ms-return-client-request-id": "true"
@@ -77,22 +77,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ce762aba-e99c-485c-9028-de67986fe77c",
+        "apim-request-id": "0a96a405-2066-4e42-bed4-61fb2c298620",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "f1c090c9-e2dd-4a1a-b901-d81d253477af",
-        "lastUpdateDateTime": "2021-09-26T18:37:53Z",
-        "createdDateTime": "2021-09-26T18:37:53Z",
-        "expirationDateTime": "2021-09-27T18:37:53Z",
+        "jobId": "b1f7ff43-6d75-454d-b3a2-b8e3a1c45dda",
+        "lastUpdateDateTime": "2021-10-25T21:19:08Z",
+        "createdDateTime": "2021-10-25T21:19:08Z",
+        "expirationDateTime": "2021-10-26T21:19:08Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -102,7 +101,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f1c090c9-e2dd-4a1a-b901-d81d253477af",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b1f7ff43-6d75-454d-b3a2-b8e3a1c45dda",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -111,8 +110,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ac8394b2f677be1091d284ab791b8c09",
         "x-ms-return-client-request-id": "true"
@@ -120,22 +119,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f63d24c7-4100-4327-9bd6-ade3253f06c7",
+        "apim-request-id": "e0558f4e-b33f-4267-9e99-317ed2d0263d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:37:55 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "93"
+        "x-envoy-upstream-service-time": "96"
       },
       "ResponseBody": {
-        "jobId": "f1c090c9-e2dd-4a1a-b901-d81d253477af",
-        "lastUpdateDateTime": "2021-09-26T18:37:54Z",
-        "createdDateTime": "2021-09-26T18:37:53Z",
-        "expirationDateTime": "2021-09-27T18:37:53Z",
+        "jobId": "b1f7ff43-6d75-454d-b3a2-b8e3a1c45dda",
+        "lastUpdateDateTime": "2021-10-25T21:19:08Z",
+        "createdDateTime": "2021-10-25T21:19:08Z",
+        "expirationDateTime": "2021-10-26T21:19:08Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -143,7 +141,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:37:54.2581916Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:08.9629456Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -176,6 +174,6 @@
   "Variables": {
     "RandomSeed": "1222401182",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyWithDisableServiceLogsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyWithDisableServiceLogsAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "585",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bebbdf6a93e0da4cb8bce44a539d4c08-53d03d48247aa54a-00",
+        "traceparent": "00-809b6ea72d8852428193b61e4413402c-5b447ea363a52a46-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "0cc53751b5e8088ad70bde584eea5b24",
         "x-ms-return-client-request-id": "true"
@@ -48,18 +48,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b7dd0470-0b60-4d59-a78f-77f43e03c512",
-        "Date": "Sun, 26 Sep 2021 18:38:05 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/df191a86-500d-40c8-93a5-0f3fdfca8063",
+        "apim-request-id": "631dae4e-3c41-48d4-919b-60318ad65d31",
+        "Date": "Mon, 25 Oct 2021 21:19:30 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e7db179d-770b-4391-9793-78f1d62054d0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "168"
+        "x-envoy-upstream-service-time": "156"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/df191a86-500d-40c8-93a5-0f3fdfca8063",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e7db179d-770b-4391-9793-78f1d62054d0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -68,8 +68,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "920ad4e241f22235a613d50d0c9708ba",
         "x-ms-return-client-request-id": "true"
@@ -77,22 +77,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "425340ab-51a1-4433-8ea3-972190949e14",
+        "apim-request-id": "4001d16e-5f7d-4dcb-b37b-d98f3433c7d3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "df191a86-500d-40c8-93a5-0f3fdfca8063",
-        "lastUpdateDateTime": "2021-09-26T18:38:05Z",
-        "createdDateTime": "2021-09-26T18:38:05Z",
-        "expirationDateTime": "2021-09-27T18:38:05Z",
-        "status": "notStarted",
+        "jobId": "e7db179d-770b-4391-9793-78f1d62054d0",
+        "lastUpdateDateTime": "2021-10-25T21:19:31Z",
+        "createdDateTime": "2021-10-25T21:19:30Z",
+        "expirationDateTime": "2021-10-26T21:19:30Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -102,7 +101,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/df191a86-500d-40c8-93a5-0f3fdfca8063",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e7db179d-770b-4391-9793-78f1d62054d0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -111,8 +110,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET Core 3.1.19; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "40e24aa3090e5727acea7d71b9400e84",
         "x-ms-return-client-request-id": "true"
@@ -120,22 +119,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "26a16e0b-a39d-4ea7-bed2-1530514550ec",
+        "apim-request-id": "9bbaf1fa-824b-4712-89f9-2c4fe7ba119a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 18:38:06 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "73"
+        "x-envoy-upstream-service-time": "602"
       },
       "ResponseBody": {
-        "jobId": "df191a86-500d-40c8-93a5-0f3fdfca8063",
-        "lastUpdateDateTime": "2021-09-26T18:38:06Z",
-        "createdDateTime": "2021-09-26T18:38:05Z",
-        "expirationDateTime": "2021-09-27T18:38:05Z",
+        "jobId": "e7db179d-770b-4391-9793-78f1d62054d0",
+        "lastUpdateDateTime": "2021-10-25T21:19:31Z",
+        "createdDateTime": "2021-10-25T21:19:30Z",
+        "expirationDateTime": "2021-10-26T21:19:30Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -143,7 +141,7 @@
           "total": 1,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T18:38:06.4863445Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:31.1782436Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -176,6 +174,6 @@
   "Variables": {
     "RandomSeed": "1982339428",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "806",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cd26d77ae1952943a6c553561200d9cb-7fa4da8e6328c74e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f26cf3d8ab8a7045a2482dab7be02716-11bd28f2d6c5174f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "40e1470f487c81679e7998dff1902916",
         "x-ms-return-client-request-id": "true"
       },
@@ -50,43 +56,49 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4bbb64e9-b1ab-439f-95d6-c00bcbe4f1f1",
-        "Date": "Thu, 21 Oct 2021 20:13:48 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9e184195-b57a-4b22-b274-5ed1f813f90b",
+        "apim-request-id": "1146263a-f727-4dae-ab03-19a11dc1674d",
+        "Date": "Mon, 25 Oct 2021 21:19:10 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/72457139-38ff-4998-ac24-cd0528de74d9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "860"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "514"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9e184195-b57a-4b22-b274-5ed1f813f90b",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/72457139-38ff-4998-ac24-cd0528de74d9",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "98696fff1ddb7f3bf091404a2acfd4d6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "08bc500c-e3bc-42b9-9d30-51f51d733759",
+        "apim-request-id": "00449c5b-da43-4f54-ace6-443ad7a4eccd",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:13:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "82"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "9e184195-b57a-4b22-b274-5ed1f813f90b",
-        "lastUpdateDateTime": "2021-10-21T20:13:48Z",
-        "createdDateTime": "2021-10-21T20:13:47Z",
-        "expirationDateTime": "2021-10-22T20:13:47Z",
-        "status": "running",
+        "jobId": "72457139-38ff-4998-ac24-cd0528de74d9",
+        "lastUpdateDateTime": "2021-10-25T21:19:10Z",
+        "createdDateTime": "2021-10-25T21:19:10Z",
+        "expirationDateTime": "2021-10-26T21:19:10Z",
+        "status": "notStarted",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -97,67 +109,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9e184195-b57a-4b22-b274-5ed1f813f90b",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/72457139-38ff-4998-ac24-cd0528de74d9",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6167bef3ddbaeadd0104a6243fef0893",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a9689b1a-e71f-4615-8cdd-6898199a7500",
+        "apim-request-id": "87f1e0b7-c466-4543-a1c4-d2d616eef168",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:13:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "3405"
       },
       "ResponseBody": {
-        "jobId": "9e184195-b57a-4b22-b274-5ed1f813f90b",
-        "lastUpdateDateTime": "2021-10-21T20:13:48Z",
-        "createdDateTime": "2021-10-21T20:13:47Z",
-        "expirationDateTime": "2021-10-22T20:13:47Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9e184195-b57a-4b22-b274-5ed1f813f90b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "07fb802779a9f18a0b614fea081d57cf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "efb1593f-a28e-4ed9-a893-c417884aded3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:13:51 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "609"
-      },
-      "ResponseBody": {
-        "jobId": "9e184195-b57a-4b22-b274-5ed1f813f90b",
-        "lastUpdateDateTime": "2021-10-21T20:13:51Z",
-        "createdDateTime": "2021-10-21T20:13:47Z",
-        "expirationDateTime": "2021-10-22T20:13:47Z",
+        "jobId": "72457139-38ff-4998-ac24-cd0528de74d9",
+        "lastUpdateDateTime": "2021-10-25T21:19:12Z",
+        "createdDateTime": "2021-10-25T21:19:10Z",
+        "expirationDateTime": "2021-10-26T21:19:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -167,7 +149,7 @@
           "total": 2,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-10-21T20:13:51.3506478Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:12.1748153Z",
               "taskName": "MultiCategoryClassifyWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -194,7 +176,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-21T20:13:51.2525398Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:12.0733523Z",
               "taskName": "MultiCategoryClassify",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/MultiCategoryClassifyTests/MultiCategoryClassifyWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "806",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c0d594b1e2469f44a1a3040fd9bc8613-12666a1ead56384d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-79f448de39ccb6448fb8ea8c6f9a653e-16de113b5e415043-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2fa05d10916b53aaaee0a24605592c6a",
         "x-ms-return-client-request-id": "true"
       },
@@ -50,42 +56,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a5342046-a4e0-4fa7-a90e-178c91696ffc",
-        "Date": "Thu, 21 Oct 2021 20:13:53 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c6ab2025-d2bd-4b5f-ad97-82eb28c1b154",
+        "apim-request-id": "c0aed346-f501-42e4-9593-de3cd95a4f05",
+        "Date": "Mon, 25 Oct 2021 21:19:32 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f3a75ab-2264-44bb-bc93-bdbcea6e8c8e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "669"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "254"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c6ab2025-d2bd-4b5f-ad97-82eb28c1b154",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f3a75ab-2264-44bb-bc93-bdbcea6e8c8e",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "71858327133e398fb9ddae770955e4e9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fc3640e9-68c3-452f-9a21-e0167c630f52",
+        "apim-request-id": "1898f435-0f23-40e6-8672-9cf12e4617d9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:13:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "75"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "c6ab2025-d2bd-4b5f-ad97-82eb28c1b154",
-        "lastUpdateDateTime": "2021-10-21T20:13:54Z",
-        "createdDateTime": "2021-10-21T20:13:53Z",
-        "expirationDateTime": "2021-10-22T20:13:53Z",
+        "jobId": "8f3a75ab-2264-44bb-bc93-bdbcea6e8c8e",
+        "lastUpdateDateTime": "2021-10-25T21:19:33Z",
+        "createdDateTime": "2021-10-25T21:19:33Z",
+        "expirationDateTime": "2021-10-26T21:19:33Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -97,31 +109,79 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c6ab2025-d2bd-4b5f-ad97-82eb28c1b154",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f3a75ab-2264-44bb-bc93-bdbcea6e8c8e",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f4915ed0c4372b6b01dbaf4cbb215edc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a919549-bd41-4a3f-9044-f8d9353d80a7",
+        "apim-request-id": "838b0e33-3c17-4fdb-bf3b-d613fb16f0d8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:13:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "472"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "c6ab2025-d2bd-4b5f-ad97-82eb28c1b154",
-        "lastUpdateDateTime": "2021-10-21T20:13:54Z",
-        "createdDateTime": "2021-10-21T20:13:53Z",
-        "expirationDateTime": "2021-10-22T20:13:53Z",
+        "jobId": "8f3a75ab-2264-44bb-bc93-bdbcea6e8c8e",
+        "lastUpdateDateTime": "2021-10-25T21:19:34Z",
+        "createdDateTime": "2021-10-25T21:19:33Z",
+        "expirationDateTime": "2021-10-26T21:19:33Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8f3a75ab-2264-44bb-bc93-bdbcea6e8c8e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "5c081a5c40a2fdcace67758de2324a58",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "22fe51a0-2d7b-4c6b-a930-46891bd9fdca",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:19:35 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "121"
+      },
+      "ResponseBody": {
+        "jobId": "8f3a75ab-2264-44bb-bc93-bdbcea6e8c8e",
+        "lastUpdateDateTime": "2021-10-25T21:19:35Z",
+        "createdDateTime": "2021-10-25T21:19:33Z",
+        "expirationDateTime": "2021-10-26T21:19:33Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -131,7 +191,7 @@
           "total": 2,
           "customMultiClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-10-21T20:13:54.637118Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:35.1420774Z",
               "taskName": "MultiCategoryClassifyWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -158,7 +218,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-21T20:13:54.6271607Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:35.106653Z",
               "taskName": "MultiCategoryClassify",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchConvenienceTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "410",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d450a3b7ad199c40a3009218558f5ec9-7c6776d1735cb946-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b3f7f413e38a054281ba5ee56b283d18-3345abf001d94d45-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c3eb54e49604a79312c6b18e5927ea06",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0ae60fa9-40e5-4574-a79c-05b2f9d524ab",
-        "Date": "Mon, 27 Sep 2021 14:28:59 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/0b3137b9-eaa3-4d87-a0a2-2d9abedc60d3",
+        "apim-request-id": "0a50ad41-9897-4a89-930f-380c7ec5f0c0",
+        "Date": "Mon, 25 Oct 2021 21:19:36 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/700b3f00-e169-4f7e-b57c-a761e1624223",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "235"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "205"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/0b3137b9-eaa3-4d87-a0a2-2d9abedc60d3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/700b3f00-e169-4f7e-b57c-a761e1624223",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8dc4d48801b8b544409fecdfe93766ef",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "faafcea0-eda4-4a3e-bb9a-908adef47f2c",
+        "apim-request-id": "ec0f4ebf-e902-4f14-a3b0-d3ebc6302628",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:28:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "46"
       },
       "ResponseBody": {
-        "jobId": "0b3137b9-eaa3-4d87-a0a2-2d9abedc60d3",
-        "lastUpdateDateTime": "2021-09-27T14:28:59Z",
-        "createdDateTime": "2021-09-27T14:28:59Z",
-        "expirationDateTime": "2021-09-28T14:28:59Z",
-        "status": "running",
+        "jobId": "700b3f00-e169-4f7e-b57c-a761e1624223",
+        "lastUpdateDateTime": "2021-10-25T21:19:36Z",
+        "createdDateTime": "2021-10-25T21:19:36Z",
+        "expirationDateTime": "2021-10-26T21:19:36Z",
+        "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/0b3137b9-eaa3-4d87-a0a2-2d9abedc60d3",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/700b3f00-e169-4f7e-b57c-a761e1624223",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bc84030af5b83db90df750441ea7e52f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e44600c2-a1af-43e5-91b3-ce70d9cde6e4",
+        "apim-request-id": "417a8df7-4831-4440-adfc-1c13f0337832",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "234"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "96"
       },
       "ResponseBody": {
-        "jobId": "0b3137b9-eaa3-4d87-a0a2-2d9abedc60d3",
-        "lastUpdateDateTime": "2021-09-27T14:29:00Z",
-        "createdDateTime": "2021-09-27T14:28:59Z",
-        "expirationDateTime": "2021-09-28T14:28:59Z",
+        "jobId": "700b3f00-e169-4f7e-b57c-a761e1624223",
+        "lastUpdateDateTime": "2021-10-25T21:19:37Z",
+        "createdDateTime": "2021-10-25T21:19:36Z",
+        "expirationDateTime": "2021-10-26T21:19:36Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -124,7 +140,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:00.3596127Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:37.6867776Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -203,8 +219,6 @@
   "Variables": {
     "RandomSeed": "409427476",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchConvenienceTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "410",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b6be1a1c03d4424dad2e90a615b16003-7d56f6717ea86546-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-3a66cbe4347fc74392acc2bcc0e751fe-b23e1eccf3152046-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "105abf0c84dde23d1d3ef35c802eeb38",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0d5133ab-74fb-49ae-ab8f-2466e57fbd2b",
-        "Date": "Mon, 27 Sep 2021 14:29:10 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9a990597-54f2-4add-b89b-aeca7fc2ddcf",
+        "apim-request-id": "4beb2f80-a638-4762-bbb4-882c21d0aec3",
+        "Date": "Mon, 25 Oct 2021 21:19:54 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/be66ed80-0d23-428d-a1ab-dd90e8f99817",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "168"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "596"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9a990597-54f2-4add-b89b-aeca7fc2ddcf",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/be66ed80-0d23-428d-a1ab-dd90e8f99817",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9686c181314c20590468c22aff06b020",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2ff6b66f-d7a0-47ea-bde4-3104fabe64d5",
+        "apim-request-id": "7bff15c8-b1eb-42ad-97c5-a008b5e803ab",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:10 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "9a990597-54f2-4add-b89b-aeca7fc2ddcf",
-        "lastUpdateDateTime": "2021-09-27T14:29:11Z",
-        "createdDateTime": "2021-09-27T14:29:11Z",
-        "expirationDateTime": "2021-09-28T14:29:11Z",
+        "jobId": "be66ed80-0d23-428d-a1ab-dd90e8f99817",
+        "lastUpdateDateTime": "2021-10-25T21:19:54Z",
+        "createdDateTime": "2021-10-25T21:19:53Z",
+        "expirationDateTime": "2021-10-26T21:19:53Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9a990597-54f2-4add-b89b-aeca7fc2ddcf",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/be66ed80-0d23-428d-a1ab-dd90e8f99817",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "77ad4f5c0741abde30727c4d4a50d26f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "27fd7e04-e091-420e-b222-d5f9d8607e30",
+        "apim-request-id": "b7c32104-f462-4ee5-9b8c-954fe3c8e6d1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:12 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "75"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "62"
       },
       "ResponseBody": {
-        "jobId": "9a990597-54f2-4add-b89b-aeca7fc2ddcf",
-        "lastUpdateDateTime": "2021-09-27T14:29:12Z",
-        "createdDateTime": "2021-09-27T14:29:11Z",
-        "expirationDateTime": "2021-09-28T14:29:11Z",
+        "jobId": "be66ed80-0d23-428d-a1ab-dd90e8f99817",
+        "lastUpdateDateTime": "2021-10-25T21:19:54Z",
+        "createdDateTime": "2021-10-25T21:19:53Z",
+        "expirationDateTime": "2021-10-26T21:19:53Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -124,7 +140,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:12.134283Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:54.9109602Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -203,8 +219,6 @@
   "Variables": {
     "RandomSeed": "950474278",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "493",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c88c67df55fbc459b5edc589f7077da-f1918d856921d14f-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-eff66fad8529e3468583eed68b429886-fd0c638b63eb2043-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "edd30e0cf5da712a7f16e1fbdd0ac637",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f61f3fcc-52a7-4be0-b146-09a4de9faca1",
-        "Date": "Mon, 27 Sep 2021 14:29:02 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6190d2cd-3a7b-450a-a517-3a919e50946c",
+        "apim-request-id": "bdf91052-8d59-49f0-a1b1-c3320821213a",
+        "Date": "Mon, 25 Oct 2021 21:19:38 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/df65c86c-9144-4bff-82fd-cbaf0f06a0d6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "193"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "259"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6190d2cd-3a7b-450a-a517-3a919e50946c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/df65c86c-9144-4bff-82fd-cbaf0f06a0d6",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4eae7ee08e5fea46934d00605573c4eb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0f66ab9b-e323-4e60-9490-a79e164cb2c4",
+        "apim-request-id": "de15321b-297a-406e-b195-ffcfbd7845af",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "6190d2cd-3a7b-450a-a517-3a919e50946c",
-        "lastUpdateDateTime": "2021-09-27T14:29:02Z",
-        "createdDateTime": "2021-09-27T14:29:02Z",
-        "expirationDateTime": "2021-09-28T14:29:02Z",
+        "jobId": "df65c86c-9144-4bff-82fd-cbaf0f06a0d6",
+        "lastUpdateDateTime": "2021-10-25T21:19:38Z",
+        "createdDateTime": "2021-10-25T21:19:38Z",
+        "expirationDateTime": "2021-10-26T21:19:38Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,34 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6190d2cd-3a7b-450a-a517-3a919e50946c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/df65c86c-9144-4bff-82fd-cbaf0f06a0d6",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8c4a55f93b72b963f2befa0124096077",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b3f1475-c0ff-404d-878d-23c27c67a2b5",
+        "apim-request-id": "b963eeaf-02ab-4bf7-a713-96a01142d885",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:03 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "85"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "75"
       },
       "ResponseBody": {
-        "jobId": "6190d2cd-3a7b-450a-a517-3a919e50946c",
-        "lastUpdateDateTime": "2021-09-27T14:29:02Z",
-        "createdDateTime": "2021-09-27T14:29:02Z",
-        "expirationDateTime": "2021-09-28T14:29:02Z",
+        "jobId": "df65c86c-9144-4bff-82fd-cbaf0f06a0d6",
+        "lastUpdateDateTime": "2021-10-25T21:19:40Z",
+        "createdDateTime": "2021-10-25T21:19:38Z",
+        "expirationDateTime": "2021-10-26T21:19:38Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -124,7 +140,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:02.9794296Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:40.3013369Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -238,8 +254,6 @@
   "Variables": {
     "RandomSeed": "871702162",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "493",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e9b1ac0f5b5f0042aff077a4ac9f3b2a-8b531d2c631fc24f-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-a14f2be1a8b1f246bb9ac6517131ab6f-23ff6184bc41b141-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4b0353aa0f1651f2538f45eecc005c85",
         "x-ms-return-client-request-id": "true"
       },
@@ -41,45 +47,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "0dad7e61-96f2-4625-befd-76790b737bee",
-        "Date": "Mon, 27 Sep 2021 14:29:12 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a34f25dd-3d55-4b14-a8e4-e2ea9e33dd30",
+        "apim-request-id": "86585eb9-43de-4194-b438-a26592ec7161",
+        "Date": "Mon, 25 Oct 2021 21:19:56 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/abb59b10-d135-4e4e-9912-007aa4044ccf",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "470"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a34f25dd-3d55-4b14-a8e4-e2ea9e33dd30",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/abb59b10-d135-4e4e-9912-007aa4044ccf",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5b675418fae20b70884cffb922a64ed4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1c1b155f-c677-4c15-84df-8c7c2c0b57ce",
+        "apim-request-id": "ba8fd26c-8d97-488c-b83b-47be036991be",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "a34f25dd-3d55-4b14-a8e4-e2ea9e33dd30",
-        "lastUpdateDateTime": "2021-09-27T14:29:12Z",
-        "createdDateTime": "2021-09-27T14:29:12Z",
-        "expirationDateTime": "2021-09-28T14:29:12Z",
-        "status": "notStarted",
+        "jobId": "abb59b10-d135-4e4e-9912-007aa4044ccf",
+        "lastUpdateDateTime": "2021-10-25T21:19:56Z",
+        "createdDateTime": "2021-10-25T21:19:56Z",
+        "expirationDateTime": "2021-10-26T21:19:56Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -89,71 +100,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a34f25dd-3d55-4b14-a8e4-e2ea9e33dd30",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/abb59b10-d135-4e4e-9912-007aa4044ccf",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "83ce8125249808d136945c8ed4f7794f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b5ca0cd1-4c84-4616-8aed-ebf52c8c2509",
+        "apim-request-id": "046fd90d-78d7-42ab-b604-3836a49056ba",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "232"
       },
       "ResponseBody": {
-        "jobId": "a34f25dd-3d55-4b14-a8e4-e2ea9e33dd30",
-        "lastUpdateDateTime": "2021-09-27T14:29:13Z",
-        "createdDateTime": "2021-09-27T14:29:12Z",
-        "expirationDateTime": "2021-09-28T14:29:12Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/a34f25dd-3d55-4b14-a8e4-e2ea9e33dd30",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b2c7e0173e97b036e3f8c2c910392eac",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "39135485-2263-4b5a-ba7b-9c3acf5e1f00",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:15 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "90"
-      },
-      "ResponseBody": {
-        "jobId": "a34f25dd-3d55-4b14-a8e4-e2ea9e33dd30",
-        "lastUpdateDateTime": "2021-09-27T14:29:14Z",
-        "createdDateTime": "2021-09-27T14:29:12Z",
-        "expirationDateTime": "2021-09-28T14:29:12Z",
+        "jobId": "abb59b10-d135-4e4e-9912-007aa4044ccf",
+        "lastUpdateDateTime": "2021-10-25T21:19:56Z",
+        "createdDateTime": "2021-10-25T21:19:56Z",
+        "expirationDateTime": "2021-10-26T21:19:56Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -161,7 +140,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:14.1653817Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:56.9189004Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -275,8 +254,6 @@
   "Variables": {
     "RandomSeed": "1000683860",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchWithErrorTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "406",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1ff2bdebc0bd7345bf0c2d0327cf8b40-1cedd615f7d3464a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e384c254486cd54ca499ef86baec7e06-89b9f4e1fb295343-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "74c58b3926e0889e80427ddefcedfe72",
         "x-ms-return-client-request-id": "true"
       },
@@ -46,45 +52,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "6258cc8f-f10d-4602-a015-55a419426d95",
-        "Date": "Mon, 27 Sep 2021 14:29:03 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8c0842f5-2e33-4efc-985e-87c53ecf2967",
+        "apim-request-id": "f78718ac-d1a7-489a-aacc-c99dd25dd4df",
+        "Date": "Mon, 25 Oct 2021 21:19:40 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/32c8eb34-bc8d-4049-8efa-efeede796b52",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "211"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "358"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8c0842f5-2e33-4efc-985e-87c53ecf2967",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/32c8eb34-bc8d-4049-8efa-efeede796b52",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a4929114c7dba9c0bda3307af4684b7a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6107b77e-89b5-432a-9ea2-39ae055ed482",
+        "apim-request-id": "aaf2564e-7a29-48a8-9177-91dfed311307",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:03 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "8c0842f5-2e33-4efc-985e-87c53ecf2967",
-        "lastUpdateDateTime": "2021-09-27T14:29:03Z",
-        "createdDateTime": "2021-09-27T14:29:03Z",
-        "expirationDateTime": "2021-09-28T14:29:03Z",
+        "jobId": "32c8eb34-bc8d-4049-8efa-efeede796b52",
+        "lastUpdateDateTime": "2021-10-25T21:19:41Z",
+        "createdDateTime": "2021-10-25T21:19:40Z",
+        "expirationDateTime": "2021-10-26T21:19:40Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -94,34 +105,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8c0842f5-2e33-4efc-985e-87c53ecf2967",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/32c8eb34-bc8d-4049-8efa-efeede796b52",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e7adef42e44692733d49d530d3684c2c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7e8179e0-f1a5-4f54-8cbe-b692ff7cc530",
+        "apim-request-id": "212f7f88-89a3-434a-b8eb-3d00139fe8d6",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "89"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "84"
       },
       "ResponseBody": {
-        "jobId": "8c0842f5-2e33-4efc-985e-87c53ecf2967",
-        "lastUpdateDateTime": "2021-09-27T14:29:05Z",
-        "createdDateTime": "2021-09-27T14:29:03Z",
-        "expirationDateTime": "2021-09-28T14:29:03Z",
+        "jobId": "32c8eb34-bc8d-4049-8efa-efeede796b52",
+        "lastUpdateDateTime": "2021-10-25T21:19:41Z",
+        "createdDateTime": "2021-10-25T21:19:40Z",
+        "expirationDateTime": "2021-10-26T21:19:40Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -129,7 +145,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:05.0603484Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:41.7685578Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -213,8 +229,6 @@
   "Variables": {
     "RandomSeed": "1422884364",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchWithErrorTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "406",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-454c85df61324f478368f0008b657260-0e0c9a6ce6230d41-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-869f1cabae87b240891ab0cd7aeb0f7d-8daca4456754354c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "dbe0afe67ce79b2b693dae40ad813deb",
         "x-ms-return-client-request-id": "true"
       },
@@ -46,45 +52,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "72084c2d-9d2b-4922-9287-c08912a9cf29",
-        "Date": "Mon, 27 Sep 2021 14:29:15 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9c09391c-a25a-4a23-b5ea-6c85e7d0db35",
+        "apim-request-id": "f8fafd43-2ed4-43b7-91a6-b745383c00a8",
+        "Date": "Mon, 25 Oct 2021 21:19:58 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/3d364646-b80b-42b3-a9e1-d61e90dd73da",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "329"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "180"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9c09391c-a25a-4a23-b5ea-6c85e7d0db35",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/3d364646-b80b-42b3-a9e1-d61e90dd73da",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c4a0d928bf6e8664354ca0981c7872fc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9b9b288a-2d2f-485b-a477-19f09fd10341",
+        "apim-request-id": "cc7ddb75-879e-412a-9a80-ac05883cbbd4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:15 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "9c09391c-a25a-4a23-b5ea-6c85e7d0db35",
-        "lastUpdateDateTime": "2021-09-27T14:29:15Z",
-        "createdDateTime": "2021-09-27T14:29:15Z",
-        "expirationDateTime": "2021-09-28T14:29:15Z",
-        "status": "notStarted",
+        "jobId": "3d364646-b80b-42b3-a9e1-d61e90dd73da",
+        "lastUpdateDateTime": "2021-10-25T21:19:58Z",
+        "createdDateTime": "2021-10-25T21:19:58Z",
+        "expirationDateTime": "2021-10-26T21:19:58Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -94,34 +105,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9c09391c-a25a-4a23-b5ea-6c85e7d0db35",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/3d364646-b80b-42b3-a9e1-d61e90dd73da",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1680984ed338facc289226a82980a8fd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bcbe403f-cd0e-43fc-9fd2-25445da24436",
+        "apim-request-id": "e09fd483-8e19-4634-aae5-e8281921e5c4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "107"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "81"
       },
       "ResponseBody": {
-        "jobId": "9c09391c-a25a-4a23-b5ea-6c85e7d0db35",
-        "lastUpdateDateTime": "2021-09-27T14:29:16Z",
-        "createdDateTime": "2021-09-27T14:29:15Z",
-        "expirationDateTime": "2021-09-28T14:29:15Z",
+        "jobId": "3d364646-b80b-42b3-a9e1-d61e90dd73da",
+        "lastUpdateDateTime": "2021-10-25T21:19:58Z",
+        "createdDateTime": "2021-10-25T21:19:58Z",
+        "expirationDateTime": "2021-10-26T21:19:58Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -129,7 +145,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:16.297647Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:58.9949599Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -213,8 +229,6 @@
   "Variables": {
     "RandomSeed": "1044415089",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchWithNullIdTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchWithNullIdTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "253",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-22339ccd25ad6b41b8cbd5e9436187d4-11fba93eaece9a4e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1647e385d9ae0d419dcad50da818e536-a3eb21eff1548e4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "701610698e4e2836b2896021426da6ec",
         "x-ms-return-client-request-id": "true"
       },
@@ -36,13 +42,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "dad2f079-7925-45b4-b379-97aad0933429",
+        "apim-request-id": "f0bbf223-402e-4191-99a7-c7b0c2d42fd8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5"
       },
       "ResponseBody": {
         "error": {
@@ -59,8 +65,6 @@
   "Variables": {
     "RandomSeed": "1937417632",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchWithNullIdTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesBatchWithNullIdTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "253",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ab24f51dc64fb946a6ff2426381ac8e7-cc6394362df2754e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b068d0ee605db946a6aa9999b3978f16-553699e4ae802e4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "031f365b46e49dc4ece8c8872a44234a",
         "x-ms-return-client-request-id": "true"
       },
@@ -36,13 +42,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "faf28fce-c9ed-4394-85b2-3a35819a5684",
+        "apim-request-id": "513c975a-204c-4c32-86ba-c190f5b1974f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4"
       },
       "ResponseBody": {
         "error": {
@@ -59,8 +65,6 @@
   "Variables": {
     "RandomSeed": "1272363559",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "330",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-08776a98efe42e48a06134cf42558e8c-aaf45ba443cb1349-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-03397c2c8aa8184eb60c7a7b920d204f-3d38df908c02c342-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "70dcf60840f7ecaa22659829d5e36ecf",
         "x-ms-return-client-request-id": "true"
       },
@@ -36,82 +42,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cb7d19ec-4ed6-4014-8146-0ce964a12fec",
-        "Date": "Mon, 27 Sep 2021 14:29:05 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d5863151-c3eb-413d-b8f0-bb7d442fac29",
+        "apim-request-id": "7b166456-5f0f-4c27-b174-e5aba2a54c2d",
+        "Date": "Mon, 25 Oct 2021 21:19:43 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/597af4d4-e888-4210-ae34-3161431bb6fc",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "571"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d5863151-c3eb-413d-b8f0-bb7d442fac29",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/597af4d4-e888-4210-ae34-3161431bb6fc",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8f5d632e99738948001123455ce65d3c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9d7fd746-8072-4604-a554-e7fcf6bd4cbf",
+        "apim-request-id": "0a1ed982-5152-4e5f-92e0-fe2737eef22f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:05 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "54"
       },
       "ResponseBody": {
-        "jobId": "d5863151-c3eb-413d-b8f0-bb7d442fac29",
-        "lastUpdateDateTime": "2021-09-27T14:29:06Z",
-        "createdDateTime": "2021-09-27T14:29:05Z",
-        "expirationDateTime": "2021-09-28T14:29:05Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/d5863151-c3eb-413d-b8f0-bb7d442fac29",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8a32edc4d34fec971212a900a31d191e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "20c29846-104b-44f8-be71-6b9a149e67f5",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:06 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
-      },
-      "ResponseBody": {
-        "jobId": "d5863151-c3eb-413d-b8f0-bb7d442fac29",
-        "lastUpdateDateTime": "2021-09-27T14:29:07Z",
-        "createdDateTime": "2021-09-27T14:29:05Z",
-        "expirationDateTime": "2021-09-28T14:29:05Z",
+        "jobId": "597af4d4-e888-4210-ae34-3161431bb6fc",
+        "lastUpdateDateTime": "2021-10-25T21:19:44Z",
+        "createdDateTime": "2021-10-25T21:19:43Z",
+        "expirationDateTime": "2021-10-26T21:19:43Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -119,7 +93,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:06.998622Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:44.1556529Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -185,8 +159,6 @@
   "Variables": {
     "RandomSeed": "1714539574",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "330",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-59b09bac88d2714bb110e3bcfa3e5ae7-34bac844a31b104b-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-0820dcccac74bc45975cfb7ac7d37790-38421e04570ca742-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "64a871e0e89498a4691673572a2e8f64",
         "x-ms-return-client-request-id": "true"
       },
@@ -36,45 +42,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "a61ffcc8-011c-4909-bcb7-12863e45a75c",
-        "Date": "Mon, 27 Sep 2021 14:29:17 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/00b0474d-ad8e-4266-b34e-44ceb64be0f9",
+        "apim-request-id": "ae0f9ae5-1543-4aec-8a32-e26053d771d4",
+        "Date": "Mon, 25 Oct 2021 21:20:00 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4279fb80-18b5-4cbe-b4b5-70a4febe1ad1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "158"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "212"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/00b0474d-ad8e-4266-b34e-44ceb64be0f9",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4279fb80-18b5-4cbe-b4b5-70a4febe1ad1",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c6d92b6214f4777946cbe3bff02452bd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "afd92868-a872-4621-a6de-e349f803f341",
+        "apim-request-id": "a6c7ac78-4dd7-4ad2-8627-2ca01958c0ab",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "00b0474d-ad8e-4266-b34e-44ceb64be0f9",
-        "lastUpdateDateTime": "2021-09-27T14:29:17Z",
-        "createdDateTime": "2021-09-27T14:29:17Z",
-        "expirationDateTime": "2021-09-28T14:29:17Z",
-        "status": "notStarted",
+        "jobId": "4279fb80-18b5-4cbe-b4b5-70a4febe1ad1",
+        "lastUpdateDateTime": "2021-10-25T21:20:01Z",
+        "createdDateTime": "2021-10-25T21:20:00Z",
+        "expirationDateTime": "2021-10-26T21:20:00Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -84,34 +95,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/00b0474d-ad8e-4266-b34e-44ceb64be0f9",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/4279fb80-18b5-4cbe-b4b5-70a4febe1ad1",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e0413a2ec18584e4fcb6ba8bf733acdf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "569cee4e-0088-445d-8054-c97478f54241",
+        "apim-request-id": "b29a01e5-a94a-4ca3-b543-4ced6beebea3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "67"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "52"
       },
       "ResponseBody": {
-        "jobId": "00b0474d-ad8e-4266-b34e-44ceb64be0f9",
-        "lastUpdateDateTime": "2021-09-27T14:29:18Z",
-        "createdDateTime": "2021-09-27T14:29:17Z",
-        "expirationDateTime": "2021-09-28T14:29:17Z",
+        "jobId": "4279fb80-18b5-4cbe-b4b5-70a4febe1ad1",
+        "lastUpdateDateTime": "2021-10-25T21:20:01Z",
+        "createdDateTime": "2021-10-25T21:20:00Z",
+        "expirationDateTime": "2021-10-26T21:20:00Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -119,7 +135,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:18.1484336Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:01.4213451Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -185,8 +201,6 @@
   "Variables": {
     "RandomSeed": "616315711",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithLanguageTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "367",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9eef6aa8c3804246905bae43a49be9de-612aa5eab342ec4a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b959b531339b884fad7582fd84c36140-58d0c410e73e8e44-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "20b2726b6f72ee77862e98bbfb8ef41b",
         "x-ms-return-client-request-id": "true"
       },
@@ -36,45 +42,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "002df656-a8b1-4f52-980f-a1ef6d8082c8",
-        "Date": "Mon, 27 Sep 2021 14:29:08 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/4c0e44ed-6d5c-4a0d-9243-d81bbb38399e",
+        "apim-request-id": "f82b4180-7b3b-4f4e-93b9-5d57f75bd29a",
+        "Date": "Mon, 25 Oct 2021 21:19:46 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7829cf34-f4aa-4575-8890-550bdd55a3bb",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "141"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "220"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/4c0e44ed-6d5c-4a0d-9243-d81bbb38399e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7829cf34-f4aa-4575-8890-550bdd55a3bb",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "96569e75810e8734457b06ee9d1971d5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "69345d67-52bf-4f0e-870f-4ddee8983726",
+        "apim-request-id": "7f4d6fd9-c846-4416-803e-a37e836f242d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:08 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "4c0e44ed-6d5c-4a0d-9243-d81bbb38399e",
-        "lastUpdateDateTime": "2021-09-27T14:29:09Z",
-        "createdDateTime": "2021-09-27T14:29:09Z",
-        "expirationDateTime": "2021-09-28T14:29:09Z",
+        "jobId": "7829cf34-f4aa-4575-8890-550bdd55a3bb",
+        "lastUpdateDateTime": "2021-10-25T21:19:46Z",
+        "createdDateTime": "2021-10-25T21:19:46Z",
+        "expirationDateTime": "2021-10-26T21:19:46Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -84,34 +95,39 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/4c0e44ed-6d5c-4a0d-9243-d81bbb38399e",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7829cf34-f4aa-4575-8890-550bdd55a3bb",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a26c7ed5ef2f5bb1ae0a76384973c0ab",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bc8017b6-2118-4d81-88f6-906e2dddc077",
+        "apim-request-id": "82b2000e-fab9-4a4e-8192-1b43f345f725",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:10 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "57"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "52"
       },
       "ResponseBody": {
-        "jobId": "4c0e44ed-6d5c-4a0d-9243-d81bbb38399e",
-        "lastUpdateDateTime": "2021-09-27T14:29:10Z",
-        "createdDateTime": "2021-09-27T14:29:09Z",
-        "expirationDateTime": "2021-09-28T14:29:09Z",
+        "jobId": "7829cf34-f4aa-4575-8890-550bdd55a3bb",
+        "lastUpdateDateTime": "2021-10-25T21:19:47Z",
+        "createdDateTime": "2021-10-25T21:19:46Z",
+        "expirationDateTime": "2021-10-26T21:19:46Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -119,7 +135,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:10.1076609Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:47.7083534Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -185,8 +201,6 @@
   "Variables": {
     "RandomSeed": "522932983",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithLanguageTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "367",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ce18a279b7b750448d57f44a9ee8c99f-3b29cbe6b9670a49-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2d7d034d985f5e4794d799addba1d7f9-a2fbc8a3e2e93641-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7d887a21c360dd0e46c78f0debb18a38",
         "x-ms-return-client-request-id": "true"
       },
@@ -36,45 +42,50 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "6febff9d-9c41-48ff-821e-a65415a436be",
-        "Date": "Mon, 27 Sep 2021 14:29:19 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/208d2931-8a60-4b4b-aaeb-6f6726282fde",
+        "apim-request-id": "a878976e-3d33-4a23-a5ec-4f9115321e85",
+        "Date": "Mon, 25 Oct 2021 21:20:03 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b1f598b-3b5a-494c-b6e8-06683f301d4e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "158"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "481"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/208d2931-8a60-4b4b-aaeb-6f6726282fde",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9b1f598b-3b5a-494c-b6e8-06683f301d4e",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210927.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6ad520feb24348dd00a9200b83146ed4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c7958de5-0125-4d3f-8114-28afbfeb8450",
+        "apim-request-id": "1c3ab0ac-9a9f-45ba-b107-ae3c22b77c71",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 27 Sep 2021 14:29:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "50"
       },
       "ResponseBody": {
-        "jobId": "208d2931-8a60-4b4b-aaeb-6f6726282fde",
-        "lastUpdateDateTime": "2021-09-27T14:29:20Z",
-        "createdDateTime": "2021-09-27T14:29:19Z",
-        "expirationDateTime": "2021-09-28T14:29:19Z",
+        "jobId": "9b1f598b-3b5a-494c-b6e8-06683f301d4e",
+        "lastUpdateDateTime": "2021-10-25T21:20:04Z",
+        "createdDateTime": "2021-10-25T21:20:03Z",
+        "expirationDateTime": "2021-10-26T21:20:03Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -82,7 +93,7 @@
           "total": 1,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-09-27T14:29:20.1437663Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:04.2521064Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -148,8 +159,6 @@
   "Variables": {
     "RandomSeed": "120361969",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_DEPLOYMENT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net",
-    "TEXT_ANALYTICS_PROJECT_NAME": "88ee0f78-fbca-444d-98e2-7c4c8631e494"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "656",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9126f8550e3acd45ae6408031f49afe4-7ac31cbc6073b54e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-a0aae9b3f93522448b3140e987f4607b-194f3075d315c54a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "811798329e93c7b0eee851ed76210b34",
         "x-ms-return-client-request-id": "true"
       },
@@ -50,42 +56,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ae1386ef-8cca-4b58-9bc1-aaa40aefaf79",
-        "Date": "Thu, 21 Oct 2021 20:15:33 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a4736413-ad8d-433b-89aa-eea0615e5e3b",
+        "apim-request-id": "d6984696-c2ea-4ad9-b8b5-bd3928238a15",
+        "Date": "Mon, 25 Oct 2021 21:19:48 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8e76695d-9310-4c89-8117-c2052b5e99d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "755"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "189"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a4736413-ad8d-433b-89aa-eea0615e5e3b",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8e76695d-9310-4c89-8117-c2052b5e99d4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0f29f833bbc61044dfbe237d258d7551",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dc4ea07f-6717-4213-bdb5-d2cad11f3135",
+        "apim-request-id": "39f5764b-fe6c-41e8-b893-47286bc1e788",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:15:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "102"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "a4736413-ad8d-433b-89aa-eea0615e5e3b",
-        "lastUpdateDateTime": "2021-10-21T20:15:34Z",
-        "createdDateTime": "2021-10-21T20:15:33Z",
-        "expirationDateTime": "2021-10-22T20:15:33Z",
+        "jobId": "8e76695d-9310-4c89-8117-c2052b5e99d4",
+        "lastUpdateDateTime": "2021-10-25T21:19:49Z",
+        "createdDateTime": "2021-10-25T21:19:48Z",
+        "expirationDateTime": "2021-10-26T21:19:48Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -97,67 +109,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a4736413-ad8d-433b-89aa-eea0615e5e3b",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/8e76695d-9310-4c89-8117-c2052b5e99d4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d52524e221c1fa02adf4517f9cdbaa1b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "032ae8cc-6cd0-41dd-9414-1269dd7b0763",
+        "apim-request-id": "bd82655d-7895-462f-a9e5-91223c95a610",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:15:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:19:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "111"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2908"
       },
       "ResponseBody": {
-        "jobId": "a4736413-ad8d-433b-89aa-eea0615e5e3b",
-        "lastUpdateDateTime": "2021-10-21T20:15:34Z",
-        "createdDateTime": "2021-10-21T20:15:33Z",
-        "expirationDateTime": "2021-10-22T20:15:33Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a4736413-ad8d-433b-89aa-eea0615e5e3b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8ec22a27048277955307a2d47a32a261",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "990c132a-5c9d-4e20-98e3-a5123f246391",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:15:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "323"
-      },
-      "ResponseBody": {
-        "jobId": "a4736413-ad8d-433b-89aa-eea0615e5e3b",
-        "lastUpdateDateTime": "2021-10-21T20:15:37Z",
-        "createdDateTime": "2021-10-21T20:15:33Z",
-        "expirationDateTime": "2021-10-22T20:15:33Z",
+        "jobId": "8e76695d-9310-4c89-8117-c2052b5e99d4",
+        "lastUpdateDateTime": "2021-10-25T21:19:49Z",
+        "createdDateTime": "2021-10-25T21:19:48Z",
+        "expirationDateTime": "2021-10-26T21:19:48Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -167,7 +149,7 @@
           "total": 2,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-21T20:15:37.6657762Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:49.1540184Z",
               "taskName": "RecognizeCustomEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -240,7 +222,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-21T20:15:37.2190436Z",
+              "lastUpdateDateTime": "2021-10-25T21:19:49.2146205Z",
               "taskName": "RecognizeCustomEntities",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeCustomEntitiesTests/RecognizeCustomEntitiesWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "656",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-af1bed3f1cffef44b6fa05c9410ea420-a6874068017c314d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1ca1df91fc07a543bec52ec02a38321a-9cff96816439f844-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "51a9ddef8cc9376c5ef234453d6d2e36",
         "x-ms-return-client-request-id": "true"
       },
@@ -50,42 +56,90 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "89ec913c-024f-43d8-9f71-db6b6917b5d4",
-        "Date": "Thu, 21 Oct 2021 20:15:53 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/76b8f165-d23b-4f60-b53d-d52d5a82cbd6",
+        "apim-request-id": "1977bfd0-d582-4835-b368-7be9dbccfcc8",
+        "Date": "Mon, 25 Oct 2021 21:20:04 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ccd33b08-03a4-427f-9b86-bc82012a7467",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "14721"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "409"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/76b8f165-d23b-4f60-b53d-d52d5a82cbd6",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ccd33b08-03a4-427f-9b86-bc82012a7467",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211021.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "28b605fdaa41e7f7c65dc469206cdb0b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "72fa7a7b-221d-497e-8898-563a518c8337",
+        "apim-request-id": "64944efa-5db3-4487-ad8a-d0b247e54cda",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:15:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "278"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "76b8f165-d23b-4f60-b53d-d52d5a82cbd6",
-        "lastUpdateDateTime": "2021-10-21T20:15:48Z",
-        "createdDateTime": "2021-10-21T20:15:47Z",
-        "expirationDateTime": "2021-10-22T20:15:47Z",
+        "jobId": "ccd33b08-03a4-427f-9b86-bc82012a7467",
+        "lastUpdateDateTime": "2021-10-25T21:20:05Z",
+        "createdDateTime": "2021-10-25T21:20:04Z",
+        "expirationDateTime": "2021-10-26T21:20:04Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ccd33b08-03a4-427f-9b86-bc82012a7467",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f540c9e3448fabf732e712f376f901fe",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3b97c4cd-2c18-4dfc-a104-3990e2fb515b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:20:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "111"
+      },
+      "ResponseBody": {
+        "jobId": "ccd33b08-03a4-427f-9b86-bc82012a7467",
+        "lastUpdateDateTime": "2021-10-25T21:20:05Z",
+        "createdDateTime": "2021-10-25T21:20:04Z",
+        "expirationDateTime": "2021-10-26T21:20:04Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -95,7 +149,7 @@
           "total": 2,
           "customEntityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-21T20:15:48.5605703Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:05.2958451Z",
               "taskName": "RecognizeCustomEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -168,7 +222,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-21T20:15:48.5783364Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:05.5838327Z",
               "taskName": "RecognizeCustomEntities",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchConvenienceTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f8601763ef5edd45b8faa2ca1dc725d8-7216dfde512c9a4c-00",
+        "traceparent": "00-13eb5d59d39e824fa70f1df60312a093-ed5934250937734c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "73b99494ac5a2b6a48730fa6d4bda24b",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1490e146-d5f7-4ca9-bea2-197d01a3cfbb",
+        "apim-request-id": "7a000609-d695-46c5-9849-3b43bd5e12e0",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "51"
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
         "documents": [
@@ -95,6 +95,6 @@
   "Variables": {
     "RandomSeed": "1057805335",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchConvenienceTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b2016b119115f4ab67bd827b009e4f6-3e3a1e3ee0989c43-00",
+        "traceparent": "00-817288a2cfae764f87458775c8b2f708-95078964f92b6546-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d2ffe8a9cd41c6a7f7eddf3ba0def75e",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2c2fc806-572a-4f17-a21f-53cca2811e1b",
+        "apim-request-id": "088ebe54-732a-4a65-8af5-503fc40327b7",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "x-envoy-upstream-service-time": "17"
       },
       "ResponseBody": {
         "documents": [
@@ -95,6 +95,6 @@
   "Variables": {
     "RandomSeed": "581345388",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchConvenienceWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-69d4fb0312f6d34dac5f5b6067c77418-7a9480f5ff2abe45-00",
+        "traceparent": "00-78c0d1e196d90245812807018fe52f6d-56621bec7592c249-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "67616e684f8b043d1e0c71e939770f42",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e7f7d307-7313-4c95-8def-5acfde98a561",
+        "apim-request-id": "562252a2-6ae0-430c-a065-74e2a0d3c361",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "53"
+        "x-envoy-upstream-service-time": "17"
       },
       "ResponseBody": {
         "statistics": {
@@ -109,6 +109,6 @@
   "Variables": {
     "RandomSeed": "706252555",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchConvenienceWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "191",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-386172e948a3b94b907f13187ea09cf6-e1523a112995aa44-00",
+        "traceparent": "00-a1a0312056cd134cb0b91b7f38723e70-f280029c6d19b244-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "3d6191fdfe339ad3e9a9a23dfab389e2",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d76da010-536d-44af-99e6-e17cca58909c",
+        "apim-request-id": "069302b5-77cb-4c0e-b5d1-7165382e1d08",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "56"
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
         "statistics": {
@@ -109,6 +109,6 @@
   "Variables": {
     "RandomSeed": "915085791",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9b38a911e7ebd94ca3d0e6b7cf86c571-9ceac004c275514b-00",
+        "traceparent": "00-1888ffe7b74a2844a266f953be218e9f-8e2ea67dcb9d144e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "c2e6195c0f4c89c31e4ed8101a9fceeb",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8210f72b-d385-4c9b-83e6-3db5434be2d0",
+        "apim-request-id": "88fc3e90-26e1-4cf3-862a-100a9694f63c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "45"
+        "x-envoy-upstream-service-time": "15"
       },
       "ResponseBody": {
         "documents": [
@@ -109,6 +109,6 @@
   "Variables": {
     "RandomSeed": "1116565065",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-301293ae346bcc4a8c2b1e6656a018dc-bd7fc607da0b6a45-00",
+        "traceparent": "00-3b5e0698bc84fa489a947f3eb3e319ca-0c8ab02a88379746-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "74826ca03adf5e0230955bc11a73f253",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "962fe54d-bfd6-4ec0-a9e3-41096ad2f17a",
+        "apim-request-id": "69c685da-e0a8-4552-85a2-4a85dd232567",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "58"
+        "x-envoy-upstream-service-time": "17"
       },
       "ResponseBody": {
         "documents": [
@@ -109,6 +109,6 @@
   "Variables": {
     "RandomSeed": "1159498521",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithErrorTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "217",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c4f13d5d013c4548a901bb6d7052d84d-4f0cec1678594041-00",
+        "traceparent": "00-3853d7efa70e3d4ca99b16b99cd0b646-b5deb16b5ba21248-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "e1ab51bf64c496574b45aba2614e8e70",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b9b82c11-b8bc-4fd1-bb5c-aa6bc87d71dd",
+        "apim-request-id": "fa459163-eedb-422f-8106-6fa8d9c1a8ab",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "47"
+        "x-envoy-upstream-service-time": "20"
       },
       "ResponseBody": {
         "documents": [
@@ -112,6 +112,6 @@
   "Variables": {
     "RandomSeed": "756961484",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithErrorTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "217",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fe52bd0afeab4a4a830d408b6aa22f20-c063fb1c1e9d0348-00",
+        "traceparent": "00-0d936c9e7bbc54488e14e0c875d5510f-49fdc3e873f7c94a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d8b08f95484a0406f97f2f7420372c35",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bd1da593-5036-4072-bbe8-41d743536a98",
+        "apim-request-id": "757c6ab9-3405-4946-af23-22889578fce2",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "60"
+        "x-envoy-upstream-service-time": "17"
       },
       "ResponseBody": {
         "documents": [
@@ -112,6 +112,6 @@
   "Variables": {
     "RandomSeed": "2014309095",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithInvalidDocumentBatch.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithInvalidDocumentBatch.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "297",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b4abd2b777453144b17ea3cab63f30f4-e32ce7703b42e641-00",
+        "traceparent": "00-46571f5a5796f7499638d8241e4ce705-4c8ed00152230143-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a8ae17c802a6c3ea068b7f13c73b934a",
         "x-ms-return-client-request-id": "true"
@@ -55,9 +55,9 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "47193eff-c9cc-4f50-b9b5-00bf887f44f3",
+        "apim-request-id": "30c811d8-1dc2-4357-977b-1aee6c4cc9a5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -78,6 +78,6 @@
   "Variables": {
     "RandomSeed": "1535542289",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithInvalidDocumentBatchAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithInvalidDocumentBatchAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "297",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4cc66ee134b6724b85c78c53faf048a8-8e2522cc0b0e3a40-00",
+        "traceparent": "00-40b27f3871a1994eabb8f0f27636b79e-21fb8523e8000041-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "28b544e5b9a5cf3535ddef0fb0fd1d43",
         "x-ms-return-client-request-id": "true"
@@ -55,13 +55,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "ea6254d3-edab-450f-abbe-e8179fd0463e",
+        "apim-request-id": "08fcf927-72bc-4e6f-ac11-370696dd64b8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "4"
       },
       "ResponseBody": {
         "error": {
@@ -78,6 +78,6 @@
   "Variables": {
     "RandomSeed": "467834574",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithNullIdTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithNullIdTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "64",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1299928fae4d084da25ebf9aebedfd3a-2936b2f2b3613b4d-00",
+        "traceparent": "00-3418bf9deec4034384c1464aed971228-e6427f9dd1810146-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "0394cc79836b8e2a0617730333d293ff",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "d7a70f63-1436-42fa-a0cb-9fb4d047626d",
+        "apim-request-id": "62f06032-8bde-4d2b-ad2e-9d2a69adfbef",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "5"
       },
       "ResponseBody": {
         "error": {
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "449438732",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithNullIdTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithNullIdTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "64",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ef109c2e7fa2ae4aaedb9c7213949b0b-82bd6b869936d842-00",
+        "traceparent": "00-1a4a4d89c2576e45bb44415ed28dfeb5-ecc5f7b183ce0049-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d2a606a042fa292271e9e0fd82e50d07",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "8beefd94-d484-4a38-bf7c-cccf0ece15c5",
+        "apim-request-id": "83298568-446d-44fe-b53b-f8997891c98a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "4"
+        "x-envoy-upstream-service-time": "5"
       },
       "ResponseBody": {
         "error": {
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "269930919",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithNullTextTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithNullTextTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d222c7219fcc6a40ba784e4d1a5b36ea-e0e97b0506b7ae4c-00",
+        "traceparent": "00-8a11873640d76643bf376c446cbb548a-87915285a7929e49-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "143a14bc880cd41cfe9c98287e990fb6",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "46f12e61-e146-49da-a764-0d17a3ac57a3",
+        "apim-request-id": "34546329-df99-4733-82e4-52b42abd3565",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "1966020734",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithNullTextTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithNullTextTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f07b3c7b89581046b36d1b87cc0777f7-617784224b930343-00",
+        "traceparent": "00-8b8befd0369aaa439abf479b1f69ed13-a50858fe57edfb47-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "7afea088ca0a22de1ccfe4f56367e3ca",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "365ee77d-e879-4e2f-b7c5-f31e9144433d",
+        "apim-request-id": "837b6c7e-06f0-4f00-85c4-f59277c77aa0",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "794759441",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5ee0aade8d9e4c4a97cc1dc5efc50af2-f2c70931ee60404d-00",
+        "traceparent": "00-dd6886c5d5987a44993405b81b643ae6-27a9a67ec5cdbd4f-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "3c7b09ea57a0a9f84c938c05ff06e377",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb3eb469-5644-483e-9eff-08646f8c6ef3",
+        "apim-request-id": "8b3f66ac-4e93-4801-a8ee-f72f8691d662",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "57"
+        "x-envoy-upstream-service-time": "17"
       },
       "ResponseBody": {
         "statistics": {
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "541291504",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesBatchWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-524c0910dcc81549a869924127780624-08999bf5c186be49-00",
+        "traceparent": "00-02743bd40b7e744f9b9003d66b924f97-7e1b74909e84dd40-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "c386dc48f454868243af3522ce69cb86",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "696d6e27-9648-4eee-a5ae-8bb2ca32f0c9",
+        "apim-request-id": "c7878d48-a67e-438d-9670-d2816bfbd0c1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "57"
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
         "statistics": {
@@ -123,6 +123,6 @@
   "Variables": {
     "RandomSeed": "438437791",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7a70efb7d116894092f303669384d27c-af4a31114272bb4a-00",
+        "traceparent": "00-90c07af61ab7a14c8261ea382b6c01e7-4b6b621e29737e44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "483a789eb74f49281b818c10882907cc",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5ab3e6d1-e686-4f4c-b702-f5f699378634",
+        "apim-request-id": "03f771ff-692b-4bb2-af6c-b8fc6d3bb5e0",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "56"
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
         "documents": [
@@ -77,6 +77,6 @@
   "Variables": {
     "RandomSeed": "958901847",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-356ad39648178948b5d25aadb64a5826-53daa3e3b5332a49-00",
+        "traceparent": "00-e16b9444c473be4db64d9d8996590fd7-a04593626290ef4a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "700659f3fdefe683be90e2b1951eb421",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c6c6ea8c-d94e-4ccd-861f-9457dad4130a",
+        "apim-request-id": "fda7a731-c38a-42f4-833e-0e2cb58136f3",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "61"
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
         "documents": [
@@ -77,6 +77,6 @@
   "Variables": {
     "RandomSeed": "988548785",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithLanguageTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "102",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f83eb9755e37104b9aa3c6edbfb0dd2c-2d810a4f143e584e-00",
+        "traceparent": "00-7c04095fc98de34dbe9cf14a00bb3ff4-7525a27da79f7843-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "fb4827053b6a1252c3b25be970bef0ff",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6086968b-acb3-4c68-a1c9-3d23935f33a2",
+        "apim-request-id": "0244920e-fad1-402b-8b32-028e7ef5f7fb",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "64"
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
         "documents": [
@@ -77,6 +77,6 @@
   "Variables": {
     "RandomSeed": "1194835107",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithLanguageTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "102",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-201585e0e4bb7f4fa300cd03ccb4e5a1-70f452eec9cc964b-00",
+        "traceparent": "00-95b60cef6448a74ab1790a06ab15db35-8dd2a4b4fc28ac49-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "b55082b33b1fe734efdcbb82c7c8a31b",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cff9fc1a-54f9-4b29-aaf9-25cb002438bd",
+        "apim-request-id": "ecdf5713-99f5-47fa-9639-d287a44ab1a6",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "x-envoy-upstream-service-time": "15"
       },
       "ResponseBody": {
         "documents": [
@@ -77,6 +77,6 @@
   "Variables": {
     "RandomSeed": "852244609",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "453",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c2043953522b5c409fedc50dd40f4de4-817736411c2a2c4c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-705bad755673a54a80781877324514e4-347a97e50d82a84f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0923d0adeca73288c4a850a185762c69",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,222 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "26429a1e-c741-4683-bbbc-938428807c8a",
-        "Date": "Wed, 20 Oct 2021 15:05:32 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
+        "apim-request-id": "088c05da-dede-400e-bdf9-2e9609eb9390",
+        "Date": "Mon, 25 Oct 2021 21:20:10 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "476"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "220"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3a39d7db401e5f5d2b7fe561c97b3d4e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bc0e7f43-eded-4a4c-b665-ba24bbfb34e4",
+        "apim-request-id": "f54eb3d5-2ac7-4c09-9e8e-afa21c29c2e9",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
-      },
-      "ResponseBody": {
-        "jobId": "d8d071b0-2e7a-446b-9c43-993b10e63840",
-        "lastUpdateDateTime": "2021-10-20T15:05:32Z",
-        "createdDateTime": "2021-10-20T15:05:32Z",
-        "expirationDateTime": "2021-10-21T15:05:32Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ad0eb5a68dc8ba01fae0c55b4729c61e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "312e505f-cece-4d0b-86f3-314ea1ea8d7a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:33 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "d8d071b0-2e7a-446b-9c43-993b10e63840",
-        "lastUpdateDateTime": "2021-10-20T15:05:32Z",
-        "createdDateTime": "2021-10-20T15:05:32Z",
-        "expirationDateTime": "2021-10-21T15:05:32Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "faeed62b27d36daa73c4de2707266948",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "28176062-907f-4353-9038-bacfabd718c0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:35 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
-      },
-      "ResponseBody": {
-        "jobId": "d8d071b0-2e7a-446b-9c43-993b10e63840",
-        "lastUpdateDateTime": "2021-10-20T15:05:32Z",
-        "createdDateTime": "2021-10-20T15:05:32Z",
-        "expirationDateTime": "2021-10-21T15:05:32Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cffa016b7f674ea1d67e403e7b011801",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "37449b4f-607a-4151-80ef-53e3133c3cdf",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:36 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "d8d071b0-2e7a-446b-9c43-993b10e63840",
-        "lastUpdateDateTime": "2021-10-20T15:05:32Z",
-        "createdDateTime": "2021-10-20T15:05:32Z",
-        "expirationDateTime": "2021-10-21T15:05:32Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f236c6b9438d7f7b0aa13a03aed9b3d4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "323352ee-288c-48b4-a332-f8f19efbf1bb",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:37 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "d8d071b0-2e7a-446b-9c43-993b10e63840",
-        "lastUpdateDateTime": "2021-10-20T15:05:32Z",
-        "createdDateTime": "2021-10-20T15:05:32Z",
-        "expirationDateTime": "2021-10-21T15:05:32Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "45f07c76f62facb7359f2454e76cf271",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e563da47-0672-4370-9002-3a5c3d46fff8",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:39 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "d8d071b0-2e7a-446b-9c43-993b10e63840",
-        "lastUpdateDateTime": "2021-10-20T15:05:38Z",
-        "createdDateTime": "2021-10-20T15:05:32Z",
-        "expirationDateTime": "2021-10-21T15:05:32Z",
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:11Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -275,31 +107,79 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "406edcac77ef28bb867bc4c6459d9ffc",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ad0eb5a68dc8ba01fae0c55b4729c61e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2d747a5f-a054-4236-b6a6-28f63c3b7e1e",
+        "apim-request-id": "4f7b38da-f9c2-4073-9fde-d668e2c2b2eb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:11Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "faeed62b27d36daa73c4de2707266948",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a741b53c-c8e6-4d11-aef3-0d54d1d28684",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:20:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "175"
       },
       "ResponseBody": {
-        "jobId": "d8d071b0-2e7a-446b-9c43-993b10e63840",
-        "lastUpdateDateTime": "2021-10-20T15:05:40Z",
-        "createdDateTime": "2021-10-20T15:05:32Z",
-        "expirationDateTime": "2021-10-21T15:05:32Z",
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:12Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -309,7 +189,7 @@
           "total": 2,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:05:40.6172502Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:12.5744457Z",
               "taskName": "RecognizeEntities",
               "state": "succeeded",
               "results": {
@@ -378,31 +258,691 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/d8d071b0-2e7a-446b-9c43-993b10e63840",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "cffa016b7f674ea1d67e403e7b011801",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f1febc88-c24d-4ede-bff5-2132f4dc93f6",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:20:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "85"
+      },
+      "ResponseBody": {
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:12Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:12.5744457Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f236c6b9438d7f7b0aa13a03aed9b3d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "17a973a4-7ff2-46f9-a0e8-fdab570cec83",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:20:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2471"
+      },
+      "ResponseBody": {
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:12Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:12.5744457Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "45f07c76f62facb7359f2454e76cf271",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4bc45329-491f-401c-8de7-edf1960c9c33",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:20:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "60"
+      },
+      "ResponseBody": {
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:17Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:12.5744457Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "406edcac77ef28bb867bc4c6459d9ffc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f3091a0e-56f7-4e08-b832-51dee0708407",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:20:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "66"
+      },
+      "ResponseBody": {
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:17Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:12.5744457Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "fec76ccad211c3d20f8abded1e26989e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2db28292-6076-4253-a7d1-30e6ae2a49dd",
+        "apim-request-id": "4b70ad1f-9c3b-4dc5-9712-f57128002c1e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:41 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "157"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "55"
       },
       "ResponseBody": {
-        "jobId": "d8d071b0-2e7a-446b-9c43-993b10e63840",
-        "lastUpdateDateTime": "2021-10-20T15:05:41Z",
-        "createdDateTime": "2021-10-20T15:05:32Z",
-        "expirationDateTime": "2021-10-21T15:05:32Z",
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:17Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:12.5744457Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d257c8af736bffe4c0c8beb331f16798",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bae50830-5e23-4c4c-8257-a9dd43a9efed",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:20:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "67"
+      },
+      "ResponseBody": {
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:17Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:12.5744457Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/c8736c74-b175-4952-a3fc-847ffaf83da3",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "7a8a2700f3a4d95f0aaa3165b9ce0960",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8d7f3ff5-a2d9-4247-aa98-50129ee42fde",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:20:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "865"
+      },
+      "ResponseBody": {
+        "jobId": "c8736c74-b175-4952-a3fc-847ffaf83da3",
+        "lastUpdateDateTime": "2021-10-25T21:20:25Z",
+        "createdDateTime": "2021-10-25T21:20:10Z",
+        "expirationDateTime": "2021-10-26T21:20:10Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -412,7 +952,7 @@
           "total": 2,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:05:41.5795135Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:25.547045Z",
               "taskName": "RecognizeEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -477,7 +1017,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:05:40.6172502Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:12.5744457Z",
               "taskName": "RecognizeEntities",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "453",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-471c85ea5ed7ec489c19966ad26b30b2-4f8b61c51fcec947-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7e712fd5357e72448110bb102f2f0dbc-6c60f63c888c0041-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9c320a9b8f291b2f412bdd52e0e2139a",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,42 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "91e1c980-8bbd-4b8a-920e-e33d27963974",
-        "Date": "Wed, 20 Oct 2021 15:05:43 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
+        "apim-request-id": "59584bff-1c5e-48e7-bd64-16a91141dc12",
+        "Date": "Mon, 25 Oct 2021 21:20:30 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "340"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "215"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "483e5a9af59e2f2a108bee82bc3a28ac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1915eab1-d050-4339-a3e5-ac1d8ed4beb9",
+        "apim-request-id": "9a6a81b5-5d6a-4143-a8fc-f1b1ff0b365d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-        "lastUpdateDateTime": "2021-10-20T15:05:43Z",
-        "createdDateTime": "2021-10-20T15:05:43Z",
-        "expirationDateTime": "2021-10-21T15:05:43Z",
+        "jobId": "54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
+        "lastUpdateDateTime": "2021-10-25T21:20:31Z",
+        "createdDateTime": "2021-10-25T21:20:31Z",
+        "expirationDateTime": "2021-10-26T21:20:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -95,247 +107,582 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "180f57150c5f727293308582edacfcc1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8d5ef0e1-b44b-4927-9b70-6f055711e667",
+        "apim-request-id": "76dfabe9-c7b7-4e06-a54f-3768bba15e6b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "867"
       },
       "ResponseBody": {
-        "jobId": "fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-        "lastUpdateDateTime": "2021-10-20T15:05:43Z",
-        "createdDateTime": "2021-10-20T15:05:43Z",
-        "expirationDateTime": "2021-10-21T15:05:43Z",
+        "jobId": "54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
+        "lastUpdateDateTime": "2021-10-25T21:20:32Z",
+        "createdDateTime": "2021-10-25T21:20:31Z",
+        "expirationDateTime": "2021-10-26T21:20:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:32.7547042Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "591a9b09d482a699e0038b9da1ad5f06",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d3787d09-b508-4369-81e9-92d68c8cd8b2",
+        "apim-request-id": "48a22020-ed2a-4077-810c-ed14583c57f1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:45 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "158"
       },
       "ResponseBody": {
-        "jobId": "fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-        "lastUpdateDateTime": "2021-10-20T15:05:43Z",
-        "createdDateTime": "2021-10-20T15:05:43Z",
-        "expirationDateTime": "2021-10-21T15:05:43Z",
+        "jobId": "54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
+        "lastUpdateDateTime": "2021-10-25T21:20:32Z",
+        "createdDateTime": "2021-10-25T21:20:31Z",
+        "expirationDateTime": "2021-10-26T21:20:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:32.7547042Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "893c3002fbd38e3ae8cbb46d6fa84164",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f55325a-fcb6-40ac-86f9-e86e47909340",
+        "apim-request-id": "2bb3e140-4a4e-4902-bffe-43951a4e46ac",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1305"
       },
       "ResponseBody": {
-        "jobId": "fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-        "lastUpdateDateTime": "2021-10-20T15:05:43Z",
-        "createdDateTime": "2021-10-20T15:05:43Z",
-        "expirationDateTime": "2021-10-21T15:05:43Z",
+        "jobId": "54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
+        "lastUpdateDateTime": "2021-10-25T21:20:32Z",
+        "createdDateTime": "2021-10-25T21:20:31Z",
+        "expirationDateTime": "2021-10-26T21:20:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:32.7547042Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "21792c8ece20412abd68385c80d4d1e5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1568ae5e-0912-4141-922e-0facb6c5586e",
+        "apim-request-id": "7a655f25-f619-4b58-9c35-3fd173535009",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:48 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "59"
       },
       "ResponseBody": {
-        "jobId": "fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-        "lastUpdateDateTime": "2021-10-20T15:05:43Z",
-        "createdDateTime": "2021-10-20T15:05:43Z",
-        "expirationDateTime": "2021-10-21T15:05:43Z",
+        "jobId": "54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
+        "lastUpdateDateTime": "2021-10-25T21:20:37Z",
+        "createdDateTime": "2021-10-25T21:20:31Z",
+        "expirationDateTime": "2021-10-26T21:20:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:32.7547042Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bc7f7fd1736f0dee608c71b61f2c3737",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "07fff414-adc5-44c9-a232-f43e99f75997",
+        "apim-request-id": "f125e470-1f14-48cd-bbd2-b3b2cfc4e135",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1303"
       },
       "ResponseBody": {
-        "jobId": "fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-        "lastUpdateDateTime": "2021-10-20T15:05:49Z",
-        "createdDateTime": "2021-10-20T15:05:43Z",
-        "expirationDateTime": "2021-10-21T15:05:43Z",
+        "jobId": "54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
+        "lastUpdateDateTime": "2021-10-25T21:20:37Z",
+        "createdDateTime": "2021-10-25T21:20:31Z",
+        "expirationDateTime": "2021-10-26T21:20:31Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:20:32.7547042Z",
+              "taskName": "RecognizeEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 25,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 40,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 0,
+                        "length": 9,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Bill Gates",
+                        "category": "Person",
+                        "offset": 26,
+                        "length": 10,
+                        "confidenceScore": 1.0
+                      },
+                      {
+                        "text": "Paul Allen",
+                        "category": "Person",
+                        "offset": 39,
+                        "length": 10,
+                        "confidenceScore": 0.99
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "740e27c13d3434e606fbcb6ac3de0d13",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1138789d-f853-4021-a4f0-172aad344ecf",
+        "apim-request-id": "7db1d174-437d-4edb-beae-07d83722ed72",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-        "lastUpdateDateTime": "2021-10-20T15:05:51Z",
-        "createdDateTime": "2021-10-20T15:05:43Z",
-        "expirationDateTime": "2021-10-21T15:05:43Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f09bcefa85281af43e6bc0935d732191",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c4ef3528-5a2a-4ee4-bd15-64300b9f5e4e",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:05:51 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "129"
       },
       "ResponseBody": {
-        "jobId": "fbbcda42-2e1f-47ca-bd31-a92245cc56aa",
-        "lastUpdateDateTime": "2021-10-20T15:05:52Z",
-        "createdDateTime": "2021-10-20T15:05:43Z",
-        "expirationDateTime": "2021-10-21T15:05:43Z",
+        "jobId": "54f71f9b-d8a6-4d76-92b7-af8ca3d9f3a4",
+        "lastUpdateDateTime": "2021-10-25T21:20:42Z",
+        "createdDateTime": "2021-10-25T21:20:31Z",
+        "expirationDateTime": "2021-10-26T21:20:31Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -345,7 +692,7 @@
           "total": 2,
           "entityRecognitionTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:05:52.1412892Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:42.8382863Z",
               "taskName": "RecognizeEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -410,7 +757,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:05:51.1730364Z",
+              "lastUpdateDateTime": "2021-10-25T21:20:32.7547042Z",
               "taskName": "RecognizeEntities",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?model-version=2020-04-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?model-version=2020-04-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aba22c074429264b8f3d82d8fbdf713b-3840da7758f2f44a-00",
+        "traceparent": "00-92639668362e9a40aebf7124ae24526c-492feaa06f2fab47-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "c580665e455e125e80a821d61e9c3c18",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b8116be-0b62-4271-b336-06afdfda5da4",
+        "apim-request-id": "fd7523b9-cbe0-462d-a402-1dc353df91a5",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "103"
+        "x-envoy-upstream-service-time": "87"
       },
       "ResponseBody": {
         "documents": [
@@ -79,6 +79,6 @@
   "Variables": {
     "RandomSeed": "1531566714",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?model-version=2020-04-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?model-version=2020-04-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2c4bd9cd202ab44faf2513f393af95bf-3afa3a3dae2fb947-00",
+        "traceparent": "00-fa54e69907e3de4fb687558cf736d1cb-8ba53f727e414d48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "3b4b745166e69035ddd947884a09aa87",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2b8a3226-44ed-4f50-b26e-1b550afe4334",
+        "apim-request-id": "074fab90-7176-4f96-90a0-1067e6bb06b1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "77"
+        "x-envoy-upstream-service-time": "101"
       },
       "ResponseBody": {
         "documents": [
@@ -79,6 +79,6 @@
   "Variables": {
     "RandomSeed": "1094081853",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesPagination.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesPagination.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a0f58c29eddfe44792f98188f365e699-250fb1c13b998a42-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e129e5de95ec8c41a4b9bfcd139ed77c-2f201cc7bc8cbe4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d518e71fb8bbde791a4a8e2d519abd2d",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,762 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1f8aec29-1bf1-4024-93be-4d8749dc2cd8",
-        "Date": "Fri, 06 Aug 2021 01:52:53 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91",
+        "apim-request-id": "92f13a16-9b4a-4ebb-bb5a-48e932a1e527",
+        "Date": "Mon, 25 Oct 2021 21:20:43 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/a4fb4bf3-3f26-4025-a4cb-09700375847e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "251"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "180"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/a4fb4bf3-3f26-4025-a4cb-09700375847e?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "15392559dddf00be7c02b37db1655d5f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "20715aa1-ef9f-45a7-b848-6f474d0ee077",
+        "apim-request-id": "1dab444d-f127-49c5-954e-3473e322de1b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:52:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
+        "jobId": "a4fb4bf3-3f26-4025-a4cb-09700375847e",
+        "lastUpdateDateTime": "2021-10-25T21:20:43Z",
+        "createdDateTime": "2021-10-25T21:20:43Z",
+        "expirationDateTime": "2021-10-26T21:20:43Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/a4fb4bf3-3f26-4025-a4cb-09700375847e?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8fbb3015ae7667cee796b09df47c3a1a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2d0dedf6-1dba-482e-8ba1-1d00ee671229",
+        "apim-request-id": "93f0fbe0-f092-4c99-b123-518027924c4b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:52:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8156"
       },
       "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9ca689c8d08e41aa291759b905fb2cb5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6acc3714-c95d-4cc6-b2a0-8707003f1e56",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:52:55 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "20182fec2ddfaab657d22e482d200cff",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9a632824-6e08-48e3-81c1-97482b118cdd",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:52:56 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "28b599c8c1be45d08679665f551561eb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "17beeb46-1418-49e6-8e6f-9a0a7083796a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:52:57 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c4b0fb6a19639a3ad3fb44bca1611408",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4ceecad9-07b4-4220-a5a8-a9e057e698e2",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:52:58 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6cf0590b03462bf65fd29a65c7575542",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b7eb4d5f-6c3d-4a63-973a-782b76b5b27c",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:52:59 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "31dd4370476fae9b5e1a55c27d13a324",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7ac1d86e-7173-4baf-8170-f8e485a3b598",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:01 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fb535e64f42466a4048565917fd4d37b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9f421e52-6ae9-4fba-99d4-08f587dd4afa",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:02 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5e4c01a5e384c398bd420e2bae33ae4b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "da0a9603-cab5-4d3c-9199-2930d7763d74",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:03 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6801762e5a037b1e9f772deae20a2f89",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "70905e4f-79da-40e6-8f4d-21873940b6fe",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:04 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "50"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7b1dd94745c781a0c58f3de1e678b8d0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6a9ca381-5d23-47c7-970b-697bff5c5082",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:05 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:52:54Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "096219d66ad34b78e3d0be0db5aee1b3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4c83f0e4-0a04-4aa5-bbf4-776df9dbd5a0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:06 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d4e485133316e984d57fa3741d3c9526",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f80ec77f-6da8-402b-980d-2e8b4ca32212",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:07 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c8135cbe26a8ddb561d198f78692cb17",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "fa52a15f-d7f4-4bd8-adea-441359a6f852",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:08 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "61ce8aade394a3b995793354c6032ea6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "a7851e78-efd2-4bb7-9cb6-6b1da209b919",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:09 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "584e983a189aed0acf0673459a8c6242",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c54e3231-3504-433f-a7a8-0a068be544c3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:10 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "92c68cb3346eda92a370332ef261165d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1b55ce3d-0e6c-477a-be23-da346c41e2a8",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:11 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "eebdf2a37344957c7fe0918d70740809",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "58e85f9d-ea67-417e-a8b7-c510cd1ed079",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:12 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3aa1f0179b3d05370573b52ae5dbfa6e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4ebe97bd-d6f0-4985-a2f2-9647e0b34b6f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:13 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a8a115f073cf40fe1030138da205692e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "e16ccc63-5394-495d-b6b6-017091f67bd5",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:14 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "02172a67dcc00820bab7e9d0bd51b0a3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9cbd911d-62f7-4e6f-8e11-08b85c589d6d",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:15 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "44"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5b9c23e65fd2a339f160290c87a962ff",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1ed27a9d-e06b-4f1a-b24e-0adc469bd898",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:16 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "bbc3870af8c413aef599ee17892d83be",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "23f5a263-3c5e-4e3a-b60c-93e248f0c1f9",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:17 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:06Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/3bac927f-96c0-4b5e-a193-6136bb78ff91?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7fa770800e69075bf074105fb2138010",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "82772326-430c-482e-96aa-b8a2631959b7",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:18 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "85"
-      },
-      "ResponseBody": {
-        "jobId": "3bac927f-96c0-4b5e-a193-6136bb78ff91",
-        "lastUpdateDateTime": "2021-08-06T01:53:19Z",
-        "createdDateTime": "2021-08-06T01:52:53Z",
-        "expirationDateTime": "2021-08-07T01:52:53Z",
+        "jobId": "a4fb4bf3-3f26-4025-a4cb-09700375847e",
+        "lastUpdateDateTime": "2021-10-25T21:20:44Z",
+        "createdDateTime": "2021-10-25T21:20:43Z",
+        "expirationDateTime": "2021-10-26T21:20:43Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1768,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "21962335",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesPaginationAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/AnalyzeHealthcareEntitiesPaginationAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-06086050746fc041a9ca5422a1340e87-664f981ea3963f41-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-a0c491f734699743afc3fcb5fc4192aa-35fdadb19303314a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "fbbc5786a282c64df8d358b9cc278a4d",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,132 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "089f3be6-a3f6-410e-aa28-c0983b57d919",
-        "Date": "Fri, 06 Aug 2021 01:54:08 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/ed796f95-889d-4ab4-83fd-63bfdb60466b",
+        "apim-request-id": "e3f547af-9156-4033-8e53-070fa2f4484f",
+        "Date": "Mon, 25 Oct 2021 21:21:19 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/6bd1f3cd-56ba-48db-b28f-fed137c0714b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "256"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "220"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/ed796f95-889d-4ab4-83fd-63bfdb60466b?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/6bd1f3cd-56ba-48db-b28f-fed137c0714b?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "bbeac74cd30307fda0d67684218a1c72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e61152f1-a83b-4599-8025-91b3c56dc4c7",
+        "apim-request-id": "0335499b-8554-4a89-b648-39218587cb57",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:08 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "ed796f95-889d-4ab4-83fd-63bfdb60466b",
-        "lastUpdateDateTime": "2021-08-06T01:54:08Z",
-        "createdDateTime": "2021-08-06T01:54:08Z",
-        "expirationDateTime": "2021-08-07T01:54:08Z",
-        "status": "notStarted",
+        "jobId": "6bd1f3cd-56ba-48db-b28f-fed137c0714b",
+        "lastUpdateDateTime": "2021-10-25T21:21:20Z",
+        "createdDateTime": "2021-10-25T21:21:19Z",
+        "expirationDateTime": "2021-10-26T21:21:19Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/ed796f95-889d-4ab4-83fd-63bfdb60466b?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/6bd1f3cd-56ba-48db-b28f-fed137c0714b?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2c9581455d02f093db0efd8af829c0c9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7c8b22cd-a7fa-4da5-a344-4910644a48a1",
+        "apim-request-id": "11f45b1a-612a-4af1-b36e-6f3f19addc32",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:09 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "68"
       },
       "ResponseBody": {
-        "jobId": "ed796f95-889d-4ab4-83fd-63bfdb60466b",
-        "lastUpdateDateTime": "2021-08-06T01:54:08Z",
-        "createdDateTime": "2021-08-06T01:54:08Z",
-        "expirationDateTime": "2021-08-07T01:54:08Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/ed796f95-889d-4ab4-83fd-63bfdb60466b?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7b312057b61ab3835ab45aac2bc8a56e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6a7d49d0-2fed-4ab2-b226-ac89f9a39b5a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:10 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
-      },
-      "ResponseBody": {
-        "jobId": "ed796f95-889d-4ab4-83fd-63bfdb60466b",
-        "lastUpdateDateTime": "2021-08-06T01:54:10Z",
-        "createdDateTime": "2021-08-06T01:54:08Z",
-        "expirationDateTime": "2021-08-07T01:54:08Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/ed796f95-889d-4ab4-83fd-63bfdb60466b?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4a74e5b65d91ee4b33f9dff4d6730f76",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9aeada2a-8e23-4fe0-a79f-e816e27ebd77",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:11 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "80"
-      },
-      "ResponseBody": {
-        "jobId": "ed796f95-889d-4ab4-83fd-63bfdb60466b",
-        "lastUpdateDateTime": "2021-08-06T01:54:11Z",
-        "createdDateTime": "2021-08-06T01:54:08Z",
-        "expirationDateTime": "2021-08-07T01:54:08Z",
+        "jobId": "6bd1f3cd-56ba-48db-b28f-fed137c0714b",
+        "lastUpdateDateTime": "2021-10-25T21:21:20Z",
+        "createdDateTime": "2021-10-25T21:21:19Z",
+        "expirationDateTime": "2021-10-26T21:21:19Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1138,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "1439010920",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchConvenienceTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4625460f3856b04da3ed48bcf326ca93-44198cf74d96e844-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-3895b966acd5cb47b386549eb4e176f0-72c061ef1918ae4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1d7c0f7df9a5be46a7bf1d0b574c6095",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,102 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d020d9e4-c7e9-4ded-a89c-7716e9779e8a",
-        "Date": "Fri, 06 Aug 2021 01:53:19 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/445e78c0-aa96-45ef-b165-d613e220d5f1",
+        "apim-request-id": "ce456f8b-a04b-4f34-9846-43ba3bcd764f",
+        "Date": "Mon, 25 Oct 2021 21:20:53 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/074f5d2a-efeb-4c84-a9ae-1c2c592bc007",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "226"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "159"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/445e78c0-aa96-45ef-b165-d613e220d5f1?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/074f5d2a-efeb-4c84-a9ae-1c2c592bc007?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9441bfd5d8fa13e75ab79017f0dbec22",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "660e6b04-f1ce-4407-a3f7-bf6078c29f37",
+        "apim-request-id": "c80a47ba-147b-4b3a-9332-051b146591d5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:19 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
       },
       "ResponseBody": {
-        "jobId": "445e78c0-aa96-45ef-b165-d613e220d5f1",
-        "lastUpdateDateTime": "2021-08-06T01:53:20Z",
-        "createdDateTime": "2021-08-06T01:53:19Z",
-        "expirationDateTime": "2021-08-07T01:53:19Z",
-        "status": "notStarted",
+        "jobId": "074f5d2a-efeb-4c84-a9ae-1c2c592bc007",
+        "lastUpdateDateTime": "2021-10-25T21:20:54Z",
+        "createdDateTime": "2021-10-25T21:20:54Z",
+        "expirationDateTime": "2021-10-26T21:20:54Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/445e78c0-aa96-45ef-b165-d613e220d5f1?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/074f5d2a-efeb-4c84-a9ae-1c2c592bc007?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1f1476b4f8decd8416de12a15e37d599",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4e4ecb6f-77a6-43d9-b31a-797538e334b0",
+        "apim-request-id": "87e06de5-ce58-4c8c-a51c-ec86c44b5baa",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "82"
       },
       "ResponseBody": {
-        "jobId": "445e78c0-aa96-45ef-b165-d613e220d5f1",
-        "lastUpdateDateTime": "2021-08-06T01:53:20Z",
-        "createdDateTime": "2021-08-06T01:53:19Z",
-        "expirationDateTime": "2021-08-07T01:53:19Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/445e78c0-aa96-45ef-b165-d613e220d5f1?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9fb8c34e36bba5c72869c2ed682ecdcc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "08e6c7c0-e689-4874-8ea1-b36af394f099",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:21 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "79"
-      },
-      "ResponseBody": {
-        "jobId": "445e78c0-aa96-45ef-b165-d613e220d5f1",
-        "lastUpdateDateTime": "2021-08-06T01:53:21Z",
-        "createdDateTime": "2021-08-06T01:53:19Z",
-        "expirationDateTime": "2021-08-07T01:53:19Z",
+        "jobId": "074f5d2a-efeb-4c84-a9ae-1c2c592bc007",
+        "lastUpdateDateTime": "2021-10-25T21:20:54Z",
+        "createdDateTime": "2021-10-25T21:20:54Z",
+        "expirationDateTime": "2021-10-26T21:20:54Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1108,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "1964733569",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchConvenienceTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1131c0312ead774487e31d6796161371-9121ea78284cdc46-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-485f0802502c1c459f86c3a84797b9cc-e40e50642b399a42-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "99aaf08b1c844fb2d7a9025199ec97e4",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,72 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ee31b467-c4b4-45a9-a145-4c927f7299fe",
-        "Date": "Fri, 06 Aug 2021 01:54:12 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/2bc6d8b7-dacd-4786-bbfa-8c11c1d9c1b7",
+        "apim-request-id": "ef2fbcda-65e6-4216-b235-f889a8c7fb30",
+        "Date": "Mon, 25 Oct 2021 21:21:22 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/ad3479f6-1f58-4aeb-82c2-d30c5e19a927",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "259"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "659"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/2bc6d8b7-dacd-4786-bbfa-8c11c1d9c1b7?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/ad3479f6-1f58-4aeb-82c2-d30c5e19a927?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a6eb27012d3e0231e64179d6488bf525",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f65cb70d-102f-4af6-a59f-e4addc8f568b",
+        "apim-request-id": "52925c70-b4fb-4c85-ad4d-cc0da29ebda3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:12 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "2bc6d8b7-dacd-4786-bbfa-8c11c1d9c1b7",
-        "lastUpdateDateTime": "2021-08-06T01:54:12Z",
-        "createdDateTime": "2021-08-06T01:54:12Z",
-        "expirationDateTime": "2021-08-07T01:54:12Z",
-        "status": "notStarted",
+        "jobId": "ad3479f6-1f58-4aeb-82c2-d30c5e19a927",
+        "lastUpdateDateTime": "2021-10-25T21:21:23Z",
+        "createdDateTime": "2021-10-25T21:21:22Z",
+        "expirationDateTime": "2021-10-26T21:21:22Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/2bc6d8b7-dacd-4786-bbfa-8c11c1d9c1b7?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/ad3479f6-1f58-4aeb-82c2-d30c5e19a927?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4d12280124119b66ed27d10225884cad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "07b03c86-eb16-46ec-891b-6458cdcbd244",
+        "apim-request-id": "75480228-289f-4899-92aa-ec3b237899e4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "73"
       },
       "ResponseBody": {
-        "jobId": "2bc6d8b7-dacd-4786-bbfa-8c11c1d9c1b7",
-        "lastUpdateDateTime": "2021-08-06T01:54:13Z",
-        "createdDateTime": "2021-08-06T01:54:12Z",
-        "expirationDateTime": "2021-08-07T01:54:12Z",
+        "jobId": "ad3479f6-1f58-4aeb-82c2-d30c5e19a927",
+        "lastUpdateDateTime": "2021-10-25T21:21:23Z",
+        "createdDateTime": "2021-10-25T21:21:22Z",
+        "expirationDateTime": "2021-10-26T21:21:22Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1078,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "2027271043",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchConvenienceWithStatisticsTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d52b98c94acbdc46bdbc32edef8e2411-f5786ec422cc1443-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-95e17dc4630df842bff7fa896bc8d5b7-10dfe0175ed02a4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "87697e405fe3a2c8182b48340c37e5c5",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,432 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8309b203-866b-4cc0-9f1c-ee8084e8b25c",
-        "Date": "Fri, 06 Aug 2021 01:53:21 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f",
+        "apim-request-id": "cea709e2-f588-496c-828f-0338b9f63855",
+        "Date": "Mon, 25 Oct 2021 21:20:56 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/388833b9-e6ea-420f-ba16-517f43a1e8af",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "191"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "244"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/388833b9-e6ea-420f-ba16-517f43a1e8af?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f1abd77b68195cb092c7f20f1aa7cc84",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "df38c7dd-ee70-472f-a257-9e4f7677f2b7",
+        "apim-request-id": "2c4d2821-8df1-47c4-aacb-f7e2249f299a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
+        "jobId": "388833b9-e6ea-420f-ba16-517f43a1e8af",
+        "lastUpdateDateTime": "2021-10-25T21:20:56Z",
+        "createdDateTime": "2021-10-25T21:20:56Z",
+        "expirationDateTime": "2021-10-26T21:20:56Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/388833b9-e6ea-420f-ba16-517f43a1e8af?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "be37acebd508d7a1d3d78987b19e23cf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fc8a558a-bc9a-4092-9d62-2c5d084460b2",
+        "apim-request-id": "1814fa8f-7cf6-48d6-90e2-d5d9eb3cce12",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:22 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "278"
       },
       "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b34190e23bc3d86ecd0cf51c6cb88870",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3a7af721-9afb-4f68-8b0b-57ba1880cf7a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:23 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6048c45f2600a6bd35d41e41de29aaf3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d2893fd9-a09e-40f4-917d-9e5c358982cf",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:24 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "892d23a31966b0c03e5ff0fbdf856a1a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7e834f11-bbe8-4e6c-b42c-24b49d5db903",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:25 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ed28194fc355bbcfd39b7def1d2cf9a4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "05fc9786-af21-4bbc-88c8-18443c474a38",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:27 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "49780162fe8b460a049822a036c1c6b0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7493583f-10ab-433f-9ec5-49b5304c9c7f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:28 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c5f10369bc01e09e5371b6ca9bd09211",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "852c098e-9f31-4c30-9dd0-3efdf702699d",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:29 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "de994b65200d518f0ee1e9bca12e8512",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9355c9f1-9eec-4c28-9a68-05686c5ef5a9",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:30 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "43"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1a86cdd5333ba5a36297f61a473faa33",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "97cd6474-20f7-4cff-8ca4-67939c375398",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:32 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:22Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ea3a1106e72849a274a0b71fd3e23e25",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b8636cd8-53e6-414f-abaa-3985a73c31bf",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:33 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:33Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "cef5a4ec784a32d5a8f37b752a7509ce",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c0682f49-57b8-48b7-a0f4-b588ab4e2cac",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:34 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:33Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "90b6b5379af3edea2a3da69b7b84d280",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3f3a8b25-375b-4347-8a6a-c28ec9f0a2f9",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:35 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:33Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/0955449a-713e-4290-ad66-540f5ab70f9f?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a32dd058dc4a8de93b0842346c2d1eff",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b0bd7a69-4a0d-49f2-a802-652325fdbaa8",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:36 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "78"
-      },
-      "ResponseBody": {
-        "jobId": "0955449a-713e-4290-ad66-540f5ab70f9f",
-        "lastUpdateDateTime": "2021-08-06T01:53:36Z",
-        "createdDateTime": "2021-08-06T01:53:22Z",
-        "expirationDateTime": "2021-08-07T01:53:22Z",
+        "jobId": "388833b9-e6ea-420f-ba16-517f43a1e8af",
+        "lastUpdateDateTime": "2021-10-25T21:20:57Z",
+        "createdDateTime": "2021-10-25T21:20:56Z",
+        "expirationDateTime": "2021-10-26T21:20:56Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1452,6 +1110,6 @@
   "Variables": {
     "RandomSeed": "609735027",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchConvenienceWithStatisticsTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c1c633b82a1717499a8e1bc7f6528f98-8a39502de355434f-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-78e4cd8b5feb7a4cb702b4422be7799f-be5084f931933e4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "da8d96a331a03c42a6c41c2d9f512b98",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,132 +35,228 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "be12be1b-40b7-4dbe-b283-23d2ff7053a4",
-        "Date": "Fri, 06 Aug 2021 01:54:13 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/b11f026f-6a74-4e52-916d-e680bb0dae9a",
+        "apim-request-id": "17053138-4b4f-4169-9b7c-53c1c9ba63c9",
+        "Date": "Mon, 25 Oct 2021 21:21:25 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/8e922ba3-dbee-4a21-873d-99d0cc537848",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "188"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "179"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/b11f026f-6a74-4e52-916d-e680bb0dae9a?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/8e922ba3-dbee-4a21-873d-99d0cc537848?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a36dbbc9f92b427287ffda298bd01507",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ef7e59b-0ff7-45c2-930e-2a85f063ff21",
+        "apim-request-id": "879fdd26-3440-46e9-bcac-b12567ed1fe7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "b11f026f-6a74-4e52-916d-e680bb0dae9a",
-        "lastUpdateDateTime": "2021-08-06T01:54:13Z",
-        "createdDateTime": "2021-08-06T01:54:13Z",
-        "expirationDateTime": "2021-08-07T01:54:13Z",
+        "jobId": "8e922ba3-dbee-4a21-873d-99d0cc537848",
+        "lastUpdateDateTime": "2021-10-25T21:21:25Z",
+        "createdDateTime": "2021-10-25T21:21:24Z",
+        "expirationDateTime": "2021-10-26T21:21:24Z",
         "status": "notStarted",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/b11f026f-6a74-4e52-916d-e680bb0dae9a?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/8e922ba3-dbee-4a21-873d-99d0cc537848?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "86c4abbaba50d8ace0d0fc3795e01d2c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3aaf9a42-a2ad-40f8-9689-78485be9f1f6",
+        "apim-request-id": "cc5e3c30-6f6b-4f54-96b2-1eb144a7b9e4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "b11f026f-6a74-4e52-916d-e680bb0dae9a",
-        "lastUpdateDateTime": "2021-08-06T01:54:13Z",
-        "createdDateTime": "2021-08-06T01:54:13Z",
-        "expirationDateTime": "2021-08-07T01:54:13Z",
+        "jobId": "8e922ba3-dbee-4a21-873d-99d0cc537848",
+        "lastUpdateDateTime": "2021-10-25T21:21:25Z",
+        "createdDateTime": "2021-10-25T21:21:24Z",
+        "expirationDateTime": "2021-10-26T21:21:24Z",
         "status": "notStarted",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/b11f026f-6a74-4e52-916d-e680bb0dae9a?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/8e922ba3-dbee-4a21-873d-99d0cc537848?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "97afe1fd518fa965244a53a05719b0d6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "91d7cfff-5c29-4df8-8e47-a43da7fe2f6c",
+        "apim-request-id": "88ca2ad2-3e88-4e6a-9282-7316dc343e65",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:15 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "b11f026f-6a74-4e52-916d-e680bb0dae9a",
-        "lastUpdateDateTime": "2021-08-06T01:54:15Z",
-        "createdDateTime": "2021-08-06T01:54:13Z",
-        "expirationDateTime": "2021-08-07T01:54:13Z",
-        "status": "running",
+        "jobId": "8e922ba3-dbee-4a21-873d-99d0cc537848",
+        "lastUpdateDateTime": "2021-10-25T21:21:25Z",
+        "createdDateTime": "2021-10-25T21:21:24Z",
+        "expirationDateTime": "2021-10-26T21:21:24Z",
+        "status": "notStarted",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/b11f026f-6a74-4e52-916d-e680bb0dae9a?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/8e922ba3-dbee-4a21-873d-99d0cc537848?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f47314aea48d0f480e95c35afd3bada6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9ecad601-794a-428a-bcc2-8f6414e3fe7a",
+        "apim-request-id": "c8a8ef91-0916-4d73-b94d-5b3e98a90310",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:16 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "29"
       },
       "ResponseBody": {
-        "jobId": "b11f026f-6a74-4e52-916d-e680bb0dae9a",
-        "lastUpdateDateTime": "2021-08-06T01:54:16Z",
-        "createdDateTime": "2021-08-06T01:54:13Z",
-        "expirationDateTime": "2021-08-07T01:54:13Z",
+        "jobId": "8e922ba3-dbee-4a21-873d-99d0cc537848",
+        "lastUpdateDateTime": "2021-10-25T21:21:25Z",
+        "createdDateTime": "2021-10-25T21:21:24Z",
+        "expirationDateTime": "2021-10-26T21:21:24Z",
+        "status": "notStarted",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/8e922ba3-dbee-4a21-873d-99d0cc537848?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a92baee17e216978451a6205660b80c6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d5d923e3-4cca-4329-98b1-54e98c2f1f58",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:21:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "jobId": "8e922ba3-dbee-4a21-873d-99d0cc537848",
+        "lastUpdateDateTime": "2021-10-25T21:21:30Z",
+        "createdDateTime": "2021-10-25T21:21:24Z",
+        "expirationDateTime": "2021-10-26T21:21:24Z",
+        "status": "running",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/8e922ba3-dbee-4a21-873d-99d0cc537848?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "8088261f296d589f999f88f98d0bace8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2137d157-5369-4440-9d19-69f72fad4700",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:21:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "78"
+      },
+      "ResponseBody": {
+        "jobId": "8e922ba3-dbee-4a21-873d-99d0cc537848",
+        "lastUpdateDateTime": "2021-10-25T21:21:30Z",
+        "createdDateTime": "2021-10-25T21:21:24Z",
+        "expirationDateTime": "2021-10-26T21:21:24Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1152,6 +1254,6 @@
   "Variables": {
     "RandomSeed": "377463297",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d19f9b4d90092e4bbd87e48610c6e5bd-ad0697c9466bd846-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e2e5925fc5e8f240908b778a36eff7d9-0f1c6a21c2b48d4a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0d63e53cea7530898179e7904fedbae6",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,102 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "27c661d4-29fc-40ce-bb4b-2cad741df250",
-        "Date": "Fri, 06 Aug 2021 01:53:36 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/37bea184-6022-4c54-95b4-ed97bc61bfa2",
+        "apim-request-id": "566ce975-0ad0-4178-9821-881ad1698bfc",
+        "Date": "Mon, 25 Oct 2021 21:20:58 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/bfb734db-55db-491d-9e1d-c752318651c6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "219"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "222"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/37bea184-6022-4c54-95b4-ed97bc61bfa2?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/bfb734db-55db-491d-9e1d-c752318651c6?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7a482533d010f661d7a330e46a9c020c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8c8d1516-cebb-44fd-bc2c-bd168f47dfd3",
+        "apim-request-id": "0e75df17-3971-468b-ae37-38af0e8d5d54",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:36 GMT",
+        "Date": "Mon, 25 Oct 2021 21:20:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "37bea184-6022-4c54-95b4-ed97bc61bfa2",
-        "lastUpdateDateTime": "2021-08-06T01:53:36Z",
-        "createdDateTime": "2021-08-06T01:53:36Z",
-        "expirationDateTime": "2021-08-07T01:53:36Z",
-        "status": "notStarted",
+        "jobId": "bfb734db-55db-491d-9e1d-c752318651c6",
+        "lastUpdateDateTime": "2021-10-25T21:20:59Z",
+        "createdDateTime": "2021-10-25T21:20:59Z",
+        "expirationDateTime": "2021-10-26T21:20:59Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/37bea184-6022-4c54-95b4-ed97bc61bfa2?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/bfb734db-55db-491d-9e1d-c752318651c6?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d4480f3cd87c0175cc930cf584ae8a9b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e0e53a8c-c5a6-40b1-8060-c3f0025c29e9",
+        "apim-request-id": "c3675f7b-526a-4309-be36-18b881ca72df",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:37 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "67"
       },
       "ResponseBody": {
-        "jobId": "37bea184-6022-4c54-95b4-ed97bc61bfa2",
-        "lastUpdateDateTime": "2021-08-06T01:53:36Z",
-        "createdDateTime": "2021-08-06T01:53:36Z",
-        "expirationDateTime": "2021-08-07T01:53:36Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/37bea184-6022-4c54-95b4-ed97bc61bfa2?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "00da5d97d0326c02836c36d1baa4c6e5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f96c32c3-f946-4789-bf59-7e1076340e58",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:38 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "100"
-      },
-      "ResponseBody": {
-        "jobId": "37bea184-6022-4c54-95b4-ed97bc61bfa2",
-        "lastUpdateDateTime": "2021-08-06T01:53:38Z",
-        "createdDateTime": "2021-08-06T01:53:36Z",
-        "expirationDateTime": "2021-08-07T01:53:36Z",
+        "jobId": "bfb734db-55db-491d-9e1d-c752318651c6",
+        "lastUpdateDateTime": "2021-10-25T21:21:00Z",
+        "createdDateTime": "2021-10-25T21:20:59Z",
+        "expirationDateTime": "2021-10-26T21:20:59Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1108,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "894243901",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e23331f3d580c54b834d5ef7a347cda4-b766f8e59e0e6f4e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-622330cba4f22443a454b5956003efcc-0b6522cef061de45-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "17e898e3099143136b2e35c82964efd9",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,72 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "dfa08d55-3947-4189-a1c6-7d30ba96bf76",
-        "Date": "Fri, 06 Aug 2021 01:54:17 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/f97bb22a-6bf7-47ff-9340-c23dd8277c26",
+        "apim-request-id": "47b96ead-f1cd-426a-86ae-e7fca3539452",
+        "Date": "Mon, 25 Oct 2021 21:21:32 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/dc82f113-1ab8-4f13-b64f-9890afc0473b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "187"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "213"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/f97bb22a-6bf7-47ff-9340-c23dd8277c26?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/dc82f113-1ab8-4f13-b64f-9890afc0473b?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7dd0fa2b947b788e4d51b90a9e064f06",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0237af3d-325d-4a14-81bb-f44e29e62fee",
+        "apim-request-id": "a25ec494-cc9d-4adf-a284-49dfb522203a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:17 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "f97bb22a-6bf7-47ff-9340-c23dd8277c26",
-        "lastUpdateDateTime": "2021-08-06T01:54:17Z",
-        "createdDateTime": "2021-08-06T01:54:17Z",
-        "expirationDateTime": "2021-08-07T01:54:17Z",
-        "status": "notStarted",
+        "jobId": "dc82f113-1ab8-4f13-b64f-9890afc0473b",
+        "lastUpdateDateTime": "2021-10-25T21:21:32Z",
+        "createdDateTime": "2021-10-25T21:21:32Z",
+        "expirationDateTime": "2021-10-26T21:21:32Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/f97bb22a-6bf7-47ff-9340-c23dd8277c26?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/dc82f113-1ab8-4f13-b64f-9890afc0473b?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ddd7cae644b1aa3bb79fb4ecc872f743",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ab8ecddf-a6ee-42db-92b1-6c7ff3e6e822",
+        "apim-request-id": "27c4e64b-1423-46ee-8962-21d7d858c919",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "59"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "79"
       },
       "ResponseBody": {
-        "jobId": "f97bb22a-6bf7-47ff-9340-c23dd8277c26",
-        "lastUpdateDateTime": "2021-08-06T01:54:18Z",
-        "createdDateTime": "2021-08-06T01:54:17Z",
-        "expirationDateTime": "2021-08-07T01:54:17Z",
+        "jobId": "dc82f113-1ab8-4f13-b64f-9890afc0473b",
+        "lastUpdateDateTime": "2021-10-25T21:21:33Z",
+        "createdDateTime": "2021-10-25T21:21:32Z",
+        "expirationDateTime": "2021-10-26T21:21:32Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1078,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "1051051872",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithCancellation.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithCancellation.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "1555",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d964a0f7cb179d489e2f8b1cdc8c009d-5f4cc067bf1bbc42-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-22bd4e1f9725374abae4d5d2432b7c2e-6a92c10f6f15cf4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET 5.0.11; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d6f2d0cc095dc3418ddc67fdaec34f8c",
         "x-ms-return-client-request-id": "true"
       },
@@ -69,65 +75,77 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8ab84981-a11f-4012-b329-99a5edcdc87c",
-        "Date": "Fri, 06 Aug 2021 01:53:39 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/90168672-730a-49cb-90d9-6e091d89def4",
+        "apim-request-id": "874e8e8e-1c5f-4740-b2aa-2fe072e76fd6",
+        "Date": "Mon, 25 Oct 2021 20:54:37 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/1945f447-3352-49f3-838c-af5a5421d4c1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "424"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "413"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/90168672-730a-49cb-90d9-6e091d89def4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/1945f447-3352-49f3-838c-af5a5421d4c1",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET 5.0.11; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e1bd0b21afaacf4ed5d58b17e46d5140",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "f95f3e23-4288-4808-8f23-1fd95859f01a",
-        "Date": "Fri, 06 Aug 2021 01:53:39 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/90168672-730a-49cb-90d9-6e091d89def4",
+        "apim-request-id": "3e715410-1721-45cf-bb87-3501e1c9c751",
+        "Date": "Mon, 25 Oct 2021 20:54:37 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/1945f447-3352-49f3-838c-af5a5421d4c1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/90168672-730a-49cb-90d9-6e091d89def4?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/1945f447-3352-49f3-838c-af5a5421d4c1?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET 5.0.11; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0b47155e744b34ff8e7def83a29a0d23",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e1e57ae1-532a-4b0d-b8a3-1d904b3b54e2",
+        "apim-request-id": "3d09fc35-56d4-43fd-bd53-e5851f6b5170",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:39 GMT",
+        "Date": "Mon, 25 Oct 2021 20:54:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "90168672-730a-49cb-90d9-6e091d89def4",
-        "lastUpdateDateTime": "2021-08-06T01:53:39Z",
-        "createdDateTime": "2021-08-06T01:53:39Z",
-        "expirationDateTime": "2021-08-07T01:53:39Z",
+        "jobId": "1945f447-3352-49f3-838c-af5a5421d4c1",
+        "lastUpdateDateTime": "2021-10-25T20:54:37Z",
+        "createdDateTime": "2021-10-25T20:54:37Z",
+        "expirationDateTime": "2021-10-26T20:54:37Z",
         "status": "cancelled",
         "errors": []
       }
@@ -136,6 +154,6 @@
   "Variables": {
     "RandomSeed": "1115976718",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithCancellationAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithCancellationAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "1555",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9347793a64e5e840a2542ee8d4ddc92f-53d80e74ca3f5d4c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ab0b04d75f54ad45b046a6baa1e51225-70846991e6399b41-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET 5.0.11; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "174f72762caf768d734c4bc2cef9931d",
         "x-ms-return-client-request-id": "true"
       },
@@ -69,65 +75,77 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "bc9e5ac4-5614-4689-8daf-64200f7cd43d",
-        "Date": "Fri, 06 Aug 2021 01:54:18 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/d1580597-7e55-4231-b0b2-2427f5ac5431",
+        "apim-request-id": "8b920b74-e188-43a3-a2fe-968c9d996f3a",
+        "Date": "Mon, 25 Oct 2021 20:55:10 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/22711700-ba2d-4986-bf3b-ac0d1e8e5b42",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "356"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "407"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/d1580597-7e55-4231-b0b2-2427f5ac5431",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/22711700-ba2d-4986-bf3b-ac0d1e8e5b42",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET 5.0.11; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b4dedd3f6eed1404f274aef6ca46c145",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "1f9f78d8-0b72-4049-a089-8b38b029900a",
-        "Date": "Fri, 06 Aug 2021 01:54:18 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/d1580597-7e55-4231-b0b2-2427f5ac5431",
+        "apim-request-id": "15f4a785-2b9e-43e1-a51c-d093bbdaa6a4",
+        "Date": "Mon, 25 Oct 2021 20:55:11 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/22711700-ba2d-4986-bf3b-ac0d1e8e5b42",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "27"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/d1580597-7e55-4231-b0b2-2427f5ac5431?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/22711700-ba2d-4986-bf3b-ac0d1e8e5b42?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET 5.0.11; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1748fd33d947290e5b3b13a681114adc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8dc5c7a0-4b54-42d1-8490-f44b5d27aba2",
+        "apim-request-id": "b9975d6d-7932-441d-ab00-2da20b779ccd",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:18 GMT",
+        "Date": "Mon, 25 Oct 2021 20:55:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "d1580597-7e55-4231-b0b2-2427f5ac5431",
-        "lastUpdateDateTime": "2021-08-06T01:54:19Z",
-        "createdDateTime": "2021-08-06T01:54:18Z",
-        "expirationDateTime": "2021-08-07T01:54:18Z",
+        "jobId": "22711700-ba2d-4986-bf3b-ac0d1e8e5b42",
+        "lastUpdateDateTime": "2021-10-25T20:55:11Z",
+        "createdDateTime": "2021-10-25T20:55:11Z",
+        "expirationDateTime": "2021-10-26T20:55:11Z",
         "status": "cancelled",
         "errors": []
       }
@@ -136,6 +154,6 @@
   "Variables": {
     "RandomSeed": "618115820",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithErrorTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "260",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3cc934a689bbb5409a73c324f10de1cb-b40056c1a70ed74e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6aeb7b1dcb9a2c42895194ec93a642f7-6f4d8630459f8448-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ed679d93c08fe171a9b236aaa757046a",
         "x-ms-return-client-request-id": "true"
       },
@@ -34,102 +40,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3d130fc5-6919-4e1b-871d-c83e2f5aa9c4",
-        "Date": "Fri, 06 Aug 2021 01:53:39 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/294f6ba6-fa39-4c63-92c6-c4a119fce7ec",
+        "apim-request-id": "09887d6f-70b7-4850-a381-df626bd35c7b",
+        "Date": "Mon, 25 Oct 2021 21:21:04 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/ea8a3eca-8313-4dc3-baa8-df5bf2105ba5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "249"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "371"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/294f6ba6-fa39-4c63-92c6-c4a119fce7ec?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/ea8a3eca-8313-4dc3-baa8-df5bf2105ba5?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8ac7fae8cf64a9249598acb3531ad44c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d1fa01e6-4727-4c85-916c-b731ebeea5d0",
+        "apim-request-id": "dc638a5b-706e-4279-b624-c326581909eb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "294f6ba6-fa39-4c63-92c6-c4a119fce7ec",
-        "lastUpdateDateTime": "2021-08-06T01:53:39Z",
-        "createdDateTime": "2021-08-06T01:53:39Z",
-        "expirationDateTime": "2021-08-07T01:53:39Z",
-        "status": "notStarted",
+        "jobId": "ea8a3eca-8313-4dc3-baa8-df5bf2105ba5",
+        "lastUpdateDateTime": "2021-10-25T21:21:05Z",
+        "createdDateTime": "2021-10-25T21:21:04Z",
+        "expirationDateTime": "2021-10-26T21:21:04Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/294f6ba6-fa39-4c63-92c6-c4a119fce7ec?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/ea8a3eca-8313-4dc3-baa8-df5bf2105ba5?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e1e35bcd7fe4ca895c5026b1fcf89877",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f38cebdf-cae8-409d-ac33-f57fd97848cc",
+        "apim-request-id": "a5daf0d9-e340-4165-897c-23c1f4c0ba96",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "85"
       },
       "ResponseBody": {
-        "jobId": "294f6ba6-fa39-4c63-92c6-c4a119fce7ec",
-        "lastUpdateDateTime": "2021-08-06T01:53:39Z",
-        "createdDateTime": "2021-08-06T01:53:39Z",
-        "expirationDateTime": "2021-08-07T01:53:39Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/294f6ba6-fa39-4c63-92c6-c4a119fce7ec?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "42e053ff1beac39b78bd58f714be8d8f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b2a9726d-58e6-4bbd-be60-a0eee32f61f1",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:41 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "90"
-      },
-      "ResponseBody": {
-        "jobId": "294f6ba6-fa39-4c63-92c6-c4a119fce7ec",
-        "lastUpdateDateTime": "2021-08-06T01:53:41Z",
-        "createdDateTime": "2021-08-06T01:53:39Z",
-        "expirationDateTime": "2021-08-07T01:53:39Z",
+        "jobId": "ea8a3eca-8313-4dc3-baa8-df5bf2105ba5",
+        "lastUpdateDateTime": "2021-10-25T21:21:05Z",
+        "createdDateTime": "2021-10-25T21:21:04Z",
+        "expirationDateTime": "2021-10-26T21:21:04Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1125,6 +1113,6 @@
   "Variables": {
     "RandomSeed": "1719176907",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithErrorTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "260",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-117ffa71562b3e4ebf52225b9f562c6a-3870c86e5b31e442-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-a6df4cb76fc1c54a9b4f9c929177843f-44bc1af875e2884f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4352d8dd6e2ff74a3743e20989f20949",
         "x-ms-return-client-request-id": "true"
       },
@@ -34,102 +40,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "8deb50d3-8297-416e-801f-696cd119914c",
-        "Date": "Fri, 06 Aug 2021 01:54:19 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/36b6a9a9-f3ea-4e02-ad0f-9afc11900575",
+        "apim-request-id": "9444f32c-1194-4107-b1e3-e98c8cf2a279",
+        "Date": "Mon, 25 Oct 2021 21:21:37 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/84067f4d-2b26-4894-855d-f5851f4c2b55",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "242"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "245"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/36b6a9a9-f3ea-4e02-ad0f-9afc11900575?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/84067f4d-2b26-4894-855d-f5851f4c2b55?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b850713105701863d1b6a799a800b67b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b6610a80-efaa-4cb2-8c47-433419e736fd",
+        "apim-request-id": "f58be599-f986-45c1-a027-38727e52849d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:19 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "36b6a9a9-f3ea-4e02-ad0f-9afc11900575",
-        "lastUpdateDateTime": "2021-08-06T01:54:19Z",
-        "createdDateTime": "2021-08-06T01:54:19Z",
-        "expirationDateTime": "2021-08-07T01:54:19Z",
+        "jobId": "84067f4d-2b26-4894-855d-f5851f4c2b55",
+        "lastUpdateDateTime": "2021-10-25T21:21:37Z",
+        "createdDateTime": "2021-10-25T21:21:37Z",
+        "expirationDateTime": "2021-10-26T21:21:37Z",
         "status": "notStarted",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/36b6a9a9-f3ea-4e02-ad0f-9afc11900575?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/84067f4d-2b26-4894-855d-f5851f4c2b55?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7b6997a8eb08a1c0115e8728d43fe710",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "74eb9014-65e3-4626-a682-71386967910f",
+        "apim-request-id": "6664a6c9-16cb-475f-8d57-eb9d5b29d1d7",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "96"
       },
       "ResponseBody": {
-        "jobId": "36b6a9a9-f3ea-4e02-ad0f-9afc11900575",
-        "lastUpdateDateTime": "2021-08-06T01:54:19Z",
-        "createdDateTime": "2021-08-06T01:54:19Z",
-        "expirationDateTime": "2021-08-07T01:54:19Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/36b6a9a9-f3ea-4e02-ad0f-9afc11900575?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c4c517d3dcd1d7de74397279c7b14e37",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5a04bdae-729c-41b7-99ee-85312d809dfd",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:21 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "97"
-      },
-      "ResponseBody": {
-        "jobId": "36b6a9a9-f3ea-4e02-ad0f-9afc11900575",
-        "lastUpdateDateTime": "2021-08-06T01:54:21Z",
-        "createdDateTime": "2021-08-06T01:54:19Z",
-        "expirationDateTime": "2021-08-07T01:54:19Z",
+        "jobId": "84067f4d-2b26-4894-855d-f5851f4c2b55",
+        "lastUpdateDateTime": "2021-10-25T21:21:38Z",
+        "createdDateTime": "2021-10-25T21:21:37Z",
+        "expirationDateTime": "2021-10-26T21:21:37Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1125,6 +1113,6 @@
   "Variables": {
     "RandomSeed": "729062063",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithStatisticsTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-74d8024bdb3437409d87f058a684b904-8db362c1b3926d46-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-4a7cb6dc835e124a9cc6d94f485d4915-42b78dc9b7e6fa47-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "8ec3c90b7880bba55b75abdb84a19321",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,72 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "29e529c4-f1f1-48ec-97bb-f044e8021930",
-        "Date": "Fri, 06 Aug 2021 01:53:42 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/642e1208-8358-4c6c-836b-65e09a15b9fd",
+        "apim-request-id": "fd3fc46f-44b0-4e71-b395-0cd3137d931a",
+        "Date": "Mon, 25 Oct 2021 21:21:06 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/93e87fe5-e05c-481a-a9d7-540ddfd6e390",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "252"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "176"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/642e1208-8358-4c6c-836b-65e09a15b9fd?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/93e87fe5-e05c-481a-a9d7-540ddfd6e390?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "56fe48ebb003114e437c6f5c1a23295d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "dfdc3490-c1b4-4863-8ea3-75cd2dd1e514",
+        "apim-request-id": "147b9362-41c1-40fb-b547-89be7a93d477",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:42 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "11"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "642e1208-8358-4c6c-836b-65e09a15b9fd",
-        "lastUpdateDateTime": "2021-08-06T01:53:42Z",
-        "createdDateTime": "2021-08-06T01:53:42Z",
-        "expirationDateTime": "2021-08-07T01:53:42Z",
+        "jobId": "93e87fe5-e05c-481a-a9d7-540ddfd6e390",
+        "lastUpdateDateTime": "2021-10-25T21:21:07Z",
+        "createdDateTime": "2021-10-25T21:21:07Z",
+        "expirationDateTime": "2021-10-26T21:21:07Z",
         "status": "notStarted",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/642e1208-8358-4c6c-836b-65e09a15b9fd?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/93e87fe5-e05c-481a-a9d7-540ddfd6e390?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e2f12bb5a78a8d006ec8d88886d7049c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8eaad053-59a8-4902-b2f2-474c50eb8db6",
+        "apim-request-id": "3f440e57-f8ae-4d99-ac91-35141cdcfe30",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "210"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "67"
       },
       "ResponseBody": {
-        "jobId": "642e1208-8358-4c6c-836b-65e09a15b9fd",
-        "lastUpdateDateTime": "2021-08-06T01:53:43Z",
-        "createdDateTime": "2021-08-06T01:53:42Z",
-        "expirationDateTime": "2021-08-07T01:53:42Z",
+        "jobId": "93e87fe5-e05c-481a-a9d7-540ddfd6e390",
+        "lastUpdateDateTime": "2021-10-25T21:21:08Z",
+        "createdDateTime": "2021-10-25T21:21:07Z",
+        "expirationDateTime": "2021-10-26T21:21:07Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1092,6 +1110,6 @@
   "Variables": {
     "RandomSeed": "858087556",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesBatchWithStatisticsTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a503ce913604324293c57df0308b78ed-6c6b6847a04d3341-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-85d2f908de0ab24e918df38465681275-4960598048d2be49-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "cb820fc464b79dcc9212329646bf509a",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,102 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3a020fee-7dab-4b13-a320-f88f24a98408",
-        "Date": "Fri, 06 Aug 2021 01:54:21 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/24ca837e-18a8-47a6-bc02-b6d4229ac50d",
+        "apim-request-id": "378e68ca-7df0-46f8-a7a0-fa4e774ca1cd",
+        "Date": "Mon, 25 Oct 2021 21:21:39 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/2c86fd3a-fcf9-4078-821e-1b460fd28f1a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "213"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "158"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/24ca837e-18a8-47a6-bc02-b6d4229ac50d?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/2c86fd3a-fcf9-4078-821e-1b460fd28f1a?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "08d18cd76fa1ba75ad5e5758b7de00e4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b3a19986-0fbd-445c-a08c-5d4db9b61fb3",
+        "apim-request-id": "edf3acea-a10e-4b6e-a238-1eeb4c2a857f",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
       },
       "ResponseBody": {
-        "jobId": "24ca837e-18a8-47a6-bc02-b6d4229ac50d",
-        "lastUpdateDateTime": "2021-08-06T01:54:22Z",
-        "createdDateTime": "2021-08-06T01:54:22Z",
-        "expirationDateTime": "2021-08-07T01:54:22Z",
-        "status": "notStarted",
+        "jobId": "2c86fd3a-fcf9-4078-821e-1b460fd28f1a",
+        "lastUpdateDateTime": "2021-10-25T21:21:40Z",
+        "createdDateTime": "2021-10-25T21:21:40Z",
+        "expirationDateTime": "2021-10-26T21:21:40Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/24ca837e-18a8-47a6-bc02-b6d4229ac50d?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/2c86fd3a-fcf9-4078-821e-1b460fd28f1a?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2ac480b3f6758c758bf3f8f60a589915",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4540d82d-b6de-47a7-8333-7d9d40966e29",
+        "apim-request-id": "e54539e1-3fc7-4638-a98b-377cc623db4d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:22 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "291"
       },
       "ResponseBody": {
-        "jobId": "24ca837e-18a8-47a6-bc02-b6d4229ac50d",
-        "lastUpdateDateTime": "2021-08-06T01:54:23Z",
-        "createdDateTime": "2021-08-06T01:54:22Z",
-        "expirationDateTime": "2021-08-07T01:54:22Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/24ca837e-18a8-47a6-bc02-b6d4229ac50d?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4456bc1eb361546e99c71e580d73e5b3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "bbe26c73-0457-4ec6-ad21-f3c3c3b7acd0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:23 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
-      },
-      "ResponseBody": {
-        "jobId": "24ca837e-18a8-47a6-bc02-b6d4229ac50d",
-        "lastUpdateDateTime": "2021-08-06T01:54:23Z",
-        "createdDateTime": "2021-08-06T01:54:22Z",
-        "expirationDateTime": "2021-08-07T01:54:22Z",
+        "jobId": "2c86fd3a-fcf9-4078-821e-1b460fd28f1a",
+        "lastUpdateDateTime": "2021-10-25T21:21:40Z",
+        "createdDateTime": "2021-10-25T21:21:40Z",
+        "expirationDateTime": "2021-10-26T21:21:40Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1122,6 +1110,6 @@
   "Variables": {
     "RandomSeed": "1450670554",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cd95247c04af4e4f818e5dd58aaf4d2f-d2fb1b2081215c4b-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-819b5942b050b147ab4c02ae2b07b26f-f245addde43c6946-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e51cbf87a321df02032925de5e6708b4",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,282 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "9eb4422c-6e6b-429e-b18a-6132408032df",
-        "Date": "Fri, 06 Aug 2021 01:53:44 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95",
+        "apim-request-id": "2c9ebe34-501e-4d48-a709-3b723a211a7f",
+        "Date": "Mon, 25 Oct 2021 21:21:08 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/e1a30ca9-991b-4a12-9ebb-0a7c8e73b470",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "565"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "152"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/e1a30ca9-991b-4a12-9ebb-0a7c8e73b470?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2cdb69530701f208f175aa6a97e2593b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "88ba2eb6-4dc0-48ba-be5c-a8ce5caa81cc",
+        "apim-request-id": "6be67a36-c70c-4f21-b09e-1942224ac1f4",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:44Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
-        "status": "notStarted",
+        "jobId": "e1a30ca9-991b-4a12-9ebb-0a7c8e73b470",
+        "lastUpdateDateTime": "2021-10-25T21:21:09Z",
+        "createdDateTime": "2021-10-25T21:21:09Z",
+        "expirationDateTime": "2021-10-26T21:21:09Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/e1a30ca9-991b-4a12-9ebb-0a7c8e73b470?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a701cb20bb11a529608aebe12f36a48e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cf53e72d-4125-4e1f-af03-5f18cbe32f33",
+        "apim-request-id": "ddc5e0c8-27d1-49f3-a4a0-5dad1be2632a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:45 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "314"
       },
       "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:44Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "03c09e10ea8d7fc1b629f4abf8984821",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1c77101f-caa1-4e61-8401-376b9d6caef3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:46 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:44Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "93bde9d0616598a24035cb771c26c3ba",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "1fbae942-3fb8-4bf4-99d5-f8aa45d76358",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:47 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:47Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f8591cd0562136ad0a82f0e8c77dacc7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d5c66ee1-b8bb-46a6-a083-8f33cae905fb",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:48 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:47Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4511ca421179ae28fc28c2571f4a628f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6f68975a-974b-4d8e-98c8-e5d902fe78c1",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:49 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
-      },
-      "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:47Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "dcda39654f3f7aff3c8788e270bad0c3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6174c5e6-4f49-4110-bceb-1e4c8d8e317d",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:50 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:47Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "523404897e15be41f4aafbf9935616bf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f526a128-6ac2-425f-ae52-11427e132215",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:51 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:47Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/17fa1624-1538-4764-b9f7-a6ab435d5e95?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8d82601fd0a2f288ca9609f188453d42",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "bb91f44e-af8d-4ec3-a360-2bab36fd0b61",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:53:52 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "93"
-      },
-      "ResponseBody": {
-        "jobId": "17fa1624-1538-4764-b9f7-a6ab435d5e95",
-        "lastUpdateDateTime": "2021-08-06T01:53:52Z",
-        "createdDateTime": "2021-08-06T01:53:44Z",
-        "expirationDateTime": "2021-08-07T01:53:44Z",
+        "jobId": "e1a30ca9-991b-4a12-9ebb-0a7c8e73b470",
+        "lastUpdateDateTime": "2021-10-25T21:21:09Z",
+        "createdDateTime": "2021-10-25T21:21:09Z",
+        "expirationDateTime": "2021-10-26T21:21:09Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1288,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "1686725774",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e19526494540414aa6e610a6ea685a93-16127bc56be9c747-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-5121d7cc4c1d7b47a55d68fa56ff536f-6f3103ebe06fe64b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "acdb13842ca5b9295fa84adf0c4870a8",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,102 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cd0fb79c-373e-436f-b85d-461e371a90c7",
-        "Date": "Fri, 06 Aug 2021 01:54:24 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/6bb6e127-63e8-4ed2-933e-e45eaa7b4c84",
+        "apim-request-id": "d5b9fa99-63d2-401a-a238-b28386e94a4e",
+        "Date": "Mon, 25 Oct 2021 21:21:41 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/2b544e30-9318-4a61-9c50-7f8e7e82f127",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "318"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "239"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/6bb6e127-63e8-4ed2-933e-e45eaa7b4c84?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/2b544e30-9318-4a61-9c50-7f8e7e82f127?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "1181511460ff1ed085a4ba80632c2cfd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f40e2a50-a409-46a1-bf1f-99128abafdde",
+        "apim-request-id": "a19d341c-dca9-4881-aa2b-3527fa5bb4da",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:24 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "6bb6e127-63e8-4ed2-933e-e45eaa7b4c84",
-        "lastUpdateDateTime": "2021-08-06T01:54:25Z",
-        "createdDateTime": "2021-08-06T01:54:24Z",
-        "expirationDateTime": "2021-08-07T01:54:24Z",
-        "status": "notStarted",
+        "jobId": "2b544e30-9318-4a61-9c50-7f8e7e82f127",
+        "lastUpdateDateTime": "2021-10-25T21:21:42Z",
+        "createdDateTime": "2021-10-25T21:21:42Z",
+        "expirationDateTime": "2021-10-26T21:21:42Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/6bb6e127-63e8-4ed2-933e-e45eaa7b4c84?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/2b544e30-9318-4a61-9c50-7f8e7e82f127?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d0605b7dc709a544ca5e0c1b0401dc1e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04ded138-691d-44e1-a1d9-b85ec4721284",
+        "apim-request-id": "041f80f8-973e-444d-83ff-94230c567221",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "726"
       },
       "ResponseBody": {
-        "jobId": "6bb6e127-63e8-4ed2-933e-e45eaa7b4c84",
-        "lastUpdateDateTime": "2021-08-06T01:54:26Z",
-        "createdDateTime": "2021-08-06T01:54:24Z",
-        "expirationDateTime": "2021-08-07T01:54:24Z",
-        "status": "running",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/6bb6e127-63e8-4ed2-933e-e45eaa7b4c84?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b5e59345e53b24c743bd270071a85633",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3f4e8a4f-51e3-46b3-b685-467a1efb058f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:26 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "77"
-      },
-      "ResponseBody": {
-        "jobId": "6bb6e127-63e8-4ed2-933e-e45eaa7b4c84",
-        "lastUpdateDateTime": "2021-08-06T01:54:26Z",
-        "createdDateTime": "2021-08-06T01:54:24Z",
-        "expirationDateTime": "2021-08-07T01:54:24Z",
+        "jobId": "2b544e30-9318-4a61-9c50-7f8e7e82f127",
+        "lastUpdateDateTime": "2021-10-25T21:21:43Z",
+        "createdDateTime": "2021-10-25T21:21:42Z",
+        "expirationDateTime": "2021-10-26T21:21:42Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1108,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "1184190609",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesWithLanguageTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7f4984dd095ad3469b669a2c413e4505-71c3df90b077a849-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-1f435947ec4a53448d3abb62194fe604-c93ba45159a1de41-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0e649e128b084513c9c62e584c5f813b",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,72 +35,228 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "3afff7a4-b8a6-48ec-8182-a6d5a8c88357",
-        "Date": "Fri, 06 Aug 2021 01:54:07 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/81cf7138-be59-42b9-8b7a-3c83dff39e57",
+        "apim-request-id": "87a29528-0e77-4169-b528-f021f6d1bfb4",
+        "Date": "Mon, 25 Oct 2021 21:21:11 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/61192f03-a823-4f32-a5c7-aadb0829744e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "204"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "194"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/81cf7138-be59-42b9-8b7a-3c83dff39e57?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/61192f03-a823-4f32-a5c7-aadb0829744e?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "796705c1528f3adf8bba34f0a8f2bd37",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "19c7bd31-ae15-43e6-a097-a7acb2b377c4",
+        "apim-request-id": "4baea389-3d16-405b-8391-773addb8188b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:07 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "81cf7138-be59-42b9-8b7a-3c83dff39e57",
-        "lastUpdateDateTime": "2021-08-06T01:54:07Z",
-        "createdDateTime": "2021-08-06T01:54:07Z",
-        "expirationDateTime": "2021-08-07T01:54:07Z",
+        "jobId": "61192f03-a823-4f32-a5c7-aadb0829744e",
+        "lastUpdateDateTime": "2021-10-25T21:21:12Z",
+        "createdDateTime": "2021-10-25T21:21:12Z",
+        "expirationDateTime": "2021-10-26T21:21:12Z",
         "status": "notStarted",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/81cf7138-be59-42b9-8b7a-3c83dff39e57?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/61192f03-a823-4f32-a5c7-aadb0829744e?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "740ea8ad2ce006c130b149d1ae645358",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1edcdf13-cafc-484d-9438-4162936a62fe",
+        "apim-request-id": "476c8fbf-205a-4d0d-9878-ace19ca7b622",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:08 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "70"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "81cf7138-be59-42b9-8b7a-3c83dff39e57",
-        "lastUpdateDateTime": "2021-08-06T01:54:08Z",
-        "createdDateTime": "2021-08-06T01:54:07Z",
-        "expirationDateTime": "2021-08-07T01:54:07Z",
+        "jobId": "61192f03-a823-4f32-a5c7-aadb0829744e",
+        "lastUpdateDateTime": "2021-10-25T21:21:12Z",
+        "createdDateTime": "2021-10-25T21:21:12Z",
+        "expirationDateTime": "2021-10-26T21:21:12Z",
+        "status": "notStarted",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/61192f03-a823-4f32-a5c7-aadb0829744e?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "07effce6ecdcc068be2a834d57229cd7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "899c2116-5aa0-4ed9-911c-dbf56ac2bbdb",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:21:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "61192f03-a823-4f32-a5c7-aadb0829744e",
+        "lastUpdateDateTime": "2021-10-25T21:21:12Z",
+        "createdDateTime": "2021-10-25T21:21:12Z",
+        "expirationDateTime": "2021-10-26T21:21:12Z",
+        "status": "notStarted",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/61192f03-a823-4f32-a5c7-aadb0829744e?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a4abf7090d51955a436148dd080e8c26",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "80b49ea9-87ee-4d10-9d95-1f89be196acd",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:21:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "61192f03-a823-4f32-a5c7-aadb0829744e",
+        "lastUpdateDateTime": "2021-10-25T21:21:12Z",
+        "createdDateTime": "2021-10-25T21:21:12Z",
+        "expirationDateTime": "2021-10-26T21:21:12Z",
+        "status": "notStarted",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/61192f03-a823-4f32-a5c7-aadb0829744e?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ac0adb67b502c15a3f4db5b5a873ae0e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "342cd8d7-c553-4f87-9563-360d5464aa5c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:21:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "61192f03-a823-4f32-a5c7-aadb0829744e",
+        "lastUpdateDateTime": "2021-10-25T21:21:18Z",
+        "createdDateTime": "2021-10-25T21:21:12Z",
+        "expirationDateTime": "2021-10-26T21:21:12Z",
+        "status": "running",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/61192f03-a823-4f32-a5c7-aadb0829744e?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "b6c77215aeb9d807a159c37ba38bb7b0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e2507995-651a-4ab3-8bdc-745ac5df3b5a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:21:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "76"
+      },
+      "ResponseBody": {
+        "jobId": "61192f03-a823-4f32-a5c7-aadb0829744e",
+        "lastUpdateDateTime": "2021-10-25T21:21:18Z",
+        "createdDateTime": "2021-10-25T21:21:12Z",
+        "expirationDateTime": "2021-10-26T21:21:12Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1078,6 +1240,6 @@
   "Variables": {
     "RandomSeed": "1940196881",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeHealthcareEntitiesTests/RecognizeHealthcareEntitiesWithLanguageTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "223",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9a9cf05cd1cedf4abd70fd71251bcd3f-ab59eaf6082d4f4f-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6db26f70a547da41a329b07baff8e28a-2515ef6536b1d641-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ac50657e0564f29f4cf677ed0a13f18a",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,102 +35,84 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "fbf83210-cae0-4d6f-82c9-fae1cc42444c",
-        "Date": "Fri, 06 Aug 2021 01:54:28 GMT",
-        "operation-location": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/1df3e2b2-aa44-4347-bbdd-e1651c9c5665",
+        "apim-request-id": "acc9d45d-5189-4856-9291-12ae393311f8",
+        "Date": "Mon, 25 Oct 2021 21:21:45 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/d206b0d2-da00-4e10-988e-2d6259cde75b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "299"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "233"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/1df3e2b2-aa44-4347-bbdd-e1651c9c5665?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/d206b0d2-da00-4e10-988e-2d6259cde75b?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ee06e8ec9851bf144fa0b3348eac9147",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0603abd8-682c-49dc-bb6c-bb277c34e413",
+        "apim-request-id": "501b6019-3097-4111-a34b-d1d8f0d50a87",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:28 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "212"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "1df3e2b2-aa44-4347-bbdd-e1651c9c5665",
-        "lastUpdateDateTime": "2021-08-06T01:54:29Z",
-        "createdDateTime": "2021-08-06T01:54:29Z",
-        "expirationDateTime": "2021-08-07T01:54:29Z",
-        "status": "notStarted",
+        "jobId": "d206b0d2-da00-4e10-988e-2d6259cde75b",
+        "lastUpdateDateTime": "2021-10-25T21:21:46Z",
+        "createdDateTime": "2021-10-25T21:21:46Z",
+        "expirationDateTime": "2021-10-26T21:21:46Z",
+        "status": "running",
         "errors": []
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/1df3e2b2-aa44-4347-bbdd-e1651c9c5665?showStats=false",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/health/jobs/d206b0d2-da00-4e10-988e-2d6259cde75b?showStats=false",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c56f00a8f06aed051c550a52700d0abf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c9ba229f-522d-438c-be3e-ff5236dc6d62",
+        "apim-request-id": "1dfb2573-b8ab-4a23-85df-db33e0ba21b8",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:30 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "584"
       },
       "ResponseBody": {
-        "jobId": "1df3e2b2-aa44-4347-bbdd-e1651c9c5665",
-        "lastUpdateDateTime": "2021-08-06T01:54:29Z",
-        "createdDateTime": "2021-08-06T01:54:29Z",
-        "expirationDateTime": "2021-08-07T01:54:29Z",
-        "status": "notStarted",
-        "errors": []
-      }
-    },
-    {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/health/jobs/1df3e2b2-aa44-4347-bbdd-e1651c9c5665?showStats=false",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c9cabda7fe2ee58e51915dc3526b639f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "db2a90d8-e5b4-4104-a8e7-21b183b8a9b8",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 06 Aug 2021 01:54:31 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "67"
-      },
-      "ResponseBody": {
-        "jobId": "1df3e2b2-aa44-4347-bbdd-e1651c9c5665",
-        "lastUpdateDateTime": "2021-08-06T01:54:31Z",
-        "createdDateTime": "2021-08-06T01:54:29Z",
-        "expirationDateTime": "2021-08-07T01:54:29Z",
+        "jobId": "d206b0d2-da00-4e10-988e-2d6259cde75b",
+        "lastUpdateDateTime": "2021-10-25T21:21:47Z",
+        "createdDateTime": "2021-10-25T21:21:46Z",
+        "expirationDateTime": "2021-10-26T21:21:46Z",
         "status": "succeeded",
         "errors": [],
         "results": {
@@ -1108,6 +1096,6 @@
   "Variables": {
     "RandomSeed": "330150674",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchConvenienceTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "192",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2a4abdd8e7642a4bb9a2aec484f5be12-db2683dff90d574c-00",
+        "traceparent": "00-4018b2fd2ec8764a964b62b7dca57cf7-b5da38308b293c4c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d727f8b3ab5caeec2a15d6a3b1743ade",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e49c77eb-1192-47d0-9bff-6bf5e7c65494",
+        "apim-request-id": "2da957ba-8919-4a79-bf54-1e572a5c0c3c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
+        "x-envoy-upstream-service-time": "25"
       },
       "ResponseBody": {
         "documents": [
@@ -147,6 +147,6 @@
   "Variables": {
     "RandomSeed": "1090158568",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchConvenienceTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "192",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ef275b2288fa604da9b7c0e346d34e58-a098800dbf9f5542-00",
+        "traceparent": "00-0359df4de62c41449247091dcf969fa7-85e2ce408841604c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "476534efbdc7cda5ab406b046713b5b6",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cf666b20-9e62-4425-ac42-02135a72dab8",
+        "apim-request-id": "83ec7984-2895-441c-b4c3-cb870307614c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "22"
       },
       "ResponseBody": {
         "documents": [
@@ -147,6 +147,6 @@
   "Variables": {
     "RandomSeed": "118147903",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchConvenienceWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "192",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dcd70ec931219249a780f8577eb52c1e-bf1ac7a6dbb73d42-00",
+        "traceparent": "00-57c04b9d2266f545bb4456c57662a8b0-83e4c3bb6fee314a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "297e980ed9e8189820ebd45ff129bc5c",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b84b68cb-8219-4a79-9af9-faabef79fb69",
+        "apim-request-id": "0aa8c172-86d3-4fe1-8dba-139f5ee7227c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "48"
+        "x-envoy-upstream-service-time": "23"
       },
       "ResponseBody": {
         "statistics": {
@@ -161,6 +161,6 @@
   "Variables": {
     "RandomSeed": "966684010",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchConvenienceWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "192",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-05d2130caca95e49a6874a842edcf8bf-4a7d14c272189e49-00",
+        "traceparent": "00-9b97094c4f3cb44b864f32ffdc005bea-e0f6eddc0c0e0840-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "efbfe45b25f6d2a2775e1edd2fe4e7aa",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e14faf46-f09f-4e18-a3ff-27053feab3a5",
+        "apim-request-id": "a684fccc-12de-452e-bdd7-2d6e68d950ee",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "19"
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
         "statistics": {
@@ -161,6 +161,6 @@
   "Variables": {
     "RandomSeed": "1003575897",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a343783e99ca51439f843d49b0b45050-774182e5dd52cf4d-00",
+        "traceparent": "00-b3bdf4e0e0518c428b6b7dc783bc7650-371f4d04165dcb41-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "70aff255bc0a587f23734ec6facb2924",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e62bfce8-de8d-4083-817d-dd602791d8b5",
+        "apim-request-id": "68fd624a-c493-412a-b76b-5b21e34b0d82",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "34"
       },
       "ResponseBody": {
         "documents": [
@@ -163,6 +163,6 @@
   "Variables": {
     "RandomSeed": "1863021454",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8b7db62a783f784f9d212bb8090d5205-78a0b4142ccf0f45-00",
+        "traceparent": "00-bed176b64483f84e94202984c137e83f-e881af98a979b446-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "b6c8d0c26960e1039b6b5addff48c5fe",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ddb41cb8-f93b-48d2-a063-0fbe0c048cb0",
+        "apim-request-id": "cef1e792-1981-40e5-b71f-581ee5a2c4e2",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "24"
+        "x-envoy-upstream-service-time": "34"
       },
       "ResponseBody": {
         "documents": [
@@ -163,6 +163,6 @@
   "Variables": {
     "RandomSeed": "1694310088",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithErrorTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "229",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d594b7f7305eb141adc583e358ed8981-c0b4aeaff0541b40-00",
+        "traceparent": "00-f9017ebda1bbc14ba0373dc9a3a0903c-988dc6cc1e430b41-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "1199dc8afc6a0ac5f0743171c35d6934",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5b79123a-8f2c-4988-9bb5-57ada427ee30",
+        "apim-request-id": "3e8f6fd5-3789-4bc6-9a99-ff9b7be826b1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "x-envoy-upstream-service-time": "23"
       },
       "ResponseBody": {
         "documents": [
@@ -164,6 +164,6 @@
   "Variables": {
     "RandomSeed": "2120326363",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithErrorTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "229",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f70b88e9196acc45ba283414d05ef0d4-9fd4712e1c9c324e-00",
+        "traceparent": "00-aedb5de92c47b540b3d16b46aab93bad-459508812d910e4e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "4f030e46456aaab2ab975c8325cfab86",
         "x-ms-return-client-request-id": "true"
@@ -40,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b2b87f82-04c8-4c58-bdf2-6fb6c9c7b9f5",
+        "apim-request-id": "a796a96e-9b54-4545-80ef-7ac75f26d5e0",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "18"
+        "x-envoy-upstream-service-time": "15"
       },
       "ResponseBody": {
         "documents": [
@@ -164,6 +164,6 @@
   "Variables": {
     "RandomSeed": "1773584232",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithInvalidDocumentBatch.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithInvalidDocumentBatch.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "561",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c8a6514bfc35f4428e7ca37f457c2a6a-9adee1e64eec634d-00",
+        "traceparent": "00-93b08d16a5f82a4182b32da19494f388-5d2e4d3b24a8074d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "192c3c1f91647770ee90b0e32a189a79",
         "x-ms-return-client-request-id": "true"
@@ -55,13 +55,13 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "9dd194fe-9568-4f84-a584-748df0901269",
+        "apim-request-id": "215ef9ba-5799-470a-99ec-45f97a23f002",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5"
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
         "error": {
@@ -78,6 +78,6 @@
   "Variables": {
     "RandomSeed": "907456664",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithInvalidDocumentBatchAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithInvalidDocumentBatchAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "561",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ca6f349437a2004ea15051c5868f4e7a-f1719c97eac4604b-00",
+        "traceparent": "00-de8212d67cc17b448b09520e4be3ce6b-15a6f4c946d4d248-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "aa01d6b77b2b2d76ec0e72d5ad5d4024",
         "x-ms-return-client-request-id": "true"
@@ -55,9 +55,9 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "e3b24464-cf82-4ec6-a89c-11267369467a",
+        "apim-request-id": "cb91aae7-3ef7-42f3-ae28-009b201f884b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -78,6 +78,6 @@
   "Variables": {
     "RandomSeed": "602192603",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithNullIdTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithNullIdTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "64",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-060e06d53770bb40842aef94f8db470e-6abfbb994737bc4d-00",
+        "traceparent": "00-6fefc88331389847bda8d49417cf0c5d-a2b16bad173ca546-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "39e775856c33e5040de74ed9f57d5d06",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "779242b8-9b0e-49d7-addf-6d7794d48427",
+        "apim-request-id": "ab63b873-3db6-476a-96de-dfe0ba0e9277",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "143174300",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithNullIdTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithNullIdTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "64",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8d73145a4ff10544bf70b57dbfda8515-9d028ca46ed67d42-00",
+        "traceparent": "00-6cb5c13ef3495c4fbb4eb0afae0456b9-9241990b3b3cd745-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9f2af246abde141d1e5ee3f98d0120cc",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 400,
       "ResponseHeaders": {
-        "apim-request-id": "0f81fd3b-c7ca-494a-86ee-37b331f02587",
+        "apim-request-id": "c5ee14eb-6e60-4a93-afae-c6ef92fbad51",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:58 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -53,6 +53,6 @@
   "Variables": {
     "RandomSeed": "688120200",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithNullTextTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithNullTextTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-22e7286de570e945b6073c23d6d0d245-fa737a4a6fe3ed44-00",
+        "traceparent": "00-58f01658e6c0f44a86fd9145dab7287b-3c1f058337bb6646-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "73d297ac9bb0c1f746fd7bde1da9241c",
         "x-ms-return-client-request-id": "true"
@@ -30,13 +30,13 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cc75d6a4-a152-49a3-9103-919d1ad844a5",
+        "apim-request-id": "15a60860-a393-4d37-94e8-b62de01a2a3e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "3"
+        "x-envoy-upstream-service-time": "5"
       },
       "ResponseBody": {
         "documents": [],
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "857365247",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithNullTextTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithNullTextTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee9a1698abe4bf40995610143033736e-24be002d76c61e4a-00",
+        "traceparent": "00-6cf5250ee4a24c4b8a07c55b55605bd2-9343eb6cffb6854f-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "eb53c4f0f4de762a1a8dd9e931cc3cf8",
         "x-ms-return-client-request-id": "true"
@@ -30,9 +30,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cf01df71-a1f9-4d04-9d5c-54bc6e2fddc2",
+        "apim-request-id": "dc133aa8-afbe-4967-9c7f-161d6346d394",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 03 Aug 2021 18:39:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
@@ -60,6 +60,6 @@
   "Variables": {
     "RandomSeed": "1341433425",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b1a06aeb63cab542a5b38f62fbd68400-73acb03a5dc07e4b-00",
+        "traceparent": "00-5471ef9536b0224a967fe991ebec77c0-d3d2103fe9a21340-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "07178a1f00e9eae492911a1486f7f75f",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "56d4b07a-272c-4e30-9e7c-f42babe6ddc2",
+        "apim-request-id": "3e60e4eb-8bf2-4afc-bb05-ea0386ae4cc5",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "26"
       },
       "ResponseBody": {
         "statistics": {
@@ -177,6 +177,6 @@
   "Variables": {
     "RandomSeed": "775198464",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesBatchWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "190",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e1cedc0c4ee4db449646458db3fdf5a3-d8033380aae3244b-00",
+        "traceparent": "00-2397aa869744094e8a8fb4ca5a314c13-90f52b495ab94849-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "c81f2c7c8424b466b144609b6251448a",
         "x-ms-return-client-request-id": "true"
@@ -35,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1aa35670-1e82-46be-af53-18d0a1aebda1",
+        "apim-request-id": "4ab28681-28a2-4cf4-b811-06bc5d215d76",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Tue, 03 Aug 2021 18:39:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "30"
+        "x-envoy-upstream-service-time": "26"
       },
       "ResponseBody": {
         "statistics": {
@@ -177,6 +177,6 @@
   "Variables": {
     "RandomSeed": "1369620328",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c76f2be97b99b54e885bcfc0af8cde7c-c5c4b9ea86695a49-00",
+        "traceparent": "00-290ba8e95bb0494bafcbdd73ee918d71-ac7fad601ff2df48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5dbd0e4d74f1991eb1c26555a87606e8",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f401ed45-efe8-4bf5-9228-9f40f194c937",
+        "apim-request-id": "a2e3830e-06a6-4512-8ca8-9e2d543bc4e0",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "15"
       },
       "ResponseBody": {
         "documents": [
@@ -104,6 +104,6 @@
   "Variables": {
     "RandomSeed": "862299711",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5153ef91700af44da97fc9e4390f6c96-8c9ea9c963b40742-00",
+        "traceparent": "00-9fae55152ddf284eaaf8deb0d6be39fb-4c4663f94507da44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "552924120f9751fcf8de062c168ba5ca",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a04a2b1-daf7-42bc-abdf-cd8cede124c3",
+        "apim-request-id": "045f908f-2f76-4527-9c76-55a4d3bf053d",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "34"
       },
       "ResponseBody": {
         "documents": [
@@ -104,6 +104,6 @@
   "Variables": {
     "RandomSeed": "451982382",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithLanguageTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "102",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fed95e85d836fd49be053384c6194ecc-3a491d7874b1514e-00",
+        "traceparent": "00-fd6e7ada71e5e844aa011bd9b53340b8-985dc10b3c30b246-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "934878dc21c8a0a984e7d2d9ad60c773",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9581e685-0cb0-4e1a-96de-d69fd00e714f",
+        "apim-request-id": "a96e6847-4fe5-4646-a7b5-8e0a3d1997a0",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "38"
       },
       "ResponseBody": {
         "documents": [
@@ -104,6 +104,6 @@
   "Variables": {
     "RandomSeed": "1916186259",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithLanguageTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/linking?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/linking?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "102",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-09ebaba408b99a4da47d659d8269d94f-6a678d2b8b189848-00",
+        "traceparent": "00-93fbeeb98b1e9744b24d278bbb891c54-f20b7664817f7e44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "25dfcc445911727a9003f8f77dc4c2e5",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d3e5fd37-040f-432a-960e-97a3fa42d730",
+        "apim-request-id": "8d7e9766-994c-47e6-b289-c1c67e67fe49",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:39:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "22"
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
         "documents": [
@@ -104,6 +104,6 @@
   "Variables": {
     "RandomSeed": "1422875153",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "461",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cb0ad4c1cf29a0458a4403689d09f3b5-1e2a20a194ff2742-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-d4d13a7e40331d45b40473492369498a-cbac6e84a37a104a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "476929731fb859169740acaba5ee9ed6",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,42 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ecd80dff-602c-4ffd-834f-7a7b9a3ddafc",
-        "Date": "Wed, 20 Oct 2021 15:06:35 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
+        "apim-request-id": "60a6a95b-4955-4e21-9f5a-12f84c70b09a",
+        "Date": "Mon, 25 Oct 2021 21:21:52 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "346"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "277"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4cbe073f3d3eebf1605108fd45983580",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "16c88913-76e5-4ad3-a491-5ffb0bec610e",
+        "apim-request-id": "1637300e-c021-4d67-a14f-d485f73d72ca",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
       },
       "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:35Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:21:53Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -95,31 +107,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d1c5b125e3ca39de7995125b7dbcd6fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5da5a7c7-0a00-462c-99f7-21a0846f45f7",
+        "apim-request-id": "c5ba3f91-e448-4023-a7ad-d65ec121fb01",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:37 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:35Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:21:53Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -131,31 +149,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "574d387fb3e53516387ee667161914ff",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "55bbef8c-9c42-4da6-9a6d-d0205a1c1d1a",
+        "apim-request-id": "512a86dd-1209-4255-a905-32bf3603082b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:38 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "19"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:35Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:21:53Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -167,31 +191,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f3862b0bcd295b0c2984d3a82b956da3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "36e72162-db94-4dcf-bedb-54e2bb4fe1e4",
+        "apim-request-id": "83bc22ff-569b-4bbf-a274-e5ce1b0e1759",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:39 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:35Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:21:53Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -203,175 +233,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0c7e097ade4a719b9a8f984bfd762360",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "628bb95c-7753-47d3-9ec1-bffa0caace70",
+        "apim-request-id": "c487a1a4-9362-4e03-835b-9f26c256d1de",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:40 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "91"
       },
       "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:35Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "514f1381e236b1d52cf12e61e06d0aa2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "d49428f4-cce0-46bd-af4d-59c561f78e38",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:42 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "29"
-      },
-      "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:35Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0cec4210089a2db49014599934c15eb2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "7401a1fc-34b2-4959-8765-220008c5c642",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:43 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
-      },
-      "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:35Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "172773611b45986d34cce059af3a912d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "63e2c937-68e5-4c5d-b4c7-de4d97eb9226",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:44 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "79"
-      },
-      "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:35Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "ba3af685168978c55f22c121893c7c6a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "aa94bf79-5465-40b9-86ff-e2047070621f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:46 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "219"
-      },
-      "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:45Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:21:57Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -381,7 +273,7 @@
           "total": 2,
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:06:45.2525333Z",
+              "lastUpdateDateTime": "2021-10-25T21:21:57.6116502Z",
               "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -516,31 +408,562 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bd3ed8ac-0b57-4e06-9976-46f9c6503292",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6cff7b93f245f55cd554d8cd285a7d56",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "514f1381e236b1d52cf12e61e06d0aa2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f6ed977-45fb-407f-a4a5-f6a7e7eb47f6",
+        "apim-request-id": "8a373a18-b870-415c-8854-263f3bd44e73",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:21:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "216"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "71"
       },
       "ResponseBody": {
-        "jobId": "bd3ed8ac-0b57-4e06-9976-46f9c6503292",
-        "lastUpdateDateTime": "2021-10-20T15:06:47Z",
-        "createdDateTime": "2021-10-20T15:06:35Z",
-        "expirationDateTime": "2021-10-21T15:06:35Z",
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:21:57Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:21:57.6116502Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "0cec4210089a2db49014599934c15eb2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "741f0951-5713-46fd-b9b0-6b8bf59ca0b8",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "364"
+      },
+      "ResponseBody": {
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:21:57Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:21:57.6116502Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "172773611b45986d34cce059af3a912d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "00ccfcae-b6f2-4856-a7bc-44468f6f224a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "69"
+      },
+      "ResponseBody": {
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:21:57Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:21:57.6116502Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f9c3f748-7b33-44b9-9ae1-48751e369f16",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "ba3af685168978c55f22c121893c7c6a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1c874028-825c-481d-a45e-27054c10b04e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "133"
+      },
+      "ResponseBody": {
+        "jobId": "f9c3f748-7b33-44b9-9ae1-48751e369f16",
+        "lastUpdateDateTime": "2021-10-25T21:22:04Z",
+        "createdDateTime": "2021-10-25T21:21:52Z",
+        "expirationDateTime": "2021-10-26T21:21:52Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -550,7 +973,7 @@
           "total": 2,
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:06:45.2525333Z",
+              "lastUpdateDateTime": "2021-10-25T21:21:57.6116502Z",
               "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -681,7 +1104,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:06:47.3879083Z",
+              "lastUpdateDateTime": "2021-10-25T21:22:04.7772792Z",
               "taskName": "RecognizeLinkedEntities",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeLinkedEntitiesTests/RecognizeLinkedEntitiesWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "461",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0af1a1ab26a6c047a9ea45d183fe5cb3-f5b8973fa352c645-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8aa7d8b6789c2c4f9ee10922755b6207-61b98f575776b547-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "a7a23cc678c67f8bea6d7fcaeff39d88",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,43 +54,49 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "66362c59-02f9-430e-8159-4a856212f210",
-        "Date": "Wed, 20 Oct 2021 15:06:49 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+        "apim-request-id": "69d96b7a-a4b2-4bf3-9dae-10203ecd9de8",
+        "Date": "Mon, 25 Oct 2021 21:22:08 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "686"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "215"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9e6a41ab9a36538db2856c07a9e32f07",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "78d826a1-edb7-4d90-b081-a06dfa478eb4",
+        "apim-request-id": "141b3014-0a5c-4948-ba33-5ebd3e032a07",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:49 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "15"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:49Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "notStarted",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:09Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -95,32 +107,38 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "2a5f1f468abb8d3c9e7e25fe2bb3ffe0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "03aa712c-63b4-468b-ad70-b9820df2a938",
+        "apim-request-id": "ec696670-89bc-4d04-8461-ba93fa46e90c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:50 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:49Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "notStarted",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:09Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -131,32 +149,38 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "480cfa2e5ce12b78af4ef5400b83d606",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8be046d9-6fc8-4a1a-848d-af468ccfa001",
+        "apim-request-id": "776a82d8-e9c3-4db7-b610-e56a302287e2",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:52 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:49Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "notStarted",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:09Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -167,32 +191,38 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d084783e739320cc04dcffb8758e28fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "85c60725-f415-4b40-a232-500a3aa2020c",
+        "apim-request-id": "414e2a16-c4c5-45d6-96d9-c64c053605e0",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "19"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:49Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "notStarted",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:09Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -203,32 +233,38 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "aed98c86e7d7ea25a6347a6c94fb821b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "29e1243c-f307-4ba4-ae3d-1fbbcb9ff2ea",
+        "apim-request-id": "abd69572-22de-4a30-b666-72bed98d8a12",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:54 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "15"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:49Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "notStarted",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:09Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -239,31 +275,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b2c01ea72e2fba4d2deb43045cbfb520",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f80eb6e5-681d-479a-8ef4-89a80701819d",
+        "apim-request-id": "c5d197c3-84a6-4c82-a0cc-a574dc9a0349",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:56 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:15Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -275,31 +317,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7fbaf62527aa562f529a295ff85f8c09",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a62403b1-f45d-4222-9fa6-e9f30f632f1e",
+        "apim-request-id": "8231200d-6b0b-47b7-a6fa-3b699260914e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:57 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:15Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -311,463 +359,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5710e45a76ce57cf3f1e81eba3218ee6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "21ab547d-717a-4465-bbc8-72aa17bafa81",
+        "apim-request-id": "c4cf8733-3071-46cb-aef9-b5e170be561d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:06:59 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "62"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9d47597e03418070ef695f9504eec1cd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5b50183e-12ba-4f19-bb66-696b3f25f2d5",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:00 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "77aa3a5f5eaeaf522763408ba644b331",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "121630c4-e652-421b-bd23-b42dcab985f5",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:01 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9ee0420bee1857c77490676416395251",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "0f8b4253-afcc-4244-8ca0-dab5f2e31e71",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:02 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "698bb35d16771f38079776dec2e5d9ab",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b3d56000-0605-44b4-9cf2-32aec02e092e",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:04 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "c2892db6220d71b47252031df7ed99ee",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "00a6c84e-f0a8-4eee-8f32-b4ed58e2d87f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:05 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f22eef1049b8f5ba0ac0978178e9948f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "200cbcfa-739b-4a74-aa76-f273bca77d02",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:06 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e8aebcb790b03a43fe19f624131a2819",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9515629f-3ef5-4a79-8d41-796fe47f9ee3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:07 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d3cd87fde7b66cf27394b74c8b33f989",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "03d9787f-bac6-4b01-8bde-60957f83f37e",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:09 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3b6674beb03f803dabf4f39e5396e1f0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "96537742-930e-4f40-b36c-d92f065fc82e",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:10 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f0837d98c11bcfd8c941751cd9f6afcb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "74507c5b-0874-4d5e-ad8e-a1deb95bbe51",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:11 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9f656d20edb34dda4a4d27c2f35319dc",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "2c9dfa69-0cf5-404a-9975-228a07ea621c",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:12 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "14"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:06:56Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0db4c7b209affd6d9b9672fd3b21a6b4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8f089faf-4059-4699-b7b5-10be80408c0b",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:13 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "122"
-      },
-      "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:07:13Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:18Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -777,7 +399,7 @@
           "total": 2,
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:07:13.2289228Z",
+              "lastUpdateDateTime": "2021-10-25T21:22:18.8304021Z",
               "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -912,31 +534,1087 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7c80125d-9f58-4bf5-a561-e24536d8ab0c",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e57e28444230aa3ca336a5ce9916dc75",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9d47597e03418070ef695f9504eec1cd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "68dec24c-32bd-4bf7-8a15-b445e8299643",
+        "apim-request-id": "af9d821f-166f-4a22-aa6a-fe24e5aa9a59",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:15 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "222"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "118"
       },
       "ResponseBody": {
-        "jobId": "7c80125d-9f58-4bf5-a561-e24536d8ab0c",
-        "lastUpdateDateTime": "2021-10-20T15:07:14Z",
-        "createdDateTime": "2021-10-20T15:06:49Z",
-        "expirationDateTime": "2021-10-21T15:06:49Z",
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:18Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:18.8304021Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "77aa3a5f5eaeaf522763408ba644b331",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6fa03ca8-1566-4fb7-bd75-30833b9974a5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "200"
+      },
+      "ResponseBody": {
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:18Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:18.8304021Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9ee0420bee1857c77490676416395251",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a9abcbd4-ba4e-4b00-be60-0b2809cd3dce",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "525"
+      },
+      "ResponseBody": {
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:18Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:18.8304021Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "698bb35d16771f38079776dec2e5d9ab",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7ff88fcb-d420-4a17-a517-4ef57f23b257",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "146"
+      },
+      "ResponseBody": {
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:18Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:18.8304021Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "c2892db6220d71b47252031df7ed99ee",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7ccb112d-d3c0-4813-9582-cf64dae16b20",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "115"
+      },
+      "ResponseBody": {
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:18Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:18.8304021Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f22eef1049b8f5ba0ac0978178e9948f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8c7d3910-4e9f-4307-b738-3e60ee3286c3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2234"
+      },
+      "ResponseBody": {
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:18Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityLinkingTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:18.8304021Z",
+              "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.49
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Microsoft",
+                        "url": "https://en.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 25,
+                            "length": 10,
+                            "confidenceScore": 0.52
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Bill Gates",
+                        "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 40,
+                            "length": 10,
+                            "confidenceScore": 0.54
+                          }
+                        ],
+                        "language": "en",
+                        "id": "Paul Allen",
+                        "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "3",
+                    "entities": [
+                      {
+                        "bingId": "a093e9b9-90f5-a3d5-c4b8-5855e1b01f85",
+                        "name": "Microsoft",
+                        "matches": [
+                          {
+                            "text": "Microsoft",
+                            "offset": 0,
+                            "length": 9,
+                            "confidenceScore": 0.38
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Microsoft",
+                        "url": "https://es.wikipedia.org/wiki/Microsoft",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "0d47c987-0042-5576-15e8-97af601614fa",
+                        "name": "Bill Gates",
+                        "matches": [
+                          {
+                            "text": "Bill Gates",
+                            "offset": 26,
+                            "length": 10,
+                            "confidenceScore": 0.37
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Bill Gates",
+                        "url": "https://es.wikipedia.org/wiki/Bill_Gates",
+                        "dataSource": "Wikipedia"
+                      },
+                      {
+                        "bingId": "df2c4376-9923-6a54-893f-2ee5a5badbc7",
+                        "name": "Paul Allen",
+                        "matches": [
+                          {
+                            "text": "Paul Allen",
+                            "offset": 39,
+                            "length": 10,
+                            "confidenceScore": 0.9
+                          }
+                        ],
+                        "language": "es",
+                        "id": "Paul Allen",
+                        "url": "https://es.wikipedia.org/wiki/Paul_Allen",
+                        "dataSource": "Wikipedia"
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [
+                  {
+                    "id": "3",
+                    "error": {
+                      "code": "InvalidArgument",
+                      "message": "Invalid Language Code.",
+                      "innererror": {
+                        "code": "UnsupportedLanguageCode",
+                        "message": "Invalid language code. Supported languages: en. For additional details see https://aka.ms/text-analytics/language-support?tabs=named-entity-recognition"
+                      }
+                    }
+                  }
+                ],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/64464be8-4728-43af-894b-7e3ad584d9a4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "e8aebcb790b03a43fe19f624131a2819",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b665a11b-6f8f-4435-9c45-d64439d67076",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "166"
+      },
+      "ResponseBody": {
+        "jobId": "64464be8-4728-43af-894b-7e3ad584d9a4",
+        "lastUpdateDateTime": "2021-10-25T21:22:31Z",
+        "createdDateTime": "2021-10-25T21:22:09Z",
+        "expirationDateTime": "2021-10-26T21:22:09Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -946,7 +1624,7 @@
           "total": 2,
           "entityLinkingTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:07:13.2289228Z",
+              "lastUpdateDateTime": "2021-10-25T21:22:18.8304021Z",
               "taskName": "RecognizeLinkedEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -1077,7 +1755,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:07:14.2875044Z",
+              "lastUpdateDateTime": "2021-10-25T21:22:31.8705296Z",
               "taskName": "RecognizeLinkedEntities",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchConvenienceTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8e97b8bfde18584ea028e15cc32afca6-0fca130d01530647-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7f43eb1fbc88b64786d339a1f5ab62d3-19d6b18f5350284c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4f9f78c612dc4ff4e6424ecbf4774e1d",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1b63f104-3eb7-49a5-ae91-54851fdb65a4",
+        "apim-request-id": "16a657e1-0aed-41cd-891e-66d7b7c5a4a2",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:31 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "44"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "47"
       },
       "ResponseBody": {
         "documents": [
@@ -112,6 +118,6 @@
   "Variables": {
     "RandomSeed": "1132826820",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchConvenienceTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5353a9cfb66ed74085bc160f8daef400-7dfbd2cba222a442-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-01fc5f4414533f47bfecdecc87b6dc92-6f7d975d389eed44-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "36b692faddb1a4a1de76fbe750ec63aa",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b891f444-05ec-47bc-80d8-d2a0f0066260",
+        "apim-request-id": "825f76ec-5d25-480e-943c-20b2afd56de8",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "24"
       },
       "ResponseBody": {
         "documents": [
@@ -112,6 +118,6 @@
   "Variables": {
     "RandomSeed": "1683535825",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchConvenienceWithStatisticsTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4b4892f05bf98340b4aa7be750ae14ce-1b1fc40e4013e24e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6294a91795c0cd40bdbd8ef1293fb91a-56dd79a815de6046-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "04ded076a7d1ef20d826d8bd22d2f313",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a08a24cb-237a-459f-8885-54c583bfb758",
+        "apim-request-id": "75ae45f6-7a5b-4832-9c4a-84b846bd5a4d",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:31 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "35"
       },
       "ResponseBody": {
         "statistics": {
@@ -126,6 +132,6 @@
   "Variables": {
     "RandomSeed": "706747963",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchConvenienceWithStatisticsTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-81bf921556fb1c4c859e75183810e388-a1ab656f78af9c4d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-91c51e0bb3d26243a287a74da4291330-035952cf85e0e543-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7d30af30e956cc708b0d87dfbe6db16a",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "47377a53-451d-49be-a87c-51f9412e769d",
+        "apim-request-id": "2e9e86cf-5d15-43a2-b2d8-5a5bee5b2860",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "32"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "30"
       },
       "ResponseBody": {
         "statistics": {
@@ -126,6 +132,6 @@
   "Variables": {
     "RandomSeed": "1608660746",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7be1ce8306c8dc43b1bd8ec4c954157f-969f676f79e62240-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f45bc5b6cbea4a409f9e09365e78233a-bd5afe3543290740-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6f9cd824ddbc141e7abad022a25067fc",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3f3aa8d5-4e37-4312-8cb8-f90a2871f982",
+        "apim-request-id": "baba5a84-56ca-494c-aae0-072915270b9a",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:31 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "35"
       },
       "ResponseBody": {
         "documents": [
@@ -112,6 +118,6 @@
   "Variables": {
     "RandomSeed": "318022589",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9a2c64d5d2ad304ba9f0c71a8591b3da-4ebf824d4a5fc940-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-841ce001350cf04a849e1c345c535e0d-aa3b987943fe3743-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d3c06bb4da2c08c1ac14eaea49cdb0bb",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f79831cd-a383-47f6-a502-9531eb10dfb9",
+        "apim-request-id": "93a95c27-8cf5-4f10-9690-0722b616693c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "39"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "35"
       },
       "ResponseBody": {
         "documents": [
@@ -112,6 +118,6 @@
   "Variables": {
     "RandomSeed": "1062926168",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWitCategoryTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWitCategoryTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-925f39ea63ffdb44b2daf357d9ecc032-ef2eab6e3d34bb4a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-22fcec8f2636e74483c300c593e47c0b-370b75b904bd364a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "940d68c3ae74cfe85a8c9b6ff397927c",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "771b7f1f-05c1-418a-ac3c-4dbd6e6cfcc5",
+        "apim-request-id": "a81b4f1b-3e1b-4db8-bfb5-cbc151fa2ba5",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:31 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "36"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "32"
       },
       "ResponseBody": {
         "documents": [
@@ -77,6 +83,6 @@
   "Variables": {
     "RandomSeed": "1827281013",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWitCategoryTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWitCategoryTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7bc249e7964bac4f891a43f758097bcd-901739ebd6753349-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2e0d4915cd467d408d9e080b97a8ad12-76274b449d9df041-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "be97255b3654fe9185dbe071fa756db5",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ec1b7221-95ba-4568-9b37-26ccadd64360",
+        "apim-request-id": "70a21c4b-7294-417b-a890-7c1b1a0e2eda",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "38"
       },
       "ResponseBody": {
         "documents": [
@@ -77,6 +83,6 @@
   "Variables": {
     "RandomSeed": "1066247175",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithDomainTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithDomainTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026domain=phi\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026domain=phi\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a766796bd3d4014e96299988a67de263-ee88844d581b3045-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e814497bfb9bff4f895802faddeed149-cc8f98dec8a2b544-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "9567a6ab75c1c0186e6c0910f26b92ac",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7f31bd19-0da4-490d-8379-08cec8fe13f5",
+        "apim-request-id": "e9ba110f-2e69-4c7f-bf6b-1640546e388e",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:31 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "41"
       },
       "ResponseBody": {
         "documents": [
@@ -105,6 +111,6 @@
   "Variables": {
     "RandomSeed": "211350078",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithDomainTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithDomainTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026domain=phi\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026domain=phi\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b1908696bcec3d4ba0c7b5e39841550a-d321ab2193b14646-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-20f95a86f23eb248af960257f4c7f9f9-0fe3e8872ae58d43-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ad760dfb47a56942a81a4fab59b3d969",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80bb8878-c41d-4e5c-a909-767d34196655",
+        "apim-request-id": "f2a5a92a-4c2e-444f-b27d-450f2e7f36b6",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "31"
       },
       "ResponseBody": {
         "documents": [
@@ -105,6 +111,6 @@
   "Variables": {
     "RandomSeed": "946759567",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithErrorTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "331",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-82d152a3e58c5b4f9efe065b967da56e-7577a8189e0f3547-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-7b5fba4cc571bf4cb74baa79969ed5b1-d3ca70a8ded5264b-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e382b2e96bf3675f4d7d7960b8b32916",
         "x-ms-return-client-request-id": "true"
       },
@@ -34,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5ccd0af3-af62-4797-b2cd-53f451a44460",
+        "apim-request-id": "3aeb195b-9573-479e-9b05-e8b5960588df",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "39"
       },
       "ResponseBody": {
         "documents": [
@@ -122,6 +128,6 @@
   "Variables": {
     "RandomSeed": "239145501",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithErrorTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "331",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bf9f1273fa8ec04da51070d6076f9b3f-05db90c93b00b84e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-a446c72404565d4a8ef76cd5b90ea838-6a06fe1f582f884f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e218864f9605e01c86941869a0be6841",
         "x-ms-return-client-request-id": "true"
       },
@@ -34,14 +40,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d8efdf6b-09fd-4593-ac41-a73ee92fcead",
+        "apim-request-id": "a4e37a26-99ec-4da5-8572-4327e65cb94a",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "31"
       },
       "ResponseBody": {
         "documents": [
@@ -122,6 +128,6 @@
   "Variables": {
     "RandomSeed": "1607409987",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithStatisticsTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f29f92f960a7de4a8e0d3c69c40ae052-dc55facae8b2bc48-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b3e4e41edd08a5419dd0f6a69a6aea88-0b15edf25600a342-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "31f09c56057d756e3c532a93aa2edb35",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "299eadcf-1cee-4a15-b03d-7f6466cf4983",
+        "apim-request-id": "c2f071b4-9eed-4a5f-a129-432d47b98bf5",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "31"
       },
       "ResponseBody": {
         "statistics": {
@@ -126,6 +132,6 @@
   "Variables": {
     "RandomSeed": "1531046284",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesBatchWithStatisticsTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=true\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=true\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "316",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-db053a869dbeb24ca0c26fdc1d5e089f-3543839c72c7854c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b23af0c766f37840a79b85a708a72f42-0a1a90c1025e054d-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f7aa1943432514c18c4fe7b77ff7d7b3",
         "x-ms-return-client-request-id": "true"
       },
@@ -29,14 +35,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1dcdf02c-438e-4dbe-8cf8-34452da85f10",
+        "apim-request-id": "b6f37b95-12cf-4523-ba58-6697d8d48ec2",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2,CognitiveServices.TextAnalytics.TextRecords=2",
-        "Date": "Fri, 06 Aug 2021 01:54:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "25"
       },
       "ResponseBody": {
         "statistics": {
@@ -126,6 +132,6 @@
   "Variables": {
     "RandomSeed": "217523161",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3928e4fe4f8b4543ba90417fc2821cb0-c26673f99fb67043-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-d5be80e7764e2b4896295970d836364e-785342f5929cbb4a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6655a12d207207ee0d1a26c668ed96aa",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c9e8ffb7-0b5b-4880-ba19-c11a5f88a988",
+        "apim-request-id": "007018f2-742c-4f34-aa71-77cd562012fa",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:32 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "33"
       },
       "ResponseBody": {
         "documents": [
@@ -79,6 +85,6 @@
   "Variables": {
     "RandomSeed": "1336683597",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9e645f1fc6da0042943a6c0479687431-2c140f05f920c64e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-ae606985fcbfd8458e2f1d0cc3ad1aff-38b27d20b0e9da42-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e99c33afa9dbd2d0544e5c85269125b4",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8ed8065a-2140-4a3d-a66f-0ee4ca9371db",
+        "apim-request-id": "2d33018e-323c-4c71-9957-bf8e5ca000d8",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "23"
       },
       "ResponseBody": {
         "documents": [
@@ -79,6 +85,6 @@
   "Variables": {
     "RandomSeed": "135557149",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithCategoriesTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithCategoriesTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4e8ceeacc8046348ab6bbe384d8481d7-6197d9814ab78f43-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-4af3a9ada81e594cb3459a5a1c472bbb-053d2aa29e622242-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "7c04cf67d0469f658d548aa093280fca",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "38697e8a-aa93-4ada-9ac3-3eadf8804e05",
+        "apim-request-id": "83b0f43d-ffe4-4893-b7ea-6ea23292ae20",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "34"
       },
       "ResponseBody": {
         "documents": [
@@ -55,15 +61,21 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber%2COrganization",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber%2COrganization",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-988cdcfcee0bd14e89aec6412ea61b96-d5f217d9cc77ea4d-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-dc898ae1ab95b14583b5e438dfdd0ae1-ebfc2ba270697d40-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5588c72a1f79c7b0129221fabf58dffc",
         "x-ms-return-client-request-id": "true"
       },
@@ -78,14 +90,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8d4471f0-c5f1-4c86-a46d-7e649898f57b",
+        "apim-request-id": "0a6adde2-02a7-4edd-930e-2853b77c4364",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "50"
       },
       "ResponseBody": {
         "documents": [
@@ -116,15 +128,21 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=ABARoutingNumber",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=ABARoutingNumber",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bc6de1fc5ff9c845a7a71d801aab23c4-260852070b33624a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-bee503c95c6c564d924c1f0df423c476-6d329057a8ff3d45-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6dc331865856b414eb9bcb80f46e6158",
         "x-ms-return-client-request-id": "true"
       },
@@ -139,14 +157,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1c81b411-c844-471b-b9a6-3e8c2f306164",
+        "apim-request-id": "761a25c5-b32f-4f97-a931-e5a82cb2e10d",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "36"
       },
       "ResponseBody": {
         "documents": [
@@ -165,6 +183,6 @@
   "Variables": {
     "RandomSeed": "1700870585",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithCategoriesTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithCategoriesTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d8522c64e6087f4bbe9d03cfc0175ca5-fe32749ae3db2e4c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-bd13d807dac9164c966a13e6bb018485-586e04b70f9f194a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "fc3e2e1d014a16e930b2baccef70bd87",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a0972b84-eccf-4554-9ff0-233004c79a83",
+        "apim-request-id": "775f5c76-ea69-4c74-97e7-910069934a65",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "25"
       },
       "ResponseBody": {
         "documents": [
@@ -55,15 +61,21 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber%2COrganization",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PhoneNumber%2COrganization",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0859bc09377f5c4c9727c3614769a746-05dc319af7ebf54e-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6d7b77a68e439746a2f648eb1fdcede0-31399d07fe46b243-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f47f8dfecab159d3b57419d3b00cf4bf",
         "x-ms-return-client-request-id": "true"
       },
@@ -78,14 +90,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2b94685b-5ad7-4aae-87fc-a4a4147f2534",
+        "apim-request-id": "73a5b77f-0e68-4d5d-9dee-0fc36cd64e06",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "25"
       },
       "ResponseBody": {
         "documents": [
@@ -116,15 +128,21 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=ABARoutingNumber",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=ABARoutingNumber",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3f157eaf6e061b4a8aaf595c3ba77cc2-71aa0ccca2dd7d4c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2b72a8ec4c9f5343800d4e2a41fd50d7-0f28893e79b67744-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "6fb8769d2a4111b2f0ea31dcd0af3166",
         "x-ms-return-client-request-id": "true"
       },
@@ -139,14 +157,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ce477d27-63fe-46c9-9c22-3eeb7760a007",
+        "apim-request-id": "0ebe719c-f248-449c-9549-d5b74b51217d",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:34 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "35"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "26"
       },
       "ResponseBody": {
         "documents": [
@@ -165,6 +183,6 @@
   "Variables": {
     "RandomSeed": "462222541",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithDomainTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithDomainTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026domain=phi\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026domain=phi\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "107",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5b826b18fd29b14392c44414c507dde4-00ad13db658f7848-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-32e0c205902e044f93e9434832922106-1952b96c1138f141-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "5757e3544f245670b8a4c82d4b10bc4c",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,13 +30,13 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6eb9699d-58b7-47b0-9fab-9969d5cfac54",
+        "apim-request-id": "c1cbdd2e-e541-4ac0-bdab-ba9d1f8a6cdc",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "32"
       },
       "ResponseBody": {
@@ -44,7 +50,7 @@
                 "category": "Organization",
                 "offset": 10,
                 "length": 9,
-                "confidenceScore": 0.94
+                "confidenceScore": 0.93
               },
               {
                 "text": "atest@microsoft.com",
@@ -65,6 +71,6 @@
   "Variables": {
     "RandomSeed": "114454170",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithDomainTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithDomainTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026domain=phi\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026domain=phi\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "107",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-54680d3a2f1bd24cb05787714d74e560-047c47bb024ecb4a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6f8cc352ecb87d498ebe4c9c471f77d7-23e066d3f9812b4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "4a37fade57ea6b5a5ff8ab22891b6b20",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8cb32d0f-cf08-4320-84fc-6e9bfd98c527",
+        "apim-request-id": "988214e4-b4f3-44ee-b3b3-4c21731ad169",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "26"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "24"
       },
       "ResponseBody": {
         "documents": [
@@ -44,7 +50,7 @@
                 "category": "Organization",
                 "offset": 10,
                 "length": 9,
-                "confidenceScore": 0.94
+                "confidenceScore": 0.93
               },
               {
                 "text": "atest@microsoft.com",
@@ -65,6 +71,6 @@
   "Variables": {
     "RandomSeed": "820241717",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithLanguageTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithLanguageTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-92eeb0b48c184349aa0c029e4fb976fb-6cf288af0a298c48-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-e30806de8224d340bac309fe993c3d56-5e7351159c6c7b4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b9843303f5caf9234c54041b46d95b45",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "604dd8bf-4732-4128-afdd-9c5350013b66",
+        "apim-request-id": "0439331f-9c50-4ea2-a6e4-e5785d4e7421",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "37"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "36"
       },
       "ResponseBody": {
         "documents": [
@@ -79,6 +85,6 @@
   "Variables": {
     "RandomSeed": "1421220879",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithLanguageTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithLanguageTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4da3a02bb3a9a04a93a6b58f9c19fb29-56e6a534e5c1b34c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f665c79d263bca4a8a163e394e29af1c-8b69d8b207fdb34a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f2ea379b57db58a82e503aae4ecdbb11",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3ec11813-97bd-49e2-902a-6358c565cbc5",
+        "apim-request-id": "67d05d58-2638-44f9-983b-8c7959adca35",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "34"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "25"
       },
       "ResponseBody": {
         "documents": [
@@ -79,6 +85,6 @@
   "Variables": {
     "RandomSeed": "1873378849",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "588",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b5fc17c3ba83245b053aeec6f4c2d0c-a10397b5db32e845-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-99a3d81af5bbf54f8590eff41044dfdd-4d9720b0cd9add46-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "71a64eb3d44b2ad9d3eec8afa979abd4",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,222 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "09d3edea-4346-4fc9-b57e-193998d21152",
-        "Date": "Wed, 20 Oct 2021 15:07:35 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/18a30105-f855-4244-b2f5-cc8bbd0f203f",
+        "apim-request-id": "de9e3ec0-983d-4d14-b008-df77c5c45d5c",
+        "Date": "Mon, 25 Oct 2021 21:22:38 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9eb4378d-1c0b-4023-b27e-f48743d77e44",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "572"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "232"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/18a30105-f855-4244-b2f5-cc8bbd0f203f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9eb4378d-1c0b-4023-b27e-f48743d77e44",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d0f83f6ccaae3c668e95979f3babb254",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "25082bd3-f621-4929-a32b-3c6bffa6eca6",
+        "apim-request-id": "fe2a494e-c9e0-4a7f-83ff-94d168d42947",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "18a30105-f855-4244-b2f5-cc8bbd0f203f",
-        "lastUpdateDateTime": "2021-10-20T15:07:35Z",
-        "createdDateTime": "2021-10-20T15:07:35Z",
-        "expirationDateTime": "2021-10-21T15:07:35Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/18a30105-f855-4244-b2f5-cc8bbd0f203f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d595b2e2f0096ee74252e6600eb4920c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "21b57b25-3c6f-4849-a7dc-727c4dc6d412",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:36 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "42"
-      },
-      "ResponseBody": {
-        "jobId": "18a30105-f855-4244-b2f5-cc8bbd0f203f",
-        "lastUpdateDateTime": "2021-10-20T15:07:35Z",
-        "createdDateTime": "2021-10-20T15:07:35Z",
-        "expirationDateTime": "2021-10-21T15:07:35Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/18a30105-f855-4244-b2f5-cc8bbd0f203f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "83ba0843ec14e9cbe86ae2b53c3aef27",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f9feff79-a924-44c4-9ce0-04938320b398",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:38 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "6"
-      },
-      "ResponseBody": {
-        "jobId": "18a30105-f855-4244-b2f5-cc8bbd0f203f",
-        "lastUpdateDateTime": "2021-10-20T15:07:35Z",
-        "createdDateTime": "2021-10-20T15:07:35Z",
-        "expirationDateTime": "2021-10-21T15:07:35Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/18a30105-f855-4244-b2f5-cc8bbd0f203f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "f7cc733cd5e47bcb588a8d5be3062dda",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "53c1cd0f-2eb0-4f02-b36e-4f788abd143a",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:39 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "12"
-      },
-      "ResponseBody": {
-        "jobId": "18a30105-f855-4244-b2f5-cc8bbd0f203f",
-        "lastUpdateDateTime": "2021-10-20T15:07:35Z",
-        "createdDateTime": "2021-10-20T15:07:35Z",
-        "expirationDateTime": "2021-10-21T15:07:35Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/18a30105-f855-4244-b2f5-cc8bbd0f203f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "325b8b032ff1f540e7abed9e0e313108",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "64f1e631-5276-44a8-a926-2c4abb7ebe90",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:40 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "18a30105-f855-4244-b2f5-cc8bbd0f203f",
-        "lastUpdateDateTime": "2021-10-20T15:07:35Z",
-        "createdDateTime": "2021-10-20T15:07:35Z",
-        "expirationDateTime": "2021-10-21T15:07:35Z",
-        "status": "notStarted",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/18a30105-f855-4244-b2f5-cc8bbd0f203f",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9a23bf639be76d273d3f2b895f6f06e1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "129fdbb5-cb97-4ff9-870d-84de2adf6307",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:41 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "18a30105-f855-4244-b2f5-cc8bbd0f203f",
-        "lastUpdateDateTime": "2021-10-20T15:07:41Z",
-        "createdDateTime": "2021-10-20T15:07:35Z",
-        "expirationDateTime": "2021-10-21T15:07:35Z",
+        "jobId": "9eb4378d-1c0b-4023-b27e-f48743d77e44",
+        "lastUpdateDateTime": "2021-10-25T21:22:39Z",
+        "createdDateTime": "2021-10-25T21:22:38Z",
+        "expirationDateTime": "2021-10-26T21:22:38Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -275,31 +107,475 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/18a30105-f855-4244-b2f5-cc8bbd0f203f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9eb4378d-1c0b-4023-b27e-f48743d77e44",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "d595b2e2f0096ee74252e6600eb4920c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cdd8c444-78c6-4b21-a9d6-f505f1c2b651",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:40 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "39"
+      },
+      "ResponseBody": {
+        "jobId": "9eb4378d-1c0b-4023-b27e-f48743d77e44",
+        "lastUpdateDateTime": "2021-10-25T21:22:39Z",
+        "createdDateTime": "2021-10-25T21:22:38Z",
+        "expirationDateTime": "2021-10-26T21:22:38Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9eb4378d-1c0b-4023-b27e-f48743d77e44",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "83ba0843ec14e9cbe86ae2b53c3aef27",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "82529df8-3f9f-4c54-9a74-5c0c47fb4f24",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "9eb4378d-1c0b-4023-b27e-f48743d77e44",
+        "lastUpdateDateTime": "2021-10-25T21:22:41Z",
+        "createdDateTime": "2021-10-25T21:22:38Z",
+        "expirationDateTime": "2021-10-26T21:22:38Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 2,
+          "total": 2
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9eb4378d-1c0b-4023-b27e-f48743d77e44",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "f7cc733cd5e47bcb588a8d5be3062dda",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bebe5cb4-21e5-41c7-9ddf-d81abc759051",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "73"
+      },
+      "ResponseBody": {
+        "jobId": "9eb4378d-1c0b-4023-b27e-f48743d77e44",
+        "lastUpdateDateTime": "2021-10-25T21:22:41Z",
+        "createdDateTime": "2021-10-25T21:22:38Z",
+        "expirationDateTime": "2021-10-26T21:22:38Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:41.6412119Z",
+              "taskName": "RecognizePiiEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "A ********* with SSN *********** whose phone number is ************ is building tools with our APIs. They work at *********",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "developer",
+                        "category": "PersonType",
+                        "offset": 2,
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "859-98-0987",
+                        "category": "USSocialSecurityNumber",
+                        "offset": 21,
+                        "length": 11,
+                        "confidenceScore": 0.65
+                      },
+                      {
+                        "text": "800-102-1100",
+                        "category": "PhoneNumber",
+                        "offset": 55,
+                        "length": 12,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 114,
+                        "length": 9,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Your ABA number - ********* - is the first 9 digits in the lower left hand corner of your personal check",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "111000025",
+                        "category": "PhoneNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "ABARoutingNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.75
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "NZSocialWelfareNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.65
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9eb4378d-1c0b-4023-b27e-f48743d77e44",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "325b8b032ff1f540e7abed9e0e313108",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3de79290-0134-4c62-89a5-4d617d57a953",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "147"
+      },
+      "ResponseBody": {
+        "jobId": "9eb4378d-1c0b-4023-b27e-f48743d77e44",
+        "lastUpdateDateTime": "2021-10-25T21:22:41Z",
+        "createdDateTime": "2021-10-25T21:22:38Z",
+        "expirationDateTime": "2021-10-26T21:22:38Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:41.6412119Z",
+              "taskName": "RecognizePiiEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "A ********* with SSN *********** whose phone number is ************ is building tools with our APIs. They work at *********",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "developer",
+                        "category": "PersonType",
+                        "offset": 2,
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "859-98-0987",
+                        "category": "USSocialSecurityNumber",
+                        "offset": 21,
+                        "length": 11,
+                        "confidenceScore": 0.65
+                      },
+                      {
+                        "text": "800-102-1100",
+                        "category": "PhoneNumber",
+                        "offset": 55,
+                        "length": 12,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 114,
+                        "length": 9,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Your ABA number - ********* - is the first 9 digits in the lower left hand corner of your personal check",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "111000025",
+                        "category": "PhoneNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "ABARoutingNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.75
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "NZSocialWelfareNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.65
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9eb4378d-1c0b-4023-b27e-f48743d77e44",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9a23bf639be76d273d3f2b895f6f06e1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c61b609d-4a6f-48f6-aca0-4bf9c52ed74b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:22:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2484"
+      },
+      "ResponseBody": {
+        "jobId": "9eb4378d-1c0b-4023-b27e-f48743d77e44",
+        "lastUpdateDateTime": "2021-10-25T21:22:44Z",
+        "createdDateTime": "2021-10-25T21:22:38Z",
+        "expirationDateTime": "2021-10-26T21:22:38Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:41.6412119Z",
+              "taskName": "RecognizePiiEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "A ********* with SSN *********** whose phone number is ************ is building tools with our APIs. They work at *********",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "developer",
+                        "category": "PersonType",
+                        "offset": 2,
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "859-98-0987",
+                        "category": "USSocialSecurityNumber",
+                        "offset": 21,
+                        "length": 11,
+                        "confidenceScore": 0.65
+                      },
+                      {
+                        "text": "800-102-1100",
+                        "category": "PhoneNumber",
+                        "offset": 55,
+                        "length": 12,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 114,
+                        "length": 9,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Your ABA number - ********* - is the first 9 digits in the lower left hand corner of your personal check",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "111000025",
+                        "category": "PhoneNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "ABARoutingNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.75
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "NZSocialWelfareNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.65
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9eb4378d-1c0b-4023-b27e-f48743d77e44",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b1b2083cbcde0c3633d70f38e82c6d26",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0ef0309f-7993-41ef-8f59-40f648825b73",
+        "apim-request-id": "b2c6abf1-7c6b-40f8-8116-2eb3d6bfea80",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:43 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "210"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "249"
       },
       "ResponseBody": {
-        "jobId": "18a30105-f855-4244-b2f5-cc8bbd0f203f",
-        "lastUpdateDateTime": "2021-10-20T15:07:43Z",
-        "createdDateTime": "2021-10-20T15:07:35Z",
-        "expirationDateTime": "2021-10-21T15:07:35Z",
+        "jobId": "9eb4378d-1c0b-4023-b27e-f48743d77e44",
+        "lastUpdateDateTime": "2021-10-25T21:22:48Z",
+        "createdDateTime": "2021-10-25T21:22:38Z",
+        "expirationDateTime": "2021-10-26T21:22:38Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -309,7 +585,7 @@
           "total": 2,
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:07:43.4184927Z",
+              "lastUpdateDateTime": "2021-10-25T21:22:48.3196378Z",
               "taskName": "RecognizePiiEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -383,7 +659,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:07:43.326227Z",
+              "lastUpdateDateTime": "2021-10-25T21:22:41.6412119Z",
               "taskName": "RecognizePiiEntities",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "588",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b6d98a42d2120c45bd0ca143c068d651-ace41864c72b1448-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-a8ab7a84df7420469ba9fe7ec6cb2b07-d6a12d5bf4bfe041-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "821d40e471b4a3a79e7730ad4fc1c667",
         "x-ms-return-client-request-id": "true"
       },
@@ -48,42 +54,48 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "7c1a3132-85b8-4387-9bd0-bb43c530a48f",
-        "Date": "Wed, 20 Oct 2021 15:07:44 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
+        "apim-request-id": "46f3f301-62ca-42d7-a9f9-d264719571f1",
+        "Date": "Mon, 25 Oct 2021 21:22:54 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "352"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "471"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "3419f09bc4750833caf320105774bf56",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "168a2352-05ce-4aec-8c20-05ce6a364f1e",
+        "apim-request-id": "42f87230-8351-4c05-a0b0-9150ecea22ed",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:44 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
-        "jobId": "38ed5859-a47f-4cec-b6fe-e81ca169df19",
-        "lastUpdateDateTime": "2021-10-20T15:07:45Z",
-        "createdDateTime": "2021-10-20T15:07:44Z",
-        "expirationDateTime": "2021-10-21T15:07:44Z",
+        "jobId": "7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
+        "lastUpdateDateTime": "2021-10-25T21:22:55Z",
+        "createdDateTime": "2021-10-25T21:22:54Z",
+        "expirationDateTime": "2021-10-26T21:22:54Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -95,31 +107,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "ccb4ad560783f76c8e420bc524d6420d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "660d6e86-7ef1-4394-9426-0a0e947bbfc3",
+        "apim-request-id": "9d315e03-adee-4eaf-84db-f9146d487e23",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:46 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "38ed5859-a47f-4cec-b6fe-e81ca169df19",
-        "lastUpdateDateTime": "2021-10-20T15:07:45Z",
-        "createdDateTime": "2021-10-20T15:07:44Z",
-        "expirationDateTime": "2021-10-21T15:07:44Z",
+        "jobId": "7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
+        "lastUpdateDateTime": "2021-10-25T21:22:55Z",
+        "createdDateTime": "2021-10-25T21:22:54Z",
+        "expirationDateTime": "2021-10-26T21:22:54Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -131,175 +149,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "93b51ac3ab9a20fa0c15b7c151974c2a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4d1ae5a5-ede2-49b0-bfd2-321d059fbf32",
+        "apim-request-id": "c4032243-6544-436b-a810-46bcee23bc04",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:47 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1443"
       },
       "ResponseBody": {
-        "jobId": "38ed5859-a47f-4cec-b6fe-e81ca169df19",
-        "lastUpdateDateTime": "2021-10-20T15:07:45Z",
-        "createdDateTime": "2021-10-20T15:07:44Z",
-        "expirationDateTime": "2021-10-21T15:07:44Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a157d9b8fa0d93e38321a533b96ee3f3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8fa0af42-ea9f-4e15-a81a-6f7355a89a4e",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:48 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
-      },
-      "ResponseBody": {
-        "jobId": "38ed5859-a47f-4cec-b6fe-e81ca169df19",
-        "lastUpdateDateTime": "2021-10-20T15:07:45Z",
-        "createdDateTime": "2021-10-20T15:07:44Z",
-        "expirationDateTime": "2021-10-21T15:07:44Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3d4d12b02bbfabbbb294c06e50aba5f7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6e641613-a773-4ff2-ba97-b7365ac0c9f7",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:49 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "19"
-      },
-      "ResponseBody": {
-        "jobId": "38ed5859-a47f-4cec-b6fe-e81ca169df19",
-        "lastUpdateDateTime": "2021-10-20T15:07:45Z",
-        "createdDateTime": "2021-10-20T15:07:44Z",
-        "expirationDateTime": "2021-10-21T15:07:44Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4b0de0f6a17fc9003621107905c7669e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "578eade3-eeb0-4fc2-82c5-fbdb12a96376",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:50 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
-      },
-      "ResponseBody": {
-        "jobId": "38ed5859-a47f-4cec-b6fe-e81ca169df19",
-        "lastUpdateDateTime": "2021-10-20T15:07:45Z",
-        "createdDateTime": "2021-10-20T15:07:44Z",
-        "expirationDateTime": "2021-10-21T15:07:44Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3f11c3310e498c6a1dacef793a7543d8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "883ff7d6-d249-4d5d-885a-899c65a59bd3",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:52 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "114"
-      },
-      "ResponseBody": {
-        "jobId": "38ed5859-a47f-4cec-b6fe-e81ca169df19",
-        "lastUpdateDateTime": "2021-10-20T15:07:52Z",
-        "createdDateTime": "2021-10-20T15:07:44Z",
-        "expirationDateTime": "2021-10-21T15:07:44Z",
+        "jobId": "7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
+        "lastUpdateDateTime": "2021-10-25T21:22:58Z",
+        "createdDateTime": "2021-10-25T21:22:54Z",
+        "expirationDateTime": "2021-10-26T21:22:54Z",
         "status": "running",
         "errors": [],
         "tasks": {
@@ -309,8 +189,8 @@
           "total": 2,
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:07:52.4210588Z",
-              "taskName": "RecognizePiiEntitiesWithDisabledServiceLogs",
+              "lastUpdateDateTime": "2021-10-25T21:22:58.0726546Z",
+              "taskName": "RecognizePiiEntities",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -387,31 +267,273 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/38ed5859-a47f-4cec-b6fe-e81ca169df19",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d83cad7b98600f741284069e1b42a5eb",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "a157d9b8fa0d93e38321a533b96ee3f3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80d9972e-66de-44b0-b1d7-6508c686944e",
+        "apim-request-id": "714ac35c-c1e7-4a56-9b08-eb0c7e005a4c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:07:53 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "284"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "142"
       },
       "ResponseBody": {
-        "jobId": "38ed5859-a47f-4cec-b6fe-e81ca169df19",
-        "lastUpdateDateTime": "2021-10-20T15:07:53Z",
-        "createdDateTime": "2021-10-20T15:07:44Z",
-        "expirationDateTime": "2021-10-21T15:07:44Z",
+        "jobId": "7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
+        "lastUpdateDateTime": "2021-10-25T21:23:01Z",
+        "createdDateTime": "2021-10-25T21:22:54Z",
+        "expirationDateTime": "2021-10-26T21:22:54Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:58.0726546Z",
+              "taskName": "RecognizePiiEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "A ********* with SSN *********** whose phone number is ************ is building tools with our APIs. They work at *********",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "developer",
+                        "category": "PersonType",
+                        "offset": 2,
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "859-98-0987",
+                        "category": "USSocialSecurityNumber",
+                        "offset": 21,
+                        "length": 11,
+                        "confidenceScore": 0.65
+                      },
+                      {
+                        "text": "800-102-1100",
+                        "category": "PhoneNumber",
+                        "offset": 55,
+                        "length": 12,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 114,
+                        "length": 9,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Your ABA number - ********* - is the first 9 digits in the lower left hand corner of your personal check",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "111000025",
+                        "category": "PhoneNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "ABARoutingNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.75
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "NZSocialWelfareNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.65
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "3d4d12b02bbfabbbb294c06e50aba5f7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ab221c35-d4f9-47aa-b021-80f86122c7c5",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:23:02 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "197"
+      },
+      "ResponseBody": {
+        "jobId": "7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
+        "lastUpdateDateTime": "2021-10-25T21:23:01Z",
+        "createdDateTime": "2021-10-25T21:22:54Z",
+        "expirationDateTime": "2021-10-26T21:22:54Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 2,
+          "entityRecognitionPiiTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:22:58.0726546Z",
+              "taskName": "RecognizePiiEntities",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "redactedText": "A ********* with SSN *********** whose phone number is ************ is building tools with our APIs. They work at *********",
+                    "id": "1",
+                    "entities": [
+                      {
+                        "text": "developer",
+                        "category": "PersonType",
+                        "offset": 2,
+                        "length": 9,
+                        "confidenceScore": 0.97
+                      },
+                      {
+                        "text": "859-98-0987",
+                        "category": "USSocialSecurityNumber",
+                        "offset": 21,
+                        "length": 11,
+                        "confidenceScore": 0.65
+                      },
+                      {
+                        "text": "800-102-1100",
+                        "category": "PhoneNumber",
+                        "offset": 55,
+                        "length": 12,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "Microsoft",
+                        "category": "Organization",
+                        "offset": 114,
+                        "length": 9,
+                        "confidenceScore": 0.96
+                      }
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "redactedText": "Your ABA number - ********* - is the first 9 digits in the lower left hand corner of your personal check",
+                    "id": "2",
+                    "entities": [
+                      {
+                        "text": "111000025",
+                        "category": "PhoneNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.8
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "ABARoutingNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.75
+                      },
+                      {
+                        "text": "111000025",
+                        "category": "NZSocialWelfareNumber",
+                        "offset": 18,
+                        "length": 9,
+                        "confidenceScore": 0.65
+                      }
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-01-15"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "4b0de0f6a17fc9003621107905c7669e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2e21d1f7-7303-43ed-8bda-2182914bff3e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:23:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "9407"
+      },
+      "ResponseBody": {
+        "jobId": "7647c58b-6e1b-4a7e-a1b3-2d4b10c16819",
+        "lastUpdateDateTime": "2021-10-25T21:23:02Z",
+        "createdDateTime": "2021-10-25T21:22:54Z",
+        "expirationDateTime": "2021-10-26T21:22:54Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -421,7 +543,7 @@
           "total": 2,
           "entityRecognitionPiiTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:07:52.4210588Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:02.9596521Z",
               "taskName": "RecognizePiiEntitiesWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -495,7 +617,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:07:53.3406343Z",
+              "lastUpdateDateTime": "2021-10-25T21:22:58.0726546Z",
               "taskName": "RecognizePiiEntities",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithResultCategoriesTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithResultCategoriesTest.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-968d8b929900fd49964489bc2d17bc91-d7dc4ed0cae8cb46-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-50b10b0f03d7534f881410ac7cf6d613-993c63d9287d9644-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d9aef1826ce78273f6e9f7d4bb40d2b3",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,13 +30,13 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f8fbd4e-01dd-46ea-bc9a-95963d0179a7",
+        "apim-request-id": "2918920a-b553-4ada-90ad-d846d7c85ffd",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "39"
       },
       "ResponseBody": {
@@ -76,15 +82,21 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PersonType%2CUSSocialSecurityNumber%2CPhoneNumber%2COrganization",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PersonType%2CUSSocialSecurityNumber%2CPhoneNumber%2COrganization",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fbda709da9714842913df0703c87e340-66dd44ce108ba94c-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-59ef6089e7b4d445b2520bfdc4df4430-70b63b54f124044a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "420a306f7cc82f4e5752f38f4114f2d3",
         "x-ms-return-client-request-id": "true"
       },
@@ -99,14 +111,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50df255a-1c59-44a8-8aad-64012c03c8b0",
+        "apim-request-id": "4927ad2c-d323-4632-adec-b4b21f0fabd4",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:22:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "40"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "30"
       },
       "ResponseBody": {
         "documents": [
@@ -154,6 +166,6 @@
   "Variables": {
     "RandomSeed": "1230179199",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithResultCategoriesTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizePiiEntitiesTests/RecognizePiiEntitiesWithResultCategoriesTestAsync.json
@@ -1,15 +1,21 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7aed81b01e93014b916ddff78b23f4ad-24114f0d5b562b42-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-4394cdb88030244b99329f1236b07ff9-c2c2736dae16ee44-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "e02262f6cfb69307bfbaa46848a55889",
         "x-ms-return-client-request-id": "true"
       },
@@ -24,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0d2bd9bc-be5f-4407-8143-841298538aa5",
+        "apim-request-id": "74d069a3-4e3f-48ab-bef1-24d91a977a39",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "38"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "24"
       },
       "ResponseBody": {
         "documents": [
@@ -76,15 +82,21 @@
       }
     },
     {
-      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PersonType%2CUSSocialSecurityNumber%2CPhoneNumber%2COrganization",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/pii?showStats=false\u0026stringIndexType=Utf16CodeUnit\u0026piiCategories=PersonType%2CUSSocialSecurityNumber%2CPhoneNumber%2COrganization",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "175",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dc57f6a963724e4aa9b17d939f6fe6f2-c9ca12227b5d604a-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210805.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-159cb2e3f49e884abc6f6ab90cc869d4-6f406ac086305340-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "00989c492da9011d6ac87cc8741ed5c9",
         "x-ms-return-client-request-id": "true"
       },
@@ -99,14 +111,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a16cdc08-c2fa-4c0c-80b9-02893c02136e",
+        "apim-request-id": "0da42c67-c20e-40c6-98d8-427200ab2add",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Fri, 06 Aug 2021 01:54:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "33"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "27"
       },
       "ResponseBody": {
         "documents": [
@@ -154,6 +166,6 @@
   "Variables": {
     "RandomSeed": "298290517",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchConvenienceTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchConvenienceTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "565",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8eaaaea07f8ee84390aa469f47a302ae-db12522bad384440-00",
+        "traceparent": "00-7b6fb31662b0b34186e5c0d7193e85d6-a76201f3f600ac40-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d1ca26e8c7b63919185ed9a9a0b75eca",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "735e3700-fbb1-4686-994d-6271315a7be1",
-        "Date": "Sun, 26 Sep 2021 17:32:08 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/c4ad3f7c-75e9-4c33-b0ce-8422b5801112",
+        "apim-request-id": "33cf6852-30e3-4813-b81e-56d60309befa",
+        "Date": "Mon, 25 Oct 2021 21:23:15 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bf4b117e-31af-4ad9-8cbd-a04cb43f301a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "186"
+        "x-envoy-upstream-service-time": "466"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/c4ad3f7c-75e9-4c33-b0ce-8422b5801112",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bf4b117e-31af-4ad9-8cbd-a04cb43f301a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "bbe32bdcbb742947306d871680eaa8e4",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "096b4414-3201-4f39-96a4-72ec0d995b42",
+        "apim-request-id": "b404c5ea-c8d2-4b00-8d96-72dfcf7668c5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:08 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "c4ad3f7c-75e9-4c33-b0ce-8422b5801112",
-        "lastUpdateDateTime": "2021-09-26T17:32:08Z",
-        "createdDateTime": "2021-09-26T17:32:08Z",
-        "expirationDateTime": "2021-09-27T17:32:08Z",
+        "jobId": "bf4b117e-31af-4ad9-8cbd-a04cb43f301a",
+        "lastUpdateDateTime": "2021-10-25T21:23:15Z",
+        "createdDateTime": "2021-10-25T21:23:15Z",
+        "expirationDateTime": "2021-10-26T21:23:15Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/c4ad3f7c-75e9-4c33-b0ce-8422b5801112",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/bf4b117e-31af-4ad9-8cbd-a04cb43f301a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a8d956ad1340d3b555b42cd04ce1ef36",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7a0e6e8f-8f29-4a7d-bdbe-0d289381c79a",
+        "apim-request-id": "970c6905-cffa-4fb4-bc7f-7a080dbd45d5",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:10 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "84"
+        "x-envoy-upstream-service-time": "659"
       },
       "ResponseBody": {
-        "jobId": "c4ad3f7c-75e9-4c33-b0ce-8422b5801112",
-        "lastUpdateDateTime": "2021-09-26T17:32:09Z",
-        "createdDateTime": "2021-09-26T17:32:08Z",
-        "expirationDateTime": "2021-09-27T17:32:08Z",
+        "jobId": "bf4b117e-31af-4ad9-8cbd-a04cb43f301a",
+        "lastUpdateDateTime": "2021-10-25T21:23:16Z",
+        "createdDateTime": "2021-10-25T21:23:15Z",
+        "expirationDateTime": "2021-10-26T21:23:15Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:09.5742581Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:16.3038233Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -176,6 +174,6 @@
   "Variables": {
     "RandomSeed": "950420539",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchConvenienceTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchConvenienceTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "565",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4c1a1c900898594d8ef8f6de713479eb-469df7f8ff0abc41-00",
+        "traceparent": "00-9dffd73d71243a49bf355b9887493e8f-cdd70ff2c6135e44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ac31d7d45c3df805f90eee9707f047d2",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "4646974e-40aa-4b01-ad5a-80113cd5679c",
-        "Date": "Sun, 26 Sep 2021 17:32:19 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6143b3ae-b183-4aa9-808f-9d849ad4ebbe",
+        "apim-request-id": "206b6828-6125-4b49-9f07-7902497e7445",
+        "Date": "Mon, 25 Oct 2021 21:23:31 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a83659e5-c0c8-48cc-b8a6-15d2ac41bc49",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "202"
+        "x-envoy-upstream-service-time": "185"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6143b3ae-b183-4aa9-808f-9d849ad4ebbe",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a83659e5-c0c8-48cc-b8a6-15d2ac41bc49",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "2e584098cb94eb31e5d96ef0bc5cf32c",
         "x-ms-return-client-request-id": "true"
@@ -76,65 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "544e271d-a439-4a6d-b5f4-fa9eac8966df",
+        "apim-request-id": "dcda138d-4b20-4d89-9adb-92a5088fa452",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:20 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "84"
       },
       "ResponseBody": {
-        "jobId": "6143b3ae-b183-4aa9-808f-9d849ad4ebbe",
-        "lastUpdateDateTime": "2021-09-26T17:32:20Z",
-        "createdDateTime": "2021-09-26T17:32:20Z",
-        "expirationDateTime": "2021-09-27T17:32:20Z",
-        "status": "running",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6143b3ae-b183-4aa9-808f-9d849ad4ebbe",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "c1d280b0e380cce36ab0945141679f19",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "f9d9a958-bd1c-495f-a5e8-6e9c9e1875e1",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:21 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "80"
-      },
-      "ResponseBody": {
-        "jobId": "6143b3ae-b183-4aa9-808f-9d849ad4ebbe",
-        "lastUpdateDateTime": "2021-09-26T17:32:20Z",
-        "createdDateTime": "2021-09-26T17:32:20Z",
-        "expirationDateTime": "2021-09-27T17:32:20Z",
+        "jobId": "a83659e5-c0c8-48cc-b8a6-15d2ac41bc49",
+        "lastUpdateDateTime": "2021-10-25T21:23:31Z",
+        "createdDateTime": "2021-10-25T21:23:30Z",
+        "expirationDateTime": "2021-10-26T21:23:30Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +98,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:20.7472078Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:31.3645984Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -176,6 +132,6 @@
   "Variables": {
     "RandomSeed": "509284946",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchConvenienceWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchConvenienceWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "565",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4b841a0b3c90db4aadf71491c216cc5b-b09e76edac232245-00",
+        "traceparent": "00-35d0257d7ceac544a5c9d85bff32aeb5-171ebb840e8ec243-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ba3620aefc61074acb4fe9cab355c3c0",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d0014491-8be7-40fa-a134-6aa052d44642",
-        "Date": "Sun, 26 Sep 2021 17:32:10 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/453b037f-9ddc-4fe7-bf47-c625a2f1ae15",
+        "apim-request-id": "d779b5bc-5ce6-4cea-885f-ea80f0d64c25",
+        "Date": "Mon, 25 Oct 2021 21:23:17 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/40cd94e8-38fb-485b-9501-7da04ec5d50d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "193"
+        "x-envoy-upstream-service-time": "361"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/453b037f-9ddc-4fe7-bf47-c625a2f1ae15?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/40cd94e8-38fb-485b-9501-7da04ec5d50d?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "22fba8cbc4b5fffd8f4e5c9b86daecae",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "023b144d-0152-4f50-9f85-953c657510ca",
+        "apim-request-id": "40da5eb1-8373-4e0f-ae7d-8f4e2d692a20",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:10 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
-        "jobId": "453b037f-9ddc-4fe7-bf47-c625a2f1ae15",
-        "lastUpdateDateTime": "2021-09-26T17:32:10Z",
-        "createdDateTime": "2021-09-26T17:32:10Z",
-        "expirationDateTime": "2021-09-27T17:32:10Z",
+        "jobId": "40cd94e8-38fb-485b-9501-7da04ec5d50d",
+        "lastUpdateDateTime": "2021-10-25T21:23:18Z",
+        "createdDateTime": "2021-10-25T21:23:17Z",
+        "expirationDateTime": "2021-10-26T21:23:17Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/453b037f-9ddc-4fe7-bf47-c625a2f1ae15?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/40cd94e8-38fb-485b-9501-7da04ec5d50d?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "21dc23bdc6789a6d1abda6f78388f37d",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9e662b98-91a2-41df-a9a9-17d47cced514",
+        "apim-request-id": "469fe161-1165-4389-ac9f-010c8adc131b",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:12 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "112"
+        "x-envoy-upstream-service-time": "170"
       },
       "ResponseBody": {
-        "jobId": "453b037f-9ddc-4fe7-bf47-c625a2f1ae15",
-        "lastUpdateDateTime": "2021-09-26T17:32:11Z",
-        "createdDateTime": "2021-09-26T17:32:10Z",
-        "expirationDateTime": "2021-09-27T17:32:10Z",
+        "jobId": "40cd94e8-38fb-485b-9501-7da04ec5d50d",
+        "lastUpdateDateTime": "2021-10-25T21:23:18Z",
+        "createdDateTime": "2021-10-25T21:23:17Z",
+        "expirationDateTime": "2021-10-26T21:23:17Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:11.6404996Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:18.7324729Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -190,6 +188,6 @@
   "Variables": {
     "RandomSeed": "1514718643",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchConvenienceWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchConvenienceWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "565",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9309e663dd9df64c82803fc76457ffa4-27f842411826f74d-00",
+        "traceparent": "00-b1858744587877498d3388b997cd4129-91d663115f4de341-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "0fb470c4efdb714e83e72fd3b5277211",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "978adeb5-8997-4333-88a0-43ad1090dbf6",
-        "Date": "Sun, 26 Sep 2021 17:32:21 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/5351525b-2710-4828-92e0-d890761da9b8",
+        "apim-request-id": "0eba8df1-a8cb-4756-bc19-507331caad02",
+        "Date": "Mon, 25 Oct 2021 21:23:32 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b0c35c29-75bf-4b1e-80a5-0c72b00e0523",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "211"
+        "x-envoy-upstream-service-time": "324"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/5351525b-2710-4828-92e0-d890761da9b8?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b0c35c29-75bf-4b1e-80a5-0c72b00e0523?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5b9acf37409e542ab340bb029525d96c",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a1165fe2-836f-4024-89b5-e8a6b287cb9c",
+        "apim-request-id": "7452a6d6-ec90-486e-90b4-6a63add8cf4a",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:21 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8"
+        "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "5351525b-2710-4828-92e0-d890761da9b8",
-        "lastUpdateDateTime": "2021-09-26T17:32:22Z",
-        "createdDateTime": "2021-09-26T17:32:21Z",
-        "expirationDateTime": "2021-09-27T17:32:21Z",
-        "status": "notStarted",
+        "jobId": "b0c35c29-75bf-4b1e-80a5-0c72b00e0523",
+        "lastUpdateDateTime": "2021-10-25T21:23:32Z",
+        "createdDateTime": "2021-10-25T21:23:31Z",
+        "expirationDateTime": "2021-10-26T21:23:31Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/5351525b-2710-4828-92e0-d890761da9b8?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/b0c35c29-75bf-4b1e-80a5-0c72b00e0523?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "b662db5877d6ebea76ce2790f66c3ace",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "009c7c72-d642-43d4-a9d0-1e59a6d78ae6",
+        "apim-request-id": "50625f7f-129b-4767-b9b1-0b090b610935",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:23 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "124"
+        "x-envoy-upstream-service-time": "3625"
       },
       "ResponseBody": {
-        "jobId": "5351525b-2710-4828-92e0-d890761da9b8",
-        "lastUpdateDateTime": "2021-09-26T17:32:22Z",
-        "createdDateTime": "2021-09-26T17:32:21Z",
-        "expirationDateTime": "2021-09-27T17:32:21Z",
+        "jobId": "b0c35c29-75bf-4b1e-80a5-0c72b00e0523",
+        "lastUpdateDateTime": "2021-10-25T21:23:32Z",
+        "createdDateTime": "2021-10-25T21:23:31Z",
+        "expirationDateTime": "2021-10-26T21:23:31Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:22.6583724Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:32.3611417Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -190,6 +188,6 @@
   "Variables": {
     "RandomSeed": "781880466",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "565",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-887e3cee6a09bf4e89351419e458beb7-22d633833fb60045-00",
+        "traceparent": "00-0ddc9a3bdb83584e894039cc1f30831b-32332b2edb0e5b4b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ed91ee508cd9b29afc6d59631ae178b9",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "275734d2-f6f8-4cfd-beee-05a664548389",
-        "Date": "Sun, 26 Sep 2021 17:32:13 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9470fc12-ef13-47bf-a768-5b38bafb21e9",
+        "apim-request-id": "f93b60bc-5789-4876-870d-97dc8daf3726",
+        "Date": "Mon, 25 Oct 2021 21:23:20 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ec8e619c-767c-4ae4-9b9e-6a1fe6d5bd48",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "224"
+        "x-envoy-upstream-service-time": "459"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9470fc12-ef13-47bf-a768-5b38bafb21e9",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ec8e619c-767c-4ae4-9b9e-6a1fe6d5bd48",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a11a84939b857bbf89f245f4038e0384",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4714122b-2f81-4704-bf7e-c35c554c57f1",
+        "apim-request-id": "50a6b961-9a0b-4ba7-a721-3a74ce8d6ed6",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:13 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "7"
       },
       "ResponseBody": {
-        "jobId": "9470fc12-ef13-47bf-a768-5b38bafb21e9",
-        "lastUpdateDateTime": "2021-09-26T17:32:13Z",
-        "createdDateTime": "2021-09-26T17:32:13Z",
-        "expirationDateTime": "2021-09-27T17:32:13Z",
+        "jobId": "ec8e619c-767c-4ae4-9b9e-6a1fe6d5bd48",
+        "lastUpdateDateTime": "2021-10-25T21:23:20Z",
+        "createdDateTime": "2021-10-25T21:23:20Z",
+        "expirationDateTime": "2021-10-26T21:23:20Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/9470fc12-ef13-47bf-a768-5b38bafb21e9",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/ec8e619c-767c-4ae4-9b9e-6a1fe6d5bd48",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "e822636173d8c47bca4dcaf660df1ba2",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "69d5a6dc-8aaa-439f-872b-d9861fdf35d5",
+        "apim-request-id": "684f596f-40ea-4628-89e1-8ce117e0c8ce",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "99"
+        "x-envoy-upstream-service-time": "93"
       },
       "ResponseBody": {
-        "jobId": "9470fc12-ef13-47bf-a768-5b38bafb21e9",
-        "lastUpdateDateTime": "2021-09-26T17:32:14Z",
-        "createdDateTime": "2021-09-26T17:32:13Z",
-        "expirationDateTime": "2021-09-27T17:32:13Z",
+        "jobId": "ec8e619c-767c-4ae4-9b9e-6a1fe6d5bd48",
+        "lastUpdateDateTime": "2021-10-25T21:23:21Z",
+        "createdDateTime": "2021-10-25T21:23:20Z",
+        "expirationDateTime": "2021-10-26T21:23:20Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:14.578858Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:21.7319683Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -176,6 +174,6 @@
   "Variables": {
     "RandomSeed": "1895922638",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "565",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d45d54ed400b884f811195b54377371b-551566007d4f5d4a-00",
+        "traceparent": "00-cb358f1a1f80ea43b050f6ea36f941e5-8c54bcd425664f48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f9645cd964117b64626a1290109f40e7",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "82924749-8168-4f3b-8031-d4183171caac",
-        "Date": "Sun, 26 Sep 2021 17:32:23 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f48106d3-5fe5-483d-b84f-e9207527c222",
+        "apim-request-id": "2ba8856c-85c8-4a51-963a-fe8566180747",
+        "Date": "Mon, 25 Oct 2021 21:23:37 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/658eca04-6220-410f-88c3-b946e5f35def",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "206"
+        "x-envoy-upstream-service-time": "372"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f48106d3-5fe5-483d-b84f-e9207527c222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/658eca04-6220-410f-88c3-b946e5f35def",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "c04ad296bfa816877b571fe8aa8ff212",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8859d8ff-5931-4185-9094-3b5fa30b535f",
+        "apim-request-id": "7f56a692-7682-4b82-a6c3-97bfda95216e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:23 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "f48106d3-5fe5-483d-b84f-e9207527c222",
-        "lastUpdateDateTime": "2021-09-26T17:32:23Z",
-        "createdDateTime": "2021-09-26T17:32:23Z",
-        "expirationDateTime": "2021-09-27T17:32:23Z",
+        "jobId": "658eca04-6220-410f-88c3-b946e5f35def",
+        "lastUpdateDateTime": "2021-10-25T21:23:37Z",
+        "createdDateTime": "2021-10-25T21:23:37Z",
+        "expirationDateTime": "2021-10-26T21:23:37Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f48106d3-5fe5-483d-b84f-e9207527c222",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/658eca04-6220-410f-88c3-b946e5f35def",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d3df144f52a5f6a90ea4bad001c9c33b",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8fb0cb0f-f624-48a0-b34f-354bf521cdab",
+        "apim-request-id": "2013e519-a54c-4d13-a8f6-910c1e23049d",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "92"
+        "x-envoy-upstream-service-time": "1086"
       },
       "ResponseBody": {
-        "jobId": "f48106d3-5fe5-483d-b84f-e9207527c222",
-        "lastUpdateDateTime": "2021-09-26T17:32:24Z",
-        "createdDateTime": "2021-09-26T17:32:23Z",
-        "expirationDateTime": "2021-09-27T17:32:23Z",
+        "jobId": "658eca04-6220-410f-88c3-b946e5f35def",
+        "lastUpdateDateTime": "2021-10-25T21:23:38Z",
+        "createdDateTime": "2021-10-25T21:23:37Z",
+        "expirationDateTime": "2021-10-26T21:23:37Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:24.7092878Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:38.4171468Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -176,6 +174,6 @@
   "Variables": {
     "RandomSeed": "1413029311",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchWithErrorTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-68820f186df12446b8105e53bfdec567-12664ef19b139544-00",
+        "traceparent": "00-bc63a8d4d6b9cf449a61a25604245302-51738e008a3a9241-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "70c068a7efbe110baf098369f527df20",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e5f588d6-6da7-4a19-8e44-ca485d2972b8",
-        "Date": "Sun, 26 Sep 2021 17:32:14 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f566ce17-5b17-47b2-84c3-1ac77cbb93b4",
+        "apim-request-id": "9f971502-1899-4ed6-b6fa-ac7b96b55d07",
+        "Date": "Mon, 25 Oct 2021 21:23:22 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2728c768-f335-414c-b5b5-b4e410a00523",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "209"
+        "x-envoy-upstream-service-time": "486"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f566ce17-5b17-47b2-84c3-1ac77cbb93b4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2728c768-f335-414c-b5b5-b4e410a00523",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "cf902fc4786b4e14ba475dc60b965f2d",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2f2c7f6f-149f-45b6-be31-03708dfb3d1f",
+        "apim-request-id": "3887e4f0-5e83-4256-8ce9-fb316f79e92e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:14 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "f566ce17-5b17-47b2-84c3-1ac77cbb93b4",
-        "lastUpdateDateTime": "2021-09-26T17:32:15Z",
-        "createdDateTime": "2021-09-26T17:32:15Z",
-        "expirationDateTime": "2021-09-27T17:32:15Z",
-        "status": "running",
+        "jobId": "2728c768-f335-414c-b5b5-b4e410a00523",
+        "lastUpdateDateTime": "2021-10-25T21:23:23Z",
+        "createdDateTime": "2021-10-25T21:23:22Z",
+        "expirationDateTime": "2021-10-26T21:23:22Z",
+        "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/f566ce17-5b17-47b2-84c3-1ac77cbb93b4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2728c768-f335-414c-b5b5-b4e410a00523",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "c99a6835c9257e5983fa76d9a9a5618c",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3b654d46-d78a-4531-8610-26808d9b77a3",
+        "apim-request-id": "5bec3896-d2ff-4b9d-91b9-7612f17d9738",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:16 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "90"
+        "x-envoy-upstream-service-time": "65"
       },
       "ResponseBody": {
-        "jobId": "f566ce17-5b17-47b2-84c3-1ac77cbb93b4",
-        "lastUpdateDateTime": "2021-09-26T17:32:15Z",
-        "createdDateTime": "2021-09-26T17:32:15Z",
-        "expirationDateTime": "2021-09-27T17:32:15Z",
+        "jobId": "2728c768-f335-414c-b5b5-b4e410a00523",
+        "lastUpdateDateTime": "2021-10-25T21:23:23Z",
+        "createdDateTime": "2021-10-25T21:23:22Z",
+        "expirationDateTime": "2021-10-26T21:23:22Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:15.5880863Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:23.9535363Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -180,6 +178,6 @@
   "Variables": {
     "RandomSeed": "1470538452",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchWithErrorTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-13cdbb9c3ba9064fa5ef49403fae0d58-851fb3aff7d1f744-00",
+        "traceparent": "00-b7f6b84e0abb484c80c7d7099dcc72da-b71df1541d77e249-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "6558376474b3cb63b9908dd07475c920",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "548fc54a-4693-4052-b59e-3fb3a24bb53d",
-        "Date": "Sun, 26 Sep 2021 17:32:25 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/3a784633-475f-4bfc-b67b-a1228b28a7f4",
+        "apim-request-id": "51b524c7-ffd4-4068-a021-e427984c5a02",
+        "Date": "Mon, 25 Oct 2021 21:23:40 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a0be3fe9-791f-409a-9911-cb720155eee6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "196"
+        "x-envoy-upstream-service-time": "447"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/3a784633-475f-4bfc-b67b-a1228b28a7f4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a0be3fe9-791f-409a-9911-cb720155eee6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "c902629aae510b96c6d2d747ee97870f",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1be74f73-ce03-4bc2-b85e-61b0335e0495",
+        "apim-request-id": "a17267c4-b263-455b-b129-45dc4b906e09",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10"
+        "x-envoy-upstream-service-time": "53"
       },
       "ResponseBody": {
-        "jobId": "3a784633-475f-4bfc-b67b-a1228b28a7f4",
-        "lastUpdateDateTime": "2021-09-26T17:32:25Z",
-        "createdDateTime": "2021-09-26T17:32:25Z",
-        "expirationDateTime": "2021-09-27T17:32:25Z",
-        "status": "notStarted",
+        "jobId": "a0be3fe9-791f-409a-9911-cb720155eee6",
+        "lastUpdateDateTime": "2021-10-25T21:23:41Z",
+        "createdDateTime": "2021-10-25T21:23:41Z",
+        "expirationDateTime": "2021-10-26T21:23:41Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -101,7 +100,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/3a784633-475f-4bfc-b67b-a1228b28a7f4",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/a0be3fe9-791f-409a-9911-cb720155eee6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -110,8 +109,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "8695dd79305e78c8787a2d2385a3493d",
         "x-ms-return-client-request-id": "true"
@@ -119,22 +118,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "687645ee-8bc1-4fd3-a97f-f4d496287fe0",
+        "apim-request-id": "994501b8-f5a6-4f12-b72a-15c0fe990233",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:26 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "79"
+        "x-envoy-upstream-service-time": "61"
       },
       "ResponseBody": {
-        "jobId": "3a784633-475f-4bfc-b67b-a1228b28a7f4",
-        "lastUpdateDateTime": "2021-09-26T17:32:25Z",
-        "createdDateTime": "2021-09-26T17:32:25Z",
-        "expirationDateTime": "2021-09-27T17:32:25Z",
+        "jobId": "a0be3fe9-791f-409a-9911-cb720155eee6",
+        "lastUpdateDateTime": "2021-10-25T21:23:41Z",
+        "createdDateTime": "2021-10-25T21:23:41Z",
+        "expirationDateTime": "2021-10-26T21:23:41Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +140,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:25.6807717Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:41.7655374Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -180,6 +178,6 @@
   "Variables": {
     "RandomSeed": "1335292864",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchWithStatisticsTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchWithStatisticsTest.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "565",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-130575d4743be84d879107a750889826-147a216cad977a40-00",
+        "traceparent": "00-8c9e6a556915d94b9eb2cd964a7e9fbf-60eedcbc5c96204b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "43bb241bd38a8b58749a66594cad84ab",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e9fd062e-f749-44fd-aeea-aa173bc5d370",
-        "Date": "Sun, 26 Sep 2021 17:32:16 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/071f898a-5b56-4062-a18f-b3b1a19f348c",
+        "apim-request-id": "5e750b1a-003e-45c4-9df9-5dad27eba684",
+        "Date": "Mon, 25 Oct 2021 21:23:24 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/158281ff-c4b2-445d-a8b8-1b1381c326b1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "226"
+        "x-envoy-upstream-service-time": "362"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/071f898a-5b56-4062-a18f-b3b1a19f348c?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/158281ff-c4b2-445d-a8b8-1b1381c326b1?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "f2838ce646aa3a0a60444d02228347b9",
         "x-ms-return-client-request-id": "true"
@@ -76,65 +76,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "29037f25-0182-4508-93a4-5e687cbc61f6",
+        "apim-request-id": "cec52d2e-5b04-41f0-8334-b811116bfb1e",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:16 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "67"
       },
       "ResponseBody": {
-        "jobId": "071f898a-5b56-4062-a18f-b3b1a19f348c",
-        "lastUpdateDateTime": "2021-09-26T17:32:17Z",
-        "createdDateTime": "2021-09-26T17:32:16Z",
-        "expirationDateTime": "2021-09-27T17:32:16Z",
-        "status": "notStarted",
-        "errors": [],
-        "displayName": "NA",
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 1,
-          "total": 1
-        }
-      }
-    },
-    {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/071f898a-5b56-4062-a18f-b3b1a19f348c?showStats=true",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "ed413ddad190926242abcda569532c02",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "59a16fb9-83af-4573-b64a-9747b5aa4c1f",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:18 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "119"
-      },
-      "ResponseBody": {
-        "jobId": "071f898a-5b56-4062-a18f-b3b1a19f348c",
-        "lastUpdateDateTime": "2021-09-26T17:32:17Z",
-        "createdDateTime": "2021-09-26T17:32:16Z",
-        "expirationDateTime": "2021-09-27T17:32:16Z",
+        "jobId": "158281ff-c4b2-445d-a8b8-1b1381c326b1",
+        "lastUpdateDateTime": "2021-10-25T21:23:25Z",
+        "createdDateTime": "2021-10-25T21:23:25Z",
+        "expirationDateTime": "2021-10-26T21:23:25Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -142,7 +98,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:17.6081578Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:25.7775343Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -190,6 +146,6 @@
   "Variables": {
     "RandomSeed": "884629089",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchWithStatisticsTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyBatchWithStatisticsTestAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "565",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8135ee7f51ca0343ac6f27a821fccca5-84b81837399c8445-00",
+        "traceparent": "00-730e7e2f2d189247b667c0584fdc141d-ecbac99d52a6ed4d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "3c8be6aa35e8db5723a8c915994557b6",
         "x-ms-return-client-request-id": "true"
@@ -47,18 +47,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "2e2cc6f2-0d26-44a3-8de5-77a37430f005",
-        "Date": "Sun, 26 Sep 2021 17:32:26 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6f49993b-a337-4871-9f72-4a3ad40e6992",
+        "apim-request-id": "2b7bcc7f-cf05-4d04-8e79-0bcfe70942e1",
+        "Date": "Mon, 25 Oct 2021 21:23:42 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f0cb1d1f-e754-4674-bf7d-46ac6b8dc448",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "198"
+        "x-envoy-upstream-service-time": "200"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/6f49993b-a337-4871-9f72-4a3ad40e6992?showStats=true",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f0cb1d1f-e754-4674-bf7d-46ac6b8dc448?showStats=true",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -67,8 +67,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "0ebd3431940a663a14ca52143b4f08e9",
         "x-ms-return-client-request-id": "true"
@@ -76,22 +76,63 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff5e2bb7-b8c9-4fb3-b691-96edace4df83",
+        "apim-request-id": "5a1c8ab4-0f07-4c0c-8abf-fb56e998e35c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
-        "jobId": "6f49993b-a337-4871-9f72-4a3ad40e6992",
-        "lastUpdateDateTime": "2021-09-26T17:32:27Z",
-        "createdDateTime": "2021-09-26T17:32:27Z",
-        "expirationDateTime": "2021-09-27T17:32:27Z",
+        "jobId": "f0cb1d1f-e754-4674-bf7d-46ac6b8dc448",
+        "lastUpdateDateTime": "2021-10-25T21:23:43Z",
+        "createdDateTime": "2021-10-25T21:23:43Z",
+        "expirationDateTime": "2021-10-26T21:23:43Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/f0cb1d1f-e754-4674-bf7d-46ac6b8dc448?showStats=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
+        "x-ms-client-request-id": "9ea2f073aaa23c392f3b21b305791374",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "48f19da4-71f1-4a36-85e7-30910719cd6c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 25 Oct 2021 21:23:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "80"
+      },
+      "ResponseBody": {
+        "jobId": "f0cb1d1f-e754-4674-bf7d-46ac6b8dc448",
+        "lastUpdateDateTime": "2021-10-25T21:23:43Z",
+        "createdDateTime": "2021-10-25T21:23:43Z",
+        "expirationDateTime": "2021-10-26T21:23:43Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -99,7 +140,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:27.7779344Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:43.7095042Z",
               "state": "succeeded",
               "results": {
                 "statistics": {
@@ -147,6 +188,6 @@
   "Variables": {
     "RandomSeed": "1016445064",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyWithDisableServiceLogs.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyWithDisableServiceLogs.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "586",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f240322944621e489026c5ccd2fa08c9-6d3b84f8b3da194d-00",
+        "traceparent": "00-a7cebae863976d4e8b26568f358a18a4-c955024f578aac4b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "6f21dc45adab5285a64e5f6a3330c880",
         "x-ms-return-client-request-id": "true"
@@ -48,18 +48,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "258609ec-0f5d-4b4d-bfd9-70a4f405e000",
-        "Date": "Sun, 26 Sep 2021 17:32:18 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8964bf50-e305-4d64-876f-d95388fdd572",
+        "apim-request-id": "cc646424-26f3-4e90-a927-d8b0109928e3",
+        "Date": "Mon, 25 Oct 2021 21:23:25 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2d3f7648-0a9f-4475-aac8-a3684b50616f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "219"
+        "x-envoy-upstream-service-time": "554"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8964bf50-e305-4d64-876f-d95388fdd572",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2d3f7648-0a9f-4475-aac8-a3684b50616f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -68,8 +68,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ff1aaecc484e98e492be893eee730cff",
         "x-ms-return-client-request-id": "true"
@@ -77,22 +77,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "12a06b99-51c2-474e-b9e2-e7cc2413ae9e",
+        "apim-request-id": "4277cb0d-1ef1-43b7-bf6d-6295f2ec0bcb",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:18 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "7"
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "8964bf50-e305-4d64-876f-d95388fdd572",
-        "lastUpdateDateTime": "2021-09-26T17:32:18Z",
-        "createdDateTime": "2021-09-26T17:32:18Z",
-        "expirationDateTime": "2021-09-27T17:32:18Z",
+        "jobId": "2d3f7648-0a9f-4475-aac8-a3684b50616f",
+        "lastUpdateDateTime": "2021-10-25T21:23:26Z",
+        "createdDateTime": "2021-10-25T21:23:26Z",
+        "expirationDateTime": "2021-10-26T21:23:26Z",
         "status": "notStarted",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -102,7 +101,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/8964bf50-e305-4d64-876f-d95388fdd572",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/2d3f7648-0a9f-4475-aac8-a3684b50616f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -111,8 +110,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "724033f50909ab7c83b8b380157c4e98",
         "x-ms-return-client-request-id": "true"
@@ -120,22 +119,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "46ea45fb-2d49-4000-b845-343353090a9c",
+        "apim-request-id": "826d2d90-66dc-43b2-b7ef-56a71dd0edca",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:19 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "142"
+        "x-envoy-upstream-service-time": "102"
       },
       "ResponseBody": {
-        "jobId": "8964bf50-e305-4d64-876f-d95388fdd572",
-        "lastUpdateDateTime": "2021-09-26T17:32:19Z",
-        "createdDateTime": "2021-09-26T17:32:18Z",
-        "expirationDateTime": "2021-09-27T17:32:18Z",
+        "jobId": "2d3f7648-0a9f-4475-aac8-a3684b50616f",
+        "lastUpdateDateTime": "2021-10-25T21:23:27Z",
+        "createdDateTime": "2021-10-25T21:23:26Z",
+        "expirationDateTime": "2021-10-26T21:23:26Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -143,7 +141,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:19.6486324Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:27.9149195Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -177,6 +175,6 @@
   "Variables": {
     "RandomSeed": "771278001",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyWithDisableServiceLogsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyWithDisableServiceLogsAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "586",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-25bad278bc2bd743a652bfd7fd45523a-05294bf6d21c6b48-00",
+        "traceparent": "00-4cfc2e2bffaf684ca391db8c611c7ce6-f7901be3aa75354a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "ecd911dcce9a9042e758218e4322842c",
         "x-ms-return-client-request-id": "true"
@@ -48,18 +48,18 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "d77825a6-65ec-45a4-8d16-46506e51ba33",
-        "Date": "Sun, 26 Sep 2021 17:32:27 GMT",
-        "operation-location": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dc38fb7a-3352-4104-b53f-0baf6d410552",
+        "apim-request-id": "273987ac-51ce-4e9d-9d28-6d8aa3f0f5b1",
+        "Date": "Mon, 25 Oct 2021 21:23:44 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/cadacfb6-5f89-4515-8f33-822022f98b17",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "185"
+        "x-envoy-upstream-service-time": "192"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dc38fb7a-3352-4104-b53f-0baf6d410552",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/cadacfb6-5f89-4515-8f33-822022f98b17",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -68,8 +68,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "0b37d9e0e15ff8f4109b6fd0e2f5f312",
         "x-ms-return-client-request-id": "true"
@@ -77,22 +77,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c6c58ad8-f4f6-4c6f-b060-bada3ad7f9a6",
+        "apim-request-id": "5d1dc18b-c6ab-418e-a4dc-bff217506628",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "13"
+        "x-envoy-upstream-service-time": "6"
       },
       "ResponseBody": {
-        "jobId": "dc38fb7a-3352-4104-b53f-0baf6d410552",
-        "lastUpdateDateTime": "2021-09-26T17:32:28Z",
-        "createdDateTime": "2021-09-26T17:32:28Z",
-        "expirationDateTime": "2021-09-27T17:32:28Z",
-        "status": "notStarted",
+        "jobId": "cadacfb6-5f89-4515-8f33-822022f98b17",
+        "lastUpdateDateTime": "2021-10-25T21:23:45Z",
+        "createdDateTime": "2021-10-25T21:23:45Z",
+        "expirationDateTime": "2021-10-26T21:23:45Z",
+        "status": "running",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 0,
           "failed": 0,
@@ -102,7 +101,7 @@
       }
     },
     {
-      "RequestUri": "https://cognitiveweppe.azure-api.net/text/analytics/v3.2-preview.2/analyze/jobs/dc38fb7a-3352-4104-b53f-0baf6d410552",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/cadacfb6-5f89-4515-8f33-822022f98b17",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": [
@@ -111,8 +110,8 @@
         ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210926.1",
-          "(.NET 5.0.10; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "296ecf084313a922adfe76ec641a2184",
         "x-ms-return-client-request-id": "true"
@@ -120,22 +119,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0e011a18-6e97-4567-8fa6-c7cc4f31da26",
+        "apim-request-id": "0358e219-3a58-4889-b87a-bd2e2fe4ca2c",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sun, 26 Sep 2021 17:32:29 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "x-envoy-upstream-service-time": "75"
       },
       "ResponseBody": {
-        "jobId": "dc38fb7a-3352-4104-b53f-0baf6d410552",
-        "lastUpdateDateTime": "2021-09-26T17:32:28Z",
-        "createdDateTime": "2021-09-26T17:32:28Z",
-        "expirationDateTime": "2021-09-27T17:32:28Z",
+        "jobId": "cadacfb6-5f89-4515-8f33-822022f98b17",
+        "lastUpdateDateTime": "2021-10-25T21:23:45Z",
+        "createdDateTime": "2021-10-25T21:23:45Z",
+        "expirationDateTime": "2021-10-26T21:23:45Z",
         "status": "succeeded",
         "errors": [],
-        "displayName": "NA",
         "tasks": {
           "completed": 1,
           "failed": 0,
@@ -143,7 +141,7 @@
           "total": 1,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-09-26T17:32:28.7995214Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:45.7512978Z",
               "state": "succeeded",
               "results": {
                 "documents": [
@@ -177,6 +175,6 @@
   "Variables": {
     "RandomSeed": "516461458",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://cognitiveweppe.azure-api.net"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyWithMultipleActions.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyWithMultipleActions.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "809",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5e398ba1cf634245a2b1a430c7714403-319e4d1cfb55e844-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-3ba328b111ad7b439d78f87edfba20f4-e9ea4e7f874b6a45-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "b4a18820f5a60d810494d1c30b1a3ae3",
         "x-ms-return-client-request-id": "true"
       },
@@ -50,43 +56,49 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "e9d36f7e-5271-4ddc-a855-da1921fb7c9d",
-        "Date": "Wed, 20 Oct 2021 15:08:33 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/cfa9ef2c-31bd-46e5-bf99-620bb5b3962f",
+        "apim-request-id": "08cb55d5-895c-4678-917b-c83e03fcf3a1",
+        "Date": "Mon, 25 Oct 2021 21:23:29 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9babf7e7-09d4-4a08-9c59-68d79d7185bd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "564"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "384"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/cfa9ef2c-31bd-46e5-bf99-620bb5b3962f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9babf7e7-09d4-4a08-9c59-68d79d7185bd",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "c750cb4ac189c7d6b678edfe3af1abca",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3f77f977-98b7-49ae-bb36-51a5c5431ce6",
+        "apim-request-id": "b4b33331-bcaf-4277-8838-1e11bb638ad3",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:08:33 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "47"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "11"
       },
       "ResponseBody": {
-        "jobId": "cfa9ef2c-31bd-46e5-bf99-620bb5b3962f",
-        "lastUpdateDateTime": "2021-10-20T15:08:34Z",
-        "createdDateTime": "2021-10-20T15:08:34Z",
-        "expirationDateTime": "2021-10-21T15:08:34Z",
-        "status": "notStarted",
+        "jobId": "9babf7e7-09d4-4a08-9c59-68d79d7185bd",
+        "lastUpdateDateTime": "2021-10-25T21:23:29Z",
+        "createdDateTime": "2021-10-25T21:23:28Z",
+        "expirationDateTime": "2021-10-26T21:23:28Z",
+        "status": "running",
         "errors": [],
         "tasks": {
           "completed": 0,
@@ -97,31 +109,37 @@
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/cfa9ef2c-31bd-46e5-bf99-620bb5b3962f",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/9babf7e7-09d4-4a08-9c59-68d79d7185bd",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0c298f97c150c3f51b910ea940f04e2f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d59a060f-fd65-4a1d-89a0-17d301fee04b",
+        "apim-request-id": "93e466a7-c7c9-483a-901a-593786fefd72",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Oct 2021 15:08:35 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "169"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "114"
       },
       "ResponseBody": {
-        "jobId": "cfa9ef2c-31bd-46e5-bf99-620bb5b3962f",
-        "lastUpdateDateTime": "2021-10-20T15:08:35Z",
-        "createdDateTime": "2021-10-20T15:08:34Z",
-        "expirationDateTime": "2021-10-21T15:08:34Z",
+        "jobId": "9babf7e7-09d4-4a08-9c59-68d79d7185bd",
+        "lastUpdateDateTime": "2021-10-25T21:23:29Z",
+        "createdDateTime": "2021-10-25T21:23:28Z",
+        "expirationDateTime": "2021-10-26T21:23:28Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -131,7 +149,7 @@
           "total": 2,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-10-20T15:08:35.1829339Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:29.3508778Z",
               "taskName": "SingleCategoryClassifyWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -159,7 +177,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-20T15:08:35.2502644Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:29.4335859Z",
               "taskName": "SingleCategoryClassify",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyWithMultipleActionsAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/SingleCategoryClassifyTests/SingleCategoryClassifyWithMultipleActionsAsync.json
@@ -4,12 +4,18 @@
       "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Content-Length": "809",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b85bce4b447289438391a843c7b103be-04f04d3698079a48-00",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-2d9e7ee792db6b45806c527cf633a065-0721224e1f93b140-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "d3c6d7105a507aaa935f7f86576ac78b",
         "x-ms-return-client-request-id": "true"
       },
@@ -50,114 +56,120 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "654d41f5-79dc-4cbf-945c-8ff4d34dba0f",
-        "Date": "Thu, 21 Oct 2021 20:11:25 GMT",
-        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/feedf500-32c4-49db-9d8c-793009839a97",
+        "apim-request-id": "1e1e1446-8c6d-4285-b7ca-0ffc40be33ec",
+        "Date": "Mon, 25 Oct 2021 21:23:47 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e953e899-ac16-494a-9465-87587748ec1e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2221"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "360"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/feedf500-32c4-49db-9d8c-793009839a97",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e953e899-ac16-494a-9465-87587748ec1e",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "f8686274c74a089d6f13ee5d8a6ce13f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "622a4d01-e44e-4944-8f96-9cacb8777d49",
+        "apim-request-id": "ddb1f9fb-87f2-4c0f-9210-912b32d276cf",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:11:25 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "121"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1507"
       },
       "ResponseBody": {
-        "jobId": "feedf500-32c4-49db-9d8c-793009839a97",
-        "lastUpdateDateTime": "2021-10-21T20:11:26Z",
-        "createdDateTime": "2021-10-21T20:11:25Z",
-        "expirationDateTime": "2021-10-22T20:11:25Z",
+        "jobId": "e953e899-ac16-494a-9465-87587748ec1e",
+        "lastUpdateDateTime": "2021-10-25T21:23:48Z",
+        "createdDateTime": "2021-10-25T21:23:47Z",
+        "expirationDateTime": "2021-10-26T21:23:47Z",
         "status": "running",
         "errors": [],
         "tasks": {
-          "completed": 0,
+          "completed": 1,
           "failed": 0,
-          "inProgress": 2,
-          "total": 2
+          "inProgress": 1,
+          "total": 2,
+          "customSingleClassificationTasks": [
+            {
+              "lastUpdateDateTime": "2021-10-25T21:23:48.0244504Z",
+              "taskName": "SingleCategoryClassifyWithDisabledServiceLogs",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "classification": {
+                      "category": "BookRestaurant",
+                      "confidenceScore": 1.0
+                    },
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "classification": {
+                      "category": "RateBook",
+                      "confidenceScore": 0.57
+                    },
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "projectName": "659c1851-be0b-4142-b12a-087da9785926",
+                "deploymentName": "659c1851-be0b-4142-b12a-087da9785926"
+              }
+            }
+          ]
         }
       }
     },
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/feedf500-32c4-49db-9d8c-793009839a97",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/e953e899-ac16-494a-9465-87587748ec1e",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "Accept": "application/json, text/json",
+        "Accept": [
+          "application/json",
+          "text/json"
+        ],
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
+        ],
         "x-ms-client-request-id": "0ffa6c06102c270b0b15ff09eaf66f07",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ea4121c6-b1b5-4076-befc-c8c8bd6cc175",
+        "apim-request-id": "8f0231f2-75cb-4319-a89a-0d5e89117457",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:11:27 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "84"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "130"
       },
       "ResponseBody": {
-        "jobId": "feedf500-32c4-49db-9d8c-793009839a97",
-        "lastUpdateDateTime": "2021-10-21T20:11:26Z",
-        "createdDateTime": "2021-10-21T20:11:25Z",
-        "expirationDateTime": "2021-10-22T20:11:25Z",
-        "status": "running",
-        "errors": [],
-        "tasks": {
-          "completed": 0,
-          "failed": 0,
-          "inProgress": 2,
-          "total": 2
-        }
-      }
-    },
-    {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/analyze/jobs/feedf500-32c4-49db-9d8c-793009839a97",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json, text/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211020.1 (.NET Framework 4.8.4341.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2125f74b40c949ac3abe633c6c4cf027",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "6424f362-27fc-46b3-bc04-e58e97325811",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 21 Oct 2021 20:11:28 GMT",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "302"
-      },
-      "ResponseBody": {
-        "jobId": "feedf500-32c4-49db-9d8c-793009839a97",
-        "lastUpdateDateTime": "2021-10-21T20:11:29Z",
-        "createdDateTime": "2021-10-21T20:11:25Z",
-        "expirationDateTime": "2021-10-22T20:11:25Z",
+        "jobId": "e953e899-ac16-494a-9465-87587748ec1e",
+        "lastUpdateDateTime": "2021-10-25T21:23:48Z",
+        "createdDateTime": "2021-10-25T21:23:47Z",
+        "expirationDateTime": "2021-10-26T21:23:47Z",
         "status": "succeeded",
         "errors": [],
         "tasks": {
@@ -167,7 +179,7 @@
           "total": 2,
           "customSingleClassificationTasks": [
             {
-              "lastUpdateDateTime": "2021-10-21T20:11:29.2937942Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:48.0244504Z",
               "taskName": "SingleCategoryClassifyWithDisabledServiceLogs",
               "state": "succeeded",
               "results": {
@@ -195,7 +207,7 @@
               }
             },
             {
-              "lastUpdateDateTime": "2021-10-21T20:11:29.3283445Z",
+              "lastUpdateDateTime": "2021-10-25T21:23:48.5015106Z",
               "taskName": "SingleCategoryClassify",
               "state": "succeeded",
               "results": {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategories.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategories.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?model-version=2020-02-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?model-version=2020-02-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "87",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-31cc7d86b86e3e4195753420b66e7548-982346b004667f4a-00",
+        "traceparent": "00-6b10eba0253d934894dcfd1f23ca1fa4-ae2e2f752dda764e-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "2bbb7414e3ce80e03f8df0adf3eb7d0c",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "626134c5-4798-4924-ac38-420006650289",
+        "apim-request-id": "2f87c194-0f90-462e-9a9d-4e374c5925fe",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "76"
+        "x-envoy-upstream-service-time": "70"
       },
       "ResponseBody": {
         "documents": [
@@ -78,6 +78,6 @@
   "Variables": {
     "RandomSeed": "1654409937",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategoriesAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategoriesAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?model-version=2020-02-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?model-version=2020-02-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "87",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ac539ee6fd7f714a8e47ec74b0a94734-affcbf7aa5a42c4e-00",
+        "traceparent": "00-fae5a92312fcdc459d3b7f002e781cae-945f084b854bfb4c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "6470d4cf3910c27ceead9bc2cf6c8aa0",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "13a547d0-ad9c-4e2d-b834-5705461aafdc",
+        "apim-request-id": "b43903a0-e7ed-41eb-951b-ecb0510156c2",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "55"
+        "x-envoy-upstream-service-time": "68"
       },
       "ResponseBody": {
         "documents": [
@@ -78,6 +78,6 @@
   "Variables": {
     "RandomSeed": "62086103",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RotateApiKey.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RotateApiKey.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d0b781ae4764d245a75cdbaa3ab35df3-05a91c486429224e-00",
+        "traceparent": "00-6a33fa9f25d66b4785ac68f8139922d1-9c1237a3ee483c49-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "31841aab9edddcddb56c91e8fafcead5",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5be764ba-29cf-46dc-9130-7afb7a4fac98",
+        "apim-request-id": "8dc83c25-38c9-4e49-9b2c-3daf3861ffcd",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
         "documents": [
@@ -56,7 +56,7 @@
       }
     },
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -66,10 +66,10 @@
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-962f83f6ea4dea4f8ead2ca31357019a-a015d50668639f4a-00",
+        "traceparent": "00-910c733fed966b42b1b66fac69472de0-2bd3e55181ce424b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "13daa31269993bffe7f19e3dc94f204e",
         "x-ms-return-client-request-id": "true"
@@ -85,10 +85,10 @@
       },
       "StatusCode": 401,
       "ResponseHeaders": {
-        "apim-request-id": "4fccbcc9-1454-445c-b252-3b7328825e70",
+        "apim-request-id": "b14a062d-386d-4330-ae8a-140c2659ec38",
         "Content-Length": "224",
         "Content-Type": "application/json",
-        "Date": "Tue, 03 Aug 2021 18:40:01 GMT"
+        "Date": "Mon, 25 Oct 2021 21:23:50 GMT"
       },
       "ResponseBody": {
         "error": {
@@ -98,7 +98,7 @@
       }
     },
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -108,10 +108,10 @@
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c5b196123ec3364299c0c4c6dcb88f90-276ba6b06340544e-00",
+        "traceparent": "00-4a4826c493664d4a93eab4ba5080c6ea-b588a5343d1f6b4a-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "d85ee288a420af625bce0d2748754fc8",
         "x-ms-return-client-request-id": "true"
@@ -127,14 +127,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6a3a0314-1ed6-4d66-ac71-20cfc391bc45",
+        "apim-request-id": "c16a0ac3-15d0-4a25-9ad0-f2b9f2adaadd",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "16"
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
         "documents": [
@@ -156,6 +156,6 @@
   "Variables": {
     "RandomSeed": "1557994243",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RotateApiKeyAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RotateApiKeyAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-25a389082eba6d4ea0018c0e42533614-1e15e0dd6dca974e-00",
+        "traceparent": "00-56b8dfc1b2ddd24792a99784917957db-736c7beda44dfc44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "fb9f47ae04f9d825012386a2a51b9727",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "91eb4c01-5bc7-4826-8df6-71f2326b452e",
+        "apim-request-id": "3f10da42-9f40-41c6-832d-da4c4fdee468",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "16"
+        "x-envoy-upstream-service-time": "8"
       },
       "ResponseBody": {
         "documents": [
@@ -56,7 +56,7 @@
       }
     },
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -66,10 +66,10 @@
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-edee1f5a486e874fb106a826e4131833-3856254ca63bae4d-00",
+        "traceparent": "00-95e12af9d619274ebd130b54dfcb4189-4e413d47a2bd0d48-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "5aa0f7e4723c7c582e8ca602e03d8c8c",
         "x-ms-return-client-request-id": "true"
@@ -85,10 +85,10 @@
       },
       "StatusCode": 401,
       "ResponseHeaders": {
-        "apim-request-id": "80f065cf-93ab-494c-9587-61a71fa121be",
+        "apim-request-id": "1f5501a3-cdf4-4620-8f74-03a96812afdd",
         "Content-Length": "224",
         "Content-Type": "application/json",
-        "Date": "Tue, 03 Aug 2021 18:40:02 GMT"
+        "Date": "Mon, 25 Oct 2021 21:23:53 GMT"
       },
       "ResponseBody": {
         "error": {
@@ -98,7 +98,7 @@
       }
     },
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/languages",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/languages",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -108,10 +108,10 @@
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2c837962191161469054096447d863ba-9178359f7e7f4143-00",
+        "traceparent": "00-218395977534534faeb489550ce85ccc-f10b4b1a8acf564b-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "1a26406b44799ec461ce0951aebc7b46",
         "x-ms-return-client-request-id": "true"
@@ -127,14 +127,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c512ee2b-ae2e-4d92-9f99-ddee25be5705",
+        "apim-request-id": "9b3da1a0-5d88-4ccf-bf29-84b1fc1ee708",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17"
+        "x-envoy-upstream-service-time": "9"
       },
       "ResponseBody": {
         "documents": [
@@ -156,6 +156,6 @@
   "Variables": {
     "RandomSeed": "1997725308",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextInKoreanNFC.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextInKoreanNFC.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "76",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f60c87e706e4224eb77e8fad728d14b9-11d6cb00a0d9944c-00",
+        "traceparent": "00-87f1cc1bc3c8364b8e49412cfeed7167-30f0c43fff10b946-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "af25edec94c2cbbfd63455e84047f9b5",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d40be74e-f95e-4c73-b257-4cec701677fd",
+        "apim-request-id": "1b6cb867-7e75-4494-bb4d-0b84289ccc39",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "46"
+        "x-envoy-upstream-service-time": "16"
       },
       "ResponseBody": {
         "documents": [
@@ -63,6 +63,6 @@
   "Variables": {
     "RandomSeed": "514682034",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextInKoreanNFCAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextInKoreanNFCAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "76",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-62b5e46b89f2b24481df306ec35641bc-afa006d995339e47-00",
+        "traceparent": "00-7415b1bcef0bef42989c05543308a270-7b84ccc641c42649-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "66b8ef6aed4353af1a0a6380bef4513f",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c4a578e6-5120-411e-bdab-0c79a2757a9c",
+        "apim-request-id": "c5ba5548-51f8-45d5-8cec-810e6fb33b6b",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "43"
+        "x-envoy-upstream-service-time": "15"
       },
       "ResponseBody": {
         "documents": [
@@ -63,6 +63,6 @@
   "Variables": {
     "RandomSeed": "1998010767",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextWithDiacriticsNFC.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextWithDiacriticsNFC.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "70",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fcf3ec3edfd4d6469761cf5cd913bf7a-a33b1c82c4a7be41-00",
+        "traceparent": "00-8f9a543dd578ba4e8bfb61569956c8c1-8b91295f57cbe947-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "9c096f0bd3a36f626316eda5be1e28c8",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f7212555-1378-4ebb-8bfe-77287c75f27a",
+        "apim-request-id": "e58125a6-9aab-49cc-a096-08de2b0b6037",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "31"
+        "x-envoy-upstream-service-time": "12"
       },
       "ResponseBody": {
         "documents": [
@@ -49,7 +49,7 @@
                 "category": "Organization",
                 "offset": 4,
                 "length": 9,
-                "confidenceScore": 0.93
+                "confidenceScore": 0.97
               }
             ],
             "warnings": []
@@ -63,6 +63,6 @@
   "Variables": {
     "RandomSeed": "665053590",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextWithDiacriticsNFCAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextWithDiacriticsNFCAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "70",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4c236aad6709514a97b7313db7f82a8a-e0eae97e1d36dd43-00",
+        "traceparent": "00-0524d7463eb8954383c70fef0b7295c9-bcc2bf68a2b82d44-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a71f02631f3c7a05f4cb179d2fb85aac",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c57ea9ce-fa27-48c5-9969-9fd7cf302212",
+        "apim-request-id": "93815212-4fb2-4388-b0ad-015d18c54963",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "25"
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
         "documents": [
@@ -49,7 +49,7 @@
                 "category": "Organization",
                 "offset": 4,
                 "length": 9,
-                "confidenceScore": 0.93
+                "confidenceScore": 0.97
               }
             ],
             "warnings": []
@@ -63,6 +63,6 @@
   "Variables": {
     "RandomSeed": "1077947182",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextWithEmoji.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextWithEmoji.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "87",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-36e1a5a33f25b849a8bb3fed38e26be9-c40780ab37ead64b-00",
+        "traceparent": "00-a272d74de200b64ba0a049b91dba58b2-a89c75d25a90664c-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "a12918df519b0dc53f87435017a62e99",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2ab53c6b-a6c1-4d76-bab7-8f4c2a06da85",
+        "apim-request-id": "5ba1a67d-30eb-4c5d-8bbc-667442214f6a",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:01 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "28"
+        "x-envoy-upstream-service-time": "13"
       },
       "ResponseBody": {
         "documents": [
@@ -63,6 +63,6 @@
   "Variables": {
     "RandomSeed": "1277894095",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextWithEmojiAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/TextWithEmojiAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://tacanaryjava.cognitiveservices.azure.com/text/analytics/v3.2-preview.1/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": [
@@ -11,10 +11,10 @@
         "Content-Length": "87",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b07fcb85969f44f93ce7704a8b364a0-9f01a63719d6db40-00",
+        "traceparent": "00-262cba1a5ac7c84683d5c714198faadd-bc59a1cbbe70b741-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20210803.1",
-          "(.NET 5.0.8; Microsoft Windows 10.0.19043)"
+          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
+          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
         ],
         "x-ms-client-request-id": "05b9b9c88ccd2f82a72e96b9014b88fb",
         "x-ms-return-client-request-id": "true"
@@ -30,14 +30,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aafb7ac9-d375-4717-8eb9-5327cdcb410e",
+        "apim-request-id": "914e3764-e932-4e5d-a6be-d86652e12b1c",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Tue, 03 Aug 2021 18:40:02 GMT",
+        "Date": "Mon, 25 Oct 2021 21:23:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "44"
+        "x-envoy-upstream-service-time": "14"
       },
       "ResponseBody": {
         "documents": [
@@ -63,6 +63,6 @@
   "Variables": {
     "RandomSeed": "1551033461",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://tacanaryjava.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
   }
 }


### PR DESCRIPTION
This PR includes session records for all the tests to target 3.2-preview.2 as was mentioned in #24791. @maririos will re-record AAD tests because they didn't pass. 