### PR TITLE
[SignalR] Enable trigger to use identity-based connection

### DIFF
--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Resolver/SignalRRequestResolver.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/TriggerBindings/Resolver/SignalRRequestResolver.cs
@@ -19,8 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         private readonly bool _validateSignature;
 
-        // Now it's only used in test, but when the trigger started to support AAD,
-        // It can be configurable in public.
+        // Now it's only used in test
         internal SignalRRequestResolver(bool validateSignature = true)
         {
             _validateSignature = validateSignature;
@@ -51,6 +50,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
             foreach (var accessKey in accessKeys)
             {
+                // Skip validation for aad access key.
+                if (accessKey is AadAccessKey)
+                {
+                    return true;
+                }
                 var accessToken = accessKey.Value;
                 if (!string.IsNullOrEmpty(accessToken) &&
                      request.Headers.TryGetValues(Constants.AsrsSignature, out var values))

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRRequestResolverTests.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Trigger/SignalRRequestResolverTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Identity;
+using Microsoft.Azure.SignalR;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests
+{
+    public class SignalRRequestResolverTests
+    {
+        [Fact]
+        public void ValidateSignatureWithAadAccessKeyFact()
+        {
+            var resolver = new SignalRRequestResolver();
+            Assert.True(resolver.ValidateSignature(new(), new[] { new AadAccessKey(new("http://localhost"), new DefaultAzureCredential()) }));
+        }
+    }
+}


### PR DESCRIPTION
Originally, we used access key to validate that the http requests come from Azure SignalR. But if users use identity-based connection, we can't get an access key. To enable users to use identity-based connection, this PR skips the validation with the presence of AadAccessKey(identity-based connection). 