### PR TITLE
Update codeowners for digital twins SDK

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -276,7 +276,7 @@
 
 # PRLabel: %Digital Twins
 # ServiceLabel: %Digital Twins %Service Attention
-/sdk/digitaltwins/                              @johngallardo
+/sdk/digitaltwins/                              @johngallardo @efriesner @abhinav-ghai
 
 # PRLabel: %IoT Models Repository
 # ServiceLabel: %IoT Models Repository %Service Attention

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -276,7 +276,7 @@
 
 # PRLabel: %Digital Twins
 # ServiceLabel: %Digital Twins %Service Attention
-/sdk/digitaltwins/                              @drwill-ms @azabbasi @johngallardo
+/sdk/digitaltwins/                              @johngallardo
 
 # PRLabel: %IoT Models Repository
 # ServiceLabel: %IoT Models Repository %Service Attention


### PR DESCRIPTION
Now that service team owns digital twins SDK, I'm taking my team's names off of it.