### PR TITLE
[Event Hubs] Remove Schema Registry Integration

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28922.388
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.31904.369
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "src\Azure.Messaging.EventHubs.csproj", "{5B00CD25-4D16-4A52-8EF7-E62501AC89F3}"
 EndProject
@@ -10,10 +10,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{2DB233D3-E757-423C-8F8D-742B0AFF4713}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{1C35D00F-F016-4ED1-98E6-813C6AE22E25}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{5D38291E-D14C-4884-A902-9F9A470392BA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -61,38 +57,12 @@ Global
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x64.Build.0 = Release|Any CPU
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x86.ActiveCfg = Release|Any CPU
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x86.Build.0 = Release|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Debug|x64.Build.0 = Debug|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Debug|x86.Build.0 = Debug|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Release|x64.ActiveCfg = Release|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Release|x64.Build.0 = Release|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Release|x86.ActiveCfg = Release|Any CPU
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25}.Release|x86.Build.0 = Release|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Debug|x64.Build.0 = Debug|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Debug|x86.Build.0 = Debug|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Release|x64.ActiveCfg = Release|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Release|x64.Build.0 = Release|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Release|x86.ActiveCfg = Release|Any CPU
-		{5D38291E-D14C-4884-A902-9F9A470392BA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
-		{1C35D00F-F016-4ED1-98E6-813C6AE22E25} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
-		{5D38291E-D14C-4884-A902-9F9A470392BA} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {509F2EE0-3348-4506-8AC7-9945B602CB43}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -1,6 +1,6 @@
 namespace Azure.Messaging.EventHubs
 {
-    public partial class EventData : Azure.Messaging.IMessageWithContentType
+    public partial class EventData
     {
         public EventData() { }
         public EventData(System.BinaryData eventBody) { }
@@ -10,7 +10,6 @@ namespace Azure.Messaging.EventHubs
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected EventData(System.ReadOnlyMemory<byte> eventBody, System.Collections.Generic.IDictionary<string, object> properties = null, System.Collections.Generic.IReadOnlyDictionary<string, object> systemProperties = null, long sequenceNumber = (long)-9223372036854775808, long offset = (long)-9223372036854775808, System.DateTimeOffset enqueuedTime = default(System.DateTimeOffset), string partitionKey = null) { }
         public EventData(string eventBody) { }
-        System.BinaryData Azure.Messaging.IMessageWithContentType.Data { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.ReadOnlyMemory<byte> Body { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -13,22 +13,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
-  <!--
-    TEMP: This is needed for schema registry support and includes the IMessageWithContentType interface used
-          with EventData.
-  -->
   <ItemGroup>
-    <!--ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" /-->
-    <PackageReference Include="Azure.Core.Experimental" />
     <PackageReference Include="Azure.Core" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!--
-      Restore when the experimental features needed are moved and published.
-
-      <PackageReference Include="Azure.Core" />
-    -->
     <PackageReference Include="Azure.Core.Amqp" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -19,7 +19,7 @@ namespace Azure.Messaging.EventHubs
     ///   An Event Hubs event, encapsulating a set of data and its associated metadata.
     /// </summary>
     ///
-    public class EventData : IMessageWithContentType
+    public class EventData
     {
         /// <summary>The AMQP representation of the event, allowing access to additional protocol data elements not used directly by the Event Hubs client library.</summary>
         private readonly AmqpAnnotatedMessage _amqpMessage;
@@ -46,19 +46,6 @@ namespace Azure.Messaging.EventHubs
         {
             get => _amqpMessage.GetEventBody();
             set => _amqpMessage.Body = AmqpMessageBody.FromData(MessageBody.FromReadOnlyMemorySegment(value.ToMemory()));
-        }
-
-        /// <summary>
-        ///   The data associated with the event, in <see cref="BinaryData" /> form, providing support
-        ///   for a variety of data transformations and <see cref="ObjectSerializer" /> integration.
-        /// </summary>
-        ///
-        /// <seealso cref="BinaryData" />
-        ///
-        BinaryData IMessageWithContentType.Data
-        {
-            get => EventBody;
-            set => EventBody = value;
         }
 
         /// <summary>
@@ -127,7 +114,6 @@ namespace Azure.Messaging.EventHubs
         ///   how Event Hubs identifies the event.
         /// </remarks>
         ///
-
         public string MessageId
         {
             get
@@ -167,7 +153,6 @@ namespace Azure.Messaging.EventHubs
         ///   telemetry, distributed tracing, or logging.
         /// </remarks>
         ///
-
         public string CorrelationId
         {
             get


### PR DESCRIPTION
# Summary

The focus of these changes is to revert the integration for Schema Registry that draws from the `Azure.Core.Experimental` package.  This will be reintroduced after the release in a different form.

# References and Related

- [Remove interface (#25210)](https://github.com/Azure/azure-sdk-for-net/pull/25210) _(this PR supersedes)_