### PR TITLE
refactor(resourcemanager): remove virtual call in ArmResource constructor

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmResource.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmResource.cs
@@ -58,11 +58,7 @@ namespace Azure.ResourceManager.Core
         /// <param name="id"> The identifier of the resource that is the target of operations. </param>
         internal ArmResource(ClientContext clientContext, ResourceIdentifier id)
         {
-            ClientOptions = clientContext.ClientOptions;
-            Id = id;
-            Credential = clientContext.Credential;
-            BaseUri = clientContext.BaseUri;
-            Pipeline = clientContext.Pipeline;
+            Initialize(clientContext, id);
             ValidateResourceType(id);
         }
 
@@ -71,7 +67,7 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets the resource identifier.
         /// </summary>
-        public virtual ResourceIdentifier Id { get; }
+        public virtual ResourceIdentifier Id { get; private set; }
 
         /// <summary>
         /// Gets the Azure Resource Manager client options.
@@ -91,7 +87,7 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets the HTTP pipeline.
         /// </summary>
-        protected internal virtual HttpPipeline Pipeline { get; }
+        protected internal virtual HttpPipeline Pipeline { get; private set; }
 
         /// <summary>
         /// Gets the valid Azure resource type for the current operations.
@@ -106,10 +102,24 @@ namespace Azure.ResourceManager.Core
         protected internal TagResource TagResource => _tagResource ??= new TagResource(this, Id);
 
         /// <summary>
+        /// Initialize base properties
+        /// </summary>
+        /// <param name="clientContext"></param>
+        /// <param name="id"></param>
+        internal void Initialize(ClientContext clientContext, ResourceIdentifier id)
+        {
+            ClientOptions = clientContext.ClientOptions;
+            Id = id;
+            Credential = clientContext.Credential;
+            BaseUri = clientContext.BaseUri;
+            Pipeline = clientContext.Pipeline;
+        }
+
+        /// <summary>
         /// Validate the resource identifier against current operations.
         /// </summary>
         /// <param name="identifier"> The resource identifier. </param>
-        protected virtual void ValidateResourceType(ResourceIdentifier identifier)
+        private void ValidateResourceType(ResourceIdentifier identifier)
         {
             if (identifier?.ResourceType != ValidResourceType)
                 throw new ArgumentException($"Invalid resource type {identifier?.ResourceType} expected {ValidResourceType}");

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Custom/Resources/PredefinedTag.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Custom/Resources/PredefinedTag.cs
@@ -35,8 +35,9 @@ namespace Azure.ResourceManager.Resources
         /// <param name="clientContext"></param>
         /// <param name="id"> The id of the subscription. </param>
         internal PredefinedTag(ClientContext clientContext, ResourceIdentifier id)
-            : base(clientContext, id)
         {
+            Initialize(clientContext, id);
+            ValidateResourceType(Id);
             _clientDiagnostics = new ClientDiagnostics(ClientOptions);
             _restClient = new TagRestOperations(_clientDiagnostics, Pipeline, ClientOptions, Id.SubscriptionId, BaseUri);
         }
@@ -47,12 +48,11 @@ namespace Azure.ResourceManager.Resources
         /// <param name="operations"> The operations object to copy the client parameters from. </param>
         /// <param name="data"> The data model representing the generic azure resource. </param>
         internal PredefinedTag(ArmResource operations, PredefinedTagData data)
-            : base(operations, data.Id)
+            : this(new ClientContext(operations.ClientOptions, operations.Credential, operations.BaseUri, operations.Pipeline), data.Id)
         {
+            ValidateResourceType(data.Id);
             _data = data;
             HasData = true;
-            _clientDiagnostics = new ClientDiagnostics(ClientOptions);
-            _restClient = new TagRestOperations(_clientDiagnostics, Pipeline, ClientOptions, Id.SubscriptionId, BaseUri);
         }
 
         /// <summary>
@@ -201,8 +201,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        /// <inheritdoc/>
-        protected override void ValidateResourceType(ResourceIdentifier identifier)
+        private static void ValidateResourceType(ResourceIdentifier identifier)
         {
             if (identifier is null)
                 throw new ArgumentException("Invalid resource type for TagsOperation", nameof(identifier));

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Feature.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Feature.cs
@@ -31,12 +31,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="operations"> The operations to copy the client options from. </param>
         /// <param name="resource"> The FeatureData to use in these operations. </param>
         internal Feature(ArmResource operations, FeatureData resource)
-            : base(operations, resource.Id)
+            : this(new ClientContext(operations.ClientOptions, operations.Credential, operations.BaseUri, operations.Pipeline), resource.Id)
         {
             _data = resource;
             HasData = true;
-            _clientDiagnostics = new ClientDiagnostics(ClientOptions);
-            _restClient = new FeaturesRestOperations(_clientDiagnostics, Pipeline, ClientOptions, Id.SubscriptionId, BaseUri);
         }
 
         /// <summary>
@@ -45,8 +43,9 @@ namespace Azure.ResourceManager.Resources
         /// <param name="options"> The client parameters to use in these operations. </param>
         /// <param name="id"> The id of the resource group to use. </param>
         internal Feature(ClientContext options, ResourceIdentifier id)
-            : base(options, id)
         {
+            Initialize(options, id);
+            ValidateResourceType(Id);
             _clientDiagnostics = new ClientDiagnostics(ClientOptions);
             _restClient = new FeaturesRestOperations(_clientDiagnostics, Pipeline, ClientOptions, Id.SubscriptionId, BaseUri);
         }
@@ -78,8 +77,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        /// <inheritdoc/>
-        protected override void ValidateResourceType(ResourceIdentifier identifier)
+        private void ValidateResourceType(ResourceIdentifier identifier)
         {
             if (identifier.ResourceType != $"{Id.ResourceType.Namespace}/features")
             {

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/GenericResource.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/GenericResource.cs
@@ -35,8 +35,9 @@ namespace Azure.ResourceManager.Resources
         /// <param name="operations"> The operation to get the client properties from. </param>
         /// <param name="id"> The id of the resource. </param>
         internal GenericResource(ArmResource operations, ResourceIdentifier id)
-            : base(operations, id)
         {
+            Initialize(new ClientContext(operations.ClientOptions, operations.Credential, operations.BaseUri, operations.Pipeline), id);
+            ValidateResourceType(Id);
             _clientDiagnostics = new ClientDiagnostics(ClientOptions);
             _restClient = new ResourcesRestOperations(_clientDiagnostics, Pipeline, ClientOptions, Id.SubscriptionId, BaseUri);
         }
@@ -48,12 +49,10 @@ namespace Azure.ResourceManager.Resources
         /// <param name="resource"> The data model representing the generic azure resource. </param>
         /// <exception cref="ArgumentNullException"> If <see cref="ArmClientOptions"/> or <see cref="TokenCredential"/> is null. </exception>
         internal GenericResource(ArmResource operations, GenericResourceData resource)
-            : base(operations, resource.Id)
+            : this(operations, resource.Id)
         {
             _data = resource;
             HasData = true;
-            _clientDiagnostics = new ClientDiagnostics(ClientOptions);
-            _restClient = new ResourcesRestOperations(_clientDiagnostics, Pipeline, ClientOptions, Id.SubscriptionId, BaseUri);
         }
 
         /// <inheritdoc/>
@@ -228,8 +227,7 @@ namespace Azure.ResourceManager.Resources
             }
         }
 
-        /// <inheritdoc/>
-        protected override void ValidateResourceType(ResourceIdentifier identifier)
+        private static void ValidateResourceType(ResourceIdentifier identifier)
         {
             if (identifier is null)
                 throw new ArgumentNullException(nameof(identifier));

--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/GenericResourceCollection.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/GenericResourceCollection.cs
@@ -34,17 +34,12 @@ namespace Azure.ResourceManager.Resources
         /// <param name="clientContext"> The client context to use. </param>
         /// <param name="id"> The id for the subscription that owns this collection. </param>
         internal GenericResourceCollection(ClientContext clientContext, ResourceIdentifier id)
-            : base(clientContext, id)
         {
+            Initialize(clientContext, id);
         }
 
         /// <inheritdoc/>
         protected override ResourceType ValidResourceType => ResourceIdentifier.RootResourceIdentifier.ResourceType;
-
-        /// <inheritdoc/>
-        protected override void ValidateResourceType(ResourceIdentifier identifier)
-        {
-        }
 
         private ResourcesRestOperations RestClient
         {


### PR DESCRIPTION
1. remove `virtual` from all `ValidateResourceType` methods
2. extract common property initialization logic into `ArmResource.Initialize`
3. for all classes inheriting `ArmResource`, change the constrctor implemenation to not rely on base class initialization, so that we can invoke local version of `ValidateResourceType` in the costructors.

resolve #1627

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
