### PR TITLE
[CLU] Fixing read me and sample links

### DIFF
--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -2,7 +2,7 @@
 
 Azure Conversations - the new version of Language Understanding (LUIS) - is a cloud-based conversational AI service that applies custom machine-learning intelligence to a user's conversational, natural language text to predict overall meaning; and pulls out relevant, detailed information. The service utilizes state-of-the-art technology to create and utilize natively multilingual models, which means that users would be able to train their models in one language but predict in others.
 
-[Source code][conversationanalysis_client_src] | [Package (NuGet)][conversationanalysis_nuget_package] | [API reference documentation][conversationanalysis_refdocs] | [Product documentation][conversationanalysis_docs] | [Samples][conversationanalysis_samples]
+[Source code][conversationanalysis_client_src] | [Package (NuGet)][conversationanalysis_nuget_package] | [Product documentation][conversationanalysis_docs] | [Samples][conversationanalysis_samples]
 
 ## Getting started
 
@@ -216,7 +216,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [conversationanalysis_samples]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/
 [conversationanalysis_nuget_package]: https://www.nuget.org/packages/Azure.AI.Language.Conversations/1.0.0-beta.1
 [conversationanalysis_docs]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview
-[conversationanalysis_docs_demos]: https://azure.microsoft.com/services/cognitive-services/qna-maker/#demo
+[conversationanalysis_docs_demos]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/quickstart?pivots=language-studio
 [conversationanalysis_docs_features]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview#features
-[conversationanalysis_refdocs]: https://docs.microsoft.com/dotnet/api/Azure.AI.Language.QuestionAnswering/
 [conversationanalysis_rest_docs]: https://docs.microsoft.com/rest/api/cognitiveservices-qnamaker/

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -218,5 +218,5 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [conversationanalysis_docs]: https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/conversational-language-understanding/overview
 [conversationanalysis_docs_demos]: https://azure.microsoft.com/services/cognitive-services/qna-maker/#demo
 [conversationanalysis_docs_features]: https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/conversational-language-understanding/overview#features
-[conversationanalysis_refdocs]: https://docs.microsoft.com/dotnet/api/Azure.AI.Language.Conversations/
+[conversationanalysis_refdocs]: https://docs.microsoft.com/dotnet/api/Azure.AI.Language.QuestionAnswering/
 [conversationanalysis_rest_docs]: https://docs.microsoft.com/rest/api/cognitiveservices-qnamaker/

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -2,7 +2,7 @@
 
 Azure Conversations - the new version of Language Understanding (LUIS) - is a cloud-based conversational AI service that applies custom machine-learning intelligence to a user's conversational, natural language text to predict overall meaning; and pulls out relevant, detailed information. The service utilizes state-of-the-art technology to create and utilize natively multilingual models, which means that users would be able to train their models in one language but predict in others.
 
-[Source code][conversationanalysis_client_src] | [Package (NuGet)][conversationanalysis_nuget_package] | [Product documentation][conversationanalysis_docs] | [Samples][conversationanalysis_samples]
+[Source code][conversationanalysis_client_src] | [Package (NuGet)][conversationanalysis_nuget_package] | [API reference documentation][conversationanalysis_refdocs] | [Product documentation][conversationanalysis_docs] | [Samples][conversationanalysis_samples]
 
 ## Getting started
 
@@ -216,5 +216,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [conversationanalysis_samples]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/
 [conversationanalysis_nuget_package]: https://www.nuget.org/packages/Azure.AI.Language.Conversations/1.0.0-beta.1
 [conversationanalysis_docs]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview
-[conversationanalysis_docs_demos]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/quickstart?pivots=language-studio
-[conversationanalysis_docs_features]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview#features
+[conversationanalysis_docs_demos]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/quickstart
+[conversationanalysis_docs_features]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview
+[conversationanalysis_refdocs]: https://review.docs.microsoft.com/dotnet/api/azure.ai.language.conversations

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -214,13 +214,9 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [conversationanalysis_client_class]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/ConversationAnalysisClient.cs
 [conversationanalysis_client_src]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/
 [conversationanalysis_samples]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/
-
-<!--Update once nuget is released-->
-[conversationanalysis_nuget_package]: https://nuget.org/packages
-
-<!--Will be updated once service documentation is public-->
-[conversationanalysis_docs]: https://docs.microsoft.com/azure/cognitive-services/qnamaker/
+[conversationanalysis_nuget_package]: https://www.nuget.org/packages/Azure.AI.Language.Conversations/1.0.0-beta.1
+[conversationanalysis_docs]: https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/conversational-language-understanding/overview
 [conversationanalysis_docs_demos]: https://azure.microsoft.com/services/cognitive-services/qna-maker/#demo
-[conversationanalysis_docs_features]: https://azure.microsoft.com/services/cognitive-services/qna-maker/#features
-[conversationanalysis_refdocs]: https://docs.microsoft.com/dotnet/api/Azure.AI.Language.QuestionAnswering/
+[conversationanalysis_docs_features]: https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/conversational-language-understanding/overview#features
+[conversationanalysis_refdocs]: https://docs.microsoft.com/dotnet/api/Azure.AI.Language.Conversations/
 [conversationanalysis_rest_docs]: https://docs.microsoft.com/rest/api/cognitiveservices-qnamaker/

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -122,7 +122,7 @@ Other optional properties can be set such as verbosity and whether service loggi
 
 ### General
 
-When you interact with the Cognitive Language Services Conversations client library using the .NET SDK, errors returned by the service correspond to the same HTTP status codes returned for [REST API][conversationanalysis_rest_docs] requests.
+When you interact with the Cognitive Language Services Conversations client library using the .NET SDK, errors returned by the service correspond to the same HTTP status codes returned for REST API requests.
 
 For example, if you submit a query to a non-existant project, a `400` error is returned indicating "Bad Request".
 
@@ -218,4 +218,3 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [conversationanalysis_docs]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview
 [conversationanalysis_docs_demos]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/quickstart?pivots=language-studio
 [conversationanalysis_docs_features]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview#features
-[conversationanalysis_rest_docs]: https://docs.microsoft.com/rest/api/cognitiveservices-qnamaker/

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/README.md
@@ -215,8 +215,8 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [conversationanalysis_client_src]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/
 [conversationanalysis_samples]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/
 [conversationanalysis_nuget_package]: https://www.nuget.org/packages/Azure.AI.Language.Conversations/1.0.0-beta.1
-[conversationanalysis_docs]: https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/conversational-language-understanding/overview
+[conversationanalysis_docs]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview
 [conversationanalysis_docs_demos]: https://azure.microsoft.com/services/cognitive-services/qna-maker/#demo
-[conversationanalysis_docs_features]: https://docs.microsoft.com/en-us/azure/cognitive-services/language-service/conversational-language-understanding/overview#features
+[conversationanalysis_docs_features]: https://docs.microsoft.com/azure/cognitive-services/language-service/conversational-language-understanding/overview#features
 [conversationanalysis_refdocs]: https://docs.microsoft.com/dotnet/api/Azure.AI.Language.QuestionAnswering/
 [conversationanalysis_rest_docs]: https://docs.microsoft.com/rest/api/cognitiveservices-qnamaker/

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/README.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/README.md
@@ -15,3 +15,7 @@ description: Samples for the Azure.AI.Language.Conversations client library
 Conversation Analysis is a cloud-based conversational AI service that applies custom machine-learning intelligence to a user's conversational, natural language text to predict overall meaning, and pull out relevant, detailed information.
 
 - [Analyze an utterance](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample1_AnalyzeConversation.md)
+- [Analyze an utterance using extra options](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample2_AnalyzeConversationWithOptions.md)
+- [Analyze an utterance in a different language](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample3_AnalyzeConversationWithLanguage.md)
+- [Analyze an utterance - Conversation project](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample4_ConversationPrediction.md)
+- [Analyze an utterance - Orchestration project](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/cognitivelanguage/Azure.AI.Language.Conversations/samples/Sample5_OrchestrationPrediction.md)


### PR DESCRIPTION
- Adding links to the sample markdowns to the sample "index".
- Fixing some broken links in the readme, however two links are still broken.
  - The service's REST API docs. (Which is still not yet developed)
  - The SDK docs parallel [to this one for question answering](https://docs.microsoft.com/en-us/dotnet/api/Azure.AI.Language.QuestionAnswering?view=azure-dotnet-preview).