### PR TITLE
[EngSys] Adding sanitizer to Purview libraries

### DIFF
--- a/sdk/purview/Azure.Analytics.Purview.Account/Azure.Analytics.Purview.Account.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Account/Azure.Analytics.Purview.Account.sln
@@ -9,11 +9,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Stress", "..\..\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{0ED9C8A0-9A19-4750-8DD3-61D086288283}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Analytics.Purview.Account", "src\Azure.Analytics.Purview.Account.csproj", "{CF37FB99-8D78-473D-8333-AD560F057B75}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Account", "src\Azure.Analytics.Purview.Account.csproj", "{CF37FB99-8D78-473D-8333-AD560F057B75}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Analytics.Purview.Account.Tests", "tests\Azure.Analytics.Purview.Account.Tests.csproj", "{002A0F15-402B-473D-8842-5507462920BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Account.Tests", "tests\Azure.Analytics.Purview.Account.Tests.csproj", "{002A0F15-402B-473D-8842-5507462920BF}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{002a0f15-402b-473d-8842-5507462920bf}*SharedItemsImports = 5
+		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{283cb4fe-a207-4d92-8431-6147f1ecbab7}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/sdk/purview/Azure.Analytics.Purview.Account/tests/AccountsClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Account/tests/AccountsClientTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
@@ -12,10 +13,12 @@ namespace Azure.Analytics.Purview.Account.Tests
     {
         public AccountsClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public AccountsClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public PurviewAccountClient GetAccountClient()

--- a/sdk/purview/Azure.Analytics.Purview.Account/tests/Azure.Analytics.Purview.Account.Tests.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.Account/tests/Azure.Analytics.Purview.Account.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="..\..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems" Label="Shared" />
+
   <ItemGroup>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/purview/Azure.Analytics.Purview.Account/tests/CollectionsClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Account/tests/CollectionsClientTestBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Azure.Identity;
@@ -17,10 +18,12 @@ namespace Azure.Analytics.Purview.Account.Tests
     {
         public CollectionsClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public CollectionsClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public PurviewCollection GetCollectionsClient(string collectionName)

--- a/sdk/purview/Azure.Analytics.Purview.Account/tests/SessionRecords/AccountsClientTest/ListKeysTask.json
+++ b/sdk/purview/Azure.Analytics.Purview.Account/tests/SessionRecords/AccountsClientTest/ListKeysTask.json
@@ -29,8 +29,8 @@
         "x-ms-correlation-request-id": "3ac84d65-0cfd-4623-a994-cb83c86b22db"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=Lp58m4PXPdjA\u002BOKwBT717op3fc/PXtVaPuONkWVVnh0=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     },
     {
@@ -58,8 +58,8 @@
         "x-ms-correlation-request-id": "974f914a-c4db-40aa-b27a-6396b74ee5b5"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=Lp58m4PXPdjA\u002BOKwBT717op3fc/PXtVaPuONkWVVnh0=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     }
   ],

--- a/sdk/purview/Azure.Analytics.Purview.Account/tests/SessionRecords/AccountsClientTest/ListKeysTaskAsync.json
+++ b/sdk/purview/Azure.Analytics.Purview.Account/tests/SessionRecords/AccountsClientTest/ListKeysTaskAsync.json
@@ -29,8 +29,8 @@
         "x-ms-correlation-request-id": "7934f311-5518-4920-810d-8bb9c87723c7"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=xre3vpyXezr4nqC4kFt78PXtH2eq7VGZi\u002BJiXfcdU5U=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     },
     {
@@ -58,8 +58,8 @@
         "x-ms-correlation-request-id": "40594ffd-874b-4ec4-a3a1-d0bae7b808c9"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=xre3vpyXezr4nqC4kFt78PXtH2eq7VGZi\u002BJiXfcdU5U=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     }
   ],

--- a/sdk/purview/Azure.Analytics.Purview.Account/tests/SessionRecords/AccountsClientTest/RegenerateKeysTask.json
+++ b/sdk/purview/Azure.Analytics.Purview.Account/tests/SessionRecords/AccountsClientTest/RegenerateKeysTask.json
@@ -29,8 +29,8 @@
         "x-ms-correlation-request-id": "7fafecf4-f119-40e0-bb2a-6b3d90347d47"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=DghPW/ZISiqsExfGFaEwwr2WiB2rjERWMzlhUAOCuPE=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     }
   ],

--- a/sdk/purview/Azure.Analytics.Purview.Account/tests/SessionRecords/AccountsClientTest/RegenerateKeysTaskAsync.json
+++ b/sdk/purview/Azure.Analytics.Purview.Account/tests/SessionRecords/AccountsClientTest/RegenerateKeysTaskAsync.json
@@ -29,8 +29,8 @@
         "x-ms-correlation-request-id": "70160618-6264-48ea-a6c1-4c2649abc6c7"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=TmfpFZBHQcZuAbzxwF2c8XAGWw02mXS/GWMkZmlufLM=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     }
   ],

--- a/sdk/purview/Azure.Analytics.Purview.Administration/Azure.Analytics.Purview.Administration.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/Azure.Analytics.Purview.Administration.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31806.525
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Administration", "src\Azure.Analytics.Purview.Administration.csproj", "{B0C276D1-2930-4887-B29A-D1A33E7009A2}"
 EndProject
@@ -13,7 +13,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Stress", "..\..\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{FA8BD3F1-8616-47B6-974C-7576CDF4717E}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
+EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{283cb4fe-a207-4d92-8431-6147f1ecbab7}*SharedItemsImports = 13
+		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{8e9a77ac-792a-4432-8320-acfd46730401}*SharedItemsImports = 5
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/AccountsClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/AccountsClientTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
@@ -12,10 +13,12 @@ namespace Azure.Analytics.Purview.Administration.Tests
     {
         public AccountsClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public AccountsClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public PurviewAccountClient GetAccountClient()

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/Azure.Analytics.Purview.Administration.Tests.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/Azure.Analytics.Purview.Administration.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="..\..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems" Label="Shared" />
+
   <ItemGroup>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/CollectionsClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/CollectionsClientTestBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Azure.Identity;
@@ -17,10 +18,12 @@ namespace Azure.Analytics.Purview.Administration.Tests
     {
         public CollectionsClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public CollectionsClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public PurviewCollection GetCollectionsClient(string collectionName)

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/MetadataPolicyClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/MetadataPolicyClientTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
@@ -11,10 +12,12 @@ namespace Azure.Analytics.Purview.Administration.Tests
     {
         public MetadataPolicyClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public MetadataPolicyClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
         public PurviewMetadataPolicyClient GetMetadataPolicyClient(string collectionName)
         {

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/MetadataRolesClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/MetadataRolesClientTestBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Azure.Identity;
@@ -18,10 +19,12 @@ namespace Azure.Analytics.Purview.Administration.Tests
     {
         public MetadataRolesClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public MetadataRolesClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
         public PurviewMetadataRolesClient GetMetadataPolicyClient()
         {

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/SessionRecords/AccountsClientTest/ListKeysTask.json
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/SessionRecords/AccountsClientTest/ListKeysTask.json
@@ -29,8 +29,8 @@
         "x-ms-correlation-request-id": "3ac84d65-0cfd-4623-a994-cb83c86b22db"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=Lp58m4PXPdjA\u002BOKwBT717op3fc/PXtVaPuONkWVVnh0=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     },
     {
@@ -58,8 +58,8 @@
         "x-ms-correlation-request-id": "974f914a-c4db-40aa-b27a-6396b74ee5b5"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=Lp58m4PXPdjA\u002BOKwBT717op3fc/PXtVaPuONkWVVnh0=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     }
   ],

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/SessionRecords/AccountsClientTest/ListKeysTaskAsync.json
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/SessionRecords/AccountsClientTest/ListKeysTaskAsync.json
@@ -29,8 +29,8 @@
         "x-ms-correlation-request-id": "7934f311-5518-4920-810d-8bb9c87723c7"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=xre3vpyXezr4nqC4kFt78PXtH2eq7VGZi\u002BJiXfcdU5U=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     },
     {
@@ -58,8 +58,8 @@
         "x-ms-correlation-request-id": "40594ffd-874b-4ec4-a3a1-d0bae7b808c9"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=xre3vpyXezr4nqC4kFt78PXtH2eq7VGZi\u002BJiXfcdU5U=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     }
   ],

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/SessionRecords/AccountsClientTest/RegenerateKeysTask.json
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/SessionRecords/AccountsClientTest/RegenerateKeysTask.json
@@ -29,8 +29,8 @@
         "x-ms-correlation-request-id": "7fafecf4-f119-40e0-bb2a-6b3d90347d47"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=DghPW/ZISiqsExfGFaEwwr2WiB2rjERWMzlhUAOCuPE=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     }
   ],

--- a/sdk/purview/Azure.Analytics.Purview.Administration/tests/SessionRecords/AccountsClientTest/RegenerateKeysTaskAsync.json
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/tests/SessionRecords/AccountsClientTest/RegenerateKeysTaskAsync.json
@@ -29,8 +29,8 @@
         "x-ms-correlation-request-id": "70160618-6264-48ea-a6c1-4c2649abc6c7"
       },
       "ResponseBody": {
-        "atlasKafkaPrimaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=TmfpFZBHQcZuAbzxwF2c8XAGWw02mXS/GWMkZmlufLM=",
-        "atlasKafkaSecondaryEndpoint": "Endpoint=sb://atlas-7fd51f91-de1e-4e8b-a5b6-da64dd299b9f.servicebus.windows.net/;SharedAccessKeyName=AlternateSharedAccessKey;SharedAccessKey=GcMVTNPGShESagjYw\u002B\u002BLGPPYfZ1h3Bj1IjL4tdejn9k="
+        "atlasKafkaPrimaryEndpoint": "Sanitized",
+        "atlasKafkaSecondaryEndpoint": "Sanitized"
       }
     }
   ],

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/Azure.Analytics.Purview.Catalog.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/Azure.Analytics.Purview.Catalog.sln
@@ -9,11 +9,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Stress", "..\..\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{0ED9C8A0-9A19-4750-8DD3-61D086288283}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Analytics.Purview.Catalog", "src\Azure.Analytics.Purview.Catalog.csproj", "{CF37FB99-8D78-473D-8333-AD560F057B75}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Catalog", "src\Azure.Analytics.Purview.Catalog.csproj", "{CF37FB99-8D78-473D-8333-AD560F057B75}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Analytics.Purview.Catalog.Tests", "tests\Azure.Analytics.Purview.Catalog.Tests.csproj", "{002A0F15-402B-473D-8842-5507462920BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Catalog.Tests", "tests\Azure.Analytics.Purview.Catalog.Tests.csproj", "{002A0F15-402B-473D-8842-5507462920BF}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{002a0f15-402b-473d-8842-5507462920bf}*SharedItemsImports = 5
+		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{283cb4fe-a207-4d92-8431-6147f1ecbab7}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/tests/Azure.Analytics.Purview.Catalog.Tests.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/tests/Azure.Analytics.Purview.Catalog.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="..\..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems" Label="Shared" />
+
   <ItemGroup>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/tests/CatalogClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/tests/CatalogClientTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
@@ -11,10 +12,12 @@ namespace Azure.Analytics.Purview.Catalog.Tests
     {
         public CatalogClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public CatalogClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public PurviewCatalogClient GetCatalogClient()

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/tests/GlossaryClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/tests/GlossaryClientTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
@@ -14,9 +15,11 @@ namespace Azure.Analytics.Purview.Catalog.Tests
     {
         public GlossaryClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
         public GlossaryClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
         public PurviewGlossaries GetGlossariesClient()
         {

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/Azure.Analytics.Purview.Scanning.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/Azure.Analytics.Purview.Scanning.sln
@@ -9,11 +9,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Stress", "..\..\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{0ED9C8A0-9A19-4750-8DD3-61D086288283}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Analytics.Purview.Scanning", "src\Azure.Analytics.Purview.Scanning.csproj", "{8697A90E-3BAF-48FA-996C-0A0CE613D405}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Scanning", "src\Azure.Analytics.Purview.Scanning.csproj", "{8697A90E-3BAF-48FA-996C-0A0CE613D405}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Analytics.Purview.Scanning.Tests", "tests\Azure.Analytics.Purview.Scanning.Tests.csproj", "{41F48A9A-86CC-4855-AB01-3B2F94E6E8CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Scanning.Tests", "tests\Azure.Analytics.Purview.Scanning.Tests.csproj", "{41F48A9A-86CC-4855-AB01-3B2F94E6E8CA}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{283cb4fe-a207-4d92-8431-6147f1ecbab7}*SharedItemsImports = 13
+		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{41f48a9a-86cc-4855-ab01-3b2f94e6e8ca}*SharedItemsImports = 5
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/tests/Azure.Analytics.Purview.Scanning.Tests.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/tests/Azure.Analytics.Purview.Scanning.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="..\..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems" Label="Shared" />
+
   <ItemGroup>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/tests/ClassificationRuleClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/tests/ClassificationRuleClientTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
@@ -12,10 +13,12 @@ namespace Azure.Analytics.Purview.Scanning.Tests
     {
         public ClassificationRuleClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public ClassificationRuleClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public PurviewClassificationRuleClient GetClassificationRuleClient(string classificationRuleName)

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/tests/DataSourceClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/tests/DataSourceClientTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
@@ -12,10 +13,12 @@ namespace Azure.Analytics.Purview.Scanning.Tests
     {
         public DataSourceClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public DataSourceClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public PurviewDataSourceClient GetPurviewDataSourceClient(string dataSourceName)

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/tests/ScanClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/tests/ScanClientTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
@@ -12,10 +13,12 @@ namespace Azure.Analytics.Purview.Scanning.Tests
     {
         public ScanClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public ScanClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
         public PurviewScanClient GetPurviewScanClient(string dataSourceName,string scanName)
         {

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/tests/ScanningServiceClientTestBase.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/tests/ScanningServiceClientTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Azure.Analytics.Purview.Tests;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 
@@ -12,10 +13,12 @@ namespace Azure.Analytics.Purview.Scanning.Tests
     {
         public ScanningServiceClientTestBase(bool isAsync) : base(isAsync)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public ScanningServiceClientTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
+            Sanitizer = new PurviewRecordedTestSanitizer();
         }
 
         public PurviewScanningServiceClient GetScanningClient()

--- a/sdk/purview/Azure.Analytics.Purview.Shared/tests/Azure.Analytics.Purview.Shared.Tests.projitems
+++ b/sdk/purview/Azure.Analytics.Purview.Shared/tests/Azure.Analytics.Purview.Shared.Tests.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>283cb4fe-a207-4d92-8431-6147f1ecbab7</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Azure.Analytics.Purview.Tests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)PurviewRecordedTestSanitizer.cs" />
+  </ItemGroup>
+</Project>

--- a/sdk/purview/Azure.Analytics.Purview.Shared/tests/Azure.Analytics.Purview.Shared.Tests.shproj
+++ b/sdk/purview/Azure.Analytics.Purview.Shared/tests/Azure.Analytics.Purview.Shared.Tests.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>283cb4fe-a207-4d92-8431-6147f1ecbab7</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Azure.Analytics.Purview.Shared.Tests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/sdk/purview/Azure.Analytics.Purview.Shared/tests/PurviewRecordedTestSanitizer.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Shared/tests/PurviewRecordedTestSanitizer.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.TestFramework;
+
+namespace Azure.Analytics.Purview.Tests
+{
+    public class PurviewRecordedTestSanitizer : RecordedTestSanitizer
+    {
+        public PurviewRecordedTestSanitizer() : base()
+        {
+            AddJsonPathSanitizer("$..atlasKafkaPrimaryEndpoint");
+            AddJsonPathSanitizer("$..atlasKafkaSecondaryEndpoint");
+        }
+    }
+}


### PR DESCRIPTION
This PR contains the following changes:
- Adds a custom sanitizer (`PurviewRecordedTestSanitizer`) to the Purview libraries. This class sanitizes some properties that are specific to Purview libraries.
- Adds a new `Azure.Analytics.Purview.Shared.Tests` shared project to include the custom sanitizer mentioned above. The sanitizer is used by all Purview libraries, so I'm keeping it in a shared project to avoid code repetition.
- Sanitizes some test recordings after passing them through the new custom sanitizer.