### PR TITLE
[LLC] Prove grow-up story for LROs

### DIFF
--- a/sdk/core/Azure.Core.Experimental/tests/Azure.Core.Experimental.Tests.csproj
+++ b/sdk/core/Azure.Core.Experimental/tests/Azure.Core.Experimental.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
+    <DefineConstants>$(DefineConstants);EXPERIMENTAL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +24,7 @@
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)OperationHelpers.cs" LinkBase="Shared" />
   </ItemGroup>
 
 </Project>

--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Experimental.Tests.Models;
 using Azure.Core.Pipeline;
 
 namespace Azure.Core.Experimental.Tests
@@ -178,6 +179,14 @@ namespace Azure.Core.Experimental.Tests
                 scope.Failed(e);
                 throw;
             }
+        }
+
+#pragma warning disable AZC0002
+        public virtual Operation<Pet> ImportPet(RequestContent content)
+#pragma warning restore AZC0002
+        {
+            LowLevelFuncOperation<BinaryData> operation = (LowLevelFuncOperation<BinaryData>)ImportPet(content, default);
+            return new LowLevelFuncOperation<Pet>((OperationInternals)(operation._operation), r => (Pet)(object)r);
         }
 
         /// <summary> Create Request for <see cref="GetPet"/> and <see cref="GetPetAsync"/> operations. </summary>

--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
@@ -148,12 +148,12 @@ namespace Azure.Core.Experimental.Tests
         public virtual Operation<BinaryData> ImportPet(RequestContent content, RequestOptions options = null)
 #pragma warning restore AZC0002
         {
-            using var scope = _clientDiagnostics.CreateScope("PurviewGlossaries.ImportPet");
+            using var scope = _clientDiagnostics.CreateScope("PetStoreClient.ImportPet");
             scope.Start();
             try
             {
                 using HttpMessage message = CreateImportPetRequest(content);
-                return LowLevelOperationHelpers.ProcessMessage(Pipeline, message, _clientDiagnostics, "PurviewGlossaries.ImportPet", OperationFinalStateVia.AzureAsyncOperation, options);
+                return LowLevelOperationHelpers.ProcessMessage(Pipeline, message, _clientDiagnostics, "PetStoreClient.ImportPet", OperationFinalStateVia.AzureAsyncOperation, options);
             }
             catch (Exception e)
             {
@@ -166,12 +166,12 @@ namespace Azure.Core.Experimental.Tests
         public virtual async Task<Operation<BinaryData>> ImportPetAsync(RequestContent content, RequestOptions options = null)
 #pragma warning restore AZC0002
         {
-            using var scope = _clientDiagnostics.CreateScope("PurviewGlossaries.ImportPet");
+            using var scope = _clientDiagnostics.CreateScope("PetStoreClient.ImportPet");
             scope.Start();
             try
             {
                 using HttpMessage message = CreateImportPetRequest(content);
-                return await LowLevelOperationHelpers.ProcessMessageAsync(Pipeline, message, _clientDiagnostics, "PurviewGlossaries.ImportPet", OperationFinalStateVia.AzureAsyncOperation, options).ConfigureAwait(false);
+                return await LowLevelOperationHelpers.ProcessMessageAsync(Pipeline, message, _clientDiagnostics, "PetStoreClient.ImportPet", OperationFinalStateVia.AzureAsyncOperation, options).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Core.Pipeline;
 
 namespace Azure.Core.Experimental.Tests
@@ -143,6 +144,42 @@ namespace Azure.Core.Experimental.Tests
             }
         }
 
+#pragma warning disable AZC0002
+        public virtual Operation<BinaryData> ImportPet(RequestContent content, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            using var scope = _clientDiagnostics.CreateScope("PurviewGlossaries.ImportPet");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateImportPetRequest(content);
+                return LowLevelOperationHelpers.ProcessMessage(Pipeline, message, _clientDiagnostics, "PurviewGlossaries.ImportPet", OperationFinalStateVia.AzureAsyncOperation, options);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
+#pragma warning disable AZC0002
+        public virtual async Task<Operation<BinaryData>> ImportPetAsync(RequestContent content, RequestOptions options = null)
+#pragma warning restore AZC0002
+        {
+            using var scope = _clientDiagnostics.CreateScope("PurviewGlossaries.ImportPet");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateImportPetRequest(content);
+                return await LowLevelOperationHelpers.ProcessMessageAsync(Pipeline, message, _clientDiagnostics, "PurviewGlossaries.ImportPet", OperationFinalStateVia.AzureAsyncOperation, options).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
         /// <summary> Create Request for <see cref="GetPet"/> and <see cref="GetPetAsync"/> operations. </summary>
         /// <param name="id"> Id of pet to return. </param>
         /// <param name="options"> The request options. </param>
@@ -157,6 +194,21 @@ namespace Azure.Core.Experimental.Tests
             uri.AppendPath(id, true);
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json, text/json");
+            message.ResponseClassifier = Classifier200;
+            return message;
+        }
+
+        private HttpMessage CreateImportPetRequest(RequestContent content)
+        {
+            var message = Pipeline.CreateMessage();
+            var request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.Reset(endpoint);
+            uri.AppendPath("/pets/import", false);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json, text/json");
+            request.Content = content;
             message.ResponseClassifier = Classifier200;
             return message;
         }

--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClient/PetStoreClient.cs
@@ -182,11 +182,21 @@ namespace Azure.Core.Experimental.Tests
         }
 
 #pragma warning disable AZC0002
-        public virtual Operation<Pet> ImportPet(RequestContent content)
+        public virtual Operation<Pet> ImportPet(Pet inputPet)
 #pragma warning restore AZC0002
         {
-            LowLevelFuncOperation<BinaryData> operation = (LowLevelFuncOperation<BinaryData>)ImportPet(content, default);
-            return new LowLevelFuncOperation<Pet>((OperationInternals)(operation._operation), r => (Pet)(object)r);
+            var content = RequestContent.Create(inputPet);
+            var operation = (LowLevelFuncOperation<BinaryData>)ImportPet(content, default);
+            return new LowLevelFuncOperation<Pet>(operation, r => (Pet)r);
+        }
+
+#pragma warning disable AZC0002
+        public virtual async Task<Operation<Pet>> ImportPetAsync(Pet inputPet)
+#pragma warning restore AZC0002
+        {
+            var content = RequestContent.Create(inputPet);
+            var operation = (LowLevelFuncOperation<BinaryData>)(await ImportPetAsync(content, default));
+            return new LowLevelFuncOperation<Pet>(operation, r => (Pet)r);
         }
 
         /// <summary> Create Request for <see cref="GetPet"/> and <see cref="GetPetAsync"/> operations. </summary>

--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClientTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClientTests.cs
@@ -260,6 +260,30 @@ namespace Azure.Core.Tests
             Assert.AreEqual("beagle", pet.Species);
         }
 
+        [Test]
+        public async Task CanGetOperationOfOutputModelForLroAsync()
+        {
+            var mockResponse = new MockResponse(200);
+
+            Pet petResponse = new Pet("snoopy", "beagle");
+            mockResponse.SetContent(SerializationHelpers.Serialize(petResponse, SerializePet));
+
+            var mockTransport = new MockTransport(mockResponse);
+            PetStoreClient client = CreateClient(mockTransport);
+
+            var data = new
+            {
+                name = "snoopy",
+                species = "beagle"
+            };
+            LowLevelFuncOperation<Pet> operation = (LowLevelFuncOperation<BinaryData>)await client.ImportPetAsync(RequestContent.Create(data), new RequestOptions());
+
+            Pet pet = await operation.WaitForCompletionAsync();
+
+            Assert.AreEqual("snoopy", pet.Name);
+            Assert.AreEqual("beagle", pet.Species);
+        }
+
         #region Helpers
         private void SerializePet(ref Utf8JsonWriter writer, Pet pet)
         {

--- a/sdk/core/Azure.Core.Experimental/tests/LowLevelClientTests.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/LowLevelClientTests.cs
@@ -271,17 +271,13 @@ namespace Azure.Core.Tests
             var mockTransport = new MockTransport(mockResponse);
             PetStoreClient client = CreateClient(mockTransport);
 
-            var data = new
-            {
-                name = "snoopy",
-                species = "beagle"
-            };
-            LowLevelFuncOperation<Pet> operation = (LowLevelFuncOperation<BinaryData>)await client.ImportPetAsync(RequestContent.Create(data), new RequestOptions());
+            Pet newPet = new Pet("", "beagle");
+            Operation<Pet> operation = await client.ImportPetAsync(newPet);
 
-            Pet pet = await operation.WaitForCompletionAsync();
+            Pet petResult = await operation.WaitForCompletionAsync();
 
-            Assert.AreEqual("snoopy", pet.Name);
-            Assert.AreEqual("beagle", pet.Species);
+            Assert.AreEqual("snoopy", petResult.Name);
+            Assert.AreEqual("beagle", petResult.Species);
         }
 
         #region Helpers


### PR DESCRIPTION
Resolve #24715

Depends on https://github.com/Azure/autorest.csharp/pull/1661

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
