### PR TITLE
Use working region/subscription for search deployments

### DIFF
--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -6,7 +6,9 @@ extends:
     ServiceDirectory: search
     TimeoutInMinutes: 240
     MaxParallel: 2
-    UnsupportedClouds: 'Canary'
-    SupportedClouds: 'Public,UsGov,China'
+    # TODO: change 'Preview' cloud back to public after search RP fixes deletion metadata issue
+    # https://github.com/Azure/azure-sdk-tools/issues/2216
+    Clouds: 'Preview'
+    SupportedClouds: 'Preview,UsGov,China'
     EnvVars:
       AZURE_SEARCH_TEST_MODE: Live


### PR DESCRIPTION
We are running into deployment issues with the search RP and deletion metadata. This switches our search deployments to a working region/subscription until their fix rolls out