### PR TITLE
[Event Hubs] Buffered Producer Partition Assignment

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/PartitionResolver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/PartitionResolver.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+
+namespace Azure.Messaging.EventHubs.Core
+{
+    /// <summary>
+    ///   Allows events to be resolved to partitions using common patterns such as
+    ///   round-robin assignment and hashing of partitions keys.
+    /// </summary>
+    ///
+    internal class PartitionResolver
+    {
+        /// <summary>The index to use for automatic partition assignment.</summary>
+        private int _partitionAssignmentIndex = -1;
+
+        /// <summary>
+        ///   Assigns a partition using a round-robin approach.
+        /// </summary>
+        ///
+        /// <param name="partitionCount">The number of partitions available.</param>
+        ///
+        /// <returns>The zero-based index of the selected partition from the available set.</returns>
+        ///
+        public virtual int AssignRoundRobin(int partitionCount)
+        {
+            // At some point, overflow is possible; ensure that the increment is
+            // unchecked to allow rollover without an exception.
+
+            unchecked
+            {
+                var index = Interlocked.Increment(ref _partitionAssignmentIndex);
+
+                // If the increment rolls over to a negative value, attempt to reset to 0.
+                //
+                // If the exchange is successful, the return from the call will match the
+                // original overflow value; in this case, the local index can safely be set to 0.
+                //
+                // If the call returns another value, a different caller has reset the assignment
+                // index, and another increment is needed to avoid duplication for the local index.
+                //
+                // It is possible (though incredibly unlikely) that the assignment index will overflow
+                // negative again after the exchange/increment.  To guard against that scenario, the
+                // reset is performed in a loop.
+                //
+                // Rolling over can create a slightly unfair distribution due to the sequence changing,
+                // but avoids corner-case errors with negative values not aligning to a valid index range.
+
+                while (index < 0)
+                {
+                    var original = index;
+
+                    index = Interlocked.CompareExchange(ref _partitionAssignmentIndex, 0, index);
+                    index = (index == original) ? 0 : Interlocked.Increment(ref _partitionAssignmentIndex);
+                }
+
+                return (index % partitionCount);
+            }
+        }
+
+        /// <summary>
+        ///   Assigns a partition using a hash-based approach based on the provided
+        ///   <paramref name="partitionKey" />.
+        /// </summary>
+        ///
+        /// <param name="partitionKey">The partition key to use as the basis for partition assignment.</param>
+        /// <param name="partitionCount">The number of partitions available.</param>
+        ///
+        /// <returns>The zero-based index of the selected partition from the available set.</returns>
+        ///
+        public virtual int AssignPartitionKey(string partitionKey,
+                                              int partitionCount)
+        {
+            var hashValue = GenerateHashCode(partitionKey);
+            return Math.Abs(hashValue % partitionCount);
+        }
+
+        /// <summary>
+        ///   Generates a hash code for a partition key using Jenkins' lookup3 algorithm.
+        /// </summary>
+        ///
+        /// <param name="partitionKey">The partition key to generate a hash code for.</param>
+        ///
+        /// <returns>The generated hash code.</returns>
+        ///
+        /// <remarks>
+        ///   This implementation is a direct port of the Event Hubs service code; it is intended to match
+        ///   the gateway hashing algorithm as closely as possible and should not be adjusted without careful
+        ///   consideration.
+        /// </remarks>
+        ///
+        private static short GenerateHashCode(string partitionKey)
+        {
+            if (partitionKey == null)
+            {
+                return 0;
+            }
+
+            ComputeHash(Encoding.UTF8.GetBytes(partitionKey), seed1: 0, seed2: 0, out uint hash1, out uint hash2);
+            return (short)(hash1 ^ hash2);
+        }
+
+        /// <summary>
+        ///   Computes a hash value using Jenkins' lookup3 algorithm.
+        /// </summary>
+        ///
+        /// <param name="data">The data to base the hash on.</param>
+        /// <param name="seed1">A seed value for the first hash.</param>
+        /// <param name="seed2">A seed value for the second hash.</param>
+        /// <param name="hash1">The first computed hash for the <paramref name="data" />.</param>
+        /// <param name="hash2">The second computed hash for the <paramref name="data" />.</param>
+        ///
+        /// <remarks>
+        ///   This implementation is a direct port of the Event Hubs service code; it is intended to match
+        ///   the gateway hashing algorithm as closely as possible and should not be adjusted without careful
+        ///   consideration.
+        /// </remarks>
+        ///
+        private static void ComputeHash(byte[] data,
+                                        uint seed1,
+                                        uint seed2,
+                                        out uint hash1,
+                                        out uint hash2)
+        {
+            uint a, b, c;
+
+            a = b = c = (uint)(0xdeadbeef + data.Length + seed1);
+            c += seed2;
+
+            int index = 0, size = data.Length;
+            while (size > 12)
+            {
+                a += BitConverter.ToUInt32(data, index);
+                b += BitConverter.ToUInt32(data, index + 4);
+                c += BitConverter.ToUInt32(data, index + 8);
+
+                a -= c;
+                a ^= (c << 4) | (c >> 28);
+                c += b;
+
+                b -= a;
+                b ^= (a << 6) | (a >> 26);
+                a += c;
+
+                c -= b;
+                c ^= (b << 8) | (b >> 24);
+                b += a;
+
+                a -= c;
+                a ^= (c << 16) | (c >> 16);
+                c += b;
+
+                b -= a;
+                b ^= (a << 19) | (a >> 13);
+                a += c;
+
+                c -= b;
+                c ^= (b << 4) | (b >> 28);
+                b += a;
+
+                index += 12;
+                size -= 12;
+            }
+
+            switch (size)
+            {
+                case 12:
+                    a += BitConverter.ToUInt32(data, index);
+                    b += BitConverter.ToUInt32(data, index + 4);
+                    c += BitConverter.ToUInt32(data, index + 8);
+                    break;
+                case 11:
+                    c += ((uint)data[index + 10]) << 16;
+                    goto case 10;
+                case 10:
+                    c += ((uint)data[index + 9]) << 8;
+                    goto case 9;
+                case 9:
+                    c += (uint)data[index + 8];
+                    goto case 8;
+                case 8:
+                    b += BitConverter.ToUInt32(data, index + 4);
+                    a += BitConverter.ToUInt32(data, index);
+                    break;
+                case 7:
+                    b += ((uint)data[index + 6]) << 16;
+                    goto case 6;
+                case 6:
+                    b += ((uint)data[index + 5]) << 8;
+                    goto case 5;
+                case 5:
+                    b += (uint)data[index + 4];
+                    goto case 4;
+                case 4:
+                    a += BitConverter.ToUInt32(data, index);
+                    break;
+                case 3:
+                    a += ((uint)data[index + 2]) << 16;
+                    goto case 2;
+                case 2:
+                    a += ((uint)data[index + 1]) << 8;
+                    goto case 1;
+                case 1:
+                    a += (uint)data[index];
+                    break;
+                case 0:
+                    hash1 = c;
+                    hash2 = b;
+                    return;
+            }
+
+            c ^= b;
+            c -= (b << 14) | (b >> 18);
+
+            a ^= c;
+            a -= (c << 11) | (c >> 21);
+
+            b ^= a;
+            b -= (a << 25) | (a >> 7);
+
+            c ^= b;
+            c -= (b << 16) | (b >> 16);
+
+            a ^= c;
+            a -= (c << 4) | (c >> 28);
+
+            b ^= a;
+            b -= (a << 14) | (a >> 18);
+
+            c ^= b;
+            c -= (b << 24) | (b >> 8);
+
+            hash1 = c;
+            hash2 = b;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/PartitionResolver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/PartitionResolver.cs
@@ -22,11 +22,11 @@ namespace Azure.Messaging.EventHubs.Core
         ///   Assigns a partition using a round-robin approach.
         /// </summary>
         ///
-        /// <param name="partitionCount">The number of partitions available.</param>
+        /// <param name="partitions">The set of available partitions.</param>
         ///
         /// <returns>The zero-based index of the selected partition from the available set.</returns>
         ///
-        public virtual int AssignRoundRobin(int partitionCount)
+        public virtual string AssignRoundRobin(string[] partitions)
         {
             // At some point, overflow is possible; ensure that the increment is
             // unchecked to allow rollover without an exception.
@@ -58,7 +58,7 @@ namespace Azure.Messaging.EventHubs.Core
                     index = (index == original) ? 0 : Interlocked.Increment(ref _partitionAssignmentIndex);
                 }
 
-                return (index % partitionCount);
+                return partitions[(index % partitions.Length)];
             }
         }
 
@@ -68,15 +68,15 @@ namespace Azure.Messaging.EventHubs.Core
         /// </summary>
         ///
         /// <param name="partitionKey">The partition key to use as the basis for partition assignment.</param>
-        /// <param name="partitionCount">The number of partitions available.</param>
+        /// <param name="partitions">The set of available partitions.</param>
         ///
         /// <returns>The zero-based index of the selected partition from the available set.</returns>
         ///
-        public virtual int AssignPartitionKey(string partitionKey,
-                                              int partitionCount)
+        public virtual string AssignForPartitionKey(string partitionKey,
+                                                 string[] partitions)
         {
             var hashValue = GenerateHashCode(partitionKey);
-            return Math.Abs(hashValue % partitionCount);
+            return partitions[Math.Abs(hashValue % partitions.Length)];
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionResolverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionResolverTests.cs
@@ -55,7 +55,7 @@ namespace Azure.Messaging.EventHubs.Tests
             for (var index = 0; index < 100; index++)
             {
                 var expected = partitions[index % partitions.Length];
-                var assigned = partitions[resolver.AssignRoundRobin(partitions.Length)];
+                var assigned = resolver.AssignRoundRobin(partitions);
 
                 Assert.That(assigned, Is.EqualTo(expected), $"The assignment was unexpected for index: [{ index }].");
             }
@@ -83,7 +83,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 for (var index = 0; index < iterationCount; index++)
                 {
-                    assigned.Add(partitions[resolver.AssignRoundRobin(partitions.Length)]);
+                    assigned.Add(resolver.AssignRoundRobin(partitions));
                 }
 
                 return Task.CompletedTask;
@@ -145,7 +145,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             for (var index = 0; index < iterationCount; index++)
             {
-                assigned.Add(partitions[resolver.AssignRoundRobin(partitions.Length)]);
+                assigned.Add(resolver.AssignRoundRobin(partitions));
             }
 
             // When grouped, the count of each partition should equal the iteration count for each
@@ -202,7 +202,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 for (var index = 0; index < iterationCount; index++)
                 {
-                    assigned.Add(partitions[resolver.AssignRoundRobin(partitions.Length)]);
+                    assigned.Add(resolver.AssignRoundRobin(partitions));
                 }
 
                 return Task.CompletedTask;
@@ -257,11 +257,11 @@ namespace Azure.Messaging.EventHubs.Tests
             var iterationCount = 25;
             var key = "this-is-a-key-1";
             var resolver = new PartitionResolver();
-            var expected = partitions[resolver.AssignPartitionKey(key, partitions.Length)];
+            var expected = resolver.AssignForPartitionKey(key, partitions);
 
             for (var index = 0; index < iterationCount; ++index)
             {
-                Assert.That(partitions[resolver.AssignPartitionKey(key, partitions.Length)], Is.EqualTo(expected), $"The assignment for iteration: [{ index }] was unstable.");
+                Assert.That(resolver.AssignForPartitionKey(key, partitions), Is.EqualTo(expected), $"The assignment for iteration: [{ index }] was unstable.");
             }
         }
 
@@ -298,7 +298,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
 
                 var key = keyBuilder.ToString();
-                var partition = partitions[resolver.AssignPartitionKey(key, partitions.Length)];
+                var partition = resolver.AssignForPartitionKey(key, partitions);
 
                 assignedHash.Add(partition);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionResolverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionResolverTests.cs
@@ -1,0 +1,333 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="PartitionResolver" /> class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class PartitionResolverTests
+    {
+        /// <summary>
+        ///   Provides the test cases for different sets of partitions.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> PartitionSetTestCases()
+        {
+            // Build some basic partition sets with 8 or less partitions.
+
+            for (var index = 1; index < 8; ++index)
+            {
+                yield return new object[] { Enumerable.Range(0, index).Select(item => item.ToString()).ToArray() };
+            }
+
+            // Build sets for 16, 32, and 2000 partitions for more extreme cases.
+
+            foreach (var count in new[] { 16, 32, 2000 })
+            {
+                yield return new object[] { Enumerable.Range(0, count).Select(item => item.ToString()).ToArray() };
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionResolver.AssignRoundRobin" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(PartitionSetTestCases))]
+        public void RoundRobinDistributesFairly(string[] partitions)
+        {
+            var resolver = new PartitionResolver();
+
+            for (var index = 0; index < 100; index++)
+            {
+                var expected = partitions[index % partitions.Length];
+                var assigned = partitions[resolver.AssignRoundRobin(partitions.Length)];
+
+                Assert.That(assigned, Is.EqualTo(expected), $"The assignment was unexpected for index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionResolver.AssignRoundRobin" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(PartitionSetTestCases))]
+        public async Task RoundRobinDistributesFairlyWhenCalledConcurrently(string[] partitions)
+        {
+            var concurrentCount = 4;
+            var assignmentsPerPartition = 20;
+            var iterationCount = partitions.Length * assignmentsPerPartition;
+            var resolver = new PartitionResolver();
+            var assigned = new List<string>();
+            var activeTasks = new List<Task>();
+
+            // Create a function that assigns partitions in a loop and track them.
+
+            Task roundRobin()
+            {
+                for (var index = 0; index < iterationCount; index++)
+                {
+                    assigned.Add(partitions[resolver.AssignRoundRobin(partitions.Length)]);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            // Run assignment concurrently.
+
+            for (var concurrentIndex = 0; concurrentIndex < concurrentCount; ++concurrentIndex)
+            {
+               activeTasks.Add(roundRobin());
+            }
+
+            await Task.WhenAll(activeTasks);
+
+            // When grouped, the count of each partition should equal the iteration count for each
+            // concurrent invocation.
+
+            var partitionAssignments = assigned
+                .GroupBy(item => item)
+                .Select( group => new { Key = group.Key, Count = group.Count() });
+
+            var assignmentHash = new HashSet<string>();
+            var expectedAssignmentCount = (concurrentCount * assignmentsPerPartition);
+
+            // Verify that each assignment is for a valid partition and has the expected distribution.
+
+            foreach (var partitionAssignment in partitionAssignments)
+            {
+                Assert.That(partitionAssignment.Count, Is.EqualTo(expectedAssignmentCount), $"The count for key: [{ partitionAssignment.Key}] should match the total number of iterations.");
+                assignmentHash.Add(partitionAssignment.Key);
+            }
+
+            // Verify that all partitions were assigned.
+
+            foreach (var partition in partitions)
+            {
+                Assert.That(assignmentHash.Contains(partition), Is.True, $"Partition: [{ partition }] should have had assignments.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionResolver.AssignRoundRobin" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(PartitionSetTestCases))]
+        public void RoundRobinRollsOverFairly(string[] partitions)
+        {
+            var assignmentsPerPartition = 20;
+            var iterationCount = partitions.Length * assignmentsPerPartition;
+            var resolver = new PartitionResolver();
+            var assigned = new List<string>();
+
+            // Set the starting index for the resolver to something just below the
+            // rollover point.
+
+            SetPartitionIndex(resolver, (int.MaxValue - 4));
+
+            for (var index = 0; index < iterationCount; index++)
+            {
+                assigned.Add(partitions[resolver.AssignRoundRobin(partitions.Length)]);
+            }
+
+            // When grouped, the count of each partition should equal the iteration count for each
+            // concurrent invocation.
+
+            var partitionAssignments = assigned
+                .GroupBy(item => item)
+                .Select( group => new { Key = group.Key, Count = group.Count() });
+
+            var assignmentHash = new HashSet<string>();
+
+            // Verify that each assignment is for a valid partition and has the expected distribution.  Because
+            // rollover can cause a small bit of assignment overlap due to the sequence change, allow for a small degree
+            // of variance from the perfect fair distribution.
+
+            foreach (var partitionAssignment in partitionAssignments)
+            {
+                Assert.That(partitionAssignment.Count, Is.EqualTo(assignmentsPerPartition).Within(2), $"The count for key: [{ partitionAssignment.Key}] should match the total number of iterations.");
+                assignmentHash.Add(partitionAssignment.Key);
+            }
+
+            // Verify that all partitions were assigned.
+
+            foreach (var partition in partitions)
+            {
+                Assert.That(assignmentHash.Contains(partition), Is.True, $"Partition: [{ partition }] should have had assignments.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionResolver.AssignRoundRobin" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(PartitionSetTestCases))]
+        public async Task RoundRobinRollsOverFairlyWhenCalledConcurrently(string[] partitions)
+        {
+            var concurrentCount = 4;
+            var assignmentsPerPartition = 20;
+            var iterationCount = partitions.Length * assignmentsPerPartition;
+            var resolver = new PartitionResolver();
+            var assigned = new List<string>();
+            var activeTasks = new List<Task>();
+
+            // Set the starting index for the resolver to something just below the
+            // rollover point.
+
+            SetPartitionIndex(resolver, (int.MaxValue - 4));
+
+            // Create a function that assigns partitions in a loop and track them.
+
+            Task roundRobin()
+            {
+                for (var index = 0; index < iterationCount; index++)
+                {
+                    assigned.Add(partitions[resolver.AssignRoundRobin(partitions.Length)]);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            // Run assignment concurrently.
+
+            for (var concurrentIndex = 0; concurrentIndex < concurrentCount; ++concurrentIndex)
+            {
+               activeTasks.Add(roundRobin());
+            }
+
+            await Task.WhenAll(activeTasks);
+
+            // When grouped, the count of each partition should equal the iteration count for each
+            // concurrent invocation.
+
+            var partitionAssignments = assigned
+                .GroupBy(item => item)
+                .Select( group => new { Key = group.Key, Count = group.Count() });
+
+            var assignmentHash = new HashSet<string>();
+            var expectedAssignmentCount = (concurrentCount * assignmentsPerPartition);
+
+            // Verify that each assignment is for a valid partition and has the expected distribution.  Because
+            // rollover can cause a small bit of assignment overlap due to the sequence change, allow for a small degree
+            // of variance from the perfect fair distribution.
+
+            foreach (var partitionAssignment in partitionAssignments)
+            {
+                Assert.That(partitionAssignment.Count, Is.EqualTo(expectedAssignmentCount).Within(2), $"The count for key: [{ partitionAssignment.Key}] should match the total number of iterations.");
+                assignmentHash.Add(partitionAssignment.Key);
+            }
+
+            // Verify that all partitions were assigned.
+
+            foreach (var partition in partitions)
+            {
+                Assert.That(assignmentHash.Contains(partition), Is.True, $"Partition: [{ partition }] should have had assignments.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionResolver.AssignRoundRobin" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(PartitionSetTestCases))]
+        public void PartitionKeyAssignmentIsStable(string[] partitions)
+        {
+            var iterationCount = 25;
+            var key = "this-is-a-key-1";
+            var resolver = new PartitionResolver();
+            var expected = partitions[resolver.AssignPartitionKey(key, partitions.Length)];
+
+            for (var index = 0; index < iterationCount; ++index)
+            {
+                Assert.That(partitions[resolver.AssignPartitionKey(key, partitions.Length)], Is.EqualTo(expected), $"The assignment for iteration: [{ index }] was unstable.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionResolver.AssignRoundRobin" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(PartitionSetTestCases))]
+        public void PartitionKeyAssignmentDistributesKeysToDifferentPartitions(string[] partitions)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var keyLength = 20;
+            var requiredAssignments = (int)Math.Floor(partitions.Length * 0.67);
+            var assignedHash = new HashSet<string>();
+            var resolver = new PartitionResolver();
+
+            // Create the random number generator using a constant seed; this is
+            // intended to allow for randomization but will also keep a consistent
+            // pattern each time the tests are run.
+
+            var rng = new Random(412);
+
+            for (var index = 0; index < int.MaxValue; ++index)
+            {
+                var keyBuilder = new StringBuilder(keyLength);
+
+                for (var charIndex = 0; charIndex < keyLength; ++charIndex)
+                {
+                    keyBuilder.Append((char)rng.Next(1, 256));
+                }
+
+                var key = keyBuilder.ToString();
+                var partition = partitions[resolver.AssignPartitionKey(key, partitions.Length)];
+
+                assignedHash.Add(partition);
+
+                // If keys were distributed to more than one partition and the minimum number of
+                // iterations was satisfied, break the loop.
+
+                if (assignedHash.Count > requiredAssignments)
+                {
+                    break;
+                }
+
+                cancellationSource.Token.ThrowIfCancellationRequested();
+            }
+
+            Assert.That(assignedHash.Count, Is.GreaterThanOrEqualTo(requiredAssignments), "Partition keys should have had some level of distribution among partitions.");
+        }
+
+        /// <summary>
+        ///   Sets the partition index for a <see cref="PartitionResolver" />
+        ///   by directly accessing its private field.
+        /// </summary>
+        ///
+        /// <param name="target">The instance to set the index of.</param>
+        /// <param name="partitionIndexValue">The value to set the index to.</param>
+        ///
+        private static void SetPartitionIndex(PartitionResolver target,
+                                              int partitionIndexValue) =>
+            typeof(PartitionResolver)
+                .GetField("_partitionAssignmentIndex", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(target, partitionIndexValue);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
@@ -1703,14 +1703,19 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partitionId = "7";
+            var partitions = new[] { partitionId };
             var events = new[] { new EventData("One"), new EventData("Two") };
             var mockPartitionResolver = new Mock<PartitionResolver>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
 
+            mockPartitionResolver
+                .Setup(resolver => resolver.AssignRoundRobin(It.IsAny<string[]>()))
+                .Returns(partitionId);
+
             mockProducer
                 .Setup(producer => producer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new[] { partitionId });
+                .ReturnsAsync(partitions);
 
             mockBufferedProducer
                 .Setup(producer => producer.PublishBatchToPartition(
@@ -1744,12 +1749,12 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignRoundRobin(1), Times.Exactly(events.Length));
+                .Verify(resolver => resolver.AssignRoundRobin(partitions), Times.Exactly(events.Length));
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignPartitionKey(
+                .Verify(resolver => resolver.AssignForPartitionKey(
                     It.IsAny<string>(),
-                    It.IsAny<int>()),
+                    It.IsAny<string[]>()),
                 Times.Never);
         }
 
@@ -1764,15 +1769,20 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partitionId = "3";
+            var partitions = new[] { partitionId };
             var partitionKey = "test-key";
             var events = new[] { new EventData("One"), new EventData("Two") };
             var mockPartitionResolver = new Mock<PartitionResolver>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
 
+            mockPartitionResolver
+                .Setup(resolver => resolver.AssignForPartitionKey(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(partitionId);
+
             mockProducer
                 .Setup(producer => producer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new[] { partitionId });
+                .ReturnsAsync(partitions);
 
             mockBufferedProducer
                 .Setup(producer => producer.PublishBatchToPartition(
@@ -1808,10 +1818,10 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignRoundRobin(It.IsAny<int>()), Times.Never);
+                .Verify(resolver => resolver.AssignRoundRobin(It.IsAny<string[]>()), Times.Never);
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignPartitionKey(partitionKey, 1), Times.Once);
+                .Verify(resolver => resolver.AssignForPartitionKey(partitionKey, partitions), Times.Once);
         }
 
         /// <summary>
@@ -1868,12 +1878,12 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignRoundRobin(It.IsAny<int>()), Times.Never);
+                .Verify(resolver => resolver.AssignRoundRobin(It.IsAny<string[]>()), Times.Never);
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignPartitionKey(
+                .Verify(resolver => resolver.AssignForPartitionKey(
                     It.IsAny<string>(),
-                    It.IsAny<int>()),
+                    It.IsAny<string[]>()),
                 Times.Never);
         }
 
@@ -2442,14 +2452,19 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partitionId = "7";
+            var partitions = new[] { partitionId };
             var expectedEvent = new EventData("One");
             var mockPartitionResolver = new Mock<PartitionResolver>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
 
+            mockPartitionResolver
+                .Setup(resolver => resolver.AssignRoundRobin(It.IsAny<string[]>()))
+                .Returns(partitionId);
+
             mockProducer
                 .Setup(producer => producer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new[] { partitionId });
+                .ReturnsAsync(partitions);
 
             mockBufferedProducer.Object.PartitionResolver = mockPartitionResolver.Object;
             mockBufferedProducer.Object.SendEventBatchFailedAsync += args => Task.CompletedTask;
@@ -2476,12 +2491,12 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignRoundRobin(1), Times.Once);
+                .Verify(resolver => resolver.AssignRoundRobin(partitions), Times.Once);
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignPartitionKey(
+                .Verify(resolver => resolver.AssignForPartitionKey(
                     It.IsAny<string>(),
-                    It.IsAny<int>()),
+                    It.IsAny<string[]>()),
                 Times.Never);
         }
 
@@ -2496,15 +2511,20 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partitionId = "3";
+            var partitions = new[] { partitionId };
             var partitionKey = "test-key";
             var expectedEvent = new EventData("One");
             var mockPartitionResolver = new Mock<PartitionResolver>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
 
+            mockPartitionResolver
+                .Setup(resolver => resolver.AssignForPartitionKey(It.IsAny<string>(), It.IsAny<string[]>()))
+                .Returns(partitionId);
+
             mockProducer
                 .Setup(producer => producer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new[] { partitionId });
+                .ReturnsAsync(partitions);
 
             mockBufferedProducer
                 .Setup(producer => producer.PublishBatchToPartition(
@@ -2540,10 +2560,10 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignRoundRobin(It.IsAny<int>()), Times.Never);
+                .Verify(resolver => resolver.AssignRoundRobin(It.IsAny<string[]>()), Times.Never);
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignPartitionKey(partitionKey, 1), Times.Once);
+                .Verify(resolver => resolver.AssignForPartitionKey(partitionKey, partitions), Times.Once);
         }
 
          /// <summary>
@@ -2600,12 +2620,12 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignRoundRobin(It.IsAny<int>()), Times.Never);
+                .Verify(resolver => resolver.AssignRoundRobin(It.IsAny<string[]>()), Times.Never);
 
             mockPartitionResolver
-                .Verify(resolver => resolver.AssignPartitionKey(
+                .Verify(resolver => resolver.AssignForPartitionKey(
                     It.IsAny<string>(),
-                    It.IsAny<int>()),
+                    It.IsAny<string[]>()),
                 Times.Never);
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the partition assignment operations for the `EventHubBufferedProducerClient`.  Partition key hashing behavior was ported directly from the code used by the Event Hubs service and left as close to its original implementation as possible.

Pending work:
- Live tests
- Samples

# Related and References

- [ EventHubBufferedProducerClient: Partition Assignment (#23481)](https://github.com/Azure/azure-sdk-for-net/issues/23481)