### PR TITLE
Plugged source of account leak

### DIFF
--- a/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/ClientBuilder.cs
@@ -64,7 +64,15 @@ namespace Azure.Storage.Test.Shared
 
         public RecordedTestBase AzureCoreRecordedTestBase => Tenants.AzureCoreRecordedTestBase;
 
+        /// <summary>
+        /// Recording reference. Unsafe to access until [Setup] step.
+        /// </summary>
         public TestRecording Recording => AzureCoreRecordedTestBase.Recording;
+
+        /// <summary>
+        /// Test mode reference. Safe to access even when <see cref="Recording"/> is not.
+        /// </summary>
+        public RecordedTestMode Mode => AzureCoreRecordedTestBase.Mode;
 
         /// <summary>
         /// Constructor.
@@ -143,11 +151,11 @@ namespace Azure.Storage.Test.Shared
             options.Diagnostics.IsLoggingEnabled = true;
             options.Retry.Mode = RetryMode.Exponential;
             options.Retry.MaxRetries = Constants.MaxReliabilityRetries;
-            options.Retry.Delay = TimeSpan.FromSeconds(Recording.Mode == RecordedTestMode.Playback ? 0.01 : 1);
-            options.Retry.MaxDelay = TimeSpan.FromSeconds(Recording.Mode == RecordedTestMode.Playback ? 0.1 : 60);
-            options.Retry.NetworkTimeout = TimeSpan.FromSeconds(Recording.Mode == RecordedTestMode.Playback ? 100 : 400);
+            options.Retry.Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1);
+            options.Retry.MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60);
+            options.Retry.NetworkTimeout = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 100 : 400);
 
-            if (Recording.Mode != RecordedTestMode.Live)
+            if (Mode != RecordedTestMode.Live)
             {
                 options.AddPolicy(new RecordedClientRequestIdPolicy(Recording, parallelRange), HttpPipelinePosition.PerCall);
             }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfigurationBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfigurationBuilder.cs
@@ -23,9 +23,14 @@ namespace Azure.Storage.Test.Shared
         public RecordedTestBase AzureCoreRecordedTestBase { get; }
 
         /// <summary>
-        /// Recording reference.
+        /// Recording reference. Unsafe to access until [Setup] step.
         /// </summary>
         public TestRecording Recording => AzureCoreRecordedTestBase.Recording;
+
+        /// <summary>
+        /// Test mode reference. Safe to access even when <see cref="Recording"/> is not.
+        /// </summary>
+        public RecordedTestMode Mode => AzureCoreRecordedTestBase.Mode;
 
         /// <summary>
         /// Gets a cache used for storing deserialized tenant configurations.
@@ -140,7 +145,7 @@ namespace Azure.Storage.Test.Shared
                 new Uri(config.ActiveDirectoryAuthEndpoint));
 
         public TokenCredential GetOAuthCredential(string tenantId, string appId, string secret, Uri authorityHost) =>
-            Recording.Mode == RecordedTestMode.Playback ?
+            Mode == RecordedTestMode.Playback ?
                 (TokenCredential)new StorageTestTokenCredential() :
                 new ClientSecretCredential(
                     tenantId,
@@ -170,7 +175,7 @@ namespace Azure.Storage.Test.Shared
         {
             TenantConfiguration config;
             string text;
-            switch (Recording.Mode)
+            switch (Mode)
             {
                 case RecordedTestMode.Playback:
                     if (!_playbackConfigCache.TryGetValue(name, out config))


### PR DESCRIPTION
VLW tests are tricky in how they need to handle container create/delete. #24351 introduced a bug where we would try to access null when tearing down those containers, making it impossible to delete the account. As this happened in a global teardown step, NUnit/DevOps didn't properly report these exceptions to us.

We no longer access the null property in that global teardown. Confirmed accounts now get deleted in the scenario that causes the property to be null.