### PR TITLE
[Event Hubs] ProcessEventArgs Doc Updates

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
@@ -21,8 +21,8 @@ namespace Azure.Messaging.EventHubs.Processor
     {
         /// <summary>
         ///   Indicates whether or not the arguments contain an event to be processed.  In
-        ///   the case where no event is contained, then the context and creation of
-        ///   checkpoints are also unavailable.
+        ///   the case where no event is contained, then and creation of checkpoints and reading the last
+        ///   enqueued event properties are unavailable.
         /// </summary>
         ///
         /// <value><c>true</c> if the arguments contain an event to be processed; otherwise, <c>false</c>.</value>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Processor
     {
         /// <summary>
         ///   Indicates whether or not the arguments contain an event to be processed.  In
-        ///   the case where no event is contained, then and creation of checkpoints and reading the last
+        ///   the case where no event is contained, then the creation of checkpoints and reading the last
         ///   enqueued event properties are unavailable.
         /// </summary>
         ///


### PR DESCRIPTION
# Summary

The focus of these changes is to clarify the documentation for the `HasEvent` property of the `ProcessEventArgs` type.  Previously, it was implied that the partition context was unavailable rather than just some functionality of the context.

# References and Related

- [Update documentation regarding the HasEvent property for ProcessEventArgs (#24969)](https://github.com/Azure/azure-sdk-for-net/issues/24969)