### PR TITLE
[Event Hubs] Performance Test Doc Comments

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/BatchPublishPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/BatchPublishPerfTest.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Producer;
 using Azure.Messaging.EventHubs.Tests;
-using Azure.Test.Perf;
 
 namespace Azure.Messaging.EventHubs.Perf
 {
@@ -112,12 +110,13 @@ namespace Azure.Messaging.EventHubs.Perf
                 await s_producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
                 return Options.BatchSize;
             }
-            catch (EventHubsException e) when (cancellationToken.IsCancellationRequested && e.IsTransient)
+            catch (EventHubsException ex) when (cancellationToken.IsCancellationRequested && ex.IsTransient)
             {
-                // If SendAsync() is cancelled during a retry loop, the most recent exception is thrown.
+                // If SendAsync() is canceled during a retry loop, the most recent exception is thrown.
                 // If the exception is transient, it should be wrapped in an OperationCanceledException
-                // which is ignored by the perf framework.
-                throw new OperationCanceledException("EventHubsException thrown during cancellation", e);
+                // which is ignored by the performance  framework.
+
+                throw new OperationCanceledException("EventHubsException thrown during cancellation", ex);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventHubsOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventHubsOptions.cs
@@ -6,12 +6,24 @@ using CommandLine;
 
 namespace Azure.Messaging.EventHubs.Perf
 {
+    /// <summary>
+    ///   The set of command-line options valid for Event Hubs performance tests.
+    /// </summary>
+    ///
     public class EventHubsOptions : PerfOptions
     {
-        [Option("body-size", HelpText = "Size of message body (in bytes)")]
+        /// <summary>
+        ///   The size of the event body, in bytes.
+        /// </summary>
+        ///
+        [Option("body-size", HelpText = "Size of event body (in bytes)")]
         public int BodySize { get; set; }
 
-        [Option("batch-size", HelpText = "Messages per batch")]
+        /// <summary>
+        ///   The number of events that should be included in each batch.
+        /// </summary>
+        ///
+        [Option("batch-size", HelpText = "Events per batch")]
         public int BatchSize { get; set; }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventHubsPartitionOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventHubsPartitionOptions.cs
@@ -1,14 +1,31 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Test.Perf;
 using CommandLine;
 
 namespace Azure.Messaging.EventHubs.Perf
 {
+    /// <summary>
+    ///   The set of command-line options for partition-based Event Hubs performance tests.
+    /// </summary>
+    ///
     public class EventHubsPartitionOptions : EventHubsOptions
     {
+        /// <summary>
+        ///   The number of partitions to test against.
+        /// </summary>
+        ///
+        /// <value>If set to -1, all available partitions will be used.</value>
+        ///
         [Option("partitions", Default = 1, HelpText = "Number of partitions to publish. -1 publishes to all partitions.")]
         public int Partitions { get; set; }
+
+        /// <summary>
+        ///   Indicates whether all partitions should be used rather than constraining to a subset.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if all partitions should be used; otherwise, <c>false</c>.</value>
+        ///
+        public bool ShouldUseAllPartitions => Partitions == -1;
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventPublishPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/EventPublishPerfTest.cs
@@ -100,12 +100,13 @@ namespace Azure.Messaging.EventHubs.Perf
 
                 return Options.BatchSize;
             }
-            catch (EventHubsException e) when (cancellationToken.IsCancellationRequested && e.IsTransient)
+            catch (EventHubsException ex) when (cancellationToken.IsCancellationRequested && ex.IsTransient)
             {
-                // If SendAsync() is cancelled during a retry loop, the most recent exception is thrown.
+                // If SendAsync() is canceled during a retry loop, the most recent exception is thrown.
                 // If the exception is transient, it should be wrapped in an OperationCancelledException
-                // which is ignored by the perf framework.
-                throw new OperationCanceledException("EventHubsException thrown during cancellation", e);
+                // which is ignored by the performance framework.
+
+                throw new OperationCanceledException("EventHubsException thrown during cancellation", ex);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/ReadPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Infrastructure/ReadPerfTest.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Producer;
 using Azure.Messaging.EventHubs.Tests;
-using Azure.Test.Perf;
 
 namespace Azure.Messaging.EventHubs.Perf
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Program.cs
@@ -5,33 +5,12 @@ using System.Reflection;
 using Azure.Messaging.EventHubs.Tests;
 using Azure.Test.Perf;
 
-try
-{
-    // Ensure that there is an active Event Hubs namespace that can be used across all
-    // scenarios.  Requesting the connection string will trigger creation of an ephemeral
-    // namespace if an existing one wasn't explicitly provided.
+// Ensure that there is an active Event Hubs namespace that can be used across all
+// scenarios.  Requesting the connection string will trigger an exception if the necessary
+// resources are not available.
 
-    _ = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+_ = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
 
-    // Allow the framework to execute the test scenarios.
+// Allow the framework to execute the test scenarios.
 
-    await PerfProgram.Main(Assembly.GetEntryAssembly(), args);
-}
-finally
-{
-    if (EventHubsTestEnvironment.Instance.ShouldRemoveNamespaceAfterTestRunCompletion)
-    {
-        try
-        {
-            await EventHubScope.DeleteNamespaceAsync(EventHubsTestEnvironment.Instance.EventHubsNamespace).ConfigureAwait(false);
-        }
-        catch
-        {
-            // This should not be considered a critical failure.  Due to ARM being temperamental, some
-            // management operations may be rejected.  Throwing here does not help to ensure resource cleanup.
-            //
-            // Assume the standard orphan resource cleanup is being run and will take responsibility
-            // for cleaning up any orphans.
-        }
-    }
-}
+await PerfProgram.Main(Assembly.GetEntryAssembly(), args);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishBatchesToGateway.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishBatchesToGateway.cs
@@ -3,7 +3,6 @@
 
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Producer;
-using Azure.Test.Perf;
 
 namespace Azure.Messaging.EventHubs.Perf.Scenarios
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishBatchesToPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishBatchesToPartition.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Producer;
-using Azure.Test.Perf;
 
 namespace Azure.Messaging.EventHubs.Perf.Scenarios
 {
@@ -40,8 +37,9 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
         protected async override Task<CreateBatchOptions> CreateBatchOptions(EventHubProducerClient producer)
         {
             // Query the available partitions and select the partition for use in the batch options.
+
             var partitions = await producer.GetPartitionIdsAsync().ConfigureAwait(false);
-            var partitionsToPublish = Options.Partitions == -1 ? partitions.Length : Options.Partitions;
+            var partitionsToPublish = Options.ShouldUseAllPartitions ? partitions.Length : Options.Partitions;
             var partition = partitions[ParallelIndex % partitionsToPublish];
 
             return new CreateBatchOptions

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishEventsToPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/PublishEventsToPartition.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Linq;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Producer;
-using Azure.Test.Perf;
 
 namespace Azure.Messaging.EventHubs.Perf.Scenarios
 {
@@ -39,8 +37,9 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
         protected async override Task<SendEventOptions> CreateSendOptions(EventHubProducerClient producer)
         {
             // Query the available partitions and select the partition for use in the batch options.
+
             var partitions = await producer.GetPartitionIdsAsync().ConfigureAwait(false);
-            var partitionsToPublish = Options.Partitions == -1 ? partitions.Length : Options.Partitions;
+            var partitionsToPublish = Options.ShouldUseAllPartitions ? partitions.Length : Options.Partitions;
             var partition = partitions[ParallelIndex % partitionsToPublish];
 
             return new SendEventOptions

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithConsumer.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Consumer;
-using Azure.Test.Perf;
 
 namespace Azure.Messaging.EventHubs.Perf.Scenarios
 {
@@ -109,7 +108,6 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
             // If iteration stopped due to cancellation, ensure that the expected exception is thrown.
 
             cancellationToken.ThrowIfCancellationRequested();
-
             return Options.BatchSize;
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Scenarios/ReadFromPartitionWithReceiver.cs
@@ -97,7 +97,6 @@ namespace Azure.Messaging.EventHubs.Perf.Scenarios
             // If iteration stopped due to cancellation, ensure that the expected exception is thrown.
 
             cancellationToken.ThrowIfCancellationRequested();
-
             return Options.BatchSize;
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to add doc comments to the members of the Event Hubs performance tests project where they were missing and to apply some small formatting clean-up.

# References and Related

- [[EventHubs] Add doc comments to perf tests (#25026)](https://github.com/Azure/azure-sdk-for-net/issues/25026)