### PR TITLE
Use arm template parameters as sole input for live test environment variables

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal const string AuthorityHostEnvironmentVariableName = "AZURE_AUTHORITY_HOST";
         internal const string ServiceManagementUrlEnvironmentVariableName = "SERVICE_MANAGEMENT_URL";
         internal const string ResourceManagerEnvironmentVariableName = "RESOURCE_MANAGER_URL";
-        internal const string StorageEndpointSuffixEnvironmentVariableName = "STORAGE_ENDPOINT_SUFFIX";
+        internal const string StorageEndpointSuffixEnvironmentVariableName = "EVENTHUB_STORAGE_ENDPOINT_SUFFIX";
         internal const string EventHubsNamespaceConnectionStringEnvironmentVariable = "EVENTHUB_NAMESPACE_CONNECTION_STRING";
         internal const string StorageConnectionStringEnvironmentVariable = "EVENTHUB_PROCESSOR_STORAGE_CONNECTION_STRING";
 

--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -176,6 +176,10 @@
     }
   ],
   "outputs": {
+    "EVENTHUB_STORAGE_ENDPOINT_SUFFIX": {
+        "type": "string",
+        "value": "[parameters('storageEndpointSuffix')]"
+    },
     "EVENTHUB_PER_TEST_LIMIT_MINUTES": {
       "type": "string",
       "value": "[parameters('perTestExecutionLimitMinutes')]"

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -48,6 +48,13 @@
               "description": "The url suffix to use when accessing the search data plane."
           }
         },
+        "storageEndpointSuffix": {
+          "type": "string",
+          "defaultValue": "core.windows.net",
+          "metadata": {
+              "description": "The url suffix to use when accessing the storage data plane."
+          }
+        },
         "searchSku": {
             "type": "string",
             "defaultValue": "basic",
@@ -165,6 +172,10 @@
         }
     ],
     "outputs": {
+        "STORAGE_ENDPOINT_SUFFIX": {
+            "type": "string",
+            "value": "[parameters('storageEndpointSuffix')]"
+        },
         "SEARCH_ENDPOINT_SUFFIX": {
             "type": "string",
             "value": "[parameters('searchEndpointSuffix')]"

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -41,6 +41,13 @@
                 "description": "The location of the resource. By default, this is the same as the resource group."
             }
         },
+        "searchEndpointSuffix": {
+          "type": "string",
+          "defaultValue": "search.windows.net",
+          "metadata": {
+              "description": "The url suffix to use when accessing the search data plane."
+          }
+        },
         "searchSku": {
             "type": "string",
             "defaultValue": "basic",
@@ -158,6 +165,10 @@
         }
     ],
     "outputs": {
+        "SEARCH_ENDPOINT_SUFFIX": {
+            "type": "string",
+            "value": "[parameters('searchEndpointSuffix')]"
+        },
         "SEARCH_SERVICE_NAME": {
             "type": "string",
             "value": "[variables('searchServiceName')]"

--- a/sdk/tables/test-resources.json
+++ b/sdk/tables/test-resources.json
@@ -17,6 +17,13 @@
           "metadata": {
               "description": "The url suffix to use when accessing the cosmos data plane."
           }
+        },
+        "storageEndpointSuffix": {
+          "type": "string",
+          "defaultValue": "core.windows.net",
+          "metadata": {
+              "description": "The url suffix to use when accessing the storage data plane."
+          }
         }
     },
     "variables": {
@@ -117,6 +124,10 @@
         "COSMOS_TABLES_ENDPOINT_SUFFIX": {
             "type": "string",
             "value": "[parameters('cosmosEndpointSuffix')]"
+        },
+        "STORAGE_ENDPOINT_SUFFIX": {
+            "type": "string",
+            "value": "[parameters('storageEndpointSuffix')]"
         },
         "TABLES_STORAGE_ACCOUNT_NAME": {
             "type": "string",

--- a/sdk/tables/test-resources.json
+++ b/sdk/tables/test-resources.json
@@ -10,6 +10,13 @@
             "metadata": {
                 "description": "The principal to assign the role to. This is application object id."
             }
+        },
+        "cosmosEndpointSuffix": {
+          "type": "string",
+          "defaultValue": "cosmos.azure.com",
+          "metadata": {
+              "description": "The url suffix to use when accessing the cosmos data plane."
+          }
         }
     },
     "variables": {
@@ -107,6 +114,10 @@
         }
     ],
     "outputs": {
+        "COSMOS_TABLES_ENDPOINT_SUFFIX": {
+            "type": "string",
+            "value": "[parameters('cosmosEndpointSuffix')]"
+        },
         "TABLES_STORAGE_ACCOUNT_NAME": {
             "type": "string",
             "value": "[variables('primaryAccountName')]"


### PR DESCRIPTION
For sovereign cloud testing, many cloud-specific arm template parameters and environment variables get passed in from an external keyvault source. This makes them hard to manage and track. I plan to move these values into source control, and as a pre-requisite I am consolidating as many values into the arm template parameters as possible (as opposed to a mismash of parameters and env var declarations).