### PR TITLE
Mitigate cspell errors

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -148,7 +148,8 @@
         "Owasp",
         "Conditon",
         "Pfsmm",
-        "Sstp"
+        "Sstp",
+        "Gcmaes"
       ]
     },
     {
@@ -187,7 +188,8 @@
         "Rslp",
         "Soundex",
         "Sorani",
-        "Unprocessable"
+        "Unprocessable",
+        "Beider"
       ]
     },
     {


### PR DESCRIPTION
These words were previously treated as valid but are now invalid. 

Investigation and fix tracked over here: https://github.com/Azure/azure-sdk-tools/issues/2200