### PR TITLE
[FormRecognizer] Implemented Words convenience properties

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
@@ -240,6 +240,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public string DocType { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentField> Fields { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> Spans { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> Words { get { throw null; } }
     }
     public partial class AnalyzeDocumentOperation : Azure.Operation<Azure.AI.FormRecognizer.DocumentAnalysis.AnalyzeResult>
     {
@@ -368,6 +369,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public string Content { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> Spans { get { throw null; } }
         public string SubCategory { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> Words { get { throw null; } }
     }
     public partial class DocumentField
     {
@@ -377,6 +379,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public string Content { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> Spans { get { throw null; } }
         public Azure.AI.FormRecognizer.DocumentAnalysis.DocumentFieldType ValueType { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> Words { get { throw null; } }
         public string AsCountryRegion() { throw null; }
         public System.DateTime AsDate() { throw null; }
         public System.Collections.Generic.IReadOnlyDictionary<string, Azure.AI.FormRecognizer.DocumentAnalysis.DocumentField> AsDictionary() { throw null; }
@@ -418,6 +421,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.BoundingRegion> BoundingRegions { get { throw null; } }
         public string Content { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> Spans { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> Words { get { throw null; } }
     }
     public partial class DocumentKeyValuePair
     {
@@ -432,6 +436,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public Azure.AI.FormRecognizer.DocumentAnalysis.BoundingBox BoundingBox { get { throw null; } }
         public string Content { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> Spans { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> Words { get { throw null; } }
     }
     public partial class DocumentModel : Azure.AI.FormRecognizer.DocumentAnalysis.DocumentModelInfo
     {
@@ -560,6 +565,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public int ColumnCount { get { throw null; } }
         public int RowCount { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> Spans { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> Words { get { throw null; } }
     }
     public partial class DocumentTableCell
     {
@@ -572,6 +578,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         public int RowIndex { get { throw null; } }
         public int? RowSpan { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentSpan> Spans { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentWord> Words { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DocumentTableCellKind : System.IEquatable<Azure.AI.FormRecognizer.DocumentAnalysis.DocumentTableCellKind>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeResult.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzeResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
@@ -11,7 +12,63 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     [CodeGenModel("AnalyzeResult")]
     public partial class AnalyzeResult
     {
+        internal AnalyzeResult(ApiVersion apiVersion, string modelId, StringIndexType stringIndexType, string content, IReadOnlyList<DocumentPage> pages, IReadOnlyList<DocumentTable> tables, IReadOnlyList<DocumentKeyValuePair> keyValuePairs, IReadOnlyList<DocumentEntity> entities, IReadOnlyList<DocumentStyle> styles, IReadOnlyList<AnalyzedDocument> documents)
+        {
+            ApiVersion = apiVersion;
+            ModelId = modelId;
+            StringIndexType = stringIndexType;
+            Content = content;
+            Pages = pages;
+            Tables = tables;
+            KeyValuePairs = keyValuePairs;
+            Entities = entities;
+            Styles = styles;
+            Documents = documents;
+
+            // Set page references for the 'Words' convenience properties.
+
+            foreach (DocumentPage page in Pages)
+            {
+                foreach (DocumentLine line in page.Lines)
+                {
+                    line.Page = page;
+                }
+            }
+
+            foreach (DocumentTable table in Tables)
+            {
+                table.Pages = Pages;
+
+                foreach (DocumentTableCell cell in table.Cells)
+                {
+                    cell.Pages = Pages;
+                }
+            }
+
+            foreach (DocumentKeyValuePair kvp in KeyValuePairs)
+            {
+                kvp.Key.Pages = Pages;
+                kvp.Value.Pages = Pages;
+            }
+
+            foreach (DocumentEntity entity in Entities)
+            {
+                entity.Pages = Pages;
+            }
+
+            foreach (AnalyzedDocument document in Documents)
+            {
+                document.Pages = Pages;
+
+                foreach (DocumentField field in document.Fields.Values)
+                {
+                    field.Pages = Pages;
+                }
+            }
+        }
+
         private ApiVersion ApiVersion { get; }
+
         private StringIndexType StringIndexType { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzedDocument.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/AnalyzedDocument.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
@@ -8,5 +9,16 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     [CodeGenModel("Document")]
     public partial class AnalyzedDocument
     {
+        /// <summary>
+        /// The words that make up this document.
+        /// </summary>
+        public IReadOnlyList<DocumentWord> Words => ClientCommon.GetWords(Pages, Spans);
+
+        /// <summary>
+        /// The complete list of pages returned in the Analyze Result, including pages
+        /// unrelated to this element. Used only for the convenience <see cref="Words"/>
+        /// property.
+        /// </summary>
+        internal IReadOnlyList<DocumentPage> Pages { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure.AI.FormRecognizer.DocumentAnalysis;
 using Azure.AI.FormRecognizer.Models;
 using Azure.Core;
 using Azure.Core.Pipeline;
@@ -88,5 +89,35 @@ namespace Azure.AI.FormRecognizer
             }
             return new RecognizedFormCollection(forms);
         }
+
+        public static IReadOnlyList<DocumentWord> GetWords(IReadOnlyList<DocumentPage> pages, IReadOnlyList<DocumentSpan> spans)
+        {
+            var selectedWords = new List<DocumentWord>();
+
+            // Very inefficient implementation for now.
+
+            foreach (DocumentPage page in pages)
+            {
+                foreach (DocumentWord word in page.Words)
+                {
+                    foreach (DocumentSpan span in spans)
+                    {
+                        // Check if word.StartPos >= span.StartPos && word.EndPos <= span.StartPos (word contained in span)
+                        // Is it possible for a word to be across multiple spans?
+                        if (word.Span.Offset >= span.Offset
+                            && word.Span.Offset + word.Span.Length <= span.Offset + span.Length)
+                        {
+                            selectedWords.Add(word);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return selectedWords;
+        }
+
+        public static IReadOnlyList<DocumentWord> GetWords(DocumentPage page, IReadOnlyList<DocumentSpan> spans) =>
+            GetWords(new List<DocumentPage>() { page }, spans);
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentEntity.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentEntity.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
@@ -8,5 +9,16 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     [CodeGenModel("DocumentEntity")]
     public partial class DocumentEntity
     {
+        /// <summary>
+        /// The words that make up this entity.
+        /// </summary>
+        public IReadOnlyList<DocumentWord> Words => ClientCommon.GetWords(Pages, Spans);
+
+        /// <summary>
+        /// The complete list of pages returned in the Analyze Result, including pages
+        /// unrelated to this element. Used only for the convenience <see cref="Words"/>
+        /// property.
+        /// </summary>
+        internal IReadOnlyList<DocumentPage> Pages { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentField.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentField.cs
@@ -16,6 +16,18 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         [CodeGenMember("Type")]
         public DocumentFieldType ValueType { get; }
 
+        /// <summary>
+        /// The words that make up this field.
+        /// </summary>
+        public IReadOnlyList<DocumentWord> Words => ClientCommon.GetWords(Pages, Spans);
+
+        /// <summary>
+        /// The complete list of pages returned in the Analyze Result, including pages
+        /// unrelated to this element. Used only for the convenience <see cref="Words"/>
+        /// property.
+        /// </summary>
+        internal IReadOnlyList<DocumentPage> Pages { get; set; }
+
         private string ValueString { get; }
 
         private DateTimeOffset? ValueDate { get; }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentKeyValueElement.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentKeyValueElement.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
@@ -8,5 +9,16 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     [CodeGenModel("DocumentKeyValueElement")]
     public partial class DocumentKeyValueElement
     {
+        /// <summary>
+        /// The words that make up this key-value element.
+        /// </summary>
+        public IReadOnlyList<DocumentWord> Words => ClientCommon.GetWords(Pages, Spans);
+
+        /// <summary>
+        /// The complete list of pages returned in the Analyze Result, including pages
+        /// unrelated to this element. Used only for the convenience <see cref="Words"/>
+        /// property.
+        /// </summary>
+        internal IReadOnlyList<DocumentPage> Pages { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentLine.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentLine.cs
@@ -17,6 +17,17 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
         /// </summary>
         public BoundingBox BoundingBox { get; private set; }
 
+        /// <summary>
+        /// The words that make up this line.
+        /// </summary>
+        public IReadOnlyList<DocumentWord> Words => ClientCommon.GetWords(Page, Spans);
+
+        /// <summary>
+        /// The page in which this element is located. Used only for the convenience
+        /// <see cref="Words"/> property.
+        /// </summary>
+        internal DocumentPage Page { get; set; }
+
         [CodeGenMember("BoundingBox")]
         private IReadOnlyList<float> BoundingBoxPrivate
         {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentPage.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentTable.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentTable.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
@@ -8,5 +9,16 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     [CodeGenModel("DocumentTable")]
     public partial class DocumentTable
     {
+        /// <summary>
+        /// The words that make up this table.
+        /// </summary>
+        public IReadOnlyList<DocumentWord> Words => ClientCommon.GetWords(Pages, Spans);
+
+        /// <summary>
+        /// The complete list of pages returned in the Analyze Result, including pages
+        /// unrelated to this element. Used only for the convenience <see cref="Words"/>
+        /// property.
+        /// </summary>
+        internal IReadOnlyList<DocumentPage> Pages { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentTableCell.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/DocumentTableCell.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.AI.FormRecognizer.DocumentAnalysis
@@ -8,5 +9,16 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
     [CodeGenModel("DocumentTableCell")]
     public partial class DocumentTableCell
     {
+        /// <summary>
+        /// The words that make up this table cell.
+        /// </summary>
+        public IReadOnlyList<DocumentWord> Words => ClientCommon.GetWords(Pages, Spans);
+
+        /// <summary>
+        /// The complete list of pages returned in the Analyze Result, including pages
+        /// unrelated to this element. Used only for the convenience <see cref="Words"/>
+        /// property.
+        /// </summary>
+        internal IReadOnlyList<DocumentPage> Pages { get; set; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeResult.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeResult.cs
@@ -48,31 +48,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis
             Styles = new ChangeTrackingList<DocumentStyle>();
             Documents = new ChangeTrackingList<AnalyzedDocument>();
         }
-
-        /// <summary> Initializes a new instance of AnalyzeResult. </summary>
-        /// <param name="apiVersion"> API version used to produce this result. </param>
-        /// <param name="modelId"> Model ID used to produce this result. </param>
-        /// <param name="stringIndexType"> Method used to compute string offset and length. </param>
-        /// <param name="content"> Concatenate string representation of all textual and visual elements in reading order. </param>
-        /// <param name="pages"> Analyzed pages. </param>
-        /// <param name="tables"> Extracted tables. </param>
-        /// <param name="keyValuePairs"> Extracted key-value pairs. </param>
-        /// <param name="entities"> Extracted entities. </param>
-        /// <param name="styles"> Extracted font styles. </param>
-        /// <param name="documents"> Extracted documents. </param>
-        internal AnalyzeResult(ApiVersion apiVersion, string modelId, StringIndexType stringIndexType, string content, IReadOnlyList<DocumentPage> pages, IReadOnlyList<DocumentTable> tables, IReadOnlyList<DocumentKeyValuePair> keyValuePairs, IReadOnlyList<DocumentEntity> entities, IReadOnlyList<DocumentStyle> styles, IReadOnlyList<AnalyzedDocument> documents)
-        {
-            ApiVersion = apiVersion;
-            ModelId = modelId;
-            StringIndexType = stringIndexType;
-            Content = content;
-            Pages = pages;
-            Tables = tables;
-            KeyValuePairs = keyValuePairs;
-            Entities = entities;
-            Styles = styles;
-            Documents = documents;
-        }
         /// <summary> Model ID used to produce this result. </summary>
         public string ModelId { get; }
         /// <summary> Concatenate string representation of all textual and visual elements in reading order. </summary>


### PR DESCRIPTION
This PR is a work in progress and won't be included in the next FR release.

We're adding the `Words` property to the following document elements: `DocumentLine`, `DocumentTable`, `DocumentTableCell`, `DocumentEntity`, `DocumentKeyValueElement`, `AnalyzedDocument`, and `DocumentField`.

The `Words` property returns the list of `DocumentWord` references that make up a document element. For example,
```cs
// Content: "The quick brown fox jumps over the lazy dog"
DocumentLine line = <...>;

// { "The", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog" }
IReadOnlyList<DocumentWord> words = line.Words;
```