### PR TITLE
Setting Kind property to the DateTime.MaxValue returned by ExiresAtUtc property

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Message.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Message.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.ServiceBus
             {
                 if (this.TimeToLive >= DateTime.MaxValue.Subtract(this.SystemProperties.EnqueuedTimeUtc))
                 {
-                    return DateTime.MaxValue;
+                    return DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
                 }
 
                 return this.SystemProperties.EnqueuedTimeUtc.Add(this.TimeToLive);


### PR DESCRIPTION
Setting Kind property to the DateTime.MaxValue returned by ExiresAtUtc property property when the message never expires.
To fix #15343 