### PR TITLE
[Event Hubs] Buffered Producer Flush and Clear

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -1387,7 +1387,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1404,7 +1404,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1421,7 +1421,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while starting to process events.
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while starting to process events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1440,7 +1440,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is beginning to stop processing events.
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is beginning to stop processing events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer</param>
@@ -1457,7 +1457,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has been stopped and is no longer processing events.
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has been stopped and is no longer processing events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1474,7 +1474,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while stopping.
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while stopping.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1493,7 +1493,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in its
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in its
         ///   background management task.
         /// </summary>
         ///
@@ -1637,7 +1637,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in its
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in its
         ///   background publishing task.
         /// </summary>
         ///
@@ -1657,7 +1657,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has begun a management
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has begun a management
         ///   cycle.
         /// </summary>
         ///
@@ -1675,7 +1675,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has begun a management
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has begun a management
         ///   cycle.
         /// </summary>
         ///
@@ -1699,7 +1699,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
         ///   has reached maximum concurrency and is waiting for a task to complete.
         /// </summary>
         ///
@@ -1721,7 +1721,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
         ///   has completed waiting for a task to complete.
         /// </summary>
         ///
@@ -1885,7 +1885,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
         ///   success handler.
         /// </summary>
         ///
@@ -1907,7 +1907,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
         ///   publishing success handler.
         /// </summary>
         ///
@@ -1931,7 +1931,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
         ///   success handler.
         /// </summary>
         ///
@@ -1953,7 +1953,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
         ///   success handler.
         /// </summary>
         ///
@@ -1975,7 +1975,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
         ///   publishing success handler.
         /// </summary>
         ///
@@ -1999,7 +1999,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
         ///   success handler.
         /// </summary>
         ///
@@ -2154,7 +2154,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the background
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is invoking the background
         ///   publishing coordination task.
         /// </summary>
         ///
@@ -2174,7 +2174,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
         ///   background publishing coordination task.
         /// </summary>
         ///
@@ -2196,7 +2196,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the background
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is invoking the background
         ///   publishing coordination task.
         /// </summary>
         ///
@@ -2216,7 +2216,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
         ///   is waiting for all active publishing to complete.
         /// </summary>
         ///
@@ -2238,7 +2238,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
         ///   is done waiting for all active publishing to complete.
         /// </summary>
         ///
@@ -2262,7 +2262,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is starting to perform
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is starting to perform
         ///   a Flush operation.
         /// </summary>
         ///
@@ -2282,7 +2282,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in an
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in an
         ///   active Flush Operation
         /// </summary>
         ///
@@ -2304,7 +2304,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has completed an active
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has completed an active
         ///   a Flush operation.
         /// </summary>
         ///
@@ -2324,7 +2324,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is starting to perform
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is starting to perform
         ///   a Clear operation.
         /// </summary>
         ///
@@ -2344,7 +2344,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in an
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in an
         ///   active Clear operation.
         /// </summary>
         ///
@@ -2366,7 +2366,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has completed an active
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has completed an active
         ///   a Clear operation.
         /// </summary>
         ///
@@ -2386,7 +2386,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is starting to drain a partition of events.
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is starting to drain a partition of events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -2407,7 +2407,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while draining
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while draining
         ///   a partition of events.
         /// </summary>
         ///
@@ -2431,7 +2431,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has completed draining a partition of events.
+        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has completed draining a partition of events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -1387,7 +1387,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1404,7 +1404,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is about to begin processing events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1421,7 +1421,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while starting to process events.
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while starting to process events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1440,7 +1440,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance is beginning to stop processing events.
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is beginning to stop processing events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer</param>
@@ -1457,7 +1457,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has been stopped and is no longer processing events.
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has been stopped and is no longer processing events.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1474,7 +1474,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while stopping.
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while stopping.
         /// </summary>
         ///
         /// <param name="identifier">A unique name used to identify the buffered producer.</param>
@@ -1493,7 +1493,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in its
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in its
         ///   background management task.
         /// </summary>
         ///
@@ -1637,7 +1637,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in its
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in its
         ///   background publishing task.
         /// </summary>
         ///
@@ -1657,7 +1657,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has begun a management
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has begun a management
         ///   cycle.
         /// </summary>
         ///
@@ -1675,7 +1675,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has begun a management
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has begun a management
         ///   cycle.
         /// </summary>
         ///
@@ -1699,7 +1699,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance publishing task
         ///   has reached maximum concurrency and is waiting for a task to complete.
         /// </summary>
         ///
@@ -1721,7 +1721,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance publishing task
         ///   has completed waiting for a task to complete.
         /// </summary>
         ///
@@ -1885,7 +1885,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has is invoking the send
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
         ///   success handler.
         /// </summary>
         ///
@@ -1907,7 +1907,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
         ///   publishing success handler.
         /// </summary>
         ///
@@ -1931,7 +1931,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has is invoking the send
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
         ///   success handler.
         /// </summary>
         ///
@@ -1953,7 +1953,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has is invoking the send
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
         ///   success handler.
         /// </summary>
         ///
@@ -1975,7 +1975,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
         ///   publishing success handler.
         /// </summary>
         ///
@@ -1999,7 +1999,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has is invoking the send
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the send
         ///   success handler.
         /// </summary>
         ///
@@ -2154,7 +2154,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has is invoking the background
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the background
         ///   publishing coordination task.
         /// </summary>
         ///
@@ -2174,7 +2174,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in the
         ///   background publishing coordination task.
         /// </summary>
         ///
@@ -2196,7 +2196,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance has is invoking the background
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is invoking the background
         ///   publishing coordination task.
         /// </summary>
         ///
@@ -2216,7 +2216,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance publishing task
         ///   is waiting for all active publishing to complete.
         /// </summary>
         ///
@@ -2238,7 +2238,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an <see cref="EventHubBufferedProducerClient" /> instance publishing task
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance publishing task
         ///   is done waiting for all active publishing to complete.
         /// </summary>
         ///
@@ -2258,6 +2258,196 @@ namespace Azure.Messaging.EventHubs.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(110, identifier ?? string.Empty, eventHubName ?? string.Empty, totalActiveTasks, operationId ?? string.Empty, durationSeconds);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is starting to perform
+        ///   a Flush operation.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        ///
+        [Event(111, Level = EventLevel.Informational, Message = "Starting to flush events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Operation Id: '{2}'.")]
+        public virtual void BufferedProducerFlushStart(string identifier,
+                                                       string eventHubName,
+                                                       string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(111, identifier ?? string.Empty, eventHubName ?? string.Empty, operationId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in an
+        ///   active Flush Operation
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(112, Level = EventLevel.Error, Message = "An exception occurred while flushing events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Operation Id: '{2}'.  Error Message: '{3}'")]
+        public virtual void BufferedProducerFlushError(string identifier,
+                                                       string eventHubName,
+                                                       string operationId,
+                                                       string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(112, identifier ?? string.Empty, eventHubName ?? string.Empty, operationId ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has completed an active
+        ///   a Flush operation.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        ///
+        [Event(113, Level = EventLevel.Informational, Message = "Completed flushing events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Operation Id: '{2}'.")]
+        public virtual void BufferedProducerFlushComplete(string identifier,
+                                                          string eventHubName,
+                                                          string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(113, identifier ?? string.Empty, eventHubName ?? string.Empty, operationId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is starting to perform
+        ///   a Clear operation.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        ///
+        [Event(114, Level = EventLevel.Informational, Message = "Starting to clear events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Operation Id: '{2}'.")]
+        public virtual void BufferedProducerClearStart(string identifier,
+                                                       string eventHubName,
+                                                       string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(114, identifier ?? string.Empty, eventHubName ?? string.Empty, operationId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception in an
+        ///   active Clear operation.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(115, Level = EventLevel.Error, Message = "An exception occurred while clearing events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Operation Id: '{2}'.  Error Message: '{3}'")]
+        public virtual void BufferedProducerClearError(string identifier,
+                                                       string eventHubName,
+                                                       string operationId,
+                                                       string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(115, identifier ?? string.Empty, eventHubName ?? string.Empty, operationId ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has completed an active
+        ///   a Clear operation.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        ///
+        [Event(116, Level = EventLevel.Informational, Message = "Completed clearing events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Operation Id: '{2}'.")]
+        public virtual void BufferedProducerClearComplete(string identifier,
+                                                          string eventHubName,
+                                                          string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(116, identifier ?? string.Empty, eventHubName ?? string.Empty, operationId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance is starting to drain a partition of events.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="partitionId">The identifier of the partition being drained.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        ///
+        [Event(117, Level = EventLevel.Informational, Message = "Starting to draining events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Partition: '{2}', Operation Id: '{3}'.")]
+        public virtual void BufferedProducerDrainStart(string identifier,
+                                                       string eventHubName,
+                                                       string partitionId,
+                                                       string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(117, identifier ?? string.Empty, eventHubName ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has encountered an exception while draining
+        ///   a partition of events.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="partitionId">The identifier of the partition being drained.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(118, Level = EventLevel.Error, Message = "An exception occurred while draining events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Partition: '{2}', Operation Id: '{3}'.  Error Message: '{4}'")]
+        public virtual void BufferedProducerDrainError(string identifier,
+                                                       string eventHubName,
+                                                       string partitionId,
+                                                       string operationId,
+                                                       string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(118, identifier ?? string.Empty, eventHubName ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that a <see cref="EventHubBufferedProducerClient" /> instance has completed draining a partition of events.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the buffered producer.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="partitionId">The identifier of the partition being drained.</param>
+        /// <param name="operationId">An artificial identifier for the publishing operation.</param>
+        ///
+        [Event(119, Level = EventLevel.Informational, Message = "Completed draining events for the buffered producer instance with identifier '{0}', Event Hub: {1}, Partition: '{2}', Operation Id: '{3}'.")]
+        public virtual void BufferedProducerDrainComplete(string identifier,
+                                                          string eventHubName,
+                                                          string partitionId,
+                                                          string operationId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(119, identifier ?? string.Empty, eventHubName ?? string.Empty, partitionId ?? string.Empty, operationId ?? string.Empty);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -75,7 +75,7 @@ namespace Azure.Messaging.EventHubs.Producer
             };
 
         /// <summary>The set of currently active partition publishing tasks.  Partition identifiers are used as keys.</summary>
-        private readonly ConcurrentDictionary<string, PartitionPublishingState> _activePartitionPublishingStateMap = new();
+        private readonly ConcurrentDictionary<string, PartitionPublishingState> _activePartitionStateMap = new();
 
         /// <summary>The set of options to use with the <see cref="EventHubBufferedProducerClient" /> instance.</summary>
         private readonly EventHubBufferedProducerClientOptions _options;
@@ -217,7 +217,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   for other use.
         /// </remarks>
         ///
-        internal ConcurrentDictionary<string, PartitionPublishingState> ActivePartitionPublishingState => _activePartitionPublishingStateMap;
+        internal ConcurrentDictionary<string, PartitionPublishingState> ActivePartitionStateMap => _activePartitionStateMap;
 
         /// <summary>
         ///    Invoked after each batch of events has been successfully published to the Event Hub, this
@@ -567,7 +567,7 @@ namespace Azure.Messaging.EventHubs.Producer
             Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
 
-            if (_activePartitionPublishingStateMap.TryGetValue(partitionId, out var publisher))
+            if (_activePartitionStateMap.TryGetValue(partitionId, out var publisher))
             {
                 return publisher.BufferedEventCount;
             }
@@ -709,6 +709,7 @@ namespace Azure.Messaging.EventHubs.Producer
                         }
 
                         releaseGuard = true;
+                        Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
 
                         // StartPublishingAsync will verify that publishing is not already taking
                         // place and act appropriately if nothing needs to be restarted; there's no need
@@ -759,7 +760,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 // Enqueue the event into the channel for the assigned partition.  Note that this call will wait
                 // if there is no room in the channel and may take some time to complete.
 
-                var partitionPublisher = _activePartitionPublishingStateMap.GetOrAdd(partitionId, partitionId => new PartitionPublishingState(partitionId, _options));
+                var partitionPublisher = _activePartitionStateMap.GetOrAdd(partitionId, partitionId => new PartitionPublishingState(partitionId, _options));
                 var writer = partitionPublisher.PendingEventsWriter;
 
                 await writer.WriteAsync(eventData, cancellationToken).ConfigureAwait(false);
@@ -874,6 +875,7 @@ namespace Azure.Messaging.EventHubs.Producer
                         }
 
                         releaseGuard = true;
+                        Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
 
                         // StartPublishingAsync will verify that publishing is not already taking
                         // place and act appropriately if nothing needs to be restarted; there's no need
@@ -909,7 +911,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 var partitionPublisher = string.IsNullOrEmpty(partitionId)
                     ? null
-                    : _activePartitionPublishingStateMap.GetOrAdd(partitionId, partitionId => new PartitionPublishingState(partitionId, _options));
+                    : _activePartitionStateMap.GetOrAdd(partitionId, partitionId => new PartitionPublishingState(partitionId, _options));
 
                 // Enumerate the events and enqueue them.
 
@@ -944,7 +946,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     // Enqueue the event into the channel for the assigned partition.  Note that this call will wait
                     // if there is no room in the channel and may take some time to complete.
 
-                    var publisher = partitionPublisher ?? _activePartitionPublishingStateMap.GetOrAdd(eventPartitionId, partitionId => new PartitionPublishingState(eventPartitionId, _options));
+                    var publisher = partitionPublisher ?? _activePartitionStateMap.GetOrAdd(eventPartitionId, partitionId => new PartitionPublishingState(eventPartitionId, _options));
                     var writer = publisher.PendingEventsWriter;
 
                     await writer.WriteAsync(eventData, cancellationToken).ConfigureAwait(false);
@@ -982,10 +984,14 @@ namespace Azure.Messaging.EventHubs.Producer
         {
             Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
 
+            var releaseGuard = false;
+
             if (!_stateGuard.Wait(0, cancellationToken))
             {
                 await _stateGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
+
+            releaseGuard = true;
 
             try
             {
@@ -994,9 +1000,10 @@ namespace Azure.Messaging.EventHubs.Producer
             }
             finally
             {
-                // If we reached the try block without an exception, it is safe to assume the guard is held.
-
-                _stateGuard.Release();
+                if (releaseGuard)
+                {
+                    _stateGuard.Release();
+                }
             }
         }
 
@@ -1021,7 +1028,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 return;
             }
 
-            var guardHeld = false;
+            var releaseGuard = false;
             var capturedExceptions = default(List<Exception>);
 
             try
@@ -1033,7 +1040,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 // If we've reached this point without an exception, the guard is held.
 
-                guardHeld = true;
+                releaseGuard = true;
 
                 if (_isClosed)
                 {
@@ -1043,45 +1050,30 @@ namespace Azure.Messaging.EventHubs.Producer
                 _isClosed = true;
                 Logger.ClientCloseStart(nameof(EventHubBufferedProducerClient), EventHubName, Identifier);
 
-                if (IsPublishing)
-                {
-                    try
-                    {
-                        if (flush)
-                        {
-                            await FlushInternalAsync(CancellationToken.None).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                           await ClearInternalAsync(CancellationToken.None).ConfigureAwait(false);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        // If flushing, the exception should cause closing to fail to protect against data loss.  State should be
-                        // reset so that applications can attempt to close/flush again.  This should be rare and limited to unexpected
-                        // scenarios, as normal exceptions during send operations will be surfaced through the handler.
-
-                        if (flush)
-                        {
-                            _isClosed = false;
-                            throw;
-                        }
-                        else
-                        {
-                            // When clearing, the exception is non-blocking; log and continue.
-
-                            Logger.ClientCloseError(nameof(EventHubBufferedProducerClient), EventHubName, Identifier, ex.Message);
-                        }
-                    }
-                }
-
-                // Stop processing and close the producer.  Capture exceptions for later bubbling to allow
-                // cleanup and disposal to complete.
+                // Flushing or clearing the buffered events; these calls will both take responsibility
+                // for stopping any active publishing.
 
                 try
                 {
-                    await StopPublishingAsync(false, CancellationToken.None).ConfigureAwait(false);
+                    if (flush)
+                    {
+                        await FlushInternalAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                       ClearInternal(CancellationToken.None);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.ClientCloseError(nameof(EventHubBufferedProducerClient), EventHubName, Identifier, ex.Message);
+                    (capturedExceptions ??= new List<Exception>()).Add(ex);
+                }
+
+                // Close the producer.
+
+                try
+                {
                     await _producer.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -1092,14 +1084,14 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 // Clean up partition state.
 
-                foreach (var pair in _activePartitionPublishingStateMap)
+                foreach (var pair in _activePartitionStateMap)
                 {
                     // Dispose for the partition publishers will log exceptions and
                     // avoid surfacing them, as processing is stopping.
 
                     try
                     {
-                        _activePartitionPublishingStateMap.TryRemove(pair.Key, out _);
+                        _activePartitionStateMap.TryRemove(pair.Key, out _);
                         pair.Value.Dispose();
                     }
                     catch (Exception ex)
@@ -1109,7 +1101,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     }
                 }
 
-                _activePartitionPublishingStateMap.Clear();
+                _activePartitionStateMap.Clear();
 
                 // Unregister the event handlers.
 
@@ -1134,13 +1126,11 @@ namespace Azure.Messaging.EventHubs.Producer
             }
             finally
             {
-                if (guardHeld)
+                if (releaseGuard)
                 {
                     _stateGuard.Release();
                 }
 
-                //TODO: Evaluate whether to use this here, depending on whether Flush failures abort closing.
-                // _stateGuard.Dispose();
                 Logger.ClientCloseComplete(nameof(EventHubBufferedProducerClient), EventHubName, Identifier);
             }
 
@@ -1206,8 +1196,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public override string ToString() => base.ToString();
 
         /// <summary>
-        ///   Cancels any active publishing and abandons all events in the buffer that are waiting to be published.
-        ///   Upon completion of this method, the buffer will be empty.
+        ///   Abandons all events in the buffer that are waiting to be published.  Upon completion of this method, the buffer will be empty.
         /// </summary>
         ///
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
@@ -1216,18 +1205,44 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   This method will modify class-level state and should be synchronized.  It is assumed that callers hold responsibility for
         ///   ensuring synchronization concerns; this method should be invoked after any primitives have been acquired.
         ///
-        ///   Callers are also assumed to own responsibility for any validation that the client is in the intended state before calling.
+        ///   Callers are also assumed to own responsibility for stopping all publishing and performing any necessary
+        ///   validation of client state before calling.
         /// </remarks>
         ///
-        internal virtual Task ClearInternalAsync(CancellationToken cancellationToken = default)
+        internal virtual void ClearInternal(CancellationToken cancellationToken = default)
         {
-            // ======================================================================
-            //  NOTE:
-            //    This method is currently just a stub; full functionality will be
-            //    added in a later set of changes.
-            // ======================================================================
+            var operationId = GenerateOperationId();
 
-            return Task.CompletedTask;
+            try
+            {
+                Logger.BufferedProducerClearStart(Identifier, EventHubName, operationId);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var partitionStateItem in _activePartitionStateMap)
+                {
+                    if ((!cancellationToken.IsCancellationRequested)
+                        && (partitionStateItem.Value.BufferedEventCount > 0))
+                    {
+                        while (partitionStateItem.Value.TryReadEvent(out _))
+                        {
+                        }
+
+                        Interlocked.Add(ref _totalBufferedEventCount, (partitionStateItem.Value.BufferedEventCount * -1));
+                        partitionStateItem.Value.BufferedEventCount = 0;
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.BufferedProducerClearError(Identifier, EventHubName, operationId, ex.Message);
+                throw;
+            }
+            finally
+            {
+                Logger.BufferedProducerClearComplete(Identifier, EventHubName, operationId);
+            }
         }
 
         /// <summary>
@@ -1244,31 +1259,72 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   This method will modify class-level state and should be synchronized.  It is assumed that callers hold responsibility for
         ///   ensuring synchronization concerns; this method should be invoked after any primitives have been acquired.
         ///
-        ///   Callers are also assumed to own responsibility for any validation that the client is in the intended state before calling.
+        ///   Callers are also assumed to own responsibility for stopping all publishing and performing any necessary
+        ///   validation of client state before calling.
         /// </remarks>
         ///
         internal virtual async Task FlushInternalAsync(CancellationToken cancellationToken = default)
         {
-            // ======================================================================
-            //  NOTE:
-            //    This method is currently just a stub; full functionality will be
-            //    added in a later set of changes.
-            // ======================================================================
+            var operationId = GenerateOperationId();
+            var activeDrains = new List<Task>(_options.MaximumConcurrentSends);
+            var activeHandlers = new ConcurrentBag<Task>();
 
-            // If publishing is taking place, but the management task has completed,
-            // restart publishing to ensure that send operations are taking place.
-
-            if ((IsPublishing) && (_producerManagementTask?.IsCompleted ?? false))
+            try
             {
-                await StartPublishingAsync(cancellationToken).ConfigureAwait(false);
-            }
+                Logger.BufferedProducerFlushStart(Identifier, EventHubName, operationId);
+                cancellationToken.ThrowIfCancellationRequested();
 
-            //TODO: Implement Flush
+                foreach (var partitionStateItem in _activePartitionStateMap)
+                {
+                    // If needed, wait for drain tasks to complete so there is room.
+
+                    while (activeDrains.Count >= _options.MaximumConcurrentSends)
+                    {
+                        var awaiSingleWatch = ValueStopwatch.StartNew();
+                        Logger.BufferedProducerPublishingAwaitStart(Identifier, EventHubName, activeDrains.Count, operationId);
+
+                        // The drain task is responsible for managing its own exceptions and will not throw.
+
+                        var finished = await Task.WhenAny(activeDrains).ConfigureAwait(false);
+                        activeDrains.Remove(finished);
+
+                        Logger.BufferedProducerPublishingAwaitComplete(Identifier, EventHubName, activeDrains.Count, operationId, awaiSingleWatch.GetElapsedTime().TotalSeconds);
+                    }
+
+                    // Drain the next partition; because this is an exclusive operation and is ensuring only a single
+                    // invocation for each partition, there's no need to acquire the partition guard.
+
+                    if ((!cancellationToken.IsCancellationRequested)
+                        && (partitionStateItem.Value.BufferedEventCount > 0))
+                    {
+                        activeDrains.Add(DrainAndPublishPartitionEvents(partitionStateItem.Value, operationId, activeHandlers, cancellationToken));
+                    }
+
+                    // If cancellation has been requested then do so; outstanding drains and handlers
+                    // will manage their own cancellation.
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                // Wait for any remaining partitions to complete, and then wait for outstanding handlers.  Both are
+                // expected to manage their own exceptions and should not throw.
+
+                await Task.WhenAll(activeDrains).ConfigureAwait(false);
+                await Task.WhenAll(activeHandlers).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Logger.BufferedProducerFlushError(Identifier, EventHubName, operationId, ex.Message);
+                throw;
+            }
+            finally
+            {
+                Logger.BufferedProducerFlushComplete(Identifier, EventHubName, operationId);
+            }
         }
 
         /// <summary>
-        ///   Attempts to publish a batch to the requested partition, assuming events are available
-        ///   and the concurrency guard can be acquired within the available time limit.
+        ///   Attempts to publish a single batch of previously buffered events to the requested partition.
         /// </summary>
         ///
         /// <param name="partitionState">The state of publishing for the partition.</param>
@@ -1321,7 +1377,7 @@ namespace Azure.Messaging.EventHubs.Producer
                         {
                             // If this event is the first for the batch, then it is too large to ever successfully publish.  Because this event is poison
                             // it should not be stashed.  Since it was not added to the batch, the normal error handler path won't properly report it.
-                            // Instead perform the logging and handler invocation inline and then exit.
+                            // Instead, perform the logging and handler invocation inline and then exit.
 
                             if (batch.Count == 0)
                             {
@@ -1331,15 +1387,12 @@ namespace Azure.Messaging.EventHubs.Producer
                                 var message = string.Format(CultureInfo.InvariantCulture, Resources.EventTooLargeMask, EventHubName, batch.MaximumSizeInBytes);
                                 var exception = new EventHubsException(EventHubName, message, EventHubsException.FailureReason.MessageSizeExceeded);
 
-                                var eventList = new List<EventData>(1);
-                                eventList.Add(currentEvent);
-
                                 Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, message);
 
                                 // Handler invocation is performed in the background as a fire-and-forget operation.  Exceptions in the handler
                                 // are logged as part of the invocation.
 
-                                _ = InvokeOnSendFailedAsync(eventList, exception, partitionId);
+                                _ = InvokeOnSendFailedAsync(new List<EventData>(1) { currentEvent }, exception, partitionId);
 
                                 return;
                             }
@@ -1383,7 +1436,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     // are logged as part of the invocation.
 
                     await _producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
-                    _ = InvokeOnSendSucceededAsync(batch.AsEnumerable<EventData>().ToList(), partitionState.PartitionId);
+                    _ = InvokeOnSendSucceededAsync(batch.AsEnumerable<EventData>().ToList(), partitionId);
                 }
             }
             catch (Exception ex)
@@ -1416,6 +1469,154 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 var duration = publishWatch.IsActive ? publishWatch.GetElapsedTime().TotalSeconds : 0;
                 Logger.BufferedProducerEventBatchPublishComplete(Identifier, EventHubName, partitionId, operationId, batchEventCount, duration);
+            }
+        }
+
+        /// <summary>
+        ///   Attempts to fully drain the events buffered for a partition, publishing them in batches.
+        /// </summary>
+        ///
+        /// <param name="partitionState">The state of publishing for the partition.</param>
+        /// <param name="operationId">An identifier for the publishing operations that can be used to correlate related log entries.  If <c>null</c> or empty, a new identifier will be generated.</param>
+        /// <param name="activeHandlers">The set of active event handler invocations; the collection will be modified by this method.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel publishing.</param>
+        ///
+        /// <remarks>
+        ///   This method has responsibility for invoking the event handlers to communicate success or failure of the
+        ///   operation and will add the resulting <see cref="Task" /> to the <paramref name="activeHandlers" /> set.
+        /// </remarks>
+        ///
+        internal virtual async Task DrainAndPublishPartitionEvents(PartitionPublishingState partitionState,
+                                                                   string operationId,
+                                                                   ConcurrentBag<Task> activeHandlers,
+                                                                   CancellationToken cancellationToken)
+        {
+            ValueStopwatch publishWatch;
+            EventData readEvent;
+
+            var drainComplete = false;
+            var partitionId = partitionState.PartitionId;
+            var batch = default(EventDataBatch);
+
+            if (string.IsNullOrEmpty(operationId))
+            {
+                operationId = GenerateOperationId();
+            }
+
+            Logger.BufferedProducerDrainStart(Identifier, EventHubName, partitionId, operationId);
+
+            try
+            {
+                while (!drainComplete)
+                {
+                    batch ??= await _producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partitionId }, cancellationToken).ConfigureAwait(false);
+                    publishWatch = ValueStopwatch.StartNew();
+
+                    // Read events until one does not fit in the batch.
+
+                    while ((partitionState.TryReadEvent(out readEvent)) && (batch.TryAdd(readEvent)))
+                    {
+                        Logger.BufferedProducerEventBatchPublishEventAdded(Identifier, EventHubName, partitionId, operationId, batch.Count, publishWatch.GetElapsedTime().TotalSeconds);
+                    }
+
+                    // If there were no events read and there are none in the batch, then draining is complete.
+
+                    if ((readEvent == null) && (batch.Count == 0))
+                    {
+                        Logger.BufferedProducerEventBatchPublishNoEventRead(Identifier, EventHubName, partitionId, operationId, 0, publishWatch.GetElapsedTime().TotalSeconds);
+                        drainComplete = true;
+                    }
+                    else if (batch.Count == 0)
+                    {
+                        // If the read event is the first for the batch, then it is too large to ever successfully publish.  Because this event is poison
+                        // it should not be stashed.  Since it was not added to the batch, the normal error handler path won't properly report it.
+                        // Instead, perform the logging and handler invocation inline.
+
+                        var message = string.Format(CultureInfo.InvariantCulture, Resources.EventTooLargeMask, EventHubName, batch.MaximumSizeInBytes);
+                        var exception = new EventHubsException(EventHubName, message, EventHubsException.FailureReason.MessageSizeExceeded);
+
+                        Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, message);
+                        activeHandlers.Add(InvokeOnSendFailedAsync(new List<EventData>(1) { readEvent }, exception, partitionId));
+                    }
+                    else
+                    {
+                        // There are events in the batch to publish, but may or may not be an event read that could not fit in the batch.
+
+                        if (readEvent != null)
+                        {
+                            partitionState.StashEvent(readEvent);
+                        }
+
+                        Logger.BufferedProducerEventBatchPublishStart(Identifier, EventHubName, partitionState.PartitionId, operationId);
+
+                        try
+                        {
+                            await _producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
+                            activeHandlers.Add(InvokeOnSendSucceededAsync(batch.AsEnumerable<EventData>().ToList(), partitionState.PartitionId));
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, ex.Message);
+                            activeHandlers.Add(InvokeOnSendFailedAsync(batch.AsEnumerable<EventData>().ToList(), ex, partitionId));
+
+                            // If publishing was canceled, break out of the drain loop.
+
+                            if (ex is OperationCanceledException)
+                            {
+                                drainComplete = true;
+                                break;
+                            }
+                        }
+                        finally
+                        {
+                            // Succeed or fail, the batch events are no longer buffered; remove them from the partition state and the total.
+
+                            if (batch.Count > 0)
+                            {
+                                var delta = (batch.Count * -1);
+
+                                Interlocked.Add(ref partitionState.BufferedEventCount, delta);
+                                Interlocked.Add(ref _totalBufferedEventCount, delta);
+                            }
+
+                            Logger.BufferedProducerEventBatchPublishComplete(Identifier, EventHubName, partitionId, operationId, batch.Count, publishWatch.GetElapsedTime().TotalSeconds);
+                        }
+
+                        batch.Dispose();
+                        batch = null;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // This is expected when cancellation is detected when creating a new batch; the partition
+                // will be left in a consistent state.
+            }
+            catch (Exception ex)
+            {
+                // This path should not be possible under normal conditions; if triggered, then
+                // something is in a corrupt state and the drain cannot continue.  Consider all remaining
+                // events to be failures and cease publishing.
+
+                Logger.BufferedProducerDrainError(Identifier, EventHubName, partitionId, operationId, ex.Message);
+                var events = new List<EventData>();
+
+                while (partitionState.TryReadEvent(out readEvent))
+                {
+                   events.Add(readEvent);
+                }
+
+                activeHandlers.Add(InvokeOnSendFailedAsync(events, ex, partitionId));
+
+                var delta = (events.Count * -1);
+
+                Interlocked.Add(ref partitionState.BufferedEventCount, delta);
+                Interlocked.Add(ref _totalBufferedEventCount, delta);
+            }
+            finally
+            {
+                batch?.Dispose();
+                Logger.BufferedProducerDrainComplete(Identifier, EventHubName, partitionId, operationId);
             }
         }
 
@@ -1612,7 +1813,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         ///   This method does not consider any events that have been enqueued and are in a pending state.  It is assumed
         ///   that the caller has responsibility for disposing of any active partition state and invoking <see cref="FlushInternalAsync" />
-        ///   or <see cref="ClearInternalAsync" /> as needed.
+        ///   or <see cref="ClearInternal" /> as needed.
         /// </remarks>
         ///
         private async Task StopPublishingAsync(bool cancelActiveSendOperations,
@@ -1697,10 +1898,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <param name="partitionId">The identifier of the partition that the batch of events was published to.</param>
         ///
         private Task InvokeOnSendSucceededAsync(IReadOnlyList<EventData> events,
-                                                string partitionId) =>
-            Task
-                .Run(() => OnSendSucceededAsync(events, partitionId), CancellationToken.None)
-                .ContinueWith(task => task.Exception.Handle(ex => true), CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                                                string partitionId) => Task.Run(() => OnSendSucceededAsync(events, partitionId), CancellationToken.None);
 
         /// <summary>
         ///   Responsible for invoking <see cref="OnSendFailedAsync" /> as an background task.
@@ -1712,10 +1910,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         private Task InvokeOnSendFailedAsync(IReadOnlyList<EventData> events,
                                              Exception exception,
-                                             string partitionId) =>
-            Task
-                .Run(() => OnSendFailedAsync(events, exception, partitionId), CancellationToken.None)
-                .ContinueWith(task => task.Exception.Handle(ex => true), CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                                             string partitionId) => Task.Run(() => OnSendFailedAsync(events, exception, partitionId), CancellationToken.None);
 
         /// <summary>
         ///   Assigns a partition for a single event using a round-robin approach.
@@ -1926,7 +2121,7 @@ namespace Azure.Messaging.EventHubs.Producer
                         // and a batch isn't going to be published for this iteration.
 
                         if ((!cancellationToken.IsCancellationRequested)
-                            && (_activePartitionPublishingStateMap.TryGetValue(partition, out var partitionState))
+                            && (_activePartitionStateMap.TryGetValue(partition, out var partitionState))
                             && (partitionState.BufferedEventCount > 0)
                             && (partitionState.PartitionGuard.Wait(PartitionPublishingGuardAcquireLimitMilliseconds, cancellationToken)))
                         {
@@ -2097,7 +2292,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   activities for a partition.
         /// </summary>
         ///
-        internal class PartitionPublishingState : IDisposable
+        internal sealed class PartitionPublishingState : IDisposable
         {
             /// <summary>The writer to use for enqueuing events to be published.</summary>
             public ChannelWriter<EventData> PendingEventsWriter => _pendingEvents.Writer;


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the flush and clear behavior for the `EventHubBufferedProducerClient`.  Riding along as additional minor tweaks and smoothing for the existing client surface.

Pending work:
- Automatic partition assignment
- Partition Key hashing
- Live tests

# Related and References

- [ EventHubBufferedProducerClient: Flush and Clear (#23482)](https://github.com/Azure/azure-sdk-for-net/issues/23482)