### PR TITLE
[TA] Add AAD variables for tests to work

### DIFF
--- a/sdk/textanalytics/tests.yml
+++ b/sdk/textanalytics/tests.yml
@@ -12,6 +12,10 @@ extends:
         Location: 'centraluseuap'
     # temporary env vars for custom text features
     EnvVars:
+        AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         TEXT_ANALYTICS_ENDPOINT: $(js-textanalytics-test-service-endpoint)
         TEXT_ANALYTICS_API_KEY: $(js-textanalytics-api-key-new)
         TEXTANALYTICS_SINGLE_CATEGORY_CLASSIFY_PROJECT_NAME: $(js-single-category-classify-project-name)


### PR DESCRIPTION
After running the [pipeline](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1161103&view=results), now that we don't create resources, we don't have the AAD variables in the environment so our tests are failing.
I am adding them from our KV instance