### PR TITLE
[Event Hubs] Buffered Producer Live Test and Fixes

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Release History
 
-## 5.7.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 5.7.0-beta.1 (2021-11-09)
 
 ### Other Changes
 
-- Added additional heuristics for the `EventProcessor<T>` load balancing cycle to help discover issues that can impact processor performance and stability; these validations will produce warnings should potential concerns be found.
+- Added additional heuristics for the `EventProcessorClient` load balancing cycle to help discover issues that can impact processor performance and stability; these validations will produce warnings should potential concerns be found.
+
+- `EventProcessorClient` will now log a verbose message indicating what event position was chosen to read from when initializing a partition.
 
 ## 5.6.2 (2021-10-05)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Release History
 
-## 5.7.0-beta.1 (Unreleased)
+## 5.7.0-beta.1 (2021-11-09)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
+- The `EventHubBufferedProducerClient` is being introduced, intended to allow for efficient publishing of events without having to explicitly manage batches in the application.  More information can be found in its [design document](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hub-buffered-producer.md).
 
 ### Other Changes
 
+- `EventData` now allows the `EventBody` to be set after construction and supports an empty constructor.
+
 - Added additional heuristics for the `EventProcessor<T>` load balancing cycle to help discover issues that can impact processor performance and stability; these validations will produce warnings should potential concerns be found.
+
+- `EventProcessor<T>` will now log a verbose message indicating what event position was chosen to read from when initializing a partition.
+
+- `EventPosition` now exposes its `ToString` method for code completion, making it more discoverable.
 
 ## 5.6.2 (2021-10-05)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -503,6 +503,16 @@ namespace Azure.Messaging.EventHubs.Producer
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }
+    public partial class EnqueueEventOptions : Azure.Messaging.EventHubs.Producer.SendEventOptions
+    {
+        public EnqueueEventOptions() { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
+    }
     public sealed partial class EventDataBatch : System.IDisposable
     {
         internal EventDataBatch() { }
@@ -511,6 +521,64 @@ namespace Azure.Messaging.EventHubs.Producer
         public long SizeInBytes { get { throw null; } }
         public void Dispose() { }
         public bool TryAdd(Azure.Messaging.EventHubs.EventData eventData) { throw null; }
+    }
+    public partial class EventHubBufferedProducerClient : System.IAsyncDisposable
+    {
+        protected EventHubBufferedProducerClient() { }
+        public EventHubBufferedProducerClient(Azure.Messaging.EventHubs.EventHubConnection connection, Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions clientOptions = null) { }
+        public EventHubBufferedProducerClient(string connectionString) { }
+        public EventHubBufferedProducerClient(string connectionString, Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions clientOptions) { }
+        public EventHubBufferedProducerClient(string connectionString, string eventHubName) { }
+        public EventHubBufferedProducerClient(string fullyQualifiedNamespace, string eventHubName, Azure.AzureNamedKeyCredential credential, Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions clientOptions = null) { }
+        public EventHubBufferedProducerClient(string fullyQualifiedNamespace, string eventHubName, Azure.AzureSasCredential credential, Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions clientOptions = null) { }
+        public EventHubBufferedProducerClient(string fullyQualifiedNamespace, string eventHubName, Azure.Core.TokenCredential credential, Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions clientOptions = null) { }
+        public EventHubBufferedProducerClient(string connectionString, string eventHubName, Azure.Messaging.EventHubs.Producer.EventHubBufferedProducerClientOptions clientOptions) { }
+        public string EventHubName { get { throw null; } }
+        public string FullyQualifiedNamespace { get { throw null; } }
+        public string Identifier { get { throw null; } }
+        public virtual bool IsClosed { get { throw null; } }
+        public virtual bool IsPublishing { get { throw null; } }
+        public virtual int TotalBufferedEventCount { get { throw null; } }
+        public event System.Func<Azure.Messaging.EventHubs.Producer.SendEventBatchFailedEventArgs, System.Threading.Tasks.Task> SendEventBatchFailedAsync { add { } remove { } }
+        public event System.Func<Azure.Messaging.EventHubs.Producer.SendEventBatchSucceededEventArgs, System.Threading.Tasks.Task> SendEventBatchSucceededAsync { add { } remove { } }
+        public virtual System.Threading.Tasks.Task CloseAsync(bool flush = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
+        public virtual System.Threading.Tasks.Task<int> EnqueueEventAsync(Azure.Messaging.EventHubs.EventData eventData, Azure.Messaging.EventHubs.Producer.EnqueueEventOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<int> EnqueueEventAsync(Azure.Messaging.EventHubs.EventData eventData, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<int> EnqueueEventsAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> events, Azure.Messaging.EventHubs.Producer.EnqueueEventOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<int> EnqueueEventsAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> events, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        public virtual System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual int GetBufferedEventCount(string partitionId) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.EventHubs.EventHubProperties> GetEventHubPropertiesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public virtual System.Threading.Tasks.Task<string[]> GetPartitionIdsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.EventHubs.PartitionProperties> GetPartitionPropertiesAsync(string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected virtual System.Threading.Tasks.Task<string[]> ListPartitionIdsAsync(Azure.Messaging.EventHubs.Producer.EventHubProducerClient producer, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected virtual System.Threading.Tasks.Task OnSendFailedAsync(System.Collections.Generic.IReadOnlyList<Azure.Messaging.EventHubs.EventData> events, System.Exception exception, string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected virtual System.Threading.Tasks.Task OnSendSucceededAsync(System.Collections.Generic.IReadOnlyList<Azure.Messaging.EventHubs.EventData> events, string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
+    }
+    public partial class EventHubBufferedProducerClientOptions
+    {
+        public EventHubBufferedProducerClientOptions() { }
+        public Azure.Messaging.EventHubs.EventHubConnectionOptions ConnectionOptions { get { throw null; } set { } }
+        public bool EnableIdempotentRetries { get { throw null; } set { } }
+        public string Identifier { get { throw null; } set { } }
+        public int MaximumConcurrentSends { get { throw null; } set { } }
+        public int MaximumConcurrentSendsPerPartition { get { throw null; } set { } }
+        public int MaximumEventBufferLengthPerPartition { get { throw null; } set { } }
+        public System.TimeSpan? MaximumWaitTime { get { throw null; } set { } }
+        public Azure.Messaging.EventHubs.EventHubsRetryOptions RetryOptions { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
     }
     public partial class EventHubProducerClient : System.IAsyncDisposable
     {
@@ -556,6 +624,21 @@ namespace Azure.Messaging.EventHubs.Producer
         public override int GetHashCode() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
+    }
+    public partial class SendEventBatchFailedEventArgs : System.EventArgs
+    {
+        public SendEventBatchFailedEventArgs(System.Collections.Generic.IReadOnlyList<Azure.Messaging.EventHubs.EventData> eventBatch, System.Exception exception, string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Messaging.EventHubs.EventData> EventBatch { get { throw null; } }
+        public System.Exception Exception { get { throw null; } }
+        public string PartitionId { get { throw null; } }
+    }
+    public partial class SendEventBatchSucceededEventArgs : System.EventArgs
+    {
+        public SendEventBatchSucceededEventArgs(System.Collections.Generic.IReadOnlyList<Azure.Messaging.EventHubs.EventData> eventBatch, string partitionId, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Messaging.EventHubs.EventData> EventBatch { get { throw null; } }
+        public string PartitionId { get { throw null; } }
     }
     public partial class SendEventOptions
     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/PartitionResolver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/PartitionResolver.cs
@@ -73,7 +73,7 @@ namespace Azure.Messaging.EventHubs.Core
         /// <returns>The zero-based index of the selected partition from the available set.</returns>
         ///
         public virtual string AssignForPartitionKey(string partitionKey,
-                                                 string[] partitions)
+                                                    string[] partitions)
         {
             var hashValue = GenerateHashCode(partitionKey);
             return partitions[Math.Abs(hashValue % partitions.Length)];

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -48,6 +48,13 @@ namespace Azure.Messaging.EventHubs
             set => _amqpMessage.Body = AmqpMessageBody.FromData(MessageBody.FromReadOnlyMemorySegment(value.ToMemory()));
         }
 
+        /// <summary>
+        ///   The data associated with the event, in <see cref="BinaryData" /> form, providing support
+        ///   for a variety of data transformations and <see cref="ObjectSerializer" /> integration.
+        /// </summary>
+        ///
+        /// <seealso cref="BinaryData" />
+        ///
         BinaryData IMessageWithContentType.Data
         {
             get => EventBody;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EnqueueEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EnqueueEventOptions.cs
@@ -10,7 +10,7 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   are published to the Event Hubs service.
     /// </summary>
     ///
-    internal class EnqueueEventOptions : SendEventOptions
+    public class EnqueueEventOptions : SendEventOptions
     {
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -14,6 +14,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Diagnostics;
+using Azure.Core.Pipeline;
 using Azure.Messaging.EventHubs.Amqp;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Diagnostics;
@@ -53,7 +54,7 @@ namespace Azure.Messaging.EventHubs.Producer
     ///
     /// <seealso cref="EventHubProducerClient" />
     ///
-    internal class EventHubBufferedProducerClient : IAsyncDisposable
+    public class EventHubBufferedProducerClient : IAsyncDisposable
     {
         /// <summary>The maximum amount of time, in milliseconds, to allow for acquiring the semaphore guarding a partition's publishing eligibility.</summary>
         private const int PartitionPublishingGuardAcquireLimitMilliseconds = 100;
@@ -109,6 +110,9 @@ namespace Azure.Messaging.EventHubs.Producer
 
         /// <summary>The count of total events that have been buffered across all partitions.</summary>
         private int _totalBufferedEventCount;
+
+        /// <summary>The set of publishing event handlers that are actively executing; these should be awaited when flushing.</summary>
+        private ConcurrentDictionary<Task, byte> _activePublishingHandlers = new();
 
         /// <summary>The handler to be called once a batch has successfully published.</summary>
         private Func<SendEventBatchSucceededEventArgs, Task> _sendSucceededHandler;
@@ -231,8 +235,10 @@ namespace Azure.Messaging.EventHubs.Producer
         internal ConcurrentDictionary<string, PartitionPublishingState> ActivePartitionStateMap => _activePartitionStateMap;
 
         /// <summary>
-        ///    Invoked after each batch of events has been successfully published to the Event Hub, this
-        ///    handler is optional and is intended to provide notifications for interested listeners.
+        ///   Invoked after each batch of events has been successfully published to the Event Hub, this handler is optional
+        ///   and is intended to provide notifications for interested listeners.  If this producer was not configured with
+        ///   <see cref="EventHubBufferedProducerClientOptions.MaximumConcurrentSends" /> and <see cref="EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition" />
+        ///   both set to 1, the handler will be invoked concurrently.
         ///
         ///   It is not recommended to invoke <see cref="CloseAsync" /> or <see cref="DisposeAsync" /> from this handler; doing so may result
         ///   in a deadlock scenario if those calls are awaited.
@@ -247,6 +253,8 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <exception cref="NotSupportedException">If an attempt is made to add or remove a handler while the processor is running.</exception>
         /// <exception cref="NotSupportedException">If an attempt is made to add a handler when one is currently registered.</exception>
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
         public event Func<SendEventBatchSucceededEventArgs, Task> SendEventBatchSucceededAsync
         {
             add
@@ -286,7 +294,9 @@ namespace Azure.Messaging.EventHubs.Producer
 
         /// <summary>
         ///   Invoked for any batch of events that failed to be published to the Event Hub, this handler must be
-        ///   provided before events may be enqueued.
+        ///   provided before events may be enqueued.  If this producer was not configured with <see cref="EventHubBufferedProducerClientOptions.MaximumConcurrentSends" />
+        ///   and <see cref="EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition" /> both set to 1, the handler will be invoked
+        ///   concurrently.
         ///
         ///   It is safe to attempt resending the events by calling <see cref="EnqueueEventAsync(EventData, CancellationToken)" /> or <see cref="EnqueueEventAsync(EventData, EnqueueEventOptions, CancellationToken)" /> from within
         ///   this handler.  It is important to note that doing so will place them at the end of the buffer; the original order will not be maintained.
@@ -315,6 +325,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <seealso cref="EventHubsRetryOptions" />
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
         public event Func<SendEventBatchFailedEventArgs, Task> SendEventBatchFailedAsync
         {
             add
@@ -772,13 +784,13 @@ namespace Azure.Messaging.EventHubs.Producer
                 // Enqueue the event into the channel for the assigned partition.  Note that this call will wait
                 // if there is no room in the channel and may take some time to complete.
 
-                var partitionPublisher = _activePartitionStateMap.GetOrAdd(partitionId, partitionId => new PartitionPublishingState(partitionId, _options));
-                var writer = partitionPublisher.PendingEventsWriter;
+                var partitionState = _activePartitionStateMap.GetOrAdd(partitionId, partitionId => new PartitionPublishingState(partitionId, _options));
+                var writer = partitionState.PendingEventsWriter;
 
                 await writer.WriteAsync(eventData, cancellationToken).ConfigureAwait(false);
 
                 var count = Interlocked.Increment(ref _totalBufferedEventCount);
-                Interlocked.Increment(ref partitionPublisher.BufferedEventCount);
+                Interlocked.Increment(ref partitionState.BufferedEventCount);
 
                 Logger.BufferedProducerEventEnqueued(Identifier, EventHubName, logPartition, partitionId, operationId, count);
             }
@@ -922,7 +934,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 // If there is a stable partition identifier for all events in the batch, acquire the publisher for it.
 
-                var partitionPublisher = string.IsNullOrEmpty(partitionId)
+                var partitionState = string.IsNullOrEmpty(partitionId)
                     ? null
                     : _activePartitionStateMap.GetOrAdd(partitionId, partitionId => new PartitionPublishingState(partitionId, _options));
 
@@ -959,13 +971,13 @@ namespace Azure.Messaging.EventHubs.Producer
                     // Enqueue the event into the channel for the assigned partition.  Note that this call will wait
                     // if there is no room in the channel and may take some time to complete.
 
-                    var publisher = partitionPublisher ?? _activePartitionStateMap.GetOrAdd(eventPartitionId, partitionId => new PartitionPublishingState(eventPartitionId, _options));
-                    var writer = publisher.PendingEventsWriter;
+                    var activePartitionState = partitionState ?? _activePartitionStateMap.GetOrAdd(eventPartitionId, partitionId => new PartitionPublishingState(eventPartitionId, _options));
+                    var writer = activePartitionState.PendingEventsWriter;
 
                     await writer.WriteAsync(eventData, cancellationToken).ConfigureAwait(false);
 
                     var count = Interlocked.Increment(ref _totalBufferedEventCount);
-                    Interlocked.Increment(ref publisher.BufferedEventCount);
+                    Interlocked.Increment(ref activePartitionState.BufferedEventCount);
 
                     Logger.BufferedProducerEventEnqueued(Identifier, EventHubName, logPartition, eventPartitionId, operationId, count);
                 }
@@ -1009,6 +1021,10 @@ namespace Azure.Messaging.EventHubs.Producer
             try
             {
                 Argument.AssertNotClosed(_isClosed, nameof(EventHubBufferedProducerClient));
+
+                // Stop publishing and allow any active send operations to complete before performing the flush.
+
+                await StopPublishingAsync(cancelActiveSendOperations: false, cancellationToken).ConfigureAwait(false);
                 await FlushInternalAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
@@ -1063,17 +1079,31 @@ namespace Azure.Messaging.EventHubs.Producer
                 _isClosed = true;
                 Logger.ClientCloseStart(nameof(EventHubBufferedProducerClient), EventHubName, Identifier);
 
-                // Flushing or clearing the buffered events; these calls will both take responsibility
-                // for stopping any active publishing.
+                // Flush or clear the buffered events.  Before doing so, ensure that publishing has been
+                // fully stopped.
 
                 try
                 {
                     if (flush)
                     {
+                        // Publishing should allow any active send operations to complete before performing the flush.
+
+                        await StopPublishingAsync(cancelActiveSendOperations: false, cancellationToken).ConfigureAwait(false);
                         await FlushInternalAsync(CancellationToken.None).ConfigureAwait(false);
                     }
                     else
                     {
+                       // Publishing should cancel any active send operations and prioritize the clear.
+
+                       try
+                       {
+                           await StopPublishingAsync(cancelActiveSendOperations: true, cancellationToken).ConfigureAwait(false);
+                       }
+                       catch (OperationCanceledException)
+                       {
+                           // This is expected and should not impact the clear.
+                       }
+
                        ClearInternal(CancellationToken.None);
                     }
                 }
@@ -1173,6 +1203,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "This signature must match the IAsyncDisposable interface.")]
         public virtual async ValueTask DisposeAsync()
         {
             await CloseAsync(true).ConfigureAwait(false);
@@ -1278,7 +1309,6 @@ namespace Azure.Messaging.EventHubs.Producer
         {
             var operationId = GenerateOperationId();
             var activeDrains = new List<Task>(_options.MaximumConcurrentSends);
-            var activeHandlers = new ConcurrentBag<Task>();
 
             try
             {
@@ -1312,15 +1342,15 @@ namespace Azure.Messaging.EventHubs.Producer
                     if ((!cancellationToken.IsCancellationRequested)
                         && (partitionStateItem.Value.BufferedEventCount > 0))
                     {
-                        activeDrains.Add(DrainAndPublishPartitionEvents(partitionStateItem.Value, operationId, activeHandlers, cancellationToken));
+                        activeDrains.Add(DrainAndPublishPartitionEvents(partitionStateItem.Value, operationId, cancellationToken));
                     }
                 }
 
                 // Wait for any remaining partitions to complete, and then wait for outstanding handlers.  Both are
                 // expected to manage their own exceptions and should not throw.
 
-                await Task.WhenAll(activeDrains).ConfigureAwait(false);
-                await Task.WhenAll(activeHandlers).ConfigureAwait(false);
+                await Task.WhenAll(activeDrains).AwaitWithCancellation(cancellationToken);
+                await WaitForActivePublishHandlersAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -1350,9 +1380,9 @@ namespace Azure.Messaging.EventHubs.Producer
                                                             bool releaseGuard,
                                                             CancellationToken cancellationToken)
         {
-            var batchEventCount = 0;
             var operationId = GenerateOperationId();
             var partitionId = partitionState.PartitionId;
+            var batchEvents = new List<EventData>();
             var publishWatch = default(ValueStopwatch);
             var batch = default(EventDataBatch);
 
@@ -1376,12 +1406,12 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 while (ShouldWait(remainingWaitTime, MinimumPublishingWaitInterval))
                 {
-                    if (partitionState.TryReadEvent(out var currentEvent))
+                    if ((partitionState.TryReadEvent(out var currentEvent)) && (currentEvent != null))
                     {
                         if (batch.TryAdd(currentEvent))
                         {
-                            ++batchEventCount;
-                            Logger.BufferedProducerEventBatchPublishEventAdded(Identifier, EventHubName, partitionId, operationId, batchEventCount, publishWatch.GetElapsedTime().TotalSeconds);
+                            batchEvents.Add(currentEvent);
+                            Logger.BufferedProducerEventBatchPublishEventAdded(Identifier, EventHubName, partitionId, operationId, batchEvents.Count, publishWatch.GetElapsedTime().TotalSeconds);
                         }
                         else
                         {
@@ -1403,7 +1433,6 @@ namespace Azure.Messaging.EventHubs.Producer
                                 // are logged as part of the invocation.
 
                                 _ = InvokeOnSendFailedAsync(new List<EventData>(1) { currentEvent }, exception, partitionId);
-
                                 return;
                             }
 
@@ -1446,7 +1475,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     // are logged as part of the invocation.
 
                     await _producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
-                    _ = InvokeOnSendSucceededAsync(batch.AsEnumerable<EventData>().ToList(), partitionId);
+                    _ = InvokeOnSendSucceededAsync(batchEvents, partitionId);
                 }
             }
             catch (Exception ex)
@@ -1458,14 +1487,14 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if (batch?.Count > 0)
                 {
-                    _ = InvokeOnSendFailedAsync(batch.AsEnumerable<EventData>().ToList(), ex, partitionId);
+                    _ = InvokeOnSendFailedAsync(batchEvents, ex, partitionId);
                 }
             }
             finally
             {
                 // Succeed or fail, the batch events are no longer buffered; remove them from the partition state and the total.
 
-                var delta = (batchEventCount * -1);
+                var delta = (batchEvents.Count * -1);
 
                 Interlocked.Add(ref partitionState.BufferedEventCount, delta);
                 Interlocked.Add(ref _totalBufferedEventCount, delta);
@@ -1478,7 +1507,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 }
 
                 var duration = publishWatch.IsActive ? publishWatch.GetElapsedTime().TotalSeconds : 0;
-                Logger.BufferedProducerEventBatchPublishComplete(Identifier, EventHubName, partitionId, operationId, batchEventCount, duration);
+                Logger.BufferedProducerEventBatchPublishComplete(Identifier, EventHubName, partitionId, operationId, batchEvents.Count, duration);
             }
         }
 
@@ -1488,17 +1517,15 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <param name="partitionState">The state of publishing for the partition.</param>
         /// <param name="operationId">An identifier for the publishing operations that can be used to correlate related log entries.  If <c>null</c> or empty, a new identifier will be generated.</param>
-        /// <param name="activeHandlers">The set of active event handler invocations; the collection will be modified by this method.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel publishing.</param>
         ///
         /// <remarks>
         ///   This method has responsibility for invoking the event handlers to communicate success or failure of the
-        ///   operation and will add the resulting <see cref="Task" /> to the <paramref name="activeHandlers" /> set.
+        ///   operation.
         /// </remarks>
         ///
         internal virtual async Task DrainAndPublishPartitionEvents(PartitionPublishingState partitionState,
                                                                    string operationId,
-                                                                   ConcurrentBag<Task> activeHandlers,
                                                                    CancellationToken cancellationToken)
         {
             ValueStopwatch publishWatch;
@@ -1506,6 +1533,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
             var drainComplete = false;
             var partitionId = partitionState.PartitionId;
+            var batchEvents = default(List<EventData>);
             var batch = default(EventDataBatch);
 
             if (string.IsNullOrEmpty(operationId))
@@ -1520,12 +1548,15 @@ namespace Azure.Messaging.EventHubs.Producer
                 while (!drainComplete)
                 {
                     batch ??= await _producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partitionId }, cancellationToken).ConfigureAwait(false);
+                    batchEvents ??= new List<EventData>();
+
                     publishWatch = ValueStopwatch.StartNew();
 
                     // Read events until one does not fit in the batch.
 
                     while ((partitionState.TryReadEvent(out readEvent)) && (batch.TryAdd(readEvent)))
                     {
+                        batchEvents.Add(readEvent);
                         Logger.BufferedProducerEventBatchPublishEventAdded(Identifier, EventHubName, partitionId, operationId, batch.Count, publishWatch.GetElapsedTime().TotalSeconds);
                     }
 
@@ -1533,8 +1564,8 @@ namespace Azure.Messaging.EventHubs.Producer
 
                     if ((readEvent == null) && (batch.Count == 0))
                     {
-                        Logger.BufferedProducerEventBatchPublishNoEventRead(Identifier, EventHubName, partitionId, operationId, 0, publishWatch.GetElapsedTime().TotalSeconds);
                         drainComplete = true;
+                        Logger.BufferedProducerEventBatchPublishNoEventRead(Identifier, EventHubName, partitionId, operationId, 0, publishWatch.GetElapsedTime().TotalSeconds);
                     }
                     else if (batch.Count == 0)
                     {
@@ -1542,11 +1573,14 @@ namespace Azure.Messaging.EventHubs.Producer
                         // it should not be stashed.  Since it was not added to the batch, the normal error handler path won't properly report it.
                         // Instead, perform the logging and handler invocation inline.
 
+                        Interlocked.Decrement(ref partitionState.BufferedEventCount);
+                        Interlocked.Decrement(ref _totalBufferedEventCount);
+
                         var message = string.Format(CultureInfo.InvariantCulture, Resources.EventTooLargeMask, EventHubName, batch.MaximumSizeInBytes);
                         var exception = new EventHubsException(EventHubName, message, EventHubsException.FailureReason.MessageSizeExceeded);
 
                         Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, message);
-                        activeHandlers.Add(InvokeOnSendFailedAsync(new List<EventData>(1) { readEvent }, exception, partitionId));
+                        _ = InvokeOnSendFailedAsync(new List<EventData>(1) { readEvent }, exception, partitionId);
                     }
                     else
                     {
@@ -1562,38 +1596,34 @@ namespace Azure.Messaging.EventHubs.Producer
                         try
                         {
                             await _producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
-                            activeHandlers.Add(InvokeOnSendSucceededAsync(batch.AsEnumerable<EventData>().ToList(), partitionState.PartitionId));
+                            _ = InvokeOnSendSucceededAsync(batchEvents, partitionState.PartitionId);
                         }
                         catch (Exception ex)
                         {
                             Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, ex.Message);
-                            activeHandlers.Add(InvokeOnSendFailedAsync(batch.AsEnumerable<EventData>().ToList(), ex, partitionId));
+                            _ = InvokeOnSendFailedAsync(batchEvents, ex, partitionId);
 
                             // If publishing was canceled, break out of the drain loop.
 
                             if (ex is OperationCanceledException)
                             {
-                                drainComplete = true;
-                                break;
+                                throw;
                             }
                         }
                         finally
                         {
-                            // Succeed or fail, the batch events are no longer buffered; remove them from the partition state and the total.
-
-                            if (batch.Count > 0)
-                            {
-                                var delta = (batch.Count * -1);
-
-                                Interlocked.Add(ref partitionState.BufferedEventCount, delta);
-                                Interlocked.Add(ref _totalBufferedEventCount, delta);
-                            }
-
                             Logger.BufferedProducerEventBatchPublishComplete(Identifier, EventHubName, partitionId, operationId, batch.Count, publishWatch.GetElapsedTime().TotalSeconds);
+
+                            var delta = (batchEvents.Count * -1);
+
+                            Interlocked.Add(ref partitionState.BufferedEventCount, delta);
+                            Interlocked.Add(ref _totalBufferedEventCount, delta);
                         }
 
                         batch.Dispose();
+
                         batch = null;
+                        batchEvents = null;
                     }
                 }
             }
@@ -1616,12 +1646,13 @@ namespace Azure.Messaging.EventHubs.Producer
                    events.Add(readEvent);
                 }
 
-                activeHandlers.Add(InvokeOnSendFailedAsync(events, ex, partitionId));
+                var partitionStateDelta = (partitionState.BufferedEventCount * -1);
+                var totalDeltaZero = (_totalBufferedEventCount * -1);
 
-                var delta = (events.Count * -1);
+                Interlocked.Add(ref _totalBufferedEventCount, Math.Max(totalDeltaZero, partitionStateDelta));
+                Interlocked.Exchange(ref partitionState.BufferedEventCount, 0);
 
-                Interlocked.Add(ref partitionState.BufferedEventCount, delta);
-                Interlocked.Add(ref _totalBufferedEventCount, delta);
+                await InvokeOnSendFailedAsync(events, ex, partitionId).ConfigureAwait(false);
             }
             finally
             {
@@ -1756,6 +1787,14 @@ namespace Azure.Messaging.EventHubs.Producer
 
             try
             {
+                // Ensure that partition information is populated.  If already populated, then allow the
+                // background management task to keep the information current.
+
+                if ((_partitions == null) || (_partitionHash == null))
+                {
+                    await UpdatePartitionInformation(cancellationToken).ConfigureAwait(false);
+                }
+
                 // If there is already a task running for the background management process,
                 // then no further initialization is needed.
 
@@ -1908,7 +1947,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <param name="partitionId">The identifier of the partition that the batch of events was published to.</param>
         ///
         private Task InvokeOnSendSucceededAsync(IReadOnlyList<EventData> events,
-                                                string partitionId) => Task.Run(() => OnSendSucceededAsync(events, partitionId), CancellationToken.None);
+                                                string partitionId) => TrackPublishHandlerAsActiveAsync(Task.Run(() => OnSendSucceededAsync(events, partitionId, CancellationToken.None)));
 
         /// <summary>
         ///   Responsible for invoking <see cref="OnSendFailedAsync" /> as an background task.
@@ -1920,7 +1959,47 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         private Task InvokeOnSendFailedAsync(IReadOnlyList<EventData> events,
                                              Exception exception,
-                                             string partitionId) => Task.Run(() => OnSendFailedAsync(events, exception, partitionId), CancellationToken.None);
+                                             string partitionId) => TrackPublishHandlerAsActiveAsync(Task.Run(() => OnSendFailedAsync(events, exception, partitionId), CancellationToken.None));
+
+        /// <summary>
+        ///   Tracks a publishing event handler invocation as active, ensuring that
+        ///   tracking stops when the handler completes.
+        /// </summary>
+        ///
+        /// <param name="handlerTask">The publishing event handler task to track.</param>
+        ///
+        private Task TrackPublishHandlerAsActiveAsync(Task handlerTask)
+        {
+            // If the handler has already completed, there is no further tracking needed.
+
+            if (handlerTask.IsCompleted)
+            {
+                return handlerTask;
+            }
+
+            // Track the handler invocation so that it can be awaited, if needed.  To ensure that
+            // the active set does not grow unbounded, attach a continuation that will prune the handler
+            // upon its completion.
+
+            _activePublishingHandlers.TryAdd(handlerTask, 0);
+
+            var continationTask = handlerTask.ContinueWith((runTask, trackedTask) => _activePublishingHandlers.TryRemove((Task)trackedTask, out _), handlerTask, TaskScheduler.Default);
+            return continationTask;
+        }
+
+        /// <summary>
+        ///   Waits for all active publishing event handlers to complete.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the stop operation.</param>
+        ///
+        private async Task WaitForActivePublishHandlersAsync(CancellationToken cancellationToken)
+        {
+            while (!_activePublishingHandlers.IsEmpty)
+            {
+                await Task.WhenAll(_activePublishingHandlers.Keys).AwaitWithCancellation(cancellationToken);
+            }
+        }
 
         /// <summary>
         ///   Performs the tasks needed to manage state for the <see cref="EventHubBufferedProducerClient" /> and
@@ -1938,26 +2017,6 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 try
                 {
-                    // Refresh the partition information.
-
-                    var currentPartitions = await _producer.GetPartitionIdsAsync(cancellationToken).ConfigureAwait(false);
-
-                    // Assume that if the count of partitions matches the current count, then no updated is needed.
-                    // This is safe because partition identifiers are stable and new partitions can be added but
-                    // the can never be removed.
-
-                    if ((_partitions?.Length ?? 0) != currentPartitions.Length)
-                    {
-                        // The partitions need to be updated.  Because the two class members tracking partitions
-                        // are used for different purposes, it is permissible for them to drift for a short time.
-                        // As a result, there's no need to synchronize them.
-
-                        var currentHash = new HashSet<string>(currentPartitions);
-
-                        _partitions = currentPartitions;
-                        _partitionHash = currentHash;
-                    }
-
                     // Ensure that the publishing task is running.
 
                     if (_publishingTask == null)
@@ -1979,6 +2038,10 @@ namespace Azure.Messaging.EventHubs.Producer
                         _publishingTask = RunPublishingAsync(cancellationToken);
                         Logger.BufferedProducerPublishingTaskRestart(Identifier, EventHubName);
                     }
+
+                    // Refresh the partition information.
+
+                    await UpdatePartitionInformation(cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -2087,41 +2150,41 @@ namespace Azure.Messaging.EventHubs.Producer
                             ++partitionIndex;
                         }
 
-                        // If the selected partition is not actively being used to enqueue or its semaphore cannot be
-                        // acquired within the time limit, the partition is not available and the loop should iterate
-                        // to consider the next available partition.
-                        //
-                        // There is a benign race condition in checking the buffered event count, resulting in a partition
-                        // that has just had an event enqueued to be skipped for a cycle, but this is permissible to favor
-                        // building dense batches.
-                        //
-                        // The semaphore guard is intentionally acquired as the last clause to ensure that it is only attempted
-                        // if all other conditions are true; this ensures that it does not need to be released if checks fail
-                        // and a batch isn't going to be published for this iteration.
-
-                        if ((!cancellationToken.IsCancellationRequested)
-                            && (_activePartitionStateMap.TryGetValue(partition, out var partitionState))
-                            && (partitionState.BufferedEventCount > 0)
-                            && (partitionState.PartitionGuard.Wait(PartitionPublishingGuardAcquireLimitMilliseconds, cancellationToken)))
+                        try
                         {
-                            // Responsibility for releasing the guard semaphore is passed to the task.
+                            // If the selected partition is not actively being used to enqueue or its semaphore cannot be
+                            // acquired within the time limit, the partition is not available and the loop should iterate
+                            // to consider the next available partition.
+                            //
+                            // There is a benign race condition in checking the buffered event count, resulting in a partition
+                            // that has just had an event enqueued to be skipped for a cycle, but this is permissible to favor
+                            // building dense batches.
+                            //
+                            // The semaphore guard is intentionally acquired as the last clause to ensure that it is only attempted
+                            // if all other conditions are true; this ensures that it does not need to be released if checks fail
+                            // and a batch isn't going to be published for this iteration.
 
-                            activeTasks.Add(PublishBatchToPartition(partitionState, releaseGuard: true, activeOperationCancellationSource.Token));
+                            if ((!cancellationToken.IsCancellationRequested)
+                                && (_activePartitionStateMap.TryGetValue(partition, out var partitionState))
+                                && (partitionState.BufferedEventCount > 0)
+                                && (partitionState.PartitionGuard.Wait(PartitionPublishingGuardAcquireLimitMilliseconds, cancellationToken)))
+                            {
+                                // Responsibility for releasing the guard semaphore is passed to the task.
+
+                                activeTasks.Add(PublishBatchToPartition(partitionState, releaseGuard: true, activeOperationCancellationSource.Token));
+                            }
+
+                            // If there are no publishing tasks active, introduce a small
+                            // delay to avoid a tight loop.
+
+                            if (activeTasks.Count == 0)
+                            {
+                                 await Task.Delay(DefaultPublishingDelayInterval, cancellationToken).ConfigureAwait(false);
+                            }
                         }
-
-                        // If there are no publishing tasks active, introduce a small
-                        // delay to avoid a tight loop.
-
-                        if (activeTasks.Count == 0)
+                        catch (OperationCanceledException)
                         {
-                            try
-                            {
-                                await Task.Delay(DefaultPublishingDelayInterval, cancellationToken).ConfigureAwait(false);
-                            }
-                            catch (OperationCanceledException)
-                            {
-                                // This is expected; allow the loop to exit with no further interaction.
-                            }
+                            // This is expected; allow the loop to exit with no further interaction.
                         }
                     }
 
@@ -2130,9 +2193,16 @@ namespace Azure.Messaging.EventHubs.Producer
                     // cancellation internally and should be fully awaited rather than allowing "WhenAll" to cancel.
 
                     Logger.BufferedProducerPublishingAwaitAllStart(Identifier, EventHubName, activeTasks.Count, operationId);
-
                     var awaitAllWatch = ValueStopwatch.StartNew();
-                    await Task.WhenAll(activeTasks).ConfigureAwait(false);
+
+                    try
+                    {
+                        await Task.WhenAll(activeTasks).ConfigureAwait(false);
+                    }
+                    catch (AggregateException ex)
+                    {
+                        ex.Handle(exception => exception is OperationCanceledException);
+                    }
 
                     Logger.BufferedProducerPublishingAwaitAllComplete(Identifier, EventHubName, activeTasks.Count, operationId, awaitAllWatch.GetElapsedTime().TotalSeconds);
                 }
@@ -2150,6 +2220,39 @@ namespace Azure.Messaging.EventHubs.Producer
                     Logger.BufferedProducerPublishingManagementComplete(Identifier, EventHubName, operationId);
                 }
             }, cancellationToken);
+
+        /// <summary>
+        ///    Ensures that class state has accurate partition information, updating it if the
+        ///    set of Event Hub partitions has changed since they were last queried.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <remarks>
+        ///   This method will potentially modify class state, overwriting the tracked set of partitions.
+        /// </remarks>
+        ///
+        private async Task UpdatePartitionInformation(CancellationToken cancellationToken)
+        {
+            var currentPartitions = _partitions;
+            var queriedPartitions = await _producer.GetPartitionIdsAsync(cancellationToken).ConfigureAwait(false);
+
+            // Assume that if the count of partitions matches the current count, then no updated is needed.
+            // This is safe because partition identifiers are stable and new partitions can be added but
+            // the can never be removed.
+
+            if ((currentPartitions?.Length ?? 0) != queriedPartitions.Length)
+            {
+                // The partitions need to be updated.  Because the two class members tracking partitions
+                // are used for different purposes, it is permissible for them to drift for a short time.
+                // As a result, there's no need to synchronize them.
+
+                var queriedHash = new HashSet<string>(queriedPartitions);
+
+                _partitions = queriedPartitions;
+                _partitionHash = queriedHash;
+            }
+        }
 
         /// <summary>
         ///   Ensures that no more than a single partition reference is active.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -2247,10 +2246,8 @@ namespace Azure.Messaging.EventHubs.Producer
                 // are used for different purposes, it is permissible for them to drift for a short time.
                 // As a result, there's no need to synchronize them.
 
-                var queriedHash = new HashSet<string>(queriedPartitions);
-
                 _partitions = queriedPartitions;
-                _partitionHash = queriedHash;
+                _partitionHash = new HashSet<string>(queriedPartitions);;
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClientOptions.cs
@@ -14,10 +14,10 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   to configure its behavior.
     /// </summary>
     ///
-    internal class EventHubBufferedProducerClientOptions
+    public class EventHubBufferedProducerClientOptions
     {
         /// <summary>The number of batches that may be sent concurrently across all partitions.</summary>
-        private int _maximumConcurrentSends = Environment.ProcessorCount * 2;
+        private int _maximumConcurrentSends = Environment.ProcessorCount;
 
         /// <summary>The number of batches that may be sent concurrently to each partition.</summary>
         private int _maximumConcurrentSendsPerPartition = 1;
@@ -35,9 +35,9 @@ namespace Azure.Messaging.EventHubs.Producer
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>
-        ///    Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing
-        ///    will attempt to avoid duplication with a minor cost to throughput.  Duplicates are still possible but the chance of them occurring is
-        ///    much lower when idempotent retries are enabled.
+        ///   Indicates whether or not events should be published using idempotent semantics for retries. If enabled, retries during publishing
+        ///   will attempt to avoid duplication with a minor cost to throughput.  Duplicates are still possible but the chance of them occurring is
+        ///   much lower when idempotent retries are enabled.
         ///</summary>
         ///
         /// <value>
@@ -115,7 +115,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// </summary>
         ///
         /// <value>
-        ///   By default, this will be set to twice the number of processors available in the host environment.
+        ///   By default, this will be set to the number of processors available in the host environment.
         /// </value>
         ///
         /// <remarks>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -23,11 +23,20 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   A client responsible for publishing <see cref="EventData" /> to a specific Event Hub,
     ///   grouped together in batches.  Depending on the options specified when sending, events may
     ///   be automatically assigned an available partition or may request a specific partition.
+    ///
+    ///   The <see cref="EventHubProducerClient" /> publishes immediately, ensuring a deterministic
+    ///   outcome for each send operation, though requires that callers own the responsibility of
+    ///   building and managing batches.
+    ///
+    ///   In scenarios where it is not important to have events published immediately and where
+    ///   maximizing partition availability is not a requirement, it is recommended to consider
+    ///   using the <see cref="EventHubBufferedProducerClient" />, which takes responsibility for
+    ///   building and managing batches to reduce the complexity of doing so in application code.
     /// </summary>
     ///
     /// <remarks>
     ///   <list type="bullet">
-    ///     <listheader><description>Allowing automatic routing of partitions is recommended when:</description></listheader>
+    ///     <listheader><description>Allowing partition assignment is recommended when:</description></listheader>
     ///     <item><description>The sending of events needs to be highly available.</description></item>
     ///     <item><description>The event data should be evenly distributed among all available partitions.</description></item>
     ///   </list>
@@ -45,6 +54,8 @@ namespace Azure.Messaging.EventHubs.Producer
     ///     method as the application is shutting down will ensure that network resources and other unmanaged objects are properly cleaned up.
     ///   </para>
     /// </remarks>
+    ///
+    /// <seealso cref="EventHubBufferedProducerClient" />
     ///
     public class EventHubProducerClient : IAsyncDisposable
     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/SendEventBatchFailedEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/SendEventBatchFailedEventArgs.cs
@@ -13,7 +13,7 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   to.
     /// </summary>
     ///
-    internal class SendEventBatchFailedEventArgs : EventArgs
+    public class SendEventBatchFailedEventArgs : EventArgs
     {
         /// <summary>
         ///   The set of events that were in the batch that failed to publish.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/SendEventBatchSucceededEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/SendEventBatchSucceededEventArgs.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   that it was published to.
     /// </summary>
     ///
-    internal class SendEventBatchSucceededEventArgs : EventArgs
+    public class SendEventBatchSucceededEventArgs : EventArgs
     {
         /// <summary>
         ///   The set of events in the batch that was published.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -1809,7 +1809,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var readTime = TimeSpan
                         .FromMilliseconds(options.MaximumWaitTime.Value.TotalMilliseconds * desiredEmptyEvents)
-                        .Add(TimeSpan.FromSeconds(10));
+                        .Add(TimeSpan.FromSeconds(30));
 
                     // Attempt to read from the empty partition and verify that no events are observed.  Because no events are expected, the
                     // read operation will not naturally complete; limit the read to only a couple of seconds and trigger cancellation.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
@@ -1,0 +1,1254 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.WebSockets;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Producer;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of live tests for the <see cref="EventHubBufferedProducerClientClient" />
+    ///   class.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   These tests have a dependency on live Azure services and may
+    ///   incur costs for the associated Azure subscription.
+    /// </remarks>
+    ///
+    [TestFixture]
+    [Category(TestCategory.Live)]
+    [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    public class EventHubBufferedProducerClientLiveTests
+    {
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCanPublishRoundRobinWithDefaultOptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitionCount = 4;
+            var eventsPerPartition = 20;
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var completionSource = new TaskCompletionSource<bool>();
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                if (handlerEvents.Count >= events.Count)
+                {
+                    completionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and avoid flushing and wait for publishing to complete.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+
+            try
+            {
+                await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"The handler did not receive all events.  { handlerEvents.Count } of { events.Count } were captured.");
+            }
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+            Assert.That(handlerEvents.Select(item => item.PartitionId).Distinct().Count(), Is.EqualTo(partitionCount), "All partitions should have received events.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCanPublishUsingPartitionKeysWithDefaultOptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitionCount = 4;
+            var eventsPerPartition = 20;
+            var enqueuedCount = 0;
+            var keys = new[] { "one", "I-like-long-keys!", "123", "short1122##" };
+            var keyHash = new HashSet<string>(keys);
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var completionSource = new TaskCompletionSource<bool>();
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                if (handlerEvents.Count >= events.Count)
+                {
+                    completionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            for (var batchIndex = 0; batchIndex < partitionCount; ++batchIndex)
+            {
+                var eventsToEnqueue = events.Skip(batchIndex * eventsPerPartition).Take(eventsPerPartition).ToList();
+                var key = keys[batchIndex % keys.Length];
+
+                await producer.EnqueueEventsAsync(eventsToEnqueue, new EnqueueEventOptions { PartitionKey = key }, cancellationSource.Token);
+                enqueuedCount += eventsToEnqueue.Count;
+            }
+
+            Assert.That(enqueuedCount, Is.EqualTo(events.Count), "All events should have been enqueued.");
+
+            // Avoid flushing and wait for publishing to complete naturally.
+
+            try
+            {
+                await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"The handler did not receive all events.  { handlerEvents.Count } of { events.Count } were captured.");
+            }
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.PartitionKey, Is.Not.Null.And.Not.Empty, $"The event read at index: [{ index }] should have a partition key set.");
+                Assert.That(keyHash.Contains(readEvents[index].Event.PartitionKey), Is.True, $"The event read at index: [{ index }] should have a known partition key.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCanPublishToPartitionIdsWithDefaultOptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitionCount = 4;
+            var eventsPerPartition = 20;
+            var enqueuedCount = 0;
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var completionSource = new TaskCompletionSource<bool>();
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            var partitions = await producer.GetPartitionIdsAsync(cancellationSource.Token);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                if (handlerEvents.Count >= events.Count)
+                {
+                    completionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            for (var batchIndex = 0; batchIndex < partitionCount; ++batchIndex)
+            {
+                var eventsToEnqueue = events.Skip(batchIndex * eventsPerPartition).Take(eventsPerPartition).ToList();
+                var id = partitions[batchIndex % partitions.Length];
+
+                await producer.EnqueueEventsAsync(eventsToEnqueue, new EnqueueEventOptions { PartitionId = id }, cancellationSource.Token);
+                enqueuedCount += eventsToEnqueue.Count;
+            }
+
+            Assert.That(enqueuedCount, Is.EqualTo(events.Count), "All events should have been enqueued.");
+
+            // Avoid flushing and wait for publishing to complete naturally.
+
+            try
+            {
+                await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"The handler did not receive all events.  { handlerEvents.Count } of { events.Count } were captured.");
+            }
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCanPublishHeterogeneousEventsWithDefaultOptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitionCount = 4;
+            var eventsPerPartition = 20;
+            var enqueuedCount = 0;
+            var keys = new[] { "one", "I-like-long-keys!", "123", "short1122##" };
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var completionSource = new TaskCompletionSource<bool>();
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            var partitions = await producer.GetPartitionIdsAsync(cancellationSource.Token);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                if (handlerEvents.Count >= events.Count)
+                {
+                    completionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            for (var batchIndex = 0; batchIndex < partitionCount; ++batchIndex)
+            {
+                var options = batchIndex switch
+                {
+                    _ when (batchIndex % 3 == 0) => new EnqueueEventOptions { PartitionId = partitions[batchIndex % partitions.Length] },
+                    _ when (batchIndex % 5 == 0) => new EnqueueEventOptions { PartitionKey = keys[batchIndex % keys.Length] },
+                    _ => null
+                };
+
+                var eventsToEnqueue = events.Skip(batchIndex * eventsPerPartition).Take(eventsPerPartition).ToList();
+
+                await producer.EnqueueEventsAsync(eventsToEnqueue, options, cancellationSource.Token);
+                enqueuedCount += eventsToEnqueue.Count;
+            }
+
+            Assert.That(enqueuedCount, Is.EqualTo(events.Count), "All events should have been enqueued.");
+
+            // Avoid flushing and wait for publishing to complete naturally.  I
+
+            try
+            {
+                await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"The handler did not receive all events.  { handlerEvents.Count } of { events.Count } were captured.");
+            }
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCanPublishWithRestrictedConcurrency()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var concurrentSends = 2;
+            var partitionCount = 4;
+            var eventsPerPartition = 20;
+            var enqueuedCount = 0;
+            var keys = new[] { "one", "I-like-long-keys!", "123", "short1122##" };
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var completionSource = new TaskCompletionSource<bool>();
+            var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = concurrentSends };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            var partitions = await producer.GetPartitionIdsAsync(cancellationSource.Token);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                if (handlerEvents.Count >= events.Count)
+                {
+                    completionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            for (var batchIndex = 0; batchIndex < partitionCount; ++batchIndex)
+            {
+                var enqueueOptions = batchIndex switch
+                {
+                    _ when (batchIndex % 3 == 0) => new EnqueueEventOptions { PartitionId = partitions[batchIndex % partitions.Length] },
+                    _ when (batchIndex % 5 == 0) => new EnqueueEventOptions { PartitionKey = keys[batchIndex % keys.Length] },
+                    _ => null
+                };
+
+                var eventsToEnqueue = events.Skip(batchIndex * eventsPerPartition).Take(eventsPerPartition).ToList();
+
+                await producer.EnqueueEventsAsync(eventsToEnqueue, enqueueOptions, cancellationSource.Token);
+                enqueuedCount += eventsToEnqueue.Count;
+            }
+
+            Assert.That(enqueuedCount, Is.EqualTo(events.Count), "All events should have been enqueued.");
+
+            // Avoid flushing and wait for publishing to complete naturally.  I
+
+            try
+            {
+                await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"The handler did not receive all events.  { handlerEvents.Count } of { events.Count } were captured.");
+            }
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCanPublishWithConcurrentPartitions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var concurrentSendsPerPartition = 4;
+            var partitionCount = 1;
+            var eventsPerPartition = 80;
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var completionSource = new TaskCompletionSource<bool>();
+
+            var options = new EventHubBufferedProducerClientOptions
+            {
+                MaximumConcurrentSends = (partitionCount * concurrentSendsPerPartition),
+                MaximumConcurrentSendsPerPartition = concurrentSendsPerPartition
+            };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                if (handlerEvents.Count >= events.Count)
+                {
+                    completionSource.TrySetResult(true);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and avoid flushing and wait for publishing to complete.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+
+            try
+            {
+                await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                Assert.Fail($"The handler did not receive all events.  { handlerEvents.Count } of { events.Count } were captured.");
+            }
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+            Assert.That(handlerEvents.Select(item => item.PartitionId).Distinct().Count(), Is.EqualTo(partitionCount), "All partitions should have received events.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task FlushSendsAllEventsAndWaitsForHandlersWithDefaultOptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var flushCount = 0;
+            var handlerInvokedAfterFlush = false;
+            var partitionCount = 2;
+            var eventsPerPartition = 50;
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = partitionCount };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                // If flush was already completed, do not capture the
+                // events; the handler should not have been invoked.
+
+                if (flushCount > 0)
+                {
+                    handlerInvokedAfterFlush = true;
+                    return Task.CompletedTask;
+                }
+
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and flush; when flushing is complete, all events should be sent and handlers
+            // should have completed executing.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+            await producer.FlushAsync(cancellationSource.Token);
+
+            Interlocked.Increment(ref flushCount);
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(handlerInvokedAfterFlush, Is.False, "The handler should not have been invoked after the FlushAsync call completed.");
+            Assert.That(producer.IsClosed, Is.False, "The producer should not report that it is closed.");
+            Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task FlushSendsAllEventsAndWaitsForHandlersWithConcurrentPartitions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var flushCount = 0;
+            var handlerInvokedAfterFlush = false;
+            var concurrentSendsPerPartition = 4;
+            var partitionCount = 1;
+            var eventsPerPartition = 80;
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+
+            var options = new EventHubBufferedProducerClientOptions
+            {
+                MaximumConcurrentSends = (partitionCount * concurrentSendsPerPartition),
+                MaximumConcurrentSendsPerPartition = concurrentSendsPerPartition
+            };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                // If flush was already completed, do not capture the
+                // events; the handler should not have been invoked.
+
+                if (flushCount > 0)
+                {
+                    handlerInvokedAfterFlush = true;
+                    return Task.CompletedTask;
+                }
+
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and flush; when flushing is complete, all events should be sent and handlers
+            // should have completed executing.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+            await producer.FlushAsync(cancellationSource.Token);
+
+            Interlocked.Increment(ref flushCount);
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(handlerInvokedAfterFlush, Is.False, "The handler should not have been invoked after the FlushAsync call completed.");
+            Assert.That(producer.IsClosed, Is.False, "The producer should not report that it is closed.");
+            Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseSendsAllEventsAndWaitsForHandlersWhenFlushingWithDefaultOptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var closeCount = 0;
+            var handlerInvokedAfterClose = false;
+            var partitionCount = 2;
+            var eventsPerPartition = 50;
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = partitionCount };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                // If close was already completed, do not capture the
+                // events; the handler should not have been invoked.
+
+                if (closeCount > 0)
+                {
+                    handlerInvokedAfterClose = true;
+                    return Task.CompletedTask;
+                }
+
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and close; when closing is complete, all events should be sent and handlers
+            // should have completed executing.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+            await producer.CloseAsync(flush: true, cancellationSource.Token);
+
+            Interlocked.Increment(ref closeCount);
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(handlerInvokedAfterClose, Is.False, "The handler should not have been invoked after the CloseAsync call completed.");
+            Assert.That(producer.IsClosed, Is.True, "The producer should report that it is closed.");
+            Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseSendsAllEventsAndWaitsForHandlersWhenFlushingWithConcurrentPartitions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var closeCount = 0;
+            var handlerInvokedAfterClose = false;
+            var concurrentSendsPerPartition = 4;
+            var partitionCount = 12;
+            var eventsPerPartition = 80;
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+
+            var options = new EventHubBufferedProducerClientOptions
+            {
+                MaximumConcurrentSends = (partitionCount * concurrentSendsPerPartition),
+                MaximumConcurrentSendsPerPartition = concurrentSendsPerPartition
+            };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.SendEventBatchSucceededAsync += args =>
+            {
+                // If close was already completed, do not capture the
+                // events; the handler should not have been invoked.
+
+                if (closeCount > 0)
+                {
+                    handlerInvokedAfterClose = true;
+                    return Task.CompletedTask;
+                }
+
+                foreach (var item in args.EventBatch.Select(item => new EventWithPartition(args.PartitionId, item)))
+                {
+                    handlerEvents.Add(item);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and close; when closing is complete, all events should be sent and handlers
+            // should have completed executing.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+            await producer.CloseAsync(flush: true, cancellationSource.Token);
+
+            Interlocked.Increment(ref closeCount);
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(handlerInvokedAfterClose, Is.False, "The handler should not have been invoked after the FlushAsync call completed.");
+            Assert.That(producer.IsClosed, Is.True, "The producer should report that it is closed.");
+            Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+            Assert.That(handlerEvents.Count, Is.EqualTo(events.Count), "All events should have been sent.");
+
+            // Read back the events and ensure all were successfully published.
+
+            await using var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            await foreach (var partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
+            {
+                readEvents.Add(new EventWithPartition(partitionEvent.Partition.PartitionId, partitionEvent.Data));
+
+                if (readEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            // Ensure that all sent events were read back.
+
+            readEvents = readEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+            var sortedHandlerEvents = handlerEvents.OrderBy(evt => evt.PartitionId).ThenBy(evt => evt.Event.Properties[EventGenerator.IdPropertyName]).ToList();
+
+            for (var index = 0; index < readEvents.Count; ++index)
+            {
+                Assert.That(readEvents[index].PartitionId, Is.EqualTo(sortedHandlerEvents[index].PartitionId), $"The partition for the read and sent events should match at index: [{ index }].");
+                Assert.That(readEvents[index].Event.IsEquivalentTo(sortedHandlerEvents[index].Event), Is.True, $"The event for the read and sent events should match at index: [{ index }].");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAbandonsEventsAndHandlersWhenClearingWithDefaultOptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitionCount = 2;
+            var eventsPerPartition = 50;
+            var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+            var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = partitionCount };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and close; when closing is complete, the state of events and handlers are non-deterministic,
+            // but the client state can be verified.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+            await producer.CloseAsync(flush: false, cancellationSource.Token);
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.IsClosed, Is.True, "The producer should report that it is closed.");
+            Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to publish events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAbandonsEventsAndHandlersWhenClearingWithConcurrentPartitions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var concurrentSendsPerPartition = 4;
+            var partitionCount = 1;
+            var eventsPerPartition = 50;
+            var events = EventGenerator.CreateEvents(partitionCount * eventsPerPartition).ToList();
+            var handlerEvents = new ConcurrentBag<EventWithPartition>();
+            var readEvents = new List<EventWithPartition>();
+
+            var options = new EventHubBufferedProducerClientOptions
+            {
+                MaximumConcurrentSends = (partitionCount * concurrentSendsPerPartition),
+                MaximumConcurrentSendsPerPartition = concurrentSendsPerPartition
+            };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, options);
+
+            producer.SendEventBatchFailedAsync += args =>
+            {
+                ExceptionDispatchInfo.Capture(args.Exception).Throw();
+                return Task.CompletedTask;
+            };
+
+            // Enqueue and close; when closing is complete, the state of events and handlers are non-deterministic,
+            // but the client state can be verified.
+
+            await producer.EnqueueEventsAsync(events, cancellationSource.Token);
+            await producer.CloseAsync(flush: false, cancellationSource.Token);
+
+            // Ensure that publishing completed with the expected state.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been signaled.");
+            Assert.That(producer.IsClosed, Is.True, "The producer should report that it is closed.");
+            Assert.That(producer.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+            Assert.That(producer.TotalBufferedEventCount, Is.EqualTo(0), "No events should remain in the buffer.");
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ProducerCanRetrieveEventHubProperties(EventHubsTransportType transportType)
+        {
+            var partitionCount = 4;
+            var connectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+            var producerOptions = new EventHubBufferedProducerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(connectionString, scope.EventHubName, producerOptions);
+
+            var properties = await producer.GetEventHubPropertiesAsync();
+
+            Assert.That(properties, Is.Not.Null, "A set of properties should have been returned.");
+            Assert.That(properties.Name, Is.EqualTo(scope.EventHubName), "The property Event Hub name should match the scope.");
+            Assert.That(properties.PartitionIds.Length, Is.EqualTo(partitionCount), "The properties should have the requested number of partitions.");
+            Assert.That(properties.CreatedOn, Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromSeconds(60)), "The Event Hub should have been created just about now.");
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ProducerCanRetrievePartitionProperties(EventHubsTransportType transportType)
+        {
+            var partitionCount = 4;
+            var connectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+            var producerOptions = new EventHubBufferedProducerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
+
+            await using var scope = await EventHubScope.CreateAsync(partitionCount);
+            await using var producer = new EventHubBufferedProducerClient(connectionString, scope.EventHubName, producerOptions);
+
+            var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+            var properties = await producer.GetEventHubPropertiesAsync();
+            var partition = properties.PartitionIds.First();
+            var partitionProperties = await producer.GetPartitionPropertiesAsync(partition, cancellation.Token);
+
+            Assert.That(partitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
+            Assert.That(partitionProperties.Id, Is.EqualTo(partition), "The partition identifier should match.");
+            Assert.That(partitionProperties.EventHubName, Is.EqualTo(scope.EventHubName).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
+            Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(long)), "The beginning sequence number should have been populated.");
+            Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(long)), "The last sequence number should have been populated.");
+            Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConnectionTransportPartitionIdsMatchPartitionProperties()
+        {
+            await using var scope = await EventHubScope.CreateAsync(4);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            var properties = await producer.GetEventHubPropertiesAsync();
+            var partitions = await producer.GetPartitionIdsAsync();
+
+            Assert.That(properties, Is.Not.Null, "A set of properties should have been returned.");
+            Assert.That(properties.PartitionIds, Is.Not.Null, "A set of partition identifiers for the properties should have been returned.");
+            Assert.That(partitions, Is.Not.Null, "A set of partition identifiers should have been returned.");
+            Assert.That(partitions, Is.EquivalentTo(properties.PartitionIds), "The partition identifiers returned directly should match those returned with properties.");
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCannotRetrieveMetadataWhenClosed()
+        {
+            await using var scope = await EventHubScope.CreateAsync(1);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            var partition = (await producer.GetPartitionIdsAsync()).First();
+
+            Assert.That(async () => await producer.GetEventHubPropertiesAsync(), Throws.Nothing);
+            Assert.That(async () => await producer.GetPartitionPropertiesAsync(partition), Throws.Nothing);
+
+            await producer.CloseAsync();
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
+            Assert.That(async () => await producer.GetPartitionIdsAsync(), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+            Assert.That(async () => await producer.GetEventHubPropertiesAsync(), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+            Assert.That(async () => await producer.GetPartitionPropertiesAsync(partition), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("XYZ")]
+        [TestCase("-1")]
+        [TestCase("1000")]
+        [TestCase("-")]
+        public async Task ProducerCannotRetrievePartitionPropertiesWhenPartitionIdIsInvalid(string invalidPartition)
+        {
+            await using var scope = await EventHubScope.CreateAsync(1);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+
+            Assert.That(async () => await producer.GetPartitionPropertiesAsync(invalidPartition), Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubBufferedProducerClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCannotRetrieveMetadataWhenProxyIsInvalid()
+        {
+            var invalidProxyOptions = new EventHubBufferedProducerClientOptions
+            {
+                RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
+
+                ConnectionOptions = new EventHubConnectionOptions
+                {
+                    Proxy = new WebProxy("http://1.2.3.4:9999"),
+                    TransportType = EventHubsTransportType.AmqpWebSockets
+                }
+            };
+
+            await using var scope = await EventHubScope.CreateAsync(1);
+            await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
+            await using var invalidProxyProducer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName, invalidProxyOptions);
+
+            var partition = (await producer.GetPartitionIdsAsync()).First();
+
+            Assert.That(async () => await invalidProxyProducer.GetPartitionIdsAsync(), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+            Assert.That(async () => await invalidProxyProducer.GetEventHubPropertiesAsync(), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+            Assert.That(async () => await invalidProxyProducer.GetPartitionPropertiesAsync(partition), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+        }
+
+        /// <summary>
+        ///   A lightweight structure for tracking events and associating with their partition.
+        /// </summary>
+        ///
+        /// <param name="PartitionId">The identifier of the partition associated with the event.</param>
+        /// <param name="Event">The event being tracked.</param>
+        ///
+        private sealed record EventWithPartition(string PartitionId, EventData Event)
+        {
+            public bool Equals(EventWithPartition other) => other.PartitionId == PartitionId && other.Event.IsEquivalentTo(Event);
+
+            public override int GetHashCode()
+            {
+                var builder = new HashCodeBuilder();
+                builder.Add(PartitionId);
+                builder.Add(Event.GetHashCode());
+
+                return builder.ToHashCode();
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientLiveTests.cs
@@ -49,7 +49,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
             var handlerEvents = new ConcurrentBag<EventWithPartition>();
             var readEvents = new List<EventWithPartition>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using var scope = await EventHubScope.CreateAsync(partitionCount);
             await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
@@ -139,7 +139,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
             var handlerEvents = new ConcurrentBag<EventWithPartition>();
             var readEvents = new List<EventWithPartition>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using var scope = await EventHubScope.CreateAsync(partitionCount);
             await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
@@ -237,7 +237,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
             var handlerEvents = new ConcurrentBag<EventWithPartition>();
             var readEvents = new List<EventWithPartition>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using var scope = await EventHubScope.CreateAsync(partitionCount);
             await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
@@ -336,7 +336,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
             var handlerEvents = new ConcurrentBag<EventWithPartition>();
             var readEvents = new List<EventWithPartition>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await using var scope = await EventHubScope.CreateAsync(partitionCount);
             await using var producer = new EventHubBufferedProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, scope.EventHubName);
@@ -442,7 +442,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
             var handlerEvents = new ConcurrentBag<EventWithPartition>();
             var readEvents = new List<EventWithPartition>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = concurrentSends };
 
             await using var scope = await EventHubScope.CreateAsync(partitionCount);
@@ -547,7 +547,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = EventGenerator.CreateSmallEvents(partitionCount * eventsPerPartition).ToList();
             var handlerEvents = new ConcurrentBag<EventWithPartition>();
             var readEvents = new List<EventWithPartition>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var options = new EventHubBufferedProducerClientOptions
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
@@ -278,6 +278,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetEventHubPropertiesAsyncIsDelegated()
         {
             using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var mockProducer = new Mock<EventHubProducerClient>();
             var bufferedProducer = new EventHubBufferedProducerClient(mockProducer.Object);
@@ -294,6 +295,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void GetPartitionIdsAsyncValidatesClosed()
         {
             using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var mockProducer = new Mock<EventHubProducerClient>();
             var bufferedProducer = new EventHubBufferedProducerClient(mockProducer.Object);
@@ -310,6 +312,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetPartitionIdsAsyncIsDelegated()
         {
             using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var mockProducer = new Mock<EventHubProducerClient>();
             var bufferedProducer = new EventHubBufferedProducerClient(mockProducer.Object);
@@ -330,6 +333,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void GetPartitionPropertiesAsyncValidatesClosed()
         {
             using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var mockProducer = new Mock<EventHubProducerClient>();
             var bufferedProducer = new EventHubBufferedProducerClient(mockProducer.Object);
@@ -346,6 +350,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetPartitionPropertiesAsyncIsDelegated()
         {
             using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var expectedPartition = "0";
             var mockProducer = new Mock<EventHubProducerClient>();
@@ -559,6 +564,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncClosesTheProducer()
         {
             using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var bufferedProducer = new EventHubBufferedProducerClient(mockProducer.Object);
@@ -595,6 +601,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncUnregistersTheEventHandlers()
         {
             using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var bufferedProducer = new EventHubBufferedProducerClient(mockProducer.Object);
@@ -898,6 +905,42 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubBufferedProducerClient.CloseAsync" />.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task CloseStopsPublishing(bool flush)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitions = new[] { "0", "1", "2", "3" };
+            var mockProducer = new Mock<EventHubProducerClient>("fakeNs", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
+            var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
+
+            mockProducer
+                .Setup(producer => producer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(partitions));
+
+            try
+            {
+                await InvokeStartPublishingAsync(mockBufferedProducer.Object, cancellationSource.Token);
+                await mockBufferedProducer.Object.CloseAsync(flush);
+
+                Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
+                Assert.That(mockBufferedProducer.Object.IsClosed, Is.True, "The producer should be closed.");
+                Assert.That(mockBufferedProducer.Object.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+                Assert.That(GetBackgroundPublishingTask(mockBufferedProducer.Object).IsCompleted, Is.True, "The publishing task should have been completed.");
+            }
+            finally
+            {
+                await InvokeStopPublishingAsync(mockBufferedProducer.Object, cancellationSource.Token);
+            }
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="EventHubBufferedProducerClient.FlushAsync" /> method.
         /// </summary>
         ///
@@ -946,7 +989,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -993,7 +1035,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(expectedException);
 
@@ -1019,6 +1060,53 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task FlushAsyncStopsPublishing()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var partitions = new[] { "0", "1", "2", "3" };
+            var options = new EventHubBufferedProducerClientOptions();
+            var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
+            var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, options) { CallBase = true };
+
+            mockProducer
+                .Setup(producer => producer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(partitions));
+
+            mockBufferedProducer
+                .Setup(producer => producer.DrainAndPublishPartitionEvents(
+                    It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            try
+            {
+                await InvokeStartPublishingAsync(mockBufferedProducer.Object, cancellationSource.Token);
+
+                foreach (var partition in partitions)
+                {
+                    mockBufferedProducer.Object.ActivePartitionStateMap[partition] = new EventHubBufferedProducerClient.PartitionPublishingState(partition, options) { BufferedEventCount = 1 };
+                }
+
+                await mockBufferedProducer.Object.FlushAsync(cancellationSource.Token);
+
+                Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
+                Assert.That(mockBufferedProducer.Object.IsPublishing, Is.False, "The producer should report that it is not publishing.");
+                Assert.That(GetBackgroundPublishingTask(mockBufferedProducer.Object).IsCompleted, Is.True, "The publishing task should have been completed.");
+            }
+            finally
+            {
+                await InvokeStopPublishingAsync(mockBufferedProducer.Object, cancellationSource.Token);
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubBufferedProducerClient.FlushAsync" /> method.
+        /// </summary>
+        ///
+        [Test]
         public async Task FlushAsyncDoesNotDrainWhenNoPartitionsAreMapped()
         {
             using var cancellationSource = new CancellationTokenSource();
@@ -1032,7 +1120,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -1045,7 +1132,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Never);
         }
@@ -1068,7 +1154,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -1086,7 +1171,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Never);
         }
@@ -1110,7 +1194,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -1128,7 +1211,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.DrainAndPublishPartitionEvents(
                     It.Is<EventHubBufferedProducerClient.PartitionPublishingState>(value => partitions.Any(item => item == value.PartitionId)),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(partitions.Length));
         }
@@ -1153,11 +1235,14 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()))
-                .Returns<EventHubBufferedProducerClient.PartitionPublishingState, string, ConcurrentBag<Task>, CancellationToken>((state, operation, handlers, token) =>
+                .Returns<EventHubBufferedProducerClient.PartitionPublishingState, string, CancellationToken>((state, operation, token) =>
                 {
-                    handlers.Add(completionSource.Task);
+                    var activeHandlers = GetActivePublishingHandlers(mockBufferedProducer.Object);
+
+                    var handlerTask = completionSource.Task.ContinueWith(t => activeHandlers.TryRemove(completionSource.Task, out _));
+                    activeHandlers[completionSource.Task] = 0;
+
                     return Task.CompletedTask;
                 });
 
@@ -1183,7 +1268,6 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.DrainAndPublishPartitionEvents(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<string>(),
-                    It.IsAny<ConcurrentBag<Task>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
         }
@@ -5050,7 +5134,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 // Start publishing and validate that publishing does not complete right away.
 
                 await InvokeStartPublishingAsync(mockBufferedProducer.Object, cancellationSource.Token);
-                await startedCompletionSource.Task;
+                await startedCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);;
                 await Task.Delay(500);
 
                 Assert.That(executionLimitCancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested for the test time limit.");
@@ -5205,7 +5289,7 @@ namespace Azure.Messaging.EventHubs.Tests
             finally
             {
                 await InvokeStopPublishingAsync(mockBufferedProducer.Object, cancellationSource.Token).IgnoreExceptions();
-                //await publishCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
+                await publishCompletionSource.Task.AwaitWithCancellation(cancellationSource.Token);
             }
 
             mockLogger
@@ -5231,7 +5315,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedPartition = "4";
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var publishedEvents = new List<EventData>();
-            var activeHandlers = new ConcurrentBag<Task>();
             var completionSource = new TaskCompletionSource<bool>();
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);            var mockLogger = new Mock<EventHubsEventSource>();
@@ -5265,7 +5348,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Drain and verify.
 
-            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, activeHandlers, cancellationSource.Token);
+            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, cancellationSource.Token);
             await completionSource.Task;
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -5305,7 +5388,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var handlerCallCount = 0;
             var batchEvents = new List<EventData>();
             var publishedEvents = new List<EventData>();
-            var activeHandlers = new ConcurrentBag<Task>();
             var completionSource = new TaskCompletionSource<bool>();
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
@@ -5355,7 +5437,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Drain and verify.
 
-            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, activeHandlers, cancellationSource.Token);
+            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, cancellationSource.Token);
             await completionSource.Task;
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -5409,7 +5491,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Drain and verify.
 
-            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, new ConcurrentBag<Task>(), cancellationSource.Token);
+            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
             Assert.That(partitionState.BufferedEventCount, Is.EqualTo(0), "The partition state should have been drained, but has a count.");
@@ -5430,7 +5512,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedException = new AccessViolationException("My access has been violated.");
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var capturedFailArgs = default(SendEventBatchFailedEventArgs);
-            var activeHandlers = new ConcurrentBag<Task>();
             var completionSource = new TaskCompletionSource<bool>();
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
@@ -5462,7 +5543,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Drain and verify.
 
-            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, activeHandlers, cancellationSource.Token);
+            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, cancellationSource.Token);
             await completionSource.Task;
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -5498,7 +5579,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedPartition = "4";
             var expectedEvent = EventGenerator.CreateSmallEvents(1).First();
             var capturedFailArgs = default(SendEventBatchFailedEventArgs);
-            var activeHandlers = new ConcurrentBag<Task>();
             var completionSource = new TaskCompletionSource<bool>();
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
@@ -5527,7 +5607,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Drain and verify.
 
-            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, activeHandlers, cancellationSource.Token);
+            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, cancellationSource.Token);
             await completionSource.Task;
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -5557,7 +5637,6 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var expectedPartition = "4";
-            var activeHandlers = new ConcurrentBag<Task>();
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockLogger = new Mock<EventHubsEventSource>();
@@ -5576,7 +5655,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Drain and verify.
 
-            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, activeHandlers, cancellationSource.Token);
+            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, cancellationSource.Token);
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
 
             mockLogger
@@ -5608,7 +5687,6 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedPartition = "4";
             var expectedException = new DivideByZeroException("You have just created a black hole.");
-            var activeHandlers = new ConcurrentBag<Task>();
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockLogger = new Mock<EventHubsEventSource>();
@@ -5623,7 +5701,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Drain and verify.
 
-            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, activeHandlers, cancellationSource.Token);
+            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, cancellationSource.Token);
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
 
             mockLogger
@@ -5649,7 +5727,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var publishedEventsCount = 0;
             var expectedPartition = "4";
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
-            var activeHandlers = new ConcurrentBag<Task>();
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(150) };
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockLogger = new Mock<EventHubsEventSource>();
@@ -5677,7 +5754,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Drain and verify.
 
-            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, activeHandlers, cancellationSource.Token);
+            await mockBufferedProducer.Object.DrainAndPublishPartitionEvents(partitionState, null, cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
             Assert.That(publishedEventsCount, Is.EqualTo(expectedEvents.Count), "The number of events published should match.");
@@ -5741,6 +5818,17 @@ namespace Azure.Messaging.EventHubs.Tests
             (Task)
                 typeof(EventHubBufferedProducerClient)
                     .GetField("_publishingTask", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(client);
+
+        /// <summary>
+        ///   Sets the non-public set of active publishing event handler invocations on the specified
+        ///   client instance using its private field.
+        /// </summary>
+        ///
+        private ConcurrentDictionary<Task, byte> GetActivePublishingHandlers(EventHubBufferedProducerClient client) =>
+            (ConcurrentDictionary<Task, byte>)
+                typeof(EventHubBufferedProducerClient)
+                    .GetField("_activePublishingHandlers", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(client);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
@@ -1226,7 +1226,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var expectedPartition = "7";
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, options) { CallBase = true };
@@ -3104,7 +3104,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var partitionRequsts = 0;
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
 
@@ -3155,7 +3155,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedInterval = TimeSpan.FromMilliseconds(250);
             var expectedPartitionRequests = 3;
             var partitionRequsts = 0;
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
 
@@ -3208,7 +3208,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedInterval = TimeSpan.FromMilliseconds(250);
             var partitionRequsts = 0;
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
@@ -3257,8 +3257,8 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var expectedErrorMessage = "This is an error that we expect.";
-            var initialCompletionSource = new TaskCompletionSource<bool>();
-            var faultCompletionSource = new TaskCompletionSource<bool>();
+            var initialCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var faultCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
@@ -3315,8 +3315,8 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var faultInjected = false;
-            var initialCompletionSource = new TaskCompletionSource<bool>();
-            var restartedCompletionSource = new TaskCompletionSource<bool>();
+            var initialCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var restartedCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
@@ -3386,7 +3386,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var partitionRequsts = 0;
             var expectedErrorMessage = "This is an error that we expect.";
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, default(EventHubBufferedProducerClientOptions)) { CallBase = true };
@@ -3920,7 +3920,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var batchedEvents = new List<EventData>();
             var handlerArgs = default(SendEventBatchSucceededEventArgs);
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -4002,7 +4002,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var batchedEvents = new List<EventData>();
             var handlerArgs = default(SendEventBatchFailedEventArgs);
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -4084,7 +4084,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var batchedEvents = new List<EventData>();
             var handlerArgs = default(SendEventBatchFailedEventArgs);
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -4167,7 +4167,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var extraEvent = EventGenerator.CreateSmallEvents(1).First();
             var bufferedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var handlerInvoked = false;
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -4238,7 +4238,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedEvents = EventGenerator.CreateSmallEvents(5).ToList();
             var batchedEvents = new List<EventData>();
             var handlerArgs = default(SendEventBatchFailedEventArgs);
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -4323,7 +4323,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedPartition = "4";
             var poisonEvent = EventGenerator.CreateEventFromBody(new byte[] { 0x65, 0x66, 0x67 });
             var handlerArgs = default(SendEventBatchFailedEventArgs);
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -4533,7 +4533,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var extraEvent = EventGenerator.CreateSmallEvents(1).First();
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var batchedEvents = new List<EventData>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockLogger = new Mock<EventHubsEventSource>();
@@ -4604,7 +4604,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedPartition = "4";
             var poisonEvent = EventGenerator.CreateEventFromBody(new byte[] { 0x65, 0x66, 0x67 });
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
             var mockLogger = new Mock<EventHubsEventSource>();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
@@ -4667,7 +4667,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var expectedPartition = "4";
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = 1, MaximumConcurrentSendsPerPartition = 1 };
             var state = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -4736,7 +4736,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var publishCount = 0;
             var validPartitions = new[] { "5", "8", "11", "frank" };
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = validPartitions.Length, MaximumConcurrentSendsPerPartition = 1 };
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, options) { CallBase = true };
@@ -4817,7 +4817,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var validPartitions = new[] { "5", "8", "11", "frank" };
             var publishCount = 0;
             var expectedPublishCount = validPartitions.Length * eventsPerPartition;
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = validPartitions.Length, MaximumConcurrentSendsPerPartition = 1 };
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, options) { CallBase = true };
@@ -4902,7 +4902,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var concurentSends = (int)Math.Floor(validPartitions.Length / 2.0);
             var publishCount = 0;
             var expectedPublishCount = validPartitions.Length * eventsPerPartition;
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = concurentSends, MaximumConcurrentSendsPerPartition = 1 };
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, options) { CallBase = true };
@@ -4988,7 +4988,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var concurentSends = (validPartitions.Length * concurrentSendsPerPartition);
             var publishCount = 0;
             var expectedPublishCount = validPartitions.Length * eventsPerPartition;
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = concurentSends, MaximumConcurrentSendsPerPartition = concurrentSendsPerPartition };
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
             var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, options) { CallBase = true };
@@ -5072,8 +5072,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var startCount = 0;
             var finishCount = 0;
             var validPartitions = new[] { "5", "8", "11", "frank" };
-            var startedCompletionSource = new TaskCompletionSource<bool>();
-            var finishedCompletionSource = new TaskCompletionSource<bool>();
+            var startedCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var finishedCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumConcurrentSends = validPartitions.Length, MaximumConcurrentSendsPerPartition = 1 };
             var mockLogger = new Mock<EventHubsEventSource>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -5187,7 +5187,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var expectedPartition = "0";
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = null };
             var publishingState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockLogger = new Mock<EventHubsEventSource>();
@@ -5250,8 +5250,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var expectedPartition = "0";
             var expectedException = new DivideByZeroException("Boom!");
-            var startCompletionSource = new TaskCompletionSource<bool>();
-            var publishCompletionSource = new TaskCompletionSource<bool>();
+            var startCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var publishCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = null };
             var publishingState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockLogger = new Mock<EventHubsEventSource>();
@@ -5315,7 +5315,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedPartition = "4";
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var publishedEvents = new List<EventData>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);            var mockLogger = new Mock<EventHubsEventSource>();
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -5388,7 +5388,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var handlerCallCount = 0;
             var batchEvents = new List<EventData>();
             var publishedEvents = new List<EventData>();
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -5512,7 +5512,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedException = new AccessViolationException("My access has been violated.");
             var expectedEvents = EventGenerator.CreateSmallEvents(10).ToList();
             var capturedFailArgs = default(SendEventBatchFailedEventArgs);
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
@@ -5579,7 +5579,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedPartition = "4";
             var expectedEvent = EventGenerator.CreateSmallEvents(1).First();
             var capturedFailArgs = default(SendEventBatchFailedEventArgs);
-            var completionSource = new TaskCompletionSource<bool>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var options = new EventHubBufferedProducerClientOptions();
             var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
             var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the live tests for end-to-end scenarios.  Where the tests exposed flaws, they were corrected and a general polish pass was done to the implementation.  This set of changes also makes the producer and associated support types `public` in anticipation of the pending beta release.  Also riding along are some minor formatting changes.

Pending work:
- Samples