### PR TITLE
[CLU] ConversationsProject Bag 

### DIFF
--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -76,7 +76,7 @@ The following examples show common scenarios using the `client` [created above](
 
 ### Analyze a conversation
 
-To analyze a conversation, we can then call the `client.AnalyzeConversation()` method which takes a conversations project and an utterance as parameters.
+To analyze a conversation, we can then call the `client.AnalyzeConversation()` method which takes a Conversations project and an utterance as parameters.
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversation
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -76,7 +76,7 @@ The following examples show common scenarios using the `client` [created above](
 
 ### Analyze a conversation
 
-To analyze a conversation, we can then call the `client.AnalyzeConversation()` method which takes the project name, deployment name, and query as parameters.
+To analyze a conversation, we can then call the `client.AnalyzeConversation()` method which takes a conversations project and an utterance as parameters.
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversation
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
@@ -124,7 +124,7 @@ Other optional properties can be set such as verbosity and whether service loggi
 
 When you interact with the Cognitive Language Services Conversations client library using the .NET SDK, errors returned by the service correspond to the same HTTP status codes returned for [REST API][conversationanalysis_rest_docs] requests.
 
-For example, if you submit a query to a non-existant project, a `400` error is returned indicating "Bad Request".
+For example, if you submit a utterance to a non-existant project, a `400` error is returned indicating "Bad Request".
 
 ```C# Snippet:ConversationAnalysisClient_BadRequest
 try

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -92,10 +92,10 @@ The specified parameters can also be used to initialize a `ConversationAnalysisO
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptions
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+AnalyzeConversationOptions options = new AnalyzeConversationOptions()
+{
     IsLoggingEnabled = true,
     Verbose = true,
-    Language = "en"
 };
 
 Response<AnalyzeConversationResult> response = client.AnalyzeConversation(

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -92,10 +92,16 @@ The specified parameters can also be used to initialize a `ConversationAnalysisO
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptions
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "We'll have 2 plates of seared salmon nigiri.");
+AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+    IsLoggingEnabled = true,
+    Verbose = true,
+    Language = "en"
+};
 
-Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
+Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
+    "We'll have 2 plates of seared salmon nigiri.",
+    conversationsProject,
+    options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -106,12 +112,14 @@ The language property in the `ConversationAnalysisOptions` can be used to specif
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithLanguage
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Tendremos 2 platos de nigiri de salmón braseado.")
+AnalyzeConversationOptions options = new AnalyzeConversationOptions()
 {
     Language = "es"
 };
-Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
+Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
+    "Tendremos 2 platos de nigiri de salmón braseado.",
+    conversationsProject,
+    options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -79,10 +79,11 @@ The following examples show common scenarios using the `client` [created above](
 To analyze a conversation, we can then call the `client.AnalyzeConversation()` method which takes the project name, deployment name, and query as parameters.
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversation
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
+
 Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-    "Menu",
-    "production",
-    "We'll have 2 plates of seared salmon nigiri.");
+    "We'll have 2 plates of seared salmon nigiri.",
+    conversationsProject);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -90,11 +91,11 @@ Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 The specified parameters can also be used to initialize a `ConversationAnalysisOptions` instance. You can then call `AnalyzeConversation()` using the options object as a parameter as shown below.
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptions
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
 AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Menu",
-    "production",
     "We'll have 2 plates of seared salmon nigiri.");
-Response<AnalyzeConversationResult> response = client.AnalyzeConversation(options);
+
+Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -104,14 +105,13 @@ Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 The language property in the `ConversationAnalysisOptions` can be used to specify the language of the conversation.
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithLanguage
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
 AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Menu",
-    "production", 
     "Tendremos 2 platos de nigiri de salmón braseado.")
 {
     Language = "es"
 };
-Response<AnalyzeConversationResult> response = client.AnalyzeConversation(options);
+Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -129,10 +129,10 @@ For example, if you submit a query to a non-existant project, a `400` error is r
 ```C# Snippet:ConversationAnalysisClient_BadRequest
 try
 {
+    ConversationsProject conversationsProject = new ConversationsProject("invalid-project", "production");
     Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-        "invalid-project",
-        "production",
-        "We'll have 2 plates of seared salmon nigiri.");
+        "We'll have 2 plates of seared salmon nigiri.",
+        conversationsProject);
 }
 catch (RequestFailedException ex)
 {

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/api/Azure.AI.Language.Conversations.netstandard2.0.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/api/Azure.AI.Language.Conversations.netstandard2.0.cs
@@ -7,13 +7,11 @@ namespace Azure.AI.Language.Conversations
     }
     public partial class AnalyzeConversationOptions
     {
-        public AnalyzeConversationOptions(string projectName, string deploymentName, string query) { }
-        public string DeploymentName { get { throw null; } }
+        public AnalyzeConversationOptions(string query) { }
         public string DirectTarget { get { throw null; } set { } }
         public bool? IsLoggingEnabled { get { throw null; } set { } }
         public string Language { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, Azure.AI.Language.Conversations.AnalysisParameters> Parameters { get { throw null; } }
-        public string ProjectName { get { throw null; } }
         public string Query { get { throw null; } }
         public bool? Verbose { get { throw null; } set { } }
     }
@@ -44,10 +42,10 @@ namespace Azure.AI.Language.Conversations
         public ConversationAnalysisClient(System.Uri endpoint, Azure.AzureKeyCredential credential) { }
         public ConversationAnalysisClient(System.Uri endpoint, Azure.AzureKeyCredential credential, Azure.AI.Language.Conversations.ConversationAnalysisClientOptions options) { }
         public virtual System.Uri Endpoint { get { throw null; } }
-        public virtual Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult> AnalyzeConversation(Azure.AI.Language.Conversations.AnalyzeConversationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult> AnalyzeConversation(string projectName, string deploymentName, string query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult>> AnalyzeConversationAsync(Azure.AI.Language.Conversations.AnalyzeConversationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult>> AnalyzeConversationAsync(string projectName, string deploymentName, string query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult> AnalyzeConversation(Azure.AI.Language.Conversations.ConversationsProject conversationsProject, Azure.AI.Language.Conversations.AnalyzeConversationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult> AnalyzeConversation(string query, Azure.AI.Language.Conversations.ConversationsProject conversationsProject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult>> AnalyzeConversationAsync(Azure.AI.Language.Conversations.ConversationsProject conversationsProject, Azure.AI.Language.Conversations.AnalyzeConversationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult>> AnalyzeConversationAsync(string query, Azure.AI.Language.Conversations.ConversationsProject conversationsProject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class ConversationAnalysisClientOptions : Azure.Core.ClientOptions
     {
@@ -117,6 +115,12 @@ namespace Azure.AI.Language.Conversations
         public static Azure.AI.Language.Conversations.OrchestratorPrediction OrchestratorPrediction(Azure.AI.Language.Conversations.ProjectKind projectKind = default(Azure.AI.Language.Conversations.ProjectKind), string topIntent = null, System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.Language.Conversations.TargetIntentResult> intents = null) { throw null; }
         public static Azure.AI.Language.Conversations.QuestionAnsweringTargetIntentResult QuestionAnsweringTargetIntentResult(Azure.AI.Language.Conversations.TargetKind targetKind = default(Azure.AI.Language.Conversations.TargetKind), string apiVersion = null, double confidenceScore = 0, Azure.AI.Language.Conversations.KnowledgeBaseAnswers result = null) { throw null; }
         public static Azure.AI.Language.Conversations.TargetIntentResult TargetIntentResult(Azure.AI.Language.Conversations.TargetKind targetKind = default(Azure.AI.Language.Conversations.TargetKind), string apiVersion = null, double confidenceScore = 0) { throw null; }
+    }
+    public partial class ConversationsProject
+    {
+        public ConversationsProject(string projectName, string deploymentName) { }
+        public string DeploymentName { get { throw null; } }
+        public string ProjectName { get { throw null; } }
     }
     public partial class ConversationTargetIntentResult : Azure.AI.Language.Conversations.TargetIntentResult
     {

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/api/Azure.AI.Language.Conversations.netstandard2.0.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/api/Azure.AI.Language.Conversations.netstandard2.0.cs
@@ -7,12 +7,11 @@ namespace Azure.AI.Language.Conversations
     }
     public partial class AnalyzeConversationOptions
     {
-        public AnalyzeConversationOptions(string query) { }
+        public AnalyzeConversationOptions() { }
         public string DirectTarget { get { throw null; } set { } }
         public bool? IsLoggingEnabled { get { throw null; } set { } }
         public string Language { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, Azure.AI.Language.Conversations.AnalysisParameters> Parameters { get { throw null; } }
-        public string Query { get { throw null; } }
         public bool? Verbose { get { throw null; } set { } }
     }
     public partial class AnalyzeConversationResult
@@ -42,10 +41,8 @@ namespace Azure.AI.Language.Conversations
         public ConversationAnalysisClient(System.Uri endpoint, Azure.AzureKeyCredential credential) { }
         public ConversationAnalysisClient(System.Uri endpoint, Azure.AzureKeyCredential credential, Azure.AI.Language.Conversations.ConversationAnalysisClientOptions options) { }
         public virtual System.Uri Endpoint { get { throw null; } }
-        public virtual Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult> AnalyzeConversation(Azure.AI.Language.Conversations.ConversationsProject conversationsProject, Azure.AI.Language.Conversations.AnalyzeConversationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult> AnalyzeConversation(string query, Azure.AI.Language.Conversations.ConversationsProject conversationsProject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult>> AnalyzeConversationAsync(Azure.AI.Language.Conversations.ConversationsProject conversationsProject, Azure.AI.Language.Conversations.AnalyzeConversationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult>> AnalyzeConversationAsync(string query, Azure.AI.Language.Conversations.ConversationsProject conversationsProject, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult> AnalyzeConversation(string utterance, Azure.AI.Language.Conversations.ConversationsProject project, Azure.AI.Language.Conversations.AnalyzeConversationOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.Language.Conversations.AnalyzeConversationResult>> AnalyzeConversationAsync(string utterance, Azure.AI.Language.Conversations.ConversationsProject project, Azure.AI.Language.Conversations.AnalyzeConversationOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class ConversationAnalysisClientOptions : Azure.Core.ClientOptions
     {

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/perf/Scenarios/AnalyzeConversation.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/perf/Scenarios/AnalyzeConversation.cs
@@ -17,12 +17,12 @@ namespace Azure.AI.Language.Conversations.Perf.Scenarios
 
         public override void Run(CancellationToken cancellationToken)
         {
-            Client.AnalyzeConversation(TestEnvironment.ProjectName, TestEnvironment.DeploymentName, "We'll have 2 plates of seared salmon nigiri.");
+            Client.AnalyzeConversation("We'll have 2 plates of seared salmon nigiri.", TestEnvironment.Project);
         }
 
         public override async Task RunAsync(CancellationToken cancellationToken)
         {
-            await Client.AnalyzeConversationAsync(TestEnvironment.ProjectName, TestEnvironment.DeploymentName, "We'll have 2 plates of seared salmon nigiri.");
+            await Client.AnalyzeConversationAsync("We'll have 2 plates of seared salmon nigiri.", TestEnvironment.Project);
         }
 
         public class ConversationAnalysisClient : PerfOptions

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample1_AnalyzeConversation.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample1_AnalyzeConversation.md
@@ -16,10 +16,11 @@ Once you have created a client, you can call synchronous or asynchronous methods
 ## Synchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversation
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
+
 Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-    "Menu",
-    "production",
-    "We'll have 2 plates of seared salmon nigiri.");
+    "We'll have 2 plates of seared salmon nigiri.",
+    conversationsProject);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -27,10 +28,11 @@ Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ## Asynchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationAsync
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
+
 Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-    "Menu",
-    "production",
-    "We'll have 2 plates of seared salmon nigiri.");
+    "We'll have 2 plates of seared salmon nigiri.",
+    conversationsProject);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample2_AnalyzeConversationWithOptions.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample2_AnalyzeConversationWithOptions.md
@@ -17,10 +17,16 @@ Once you have created a client, you can call synchronous or asynchronous methods
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptions
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "We'll have 2 plates of seared salmon nigiri.");
+AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+    IsLoggingEnabled = true,
+    Verbose = true,
+    Language = "en"
+};
 
-Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
+Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
+    "We'll have 2 plates of seared salmon nigiri.",
+    conversationsProject,
+    options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -29,10 +35,16 @@ Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptionsAsync
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "We'll have 2 plates of seared salmon nigiri.");
+AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+    IsLoggingEnabled = true,
+    Verbose = true,
+    Language = "en"
+};
 
-Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(conversationsProject, options);
+Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
+    "We'll have 2 plates of seared salmon nigiri.",
+    conversationsProject,
+    options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample2_AnalyzeConversationWithOptions.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample2_AnalyzeConversationWithOptions.md
@@ -16,11 +16,11 @@ Once you have created a client, you can call synchronous or asynchronous methods
 ## Synchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptions
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
 AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Menu",
-    "production",
     "We'll have 2 plates of seared salmon nigiri.");
-Response<AnalyzeConversationResult> response = client.AnalyzeConversation(options);
+
+Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -28,11 +28,11 @@ Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ## Asynchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptionsAsync
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
 AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Menu",
-    "production",
     "We'll have 2 plates of seared salmon nigiri.");
-Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(options);
+
+Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(conversationsProject, options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample2_AnalyzeConversationWithOptions.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample2_AnalyzeConversationWithOptions.md
@@ -17,10 +17,10 @@ Once you have created a client, you can call synchronous or asynchronous methods
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptions
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+AnalyzeConversationOptions options = new AnalyzeConversationOptions()
+{
     IsLoggingEnabled = true,
     Verbose = true,
-    Language = "en"
 };
 
 Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
@@ -35,10 +35,10 @@ Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithOptionsAsync
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+AnalyzeConversationOptions options = new AnalyzeConversationOptions()
+{
     IsLoggingEnabled = true,
     Verbose = true,
-    Language = "en"
 };
 
 Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample3_AnalyzeConversationWithLanguage.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample3_AnalyzeConversationWithLanguage.md
@@ -16,14 +16,13 @@ Once you have created a client, you can call synchronous or asynchronous methods
 ## Synchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithLanguage
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
 AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Menu",
-    "production", 
     "Tendremos 2 platos de nigiri de salmón braseado.")
 {
     Language = "es"
 };
-Response<AnalyzeConversationResult> response = client.AnalyzeConversation(options);
+Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -31,14 +30,13 @@ Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ## Asynchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithLanguageAsync
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
 AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Menu",
-    "production",
     "Tendremos 2 platos de nigiri de salmón braseado.")
 {
     Language = "es"
 };
-Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(options);
+Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(conversationsProject, options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample3_AnalyzeConversationWithLanguage.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample3_AnalyzeConversationWithLanguage.md
@@ -17,12 +17,14 @@ Once you have created a client, you can call synchronous or asynchronous methods
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithLanguage
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Tendremos 2 platos de nigiri de salmón braseado.")
+AnalyzeConversationOptions options = new AnalyzeConversationOptions()
 {
     Language = "es"
 };
-Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
+Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
+    "Tendremos 2 platos de nigiri de salmón braseado.",
+    conversationsProject,
+    options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```
@@ -31,12 +33,14 @@ Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithLanguageAsync
 ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-    "Tendremos 2 platos de nigiri de salmón braseado.")
+AnalyzeConversationOptions options = new AnalyzeConversationOptions()
 {
     Language = "es"
 };
-Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(conversationsProject, options);
+Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
+    "Tendremos 2 platos de nigiri de salmón braseado.",
+    conversationsProject,
+    options);
 
 Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample4_ConversationPrediction.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample4_ConversationPrediction.md
@@ -16,10 +16,10 @@ Once you have created a client, you can call synchronous or asynchronous methods
 ## Synchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithConversationPrediction
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
 Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-    "Menu",
-    "production",
-    "We'll have 2 plates of seared salmon nigiri.");
+    "We'll have 2 plates of seared salmon nigiri.",
+    conversationsProject);
 
 ConversationPrediction conversationPrediction = response.Value.Prediction as ConversationPrediction;
 
@@ -46,10 +46,10 @@ foreach (ConversationEntity entity in conversationPrediction.Entities)
 ## Asynchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationWithConversationPredictionAsync
+ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
 Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-    "Menu",
-    "production",
-    "We'll have 2 plates of seared salmon nigiri.");
+    "We'll have 2 plates of seared salmon nigiri.",
+    conversationsProject);
 
 ConversationPrediction conversationPrediction = response.Value.Prediction as ConversationPrediction;
 

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample5_OrchestrationPrediction.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample5_OrchestrationPrediction.md
@@ -16,10 +16,10 @@ Once you have created a client, you can call synchronous or asynchronous methods
 ## Synchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationOrchestrationPrediction
+ConversationsProject orchestrationProject = new ConversationsProject("DomainOrchestrator", "production");
 Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-    "DomainOrchestrator",
-    "production",
-    "Where are the calories per recipe?");
+    "Where are the calories per recipe?",
+    orchestrationProject);
 
 OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as OrchestratorPrediction;
 ```
@@ -27,10 +27,10 @@ OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as Orc
 ## Asynchronous
 
 ```C# Snippet:ConversationAnalysis_AnalyzeConversationOrchestrationPredictionAsync
+ConversationsProject orchestrationProject = new ConversationsProject("DomainOrchestrator", "production");
 Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-    "DomainOrchestrator",
-    "production",
-    "Where are the calories per recipe?");
+    "Where are the calories per recipe?",
+    orchestrationProject);
 
 OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as OrchestratorPrediction;
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/AnalyzeConversationOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/AnalyzeConversationOptions.cs
@@ -18,6 +18,7 @@ namespace Azure.AI.Language.Conversations
         }
 
         /// <summary> The conversation utterance to be analyzed. </summary>
-        internal string Query { get; set; }
+        [CodeGenMember("Query")]
+        internal string Utterance { get; set; }
     }
 }

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/AnalyzeConversationOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/AnalyzeConversationOptions.cs
@@ -8,7 +8,16 @@ namespace Azure.AI.Language.Conversations
 {
     /// <summary> The request body. </summary>
     [CodeGenModel("ConversationAnalysisOptions")]
+    [CodeGenSuppress("AnalyzeConversationOptions", typeof(string))]
     public partial class AnalyzeConversationOptions
     {
+        /// <summary> Initializes a new instance of AnalyzeConversationOptions. </summary>
+        public AnalyzeConversationOptions()
+        {
+            Parameters = new ChangeTrackingDictionary<string, AnalysisParameters>();
+        }
+
+        /// <summary> The conversation utterance to be analyzed. </summary>
+        internal string Query { get; set; }
     }
 }

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/AnalyzeConversationOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/AnalyzeConversationOptions.cs
@@ -10,38 +10,5 @@ namespace Azure.AI.Language.Conversations
     [CodeGenModel("ConversationAnalysisOptions")]
     public partial class AnalyzeConversationOptions
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AnalyzeConversationOptions"/> class.
-        /// </summary>
-        /// <param name="projectName">The name of the project to use.</param>
-        /// <param name="deploymentName">The deployment name of the project to use, such as "test" or "production".</param>
-        /// <param name="query">The conversation utterance to be analyzed.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="projectName"/>, <paramref name="deploymentName"/>, or <paramref name="query"/> is null.</exception>
-        public AnalyzeConversationOptions(string projectName, string deploymentName, string query) : this(query)
-        {
-            ProjectName = Argument.CheckNotNull(projectName, nameof(projectName));
-            DeploymentName = Argument.CheckNotNull(deploymentName, nameof(deploymentName));
-        }
-
-        internal AnalyzeConversationOptions(string query)
-        {
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
-            Query = query;
-            Parameters = new ChangeTrackingDictionary<string, AnalysisParameters>();
-        }
-
-        /// <summary>
-        /// Gets the name of the project to use.
-        /// </summary>
-        public string ProjectName { get; }
-
-        /// <summary>
-        /// Gets the deployment name of the project to use, such as "test" or "production".
-        /// </summary>
-        public string DeploymentName { get; }
     }
 }

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/ConversationAnalysisClient.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/ConversationAnalysisClient.cs
@@ -86,7 +86,7 @@ namespace Azure.AI.Language.Conversations
             Argument.AssertNotNull(utterance, nameof(utterance));
 
             options = options ?? new();
-            options.Query = utterance;
+            options.Utterance = utterance;
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(ConversationAnalysisClient)}.{nameof(AnalyzeConversation)}");
             scope.AddAttribute("projectName", project.ProjectName);
@@ -117,7 +117,7 @@ namespace Azure.AI.Language.Conversations
             Argument.AssertNotNull(utterance, nameof(utterance));
 
             options = options ?? new();
-            options.Query = utterance;
+            options.Utterance = utterance;
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(ConversationAnalysisClient)}.{nameof(AnalyzeConversation)}");
             scope.AddAttribute("projectName", project.ProjectName);

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/ConversationAnalysisClient.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/ConversationAnalysisClient.cs
@@ -74,34 +74,36 @@ namespace Azure.AI.Language.Conversations
         private protected virtual HttpPipeline Pipeline { get; }
 
         /// <summary>Analyzes a conversational utterance.</summary>
-        /// <param name="projectName">The name of the project to use.</param>
-        /// <param name="deploymentName">The deployment name of the project to use, such as "test" or "production".</param>
         /// <param name="query">The conversation utterance to be analyzed.</param>
+        /// <param name="conversationsProject">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="projectName"/>, <paramref name="deploymentName"/>, or <paramref name="query"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="conversationsProject"/> or <paramref name="query"/> is null.</exception>
         /// <exception cref="RequestFailedException">The service returned an error. The exception contains details of the service error.</exception>
-        public virtual Task<Response<AnalyzeConversationResult>> AnalyzeConversationAsync(string projectName, string deploymentName, string query, CancellationToken cancellationToken = default) =>
-            AnalyzeConversationAsync(new AnalyzeConversationOptions(projectName, deploymentName, query), cancellationToken);
+        public virtual Task<Response<AnalyzeConversationResult>> AnalyzeConversationAsync(string query, ConversationsProject conversationsProject, CancellationToken cancellationToken = default) =>
+            AnalyzeConversationAsync(conversationsProject, new AnalyzeConversationOptions(query), cancellationToken);
 
         /// <summary>Analyzes a conversational utterance.</summary>
+        /// <param name="conversationsProject">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
         /// <param name="options">
-        /// An <see cref="AnalyzeConversationOptions"/> containing the <see cref="AnalyzeConversationOptions.ProjectName"/>,
-        /// <see cref="AnalyzeConversationOptions.DeploymentName"/>, <see cref="AnalyzeConversationOptions.Query"/>, and other options to analyze.</param>
+        /// An <see cref="AnalyzeConversationOptions"/> containing the <see cref="AnalyzeConversationOptions.Query"/>,
+        /// <see cref="AnalyzeConversationOptions.Language"/>, and other options to analyze.
+        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="conversationsProject"/> or <paramref name="options"/> is null.</exception>
         /// <exception cref="RequestFailedException">The service returned an error. The exception contains details of the service error.</exception>
-        public virtual async Task<Response<AnalyzeConversationResult>> AnalyzeConversationAsync(AnalyzeConversationOptions options, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<AnalyzeConversationResult>> AnalyzeConversationAsync(ConversationsProject conversationsProject, AnalyzeConversationOptions options, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(options, nameof(options));
+            Argument.AssertNotNull(conversationsProject, nameof(conversationsProject));
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(ConversationAnalysisClient)}.{nameof(AnalyzeConversation)}");
-            scope.AddAttribute("projectName", options.ProjectName);
-            scope.AddAttribute("deploymentName", options.DeploymentName);
+            scope.AddAttribute("projectName", conversationsProject.ProjectName);
+            scope.AddAttribute("deploymentName", conversationsProject.DeploymentName);
             scope.Start();
 
             try
             {
-                return await _analysisRestClient.AnalyzeConversationAsync(options.ProjectName, options.DeploymentName, options, cancellationToken).ConfigureAwait(false);
+                return await _analysisRestClient.AnalyzeConversationAsync(conversationsProject.ProjectName, conversationsProject.DeploymentName, options, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -111,34 +113,36 @@ namespace Azure.AI.Language.Conversations
         }
 
         /// <summary>Analyzes a conversational utterance.</summary>
-        /// <param name="projectName">The name of the project to use.</param>
-        /// <param name="deploymentName">The deployment name of the project to use, such as "test" or "production".</param>
         /// <param name="query">The conversation utterance to be analyzed.</param>
+        /// <param name="conversationsProject">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="projectName"/>, <paramref name="deploymentName"/>, or <paramref name="query"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="conversationsProject"/> or <paramref name="query"/> is null.</exception>
         /// <exception cref="RequestFailedException">The service returned an error. The exception contains details of the service error.</exception>
-        public virtual Response<AnalyzeConversationResult> AnalyzeConversation(string projectName, string deploymentName, string query, CancellationToken cancellationToken = default) =>
-            AnalyzeConversation(new AnalyzeConversationOptions(projectName, deploymentName, query), cancellationToken);
+        public virtual Response<AnalyzeConversationResult> AnalyzeConversation(string query, ConversationsProject conversationsProject, CancellationToken cancellationToken = default) =>
+            AnalyzeConversation(conversationsProject, new AnalyzeConversationOptions(query), cancellationToken);
 
         /// <summary>Analyzes a conversational utterance.</summary>
+        /// <param name="conversationsProject">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
         /// <param name="options">
-        /// An <see cref="AnalyzeConversationOptions"/> containing the <see cref="AnalyzeConversationOptions.ProjectName"/>,
-        /// <see cref="AnalyzeConversationOptions.DeploymentName"/>, <see cref="AnalyzeConversationOptions.Query"/>, and other options to analyze.</param>
+        /// An <see cref="AnalyzeConversationOptions"/> containing the <see cref="AnalyzeConversationOptions.Query"/>,
+        /// <see cref="AnalyzeConversationOptions.Language"/>, and other options to analyze.
+        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the request.</param>
         /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
         /// <exception cref="RequestFailedException">The service returned an error. The exception contains details of the service error.</exception>
-        public virtual Response<AnalyzeConversationResult> AnalyzeConversation(AnalyzeConversationOptions options, CancellationToken cancellationToken = default)
+        public virtual Response<AnalyzeConversationResult> AnalyzeConversation(ConversationsProject conversationsProject, AnalyzeConversationOptions options, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(options, nameof(options));
+            Argument.AssertNotNull(conversationsProject, nameof(conversationsProject));
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(ConversationAnalysisClient)}.{nameof(AnalyzeConversation)}");
-            scope.AddAttribute("projectName", options.ProjectName);
-            scope.AddAttribute("deploymentName", options.DeploymentName);
+            scope.AddAttribute("projectName", conversationsProject.ProjectName);
+            scope.AddAttribute("deploymentName", conversationsProject.DeploymentName);
             scope.Start();
 
             try
             {
-                return _analysisRestClient.AnalyzeConversation(options.ProjectName, options.DeploymentName, options, cancellationToken);
+                return _analysisRestClient.AnalyzeConversation(conversationsProject.ProjectName, conversationsProject.DeploymentName, options, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/ConversationAnalysisClient.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/ConversationAnalysisClient.cs
@@ -74,36 +74,28 @@ namespace Azure.AI.Language.Conversations
         private protected virtual HttpPipeline Pipeline { get; }
 
         /// <summary>Analyzes a conversational utterance.</summary>
-        /// <param name="query">The conversation utterance to be analyzed.</param>
-        /// <param name="conversationsProject">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
+        /// <param name="utterance">The conversation utterance to be analyzed.</param>
+        /// <param name="project">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
+        /// <param name="options">Optional <see cref="AnalyzeConversationOptions"/> with additional query options.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="conversationsProject"/> or <paramref name="query"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="project"/> or <paramref name="utterance"/> is null.</exception>
         /// <exception cref="RequestFailedException">The service returned an error. The exception contains details of the service error.</exception>
-        public virtual Task<Response<AnalyzeConversationResult>> AnalyzeConversationAsync(string query, ConversationsProject conversationsProject, CancellationToken cancellationToken = default) =>
-            AnalyzeConversationAsync(conversationsProject, new AnalyzeConversationOptions(query), cancellationToken);
-
-        /// <summary>Analyzes a conversational utterance.</summary>
-        /// <param name="conversationsProject">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
-        /// <param name="options">
-        /// An <see cref="AnalyzeConversationOptions"/> containing the <see cref="AnalyzeConversationOptions.Query"/>,
-        /// <see cref="AnalyzeConversationOptions.Language"/>, and other options to analyze.
-        /// </param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="conversationsProject"/> or <paramref name="options"/> is null.</exception>
-        /// <exception cref="RequestFailedException">The service returned an error. The exception contains details of the service error.</exception>
-        public virtual async Task<Response<AnalyzeConversationResult>> AnalyzeConversationAsync(ConversationsProject conversationsProject, AnalyzeConversationOptions options, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<AnalyzeConversationResult>> AnalyzeConversationAsync(string utterance, ConversationsProject project, AnalyzeConversationOptions options = null, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(options, nameof(options));
-            Argument.AssertNotNull(conversationsProject, nameof(conversationsProject));
+            Argument.AssertNotNull(project, nameof(project));
+            Argument.AssertNotNull(utterance, nameof(utterance));
+
+            options = options ?? new();
+            options.Query = utterance;
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(ConversationAnalysisClient)}.{nameof(AnalyzeConversation)}");
-            scope.AddAttribute("projectName", conversationsProject.ProjectName);
-            scope.AddAttribute("deploymentName", conversationsProject.DeploymentName);
+            scope.AddAttribute("projectName", project.ProjectName);
+            scope.AddAttribute("deploymentName", project.DeploymentName);
             scope.Start();
 
             try
             {
-                return await _analysisRestClient.AnalyzeConversationAsync(conversationsProject.ProjectName, conversationsProject.DeploymentName, options, cancellationToken).ConfigureAwait(false);
+                return await _analysisRestClient.AnalyzeConversationAsync(project.ProjectName, project.DeploymentName, options, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -113,36 +105,28 @@ namespace Azure.AI.Language.Conversations
         }
 
         /// <summary>Analyzes a conversational utterance.</summary>
-        /// <param name="query">The conversation utterance to be analyzed.</param>
-        /// <param name="conversationsProject">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
+        /// <param name="utterance">The conversation utterance to be analyzed.</param>
+        /// <param name="project">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
+        /// <param name="options">Optional <see cref="AnalyzeConversationOptions"/> with additional query options.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="conversationsProject"/> or <paramref name="query"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="project"/> or <paramref name="utterance"/> is null.</exception>
         /// <exception cref="RequestFailedException">The service returned an error. The exception contains details of the service error.</exception>
-        public virtual Response<AnalyzeConversationResult> AnalyzeConversation(string query, ConversationsProject conversationsProject, CancellationToken cancellationToken = default) =>
-            AnalyzeConversation(conversationsProject, new AnalyzeConversationOptions(query), cancellationToken);
-
-        /// <summary>Analyzes a conversational utterance.</summary>
-        /// <param name="conversationsProject">The <see cref="ConversationsProject"/> used for conversation analysis.</param>
-        /// <param name="options">
-        /// An <see cref="AnalyzeConversationOptions"/> containing the <see cref="AnalyzeConversationOptions.Query"/>,
-        /// <see cref="AnalyzeConversationOptions.Language"/>, and other options to analyze.
-        /// </param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> to cancel the request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
-        /// <exception cref="RequestFailedException">The service returned an error. The exception contains details of the service error.</exception>
-        public virtual Response<AnalyzeConversationResult> AnalyzeConversation(ConversationsProject conversationsProject, AnalyzeConversationOptions options, CancellationToken cancellationToken = default)
+        public virtual Response<AnalyzeConversationResult> AnalyzeConversation(string utterance, ConversationsProject project, AnalyzeConversationOptions options = null, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(options, nameof(options));
-            Argument.AssertNotNull(conversationsProject, nameof(conversationsProject));
+            Argument.AssertNotNull(project, nameof(project));
+            Argument.AssertNotNull(utterance, nameof(utterance));
+
+            options = options ?? new();
+            options.Query = utterance;
 
             using DiagnosticScope scope = Diagnostics.CreateScope($"{nameof(ConversationAnalysisClient)}.{nameof(AnalyzeConversation)}");
-            scope.AddAttribute("projectName", conversationsProject.ProjectName);
-            scope.AddAttribute("deploymentName", conversationsProject.DeploymentName);
+            scope.AddAttribute("projectName", project.ProjectName);
+            scope.AddAttribute("deploymentName", project.DeploymentName);
             scope.Start();
 
             try
             {
-                return _analysisRestClient.AnalyzeConversation(conversationsProject.ProjectName, conversationsProject.DeploymentName, options, cancellationToken);
+                return _analysisRestClient.AnalyzeConversation(project.ProjectName, project.DeploymentName, options, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Generated/Models/AnalyzeConversationOptions.Serialization.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Generated/Models/AnalyzeConversationOptions.Serialization.cs
@@ -16,7 +16,7 @@ namespace Azure.AI.Language.Conversations
         {
             writer.WriteStartObject();
             writer.WritePropertyName("query");
-            writer.WriteStringValue(Query);
+            writer.WriteStringValue(Utterance);
             if (Optional.IsDefined(DirectTarget))
             {
                 writer.WritePropertyName("directTarget");

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Generated/Models/AnalyzeConversationOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Generated/Models/AnalyzeConversationOptions.cs
@@ -14,22 +14,6 @@ namespace Azure.AI.Language.Conversations
     /// <summary> The request body. </summary>
     public partial class AnalyzeConversationOptions
     {
-        /// <summary> Initializes a new instance of AnalyzeConversationOptions. </summary>
-        /// <param name="query"> The conversation utterance to be analyzed. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="query"/> is null. </exception>
-        public AnalyzeConversationOptions(string query)
-        {
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
-            Query = query;
-            Parameters = new ChangeTrackingDictionary<string, AnalysisParameters>();
-        }
-
-        /// <summary> The conversation utterance to be analyzed. </summary>
-        public string Query { get; }
         /// <summary> The name of the target project this request is sending to directly. </summary>
         public string DirectTarget { get; set; }
         /// <summary> The language to use in this request. This will be the language setting when communicating with all other target projects. </summary>

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Generated/Models/AnalyzeConversationOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Generated/Models/AnalyzeConversationOptions.cs
@@ -14,6 +14,19 @@ namespace Azure.AI.Language.Conversations
     /// <summary> The request body. </summary>
     public partial class AnalyzeConversationOptions
     {
+        /// <summary> Initializes a new instance of AnalyzeConversationOptions. </summary>
+        /// <param name="query"> The conversation utterance to be analyzed. </param>
+        /// <exception cref="ArgumentNullException"> <paramref name="query"/> is null. </exception>
+        public AnalyzeConversationOptions(string query)
+        {
+            if (query == null)
+            {
+                throw new ArgumentNullException(nameof(query));
+            }
+
+            Query = query;
+            Parameters = new ChangeTrackingDictionary<string, AnalysisParameters>();
+        }
 
         /// <summary> The conversation utterance to be analyzed. </summary>
         public string Query { get; }

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Models/ConversationsProject.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/Models/ConversationsProject.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+
+namespace Azure.AI.Language.Conversations
+{
+    /// <summary>
+    /// Represents a project for the Conversations service
+    /// </summary>
+    public class ConversationsProject
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ConversationsProject"/> class
+        /// </summary>
+        /// <param name="projectName">The name of the project to use.</param>
+        /// <param name="deploymentName">The deployment name of the project to use, such as "test" or "production".</param>
+        /// <exception cref="ArgumentNullException"><paramref name="projectName"/> or <paramref name="deploymentName"/> is null.</exception>
+        public ConversationsProject(string projectName, string deploymentName)
+        {
+            ProjectName = Argument.CheckNotNull(projectName, nameof(projectName));
+            DeploymentName = Argument.CheckNotNull(deploymentName, nameof(deploymentName));
+        }
+
+        /// <summary>
+        /// Gets the name of the project to use.
+        /// </summary>
+        public string ProjectName { get; }
+
+        /// <summary>
+        /// Gets the deployment name of the project to use, such as "test" or "production".
+        /// </summary>
+        public string DeploymentName { get; }
+    }
+}

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/ConversationAnalysisClientLiveTests.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/ConversationAnalysisClientLiveTests.cs
@@ -26,12 +26,9 @@ namespace Azure.AI.Language.Conversations.Tests
         [RecordedTest]
         public async Task AnalyzeConversation()
         {
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-               TestEnvironment.ProjectName,
-               TestEnvironment.DeploymentName,
-               EnglishText);
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions(EnglishText);
 
-            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(options);
+            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(TestEnvironment.Project, options);
 
             Assert.That(response.Value.Prediction.TopIntent, Is.EqualTo("Order"));
             Assert.That(response.Value.Prediction.ProjectKind, Is.EqualTo(ProjectKind.Conversation));
@@ -40,15 +37,12 @@ namespace Azure.AI.Language.Conversations.Tests
         [RecordedTest]
         public async Task AnalyzeConversationWithLanguage()
         {
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-               TestEnvironment.ProjectName,
-               TestEnvironment.DeploymentName,
-               SpanishText)
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions(SpanishText)
             {
                 Language = "es"
             };
 
-            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(options);
+            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(TestEnvironment.Project, options);
 
             Assert.That(response.Value.Prediction.TopIntent, Is.EqualTo("Order"));
             Assert.That(response.Value.Prediction.ProjectKind, Is.EqualTo(ProjectKind.Conversation));
@@ -57,12 +51,9 @@ namespace Azure.AI.Language.Conversations.Tests
         [RecordedTest]
         public async Task AnalyzeConversationsWithConversationPrediction()
         {
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-               TestEnvironment.ProjectName,
-               TestEnvironment.DeploymentName,
-               EnglishText);
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions(EnglishText);
 
-            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(options);
+            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(TestEnvironment.Project, options);
 
             ConversationPrediction conversationPrediction = response.Value.Prediction as ConversationPrediction;
 
@@ -78,14 +69,11 @@ namespace Azure.AI.Language.Conversations.Tests
         [RecordedTest]
         public void AnalyzeConversationsInvalidArgument()
         {
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-              TestEnvironment.ProjectName,
-              TestEnvironment.DeploymentName,
-              "");
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions("");
 
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await Client.AnalyzeConversationAsync(options);
+                await Client.AnalyzeConversationAsync(TestEnvironment.Project, options);
             });
 
             Assert.That(ex.Status, Is.EqualTo(400));

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/ConversationAnalysisClientLiveTests.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/ConversationAnalysisClientLiveTests.cs
@@ -26,9 +26,7 @@ namespace Azure.AI.Language.Conversations.Tests
         [RecordedTest]
         public async Task AnalyzeConversation()
         {
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(EnglishText);
-
-            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(TestEnvironment.Project, options);
+            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(EnglishText, TestEnvironment.Project);
 
             Assert.That(response.Value.Prediction.TopIntent, Is.EqualTo("Order"));
             Assert.That(response.Value.Prediction.ProjectKind, Is.EqualTo(ProjectKind.Conversation));
@@ -37,12 +35,12 @@ namespace Azure.AI.Language.Conversations.Tests
         [RecordedTest]
         public async Task AnalyzeConversationWithLanguage()
         {
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(SpanishText)
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
             {
                 Language = "es"
             };
 
-            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(TestEnvironment.Project, options);
+            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(SpanishText, TestEnvironment.Project, options);
 
             Assert.That(response.Value.Prediction.TopIntent, Is.EqualTo("Order"));
             Assert.That(response.Value.Prediction.ProjectKind, Is.EqualTo(ProjectKind.Conversation));
@@ -51,9 +49,7 @@ namespace Azure.AI.Language.Conversations.Tests
         [RecordedTest]
         public async Task AnalyzeConversationsWithConversationPrediction()
         {
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(EnglishText);
-
-            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(TestEnvironment.Project, options);
+            Response<AnalyzeConversationResult> response = await Client.AnalyzeConversationAsync(EnglishText, TestEnvironment.Project);
 
             ConversationPrediction conversationPrediction = response.Value.Prediction as ConversationPrediction;
 
@@ -69,11 +65,9 @@ namespace Azure.AI.Language.Conversations.Tests
         [RecordedTest]
         public void AnalyzeConversationsInvalidArgument()
         {
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions("");
-
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await Client.AnalyzeConversationAsync(TestEnvironment.Project, options);
+                await Client.AnalyzeConversationAsync("", TestEnvironment.Project);
             });
 
             Assert.That(ex.Status, Is.EqualTo(400));

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/ConversationAnalysisClientTests.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/ConversationAnalysisClientTests.cs
@@ -30,22 +30,31 @@ namespace Azure.AI.Language.Conversations.Tests
                 () => new ConversationAnalysisClient(endpoint, null));
             Assert.AreEqual("credential", ex.ParamName);
         }
+        [Test]
+        public void ValidateConversationsProject()
+        {
+            // Validate query parameter first given the order the constructors get called.
+            Assert.That<ConversationsProject>(() => new ConversationsProject(null, "test"), Throws.ArgumentNullException.WithParamName("projectName"));
+            Assert.That<ConversationsProject>(() => new ConversationsProject("test", null), Throws.ArgumentNullException.WithParamName("deploymentName"));
+        }
 
         [Test]
         public void ValidateAnalyzeConversation()
         {
+            ConversationsProject conversationsProject = new ConversationsProject("project","deployment");
+
             // Validate query parameter first given the order the constructors get called.
-            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(null, null, null), Throws.ArgumentNullException.WithParamName("query"));
-            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(null, null, null), Throws.ArgumentNullException.WithParamName("query"));
+            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(null, conversationsProject), Throws.ArgumentNullException.WithParamName("query"));
+            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(null, conversationsProject), Throws.ArgumentNullException.WithParamName("query"));
 
-            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(null, null, "test"), Throws.ArgumentNullException.WithParamName("projectName"));
-            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(null, null, "test"), Throws.ArgumentNullException.WithParamName("projectName"));
+            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation("test", null), Throws.ArgumentNullException.WithParamName("conversationsProject"));
+            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync("test", null), Throws.ArgumentNullException.WithParamName("conversationsProject"));
 
-            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation("test", null, "test"), Throws.ArgumentNullException.WithParamName("deploymentName"));
-            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync("test", null, "test"), Throws.ArgumentNullException.WithParamName("deploymentName"));
+            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(null, new AnalyzeConversationOptions("test")), Throws.ArgumentNullException.WithParamName("conversationsProject"));
+            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(null, new AnalyzeConversationOptions("test")), Throws.ArgumentNullException.WithParamName("conversationsProject"));
 
-            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(null), Throws.ArgumentNullException.WithParamName("options"));
-            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(null), Throws.ArgumentNullException.WithParamName("options"));
+            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(conversationsProject, null), Throws.ArgumentNullException.WithParamName("options"));
+            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(conversationsProject, null), Throws.ArgumentNullException.WithParamName("options"));
         }
     }
 }

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/ConversationAnalysisClientTests.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/ConversationAnalysisClientTests.cs
@@ -44,17 +44,11 @@ namespace Azure.AI.Language.Conversations.Tests
             ConversationsProject conversationsProject = new ConversationsProject("project","deployment");
 
             // Validate query parameter first given the order the constructors get called.
-            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(null, conversationsProject), Throws.ArgumentNullException.WithParamName("query"));
-            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(null, conversationsProject), Throws.ArgumentNullException.WithParamName("query"));
+            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(null, conversationsProject), Throws.ArgumentNullException.WithParamName("utterance"));
+            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(null, conversationsProject), Throws.ArgumentNullException.WithParamName("utterance"));
 
-            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation("test", null), Throws.ArgumentNullException.WithParamName("conversationsProject"));
-            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync("test", null), Throws.ArgumentNullException.WithParamName("conversationsProject"));
-
-            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(null, new AnalyzeConversationOptions("test")), Throws.ArgumentNullException.WithParamName("conversationsProject"));
-            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(null, new AnalyzeConversationOptions("test")), Throws.ArgumentNullException.WithParamName("conversationsProject"));
-
-            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation(conversationsProject, null), Throws.ArgumentNullException.WithParamName("options"));
-            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync(conversationsProject, null), Throws.ArgumentNullException.WithParamName("options"));
+            Assert.That<Response<AnalyzeConversationResult>>(() => Client.AnalyzeConversation("test", null), Throws.ArgumentNullException.WithParamName("project"));
+            Assert.That<Task<Response<AnalyzeConversationResult>>>(async () => await Client.AnalyzeConversationAsync("test", null), Throws.ArgumentNullException.WithParamName("project"));
         }
     }
 }

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Infrastructure/ConversationAnalysisTestBase.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Infrastructure/ConversationAnalysisTestBase.cs
@@ -13,7 +13,7 @@ namespace Azure.AI.Language.Conversations.Tests
     public abstract class ConversationAnalysisTestBase<TClient> : RecordedTestBase<ConversationAnalysisTestEnvironment> where TClient : class
     {
         protected ConversationAnalysisTestBase(bool isAsync, ConversationAnalysisClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode)
-            : base(isAsync, mode)
+            : base(isAsync, RecordedTestMode.Live)
         {
             // TODO: Compare bodies again when https://github.com/Azure/azure-sdk-for-net/issues/22219 is resolved.
             Matcher = new RecordMatcher(compareBodies: false);

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Infrastructure/ConversationAnalysisTestBase.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Infrastructure/ConversationAnalysisTestBase.cs
@@ -13,7 +13,7 @@ namespace Azure.AI.Language.Conversations.Tests
     public abstract class ConversationAnalysisTestBase<TClient> : RecordedTestBase<ConversationAnalysisTestEnvironment> where TClient : class
     {
         protected ConversationAnalysisTestBase(bool isAsync, ConversationAnalysisClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode)
-            : base(isAsync, RecordedTestMode.Live)
+            : base(isAsync, mode)
         {
             // TODO: Compare bodies again when https://github.com/Azure/azure-sdk-for-net/issues/22219 is resolved.
             Matcher = new RecordMatcher(compareBodies: false);

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Infrastructure/ConversationAnalysisTestEnvironment.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Infrastructure/ConversationAnalysisTestEnvironment.cs
@@ -35,5 +35,15 @@ namespace Azure.AI.Language.Conversations.Tests
         /// Gets the endpoint.
         /// </summary>
         public Uri Endpoint => new(GetRecordedVariable("CONVERSATIONS_URI"), UriKind.Absolute);
+
+        /// <summary>
+        /// Gets a <see cref="ConversationsProject"/> using the <see cref="ProjectName"/> and <see cref="DeploymentName"/>.
+        /// </summary>
+        public ConversationsProject Project => new ConversationsProject(ProjectName, DeploymentName);
+
+        /// <summary>
+        /// Gets an orchestration <see cref="ConversationsProject"/> using the <see cref="OrchestrationProjectName"/> and <see cref="DeploymentName"/>.
+        /// </summary>
+        public ConversationsProject OrchestrationProject => new ConversationsProject(OrchestrationProjectName, DeploymentName);
     }
 }

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Readme.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Readme.cs
@@ -27,10 +27,10 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysisClient_BadRequest
             try
             {
+                ConversationsProject conversationsProject = new ConversationsProject("invalid-project", "production");
                 Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                    "invalid-project",
-                    "production",
-                    "We'll have 2 plates of seared salmon nigiri.");
+                    "We'll have 2 plates of seared salmon nigiri.",
+                    conversationsProject);
             }
             catch (RequestFailedException ex)
             {

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample1_AnalyzeConversation.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample1_AnalyzeConversation.cs
@@ -19,15 +19,15 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversation
 
 #if SNIPPET
+            ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
+
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                "Menu",
-                "production",
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                conversationsProject);
 #else
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                TestEnvironment.ProjectName,
-                TestEnvironment.DeploymentName,
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                TestEnvironment.Project);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
@@ -46,15 +46,15 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationAsync
 
 #if SNIPPET
+            ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
+
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-                "Menu",
-                "production",
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                conversationsProject);
 #else
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-                TestEnvironment.ProjectName,
-                TestEnvironment.DeploymentName,
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                TestEnvironment.Project);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample2_AnalyzeConversationWithOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample2_AnalyzeConversationWithOptions.cs
@@ -19,17 +19,16 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationWithOptions
 
 #if SNIPPET
+            ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
             AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "Menu",
-                "production",
                 "We'll have 2 plates of seared salmon nigiri.");
-            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(options);
+
+            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
 #else
             AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                TestEnvironment.ProjectName,
-                TestEnvironment.DeploymentName,
                 "We'll have 2 plates of seared salmon nigiri.");
-            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(options);
+
+            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(TestEnvironment.Project, options);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
@@ -49,17 +48,16 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationWithOptionsAsync
 
 #if SNIPPET
+            ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
             AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "Menu",
-                "production",
                 "We'll have 2 plates of seared salmon nigiri.");
-            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(options);
+
+            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(conversationsProject, options);
 #else
             AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                TestEnvironment.ProjectName,
-                TestEnvironment.DeploymentName,
                 "We'll have 2 plates of seared salmon nigiri.");
-            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(options);
+
+            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(TestEnvironment.Project, options);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample2_AnalyzeConversationWithOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample2_AnalyzeConversationWithOptions.cs
@@ -20,10 +20,10 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
 
 #if SNIPPET
             ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
+            {
                 IsLoggingEnabled = true,
                 Verbose = true,
-                Language = "en"
             };
 
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
@@ -31,10 +31,10 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
                 conversationsProject,
                 options);
 #else
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
+            {
                 IsLoggingEnabled = true,
                 Verbose = true,
-                Language = "en"
             };
 
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
@@ -61,10 +61,10 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
 
 #if SNIPPET
             ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
+            {
                 IsLoggingEnabled = true,
                 Verbose = true,
-                Language = "en"
             };
 
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
@@ -72,10 +72,10 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
                 conversationsProject,
                 options);
 #else
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
+            {
                 IsLoggingEnabled = true,
                 Verbose = true,
-                Language = "en"
             };
 
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample2_AnalyzeConversationWithOptions.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample2_AnalyzeConversationWithOptions.cs
@@ -20,15 +20,27 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
 
 #if SNIPPET
             ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "We'll have 2 plates of seared salmon nigiri.");
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+                IsLoggingEnabled = true,
+                Verbose = true,
+                Language = "en"
+            };
 
-            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
+            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
+                "We'll have 2 plates of seared salmon nigiri.",
+                conversationsProject,
+                options);
 #else
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "We'll have 2 plates of seared salmon nigiri.");
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+                IsLoggingEnabled = true,
+                Verbose = true,
+                Language = "en"
+            };
 
-            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(TestEnvironment.Project, options);
+            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
+                "We'll have 2 plates of seared salmon nigiri.",
+                TestEnvironment.Project,
+                options);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
@@ -49,15 +61,27 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
 
 #if SNIPPET
             ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "We'll have 2 plates of seared salmon nigiri.");
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+                IsLoggingEnabled = true,
+                Verbose = true,
+                Language = "en"
+            };
 
-            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(conversationsProject, options);
+            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
+                "We'll have 2 plates of seared salmon nigiri.",
+                conversationsProject,
+                options);
 #else
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "We'll have 2 plates of seared salmon nigiri.");
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions(){
+                IsLoggingEnabled = true,
+                Verbose = true,
+                Language = "en"
+            };
 
-            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(TestEnvironment.Project, options);
+            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
+                "We'll have 2 plates of seared salmon nigiri.",
+                TestEnvironment.Project,
+                options);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample3_AnalyzeConversationWithLanguage.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample3_AnalyzeConversationWithLanguage.cs
@@ -20,19 +20,23 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
 
 #if SNIPPET
             ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "Tendremos 2 platos de nigiri de salmón braseado.")
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
             {
                 Language = "es"
             };
-            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
+            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
+                "Tendremos 2 platos de nigiri de salmón braseado.",
+                conversationsProject,
+                options);
 #else
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "Tendremos 2 platos de nigiri de salmón braseado.")
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
             {
                 Language = "es"
             };
-            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(TestEnvironment.Project, options);
+            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
+                "Tendremos 2 platos de nigiri de salmón braseado.",
+                TestEnvironment.Project,
+                options);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
@@ -53,19 +57,23 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
 
 #if SNIPPET
             ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "Tendremos 2 platos de nigiri de salmón braseado.")
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
             {
                 Language = "es"
             };
-            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(conversationsProject, options);
+            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
+                "Tendremos 2 platos de nigiri de salmón braseado.",
+                conversationsProject,
+                options);
 #else
-            AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "Tendremos 2 platos de nigiri de salmón braseado.")
+            AnalyzeConversationOptions options = new AnalyzeConversationOptions()
             {
                 Language = "es"
             };
-            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(TestEnvironment.Project, options);
+            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
+                "Tendremos 2 platos de nigiri de salmón braseado.",
+                TestEnvironment.Project,
+                options);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample3_AnalyzeConversationWithLanguage.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample3_AnalyzeConversationWithLanguage.cs
@@ -19,23 +19,20 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationWithLanguage
 
 #if SNIPPET
+            ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
             AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "Menu",
-                "production", 
                 "Tendremos 2 platos de nigiri de salmón braseado.")
             {
                 Language = "es"
             };
-            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(options);
+            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(conversationsProject, options);
 #else
             AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                TestEnvironment.ProjectName,
-                TestEnvironment.DeploymentName,
                 "Tendremos 2 platos de nigiri de salmón braseado.")
             {
                 Language = "es"
             };
-            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(options);
+            Response<AnalyzeConversationResult> response = client.AnalyzeConversation(TestEnvironment.Project, options);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");
@@ -55,23 +52,20 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationWithLanguageAsync
 
 #if SNIPPET
+            ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
             AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                "Menu",
-                "production",
                 "Tendremos 2 platos de nigiri de salmón braseado.")
             {
                 Language = "es"
             };
-            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(options);
+            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(conversationsProject, options);
 #else
             AnalyzeConversationOptions options = new AnalyzeConversationOptions(
-                TestEnvironment.ProjectName,
-                TestEnvironment.DeploymentName,
                 "Tendremos 2 platos de nigiri de salmón braseado.")
             {
                 Language = "es"
             };
-            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(options);
+            Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(TestEnvironment.Project, options);
 #endif
 
             Console.WriteLine($"Top intent: {response.Value.Prediction.TopIntent}");

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample4_ConversationPrediction.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample4_ConversationPrediction.cs
@@ -19,15 +19,14 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationWithConversationPrediction
 
 #if SNIPPET
+            ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                "Menu",
-                "production",
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                conversationsProject);
 #else
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                TestEnvironment.ProjectName,
-                TestEnvironment.DeploymentName,
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                TestEnvironment.Project);
 #endif
 
             ConversationPrediction conversationPrediction = response.Value.Prediction as ConversationPrediction;
@@ -65,15 +64,14 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationWithConversationPredictionAsync
 
 #if SNIPPET
+            ConversationsProject conversationsProject = new ConversationsProject("Menu", "production");
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-                "Menu",
-                "production",
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                conversationsProject);
 #else
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-                TestEnvironment.ProjectName,
-                TestEnvironment.DeploymentName,
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                TestEnvironment.Project);
 #endif
 
             ConversationPrediction conversationPrediction = response.Value.Prediction as ConversationPrediction;

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample5_OrchestrationPrediction.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/tests/Samples/Sample5_OrchestrationPrediction.cs
@@ -21,15 +21,14 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationOrchestrationPrediction
 
 #if SNIPPET
+            ConversationsProject orchestrationProject = new ConversationsProject("DomainOrchestrator", "production");
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                "DomainOrchestrator",
-                "production",
-                "Where are the calories per recipe?");
+                "Where are the calories per recipe?",
+                orchestrationProject);
 #else
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                TestEnvironment.OrchestrationProjectName,
-                TestEnvironment.DeploymentName,
-                "Where are the calories per recipe?");
+                "Where are the calories per recipe?",
+                TestEnvironment.OrchestrationProject);
 #endif
 
             OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as OrchestratorPrediction;
@@ -65,9 +64,8 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             ConversationAnalysisClient client = Client;
 
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                TestEnvironment.OrchestrationProjectName,
-                TestEnvironment.DeploymentName,
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                TestEnvironment.OrchestrationProject);
 
             OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as OrchestratorPrediction;
 
@@ -118,9 +116,8 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             ConversationAnalysisClient client = Client;
 
             Response<AnalyzeConversationResult> response = client.AnalyzeConversation(
-                TestEnvironment.OrchestrationProjectName,
-                TestEnvironment.DeploymentName,
-                "Book me flight from London to Paris");
+                "Book me flight from London to Paris",
+                TestEnvironment.OrchestrationProject);
 
             OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as OrchestratorPrediction;
 
@@ -150,15 +147,14 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             #region Snippet:ConversationAnalysis_AnalyzeConversationOrchestrationPredictionAsync
 
 #if SNIPPET
+            ConversationsProject orchestrationProject = new ConversationsProject("DomainOrchestrator", "production");
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-                "DomainOrchestrator",
-                "production",
-                "Where are the calories per recipe?");
+                "Where are the calories per recipe?",
+                orchestrationProject);
 #else
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-                TestEnvironment.OrchestrationProjectName,
-                TestEnvironment.DeploymentName,
-                "Where are the calories per recipe?");
+                "Where are the calories per recipe?",
+                TestEnvironment.OrchestrationProject);
 #endif
 
             OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as OrchestratorPrediction;
@@ -193,9 +189,8 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             ConversationAnalysisClient client = Client;
 
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-                TestEnvironment.OrchestrationProjectName,
-                TestEnvironment.DeploymentName,
-                "We'll have 2 plates of seared salmon nigiri.");
+                "We'll have 2 plates of seared salmon nigiri.",
+                TestEnvironment.OrchestrationProject);
 
             OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as OrchestratorPrediction;
 
@@ -245,9 +240,8 @@ namespace Azure.AI.Language.Conversations.Tests.Samples
             ConversationAnalysisClient client = Client;
 
             Response<AnalyzeConversationResult> response = await client.AnalyzeConversationAsync(
-                TestEnvironment.OrchestrationProjectName,
-                TestEnvironment.DeploymentName,
-                "Book me flight from London to Paris");
+                "Book me flight from London to Paris",
+                TestEnvironment.OrchestrationProject);
 
             OrchestratorPrediction orchestratorPrediction = response.Value.Prediction as OrchestratorPrediction;
 


### PR DESCRIPTION
Closes #25027. 

This PR includes a new class for holding the ProjectName and DeploymentName attributes with the name of `ConversationsProject`. The following three changes were also made for consistency with Question Answering and the `GetAnswersAsync` client method was mainly used as reference:

- `AnalyzeConversation` now takes the following parameters
```
AnalyzeConversation(string query, ConversationsProject conversationsProject, CancellationToken cancellationToken = default)
```
- Deployment and Project Names were removed from `AnalyzeConversationOptions` (similar to how they were removed from `QueryKnowledgeBaseOptions`.

- The options overload for `AnalyzeConversation` is now:
```
AnalyzeConversation(ConversationsProject conversationsProject, AnalyzeConversationOptions options, CancellationToken cancellationToken = default)
```
The PR is temporarily placed as a draft pull request since we would like to merge this change post the release of the SDK preview on the third of November.

