### PR TITLE
Storage/test infra/test fixture abstraction

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/Azure.Storage.Blobs.Batch.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/Azure.Storage.Blobs.Batch.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared\Core" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobsClientTestFixtureAttribute.cs" LinkBase="Shared" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobTestBase.cs" LinkBase="Shared" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\BlobTestEnvironment.cs" LinkBase="Shared" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\Azure.Storage.Blobs\tests\ClientBuilderExtensions.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTransactionalHashingTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTransactionalHashingTests.cs
@@ -11,20 +11,7 @@ using NUnit.Framework;
 
 namespace Azure.Storage.Blobs.Tests
 {
-    [ClientTestFixture(
-        BlobClientOptions.ServiceVersion.V2019_02_02,
-        BlobClientOptions.ServiceVersion.V2019_07_07,
-        BlobClientOptions.ServiceVersion.V2019_12_12,
-        BlobClientOptions.ServiceVersion.V2020_02_10,
-        BlobClientOptions.ServiceVersion.V2020_04_08,
-        BlobClientOptions.ServiceVersion.V2020_06_12,
-        BlobClientOptions.ServiceVersion.V2020_08_04,
-        BlobClientOptions.ServiceVersion.V2020_10_02,
-        BlobClientOptions.ServiceVersion.V2020_12_06,
-        StorageVersionExtensions.LatestVersion,
-        StorageVersionExtensions.MaxVersion,
-        RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
-        LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
+    [BlobsClientTestFixture]
     public abstract class BlobBaseClientTransactionalHashingTests<TBlobClient> : TransactionalHashingTestBase<
         BlobServiceClient,
         BlobContainerClient,

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -18,21 +18,7 @@ using NUnit.Framework;
 
 namespace Azure.Storage.Test.Shared
 {
-    [ClientTestFixture(
-        BlobClientOptions.ServiceVersion.V2019_02_02,
-        BlobClientOptions.ServiceVersion.V2019_07_07,
-        BlobClientOptions.ServiceVersion.V2019_12_12,
-        BlobClientOptions.ServiceVersion.V2020_02_10,
-        BlobClientOptions.ServiceVersion.V2020_04_08,
-        BlobClientOptions.ServiceVersion.V2020_06_12,
-        BlobClientOptions.ServiceVersion.V2020_08_04,
-        BlobClientOptions.ServiceVersion.V2020_10_02,
-        BlobClientOptions.ServiceVersion.V2020_12_06,
-        BlobClientOptions.ServiceVersion.V2021_02_12,
-        StorageVersionExtensions.LatestVersion,
-        StorageVersionExtensions.MaxVersion,
-        RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
-        LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
+    [BlobsClientTestFixture]
     public abstract class BlobTestBase : StorageTestBase<BlobTestEnvironment>
     {
         /// <summary>
@@ -52,7 +38,7 @@ namespace Azure.Storage.Test.Shared
             new Uri(Tenants.TestConfigSecondary.BlobServiceSecondaryEndpoint).Host;
 
         public BlobTestBase(bool async, BlobClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
-            : base(async, mode)
+            : base(async, RecordedTestMode.Playback)
         {
             _serviceVersion = serviceVersion;
             BlobsClientBuilder = ClientBuilderExtensions.GetNewBlobsClientBuilder(Tenants, _serviceVersion);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -38,7 +38,7 @@ namespace Azure.Storage.Test.Shared
             new Uri(Tenants.TestConfigSecondary.BlobServiceSecondaryEndpoint).Host;
 
         public BlobTestBase(bool async, BlobClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
-            : base(async, RecordedTestMode.Playback)
+            : base(async, mode)
         {
             _serviceVersion = serviceVersion;
             BlobsClientBuilder = ClientBuilderExtensions.GetNewBlobsClientBuilder(Tenants, _serviceVersion);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobsClientTestFixtureAttribute.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobsClientTestFixtureAttribute.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.TestFramework;
+
+namespace Azure.Storage.Blobs.Tests
+{
+    public class BlobsClientTestFixtureAttribute : ClientTestFixtureAttribute
+    {
+        public BlobsClientTestFixtureAttribute()
+            : base(
+                BlobClientOptions.ServiceVersion.V2019_02_02,
+                BlobClientOptions.ServiceVersion.V2019_07_07,
+                BlobClientOptions.ServiceVersion.V2019_12_12,
+                BlobClientOptions.ServiceVersion.V2020_02_10,
+                BlobClientOptions.ServiceVersion.V2020_04_08,
+                BlobClientOptions.ServiceVersion.V2020_06_12,
+                BlobClientOptions.ServiceVersion.V2020_08_04,
+                BlobClientOptions.ServiceVersion.V2020_10_02,
+                BlobClientOptions.ServiceVersion.V2020_12_06,
+                BlobClientOptions.ServiceVersion.V2021_02_12,
+                StorageVersionExtensions.LatestVersion,
+                StorageVersionExtensions.MaxVersion)
+        {
+            RecordingServiceVersion = StorageVersionExtensions.MaxVersion;
+            LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion };
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeClientTestFixtureAttribute.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeClientTestFixtureAttribute.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.TestFramework;
+
+namespace Azure.Storage.Files.DataLake.Tests
+{
+    public class DataLakeClientTestFixtureAttribute : ClientTestFixtureAttribute
+    {
+        public DataLakeClientTestFixtureAttribute()
+            : base(
+                DataLakeClientOptions.ServiceVersion.V2019_02_02,
+                DataLakeClientOptions.ServiceVersion.V2019_07_07,
+                DataLakeClientOptions.ServiceVersion.V2019_12_12,
+                DataLakeClientOptions.ServiceVersion.V2020_02_10,
+                DataLakeClientOptions.ServiceVersion.V2020_04_08,
+                DataLakeClientOptions.ServiceVersion.V2020_06_12,
+                DataLakeClientOptions.ServiceVersion.V2020_08_04,
+                DataLakeClientOptions.ServiceVersion.V2020_10_02,
+                DataLakeClientOptions.ServiceVersion.V2020_12_06,
+                DataLakeClientOptions.ServiceVersion.V2021_02_12,
+                StorageVersionExtensions.LatestVersion,
+                StorageVersionExtensions.MaxVersion)
+        {
+            RecordingServiceVersion = StorageVersionExtensions.MaxVersion;
+            LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion };
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeFileClientTransactionalHashingTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeFileClientTransactionalHashingTests.cs
@@ -11,20 +11,7 @@ using Azure.Storage.Test.Shared;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
-    [ClientTestFixture(
-        DataLakeClientOptions.ServiceVersion.V2019_02_02,
-        DataLakeClientOptions.ServiceVersion.V2019_07_07,
-        DataLakeClientOptions.ServiceVersion.V2019_12_12,
-        DataLakeClientOptions.ServiceVersion.V2020_02_10,
-        DataLakeClientOptions.ServiceVersion.V2020_04_08,
-        DataLakeClientOptions.ServiceVersion.V2020_06_12,
-        DataLakeClientOptions.ServiceVersion.V2020_08_04,
-        DataLakeClientOptions.ServiceVersion.V2020_10_02,
-        DataLakeClientOptions.ServiceVersion.V2020_12_06,
-        StorageVersionExtensions.LatestVersion,
-        StorageVersionExtensions.MaxVersion,
-        RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
-        LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
+    [DataLakeClientTestFixture]
     public class DataLakeFileClientTransactionalHashingTests : TransactionalHashingTestBase<
         DataLakeServiceClient,
         DataLakeFileSystemClient,

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -17,21 +17,7 @@ using NUnit.Framework;
 
 namespace Azure.Storage.Files.DataLake.Tests
 {
-    [ClientTestFixture(
-        DataLakeClientOptions.ServiceVersion.V2019_02_02,
-        DataLakeClientOptions.ServiceVersion.V2019_07_07,
-        DataLakeClientOptions.ServiceVersion.V2019_12_12,
-        DataLakeClientOptions.ServiceVersion.V2020_02_10,
-        DataLakeClientOptions.ServiceVersion.V2020_04_08,
-        DataLakeClientOptions.ServiceVersion.V2020_06_12,
-        DataLakeClientOptions.ServiceVersion.V2020_08_04,
-        DataLakeClientOptions.ServiceVersion.V2020_10_02,
-        DataLakeClientOptions.ServiceVersion.V2020_12_06,
-        DataLakeClientOptions.ServiceVersion.V2021_02_12,
-        StorageVersionExtensions.LatestVersion,
-        StorageVersionExtensions.MaxVersion,
-        RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
-        LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
+    [DataLakeClientTestFixture]
     public abstract class DataLakeTestBase : StorageTestBase<DataLakeTestEnvironment>
     {
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -16,21 +16,7 @@ using NUnit.Framework;
 
 namespace Azure.Storage.Files.Shares.Tests
 {
-    [ClientTestFixture(
-        ShareClientOptions.ServiceVersion.V2019_02_02,
-        ShareClientOptions.ServiceVersion.V2019_07_07,
-        ShareClientOptions.ServiceVersion.V2019_12_12,
-        ShareClientOptions.ServiceVersion.V2020_02_10,
-        ShareClientOptions.ServiceVersion.V2020_04_08,
-        ShareClientOptions.ServiceVersion.V2020_06_12,
-        ShareClientOptions.ServiceVersion.V2020_08_04,
-        ShareClientOptions.ServiceVersion.V2020_10_02,
-        ShareClientOptions.ServiceVersion.V2020_12_06,
-        ShareClientOptions.ServiceVersion.V2021_02_12,
-        StorageVersionExtensions.LatestVersion,
-        StorageVersionExtensions.MaxVersion,
-        RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
-        LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion, })]
+    [ShareClientTestFixture]
     public class FileTestBase : StorageTestBase<StorageTestEnvironment>
     {
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTestFixtureAttribute.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTestFixtureAttribute.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.TestFramework;
+
+namespace Azure.Storage.Files.Shares.Tests
+{
+    public class ShareClientTestFixtureAttribute : ClientTestFixtureAttribute
+    {
+        public ShareClientTestFixtureAttribute()
+            : base(
+                ShareClientOptions.ServiceVersion.V2019_02_02,
+                ShareClientOptions.ServiceVersion.V2019_07_07,
+                ShareClientOptions.ServiceVersion.V2019_12_12,
+                ShareClientOptions.ServiceVersion.V2020_02_10,
+                ShareClientOptions.ServiceVersion.V2020_04_08,
+                ShareClientOptions.ServiceVersion.V2020_06_12,
+                ShareClientOptions.ServiceVersion.V2020_08_04,
+                ShareClientOptions.ServiceVersion.V2020_10_02,
+                ShareClientOptions.ServiceVersion.V2020_12_06,
+                ShareClientOptions.ServiceVersion.V2021_02_12,
+                StorageVersionExtensions.LatestVersion,
+                StorageVersionExtensions.MaxVersion)
+        {
+            RecordingServiceVersion = StorageVersionExtensions.MaxVersion;
+            LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion, };
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareFileClientTransactionalHashingTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareFileClientTransactionalHashingTests.cs
@@ -12,20 +12,7 @@ using NUnit.Framework;
 
 namespace Azure.Storage.Files.Shares.Tests
 {
-    [ClientTestFixture(
-        ShareClientOptions.ServiceVersion.V2019_02_02,
-        ShareClientOptions.ServiceVersion.V2019_07_07,
-        ShareClientOptions.ServiceVersion.V2019_12_12,
-        ShareClientOptions.ServiceVersion.V2020_02_10,
-        ShareClientOptions.ServiceVersion.V2020_04_08,
-        ShareClientOptions.ServiceVersion.V2020_06_12,
-        ShareClientOptions.ServiceVersion.V2020_08_04,
-        ShareClientOptions.ServiceVersion.V2020_10_02,
-        ShareClientOptions.ServiceVersion.V2020_12_06,
-        StorageVersionExtensions.LatestVersion,
-        StorageVersionExtensions.MaxVersion,
-        RecordingServiceVersion = StorageVersionExtensions.MaxVersion,
-        LiveServiceVersions = new object[] { StorageVersionExtensions.LatestVersion })]
+    [ShareClientTestFixture]
     public class ShareFileClientTransactionalHashingTests : TransactionalHashingTestBase<
         ShareServiceClient,
         ShareClient,


### PR DESCRIPTION
With the adoption of a new test class inheritance pattern for cross-service tests, it has become harder to keep test service version declarations in sync. Each service has to separately declare it's service versions with the attribute, and now that not every test inherits from `BlobTestBase` (or equivalent), they don't get the service version declarations that was made there.

This PR extends `ClientTestFixtureAttribute` in each service package and gives that sub-class an empty constructor that calls into its base constructor the way individual attribute declarations were previously invoking it. Now that class is the only place those declarations need to be updated and any test class can add that attribute to get all of the up-to-date testing service version management for free.

Did not extend to Queues tests because this doesn't appear to be a concern there.