### PR TITLE
Enable JSON serialization customization via code by adding SignalROptions

### DIFF
--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/DependencyInjectionExtensions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/DependencyInjectionExtensions.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
     {
         private const string HubProtocolError = "It's invalid to configure hub protocol on Azure Functions runtime V2. Newtonsoft.Json protocol will be used.";
 
+        /// <summary>
+        /// Provides limited JSON serialization configuration. <see cref="SignalROptions"/> provides more configuration.
+        /// </summary>
         public static IServiceCollection SetHubProtocol(this IServiceCollection services, IConfiguration configuration)
         {
             var hubProtocolConfig = configuration[Constants.AzureSignalRHubProtocol];

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/OptionsSetupFromOptions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/OptionsSetupFromOptions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    /// <summary>
+    /// Sets up <see cref="ServiceManagerOptions"/> from <see cref="SignalROptions"/>.
+    /// </summary>
+    internal class OptionsSetupFromOptions : IConfigureOptions<ServiceManagerOptions>, IOptionsChangeTokenSource<ServiceManagerOptions>
+    {
+        private readonly SignalROptions _sourceOptions;
+
+        public string Name => Options.DefaultName;
+
+        public OptionsSetupFromOptions(SignalROptions sourceOptions)
+        {
+            _sourceOptions = sourceOptions;
+        }
+
+        public void Configure(ServiceManagerOptions options)
+        {
+            options.ServiceEndpoints = _sourceOptions.ServiceEndpoints;
+            if (_sourceOptions.ServiceTransportType.HasValue)
+            {
+                options.ServiceTransportType = _sourceOptions.ServiceTransportType.Value;
+            }
+        }
+
+        public IChangeToken GetChangeToken() => NullChangeToken.Singleton;
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceHubContextStore.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/ServiceHubContextStore.cs
@@ -17,12 +17,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
 
         public IServiceManager ServiceManager { get; }
 
+        //Used for internal test
+        public IServiceProvider ServiceProvider { get; }
+
         public AccessKey[] AccessKeys => _endpointManager.Endpoints.Keys.Select(endpoint => endpoint.AccessKey).ToArray();
 
-        public ServiceHubContextStore(IServiceEndpointManager endpointManager, IServiceManager serviceManager)
+        public ServiceHubContextStore(IServiceEndpointManager endpointManager, IServiceManager serviceManager, IServiceProvider serviceProvider)
         {
             _endpointManager = endpointManager;
             ServiceManager = serviceManager;
+            ServiceProvider = serviceProvider;
         }
 
         public ValueTask<IServiceHubContext> GetAsync(string hubName)

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalROptions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalROptions.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Azure.SignalR;
+using Microsoft.Azure.SignalR.Management;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
+{
+    /// <summary>
+    /// Configuration options for SignalR extensions.
+    /// </summary>
+    /// <remarks>
+    /// Most properties here can be configured in <see cref="IConfiguration"/>, except JSON serialization.
+    /// </remarks>
+    public class SignalROptions
+    {
+        /// <summary>
+        /// Gets or sets the service endpoints.
+        /// </summary>
+        public ServiceEndpoint[] ServiceEndpoints { get; set; }
+
+        /// <summary>
+        /// Gets or sets the service transport type.
+        /// </summary>
+        public ServiceTransportType? ServiceTransportType { get; set; }
+
+        /// <summary>
+        /// Use Newtonsoft.Json as the JSON serialization library.
+        /// </summary>
+        /// <param name="configure">Configure the Newtonsoft Json service hub protocol options.</param>
+        public void UseNewtonsoftJson(Action<NewtonsoftServiceHubProtocolOptions> configure)
+        {
+            NewtonsoftOptionsAction = configure;
+        }
+
+        internal Action<NewtonsoftServiceHubProtocolOptions> NewtonsoftOptionsAction { get; set; }
+    }
+}

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRWebJobsBuilderExtensions.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Config/SignalRWebJobsBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
@@ -25,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
             }
 
             builder.AddExtension<SignalRConfigProvider>();
+            builder.Services.AddAzureClientsCore();
             builder.Services.AddSingleton<IServiceManagerStore, ServiceManagerStore>();
             return builder;
         }

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/OptionsSetupFromConfigFacts.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/tests/Config/OptionsSetupFromConfigFacts.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Linq;
 using Microsoft.Azure.SignalR.Management;
+using Microsoft.Azure.SignalR.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.SignalRService;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace SignalRServiceExtension.Tests.Config
 {
-    public class OptionsSetupFacts
+    public class OptionsSetupFromConfigFacts
     {
         [Fact]
         public void TestIdentityBasedSingleEndpointConfiguration()
@@ -18,7 +19,7 @@ namespace SignalRServiceExtension.Tests.Config
             var sectionKey = "connection";
             var serviceUri = "http://localhost.signalr.com";
             configuration[$"{sectionKey}:serviceUri"] = serviceUri;
-            var optionsSetup = new OptionsSetup(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, sectionKey);
+            var optionsSetup = new OptionsSetupFromConfig(configuration, SingletonAzureComponentFactory.Instance, sectionKey);
             var options = new ServiceManagerOptions();
             optionsSetup.Configure(options);
 
@@ -35,7 +36,7 @@ namespace SignalRServiceExtension.Tests.Config
             var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
             configuration[$"Azure:SignalR:Endpoints:{endpointNames[0]}:serviceUri"] = serviceUris[0];
             configuration[$"Azure:SignalR:Endpoints:{endpointNames[1]}:serviceUri"] = serviceUris[1];
-            var optionsSetup = new OptionsSetup(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, "does_not_matter");
+            var optionsSetup = new OptionsSetupFromConfig(configuration, SingletonAzureComponentFactory.Instance, "does_not_matter");
             var options = new ServiceManagerOptions();
             optionsSetup.Configure(options);
 
@@ -57,13 +58,53 @@ namespace SignalRServiceExtension.Tests.Config
             configuration[$"Azure:SignalR:Endpoints:{endpointName}:serviceUri"] = serviceUris[0];
             configuration[$"{namelessEndpointKey}:serviceUri"] = serviceUris[1];
 
-            var optionsSetup = new OptionsSetup(configuration, NullLoggerFactory.Instance, SingletonAzureComponentFactory.Instance, namelessEndpointKey);
+            var optionsSetup = new OptionsSetupFromConfig(configuration, SingletonAzureComponentFactory.Instance, namelessEndpointKey);
             var options = new ServiceManagerOptions();
             optionsSetup.Configure(options);
 
             Assert.Equal(2, options.ServiceEndpoints.Length);
             Assert.Contains(options.ServiceEndpoints, e => endpointName == e.Name && serviceUris[0] == e.Endpoint);
             Assert.Contains(options.ServiceEndpoints, e => string.Empty == e.Name && serviceUris[1] == e.Endpoint);
+        }
+
+        /// <summary>
+        /// Make sure don't override the settings from SignalROptions when <see cref="IConfiguration"/> doesn't have corresponding items.
+        /// </summary>
+        [Fact]
+        public void TestConfigItemNotExist()
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            var optionsSetup = new OptionsSetupFromConfig(configuration, SingletonAzureComponentFactory.Instance, "_");
+            var options = new ServiceManagerOptions()
+            {
+                ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(1).ToArray(),
+                ServiceTransportType = ServiceTransportType.Persistent
+            };
+            optionsSetup.Configure(options);
+            Assert.NotNull(options.ServiceEndpoints);
+            Assert.Single(options.ServiceEndpoints);
+            Assert.Equal(ServiceTransportType.Persistent, options.ServiceTransportType);
+        }
+
+        /// <summary>
+        /// Make sure override the settings from SignalROptions when <see cref="IConfiguration"/> has specific items.
+        /// </summary>
+        [Fact]
+        public void TestConfigItemExist()
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+            configuration["SignalRConnection:serviceUri"] = "https://signalr.com";
+            configuration["AzureSignalRServiceTransportType"] = "Transient";
+            var optionsSetup = new OptionsSetupFromConfig(configuration, SingletonAzureComponentFactory.Instance, "SignalRConnection");
+            var options = new ServiceManagerOptions()
+            {
+                ServiceEndpoints = FakeEndpointUtils.GetFakeEndpoint(2).ToArray(),
+                ServiceTransportType = ServiceTransportType.Persistent
+            };
+            optionsSetup.Configure(options);
+            Assert.NotNull(options.ServiceEndpoints);
+            Assert.Single(options.ServiceEndpoints);
+            Assert.Equal(ServiceTransportType.Transient, options.ServiceTransportType);
         }
     }
 }


### PR DESCRIPTION
- Fix `AzureComponentFactory` is null.
- Enable JSON serialization customization via code by adding `SignalROptions`

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

Users need to customize JSON serialization settings, which can hardly accomplished by App settings, so this PR adds an `SignalROptions`.

Usage:
```cs
  public class Startup : FunctionsStartup
  {
      public override void Configure(IFunctionsHostBuilder builder)
      {
          builder.Services.Configure<SignalROptions>(o =>
          {
              o.UseNewtonsoftJson(protocolOptions => protocolOptions.PayloadSerializerSettings.DateFormatHandling = Newtonsoft.Json.DateFormatHandling.MicrosoftDateFormat);
              o.ServiceTransportType = ServiceTransportType.Persistent;
              o.ServiceEndpoints = new ServiceEndpoint[] { new ServiceEndpoint(new Uri("https://service.signalr.net"), new DefaultAzureCredential()) };
          });
      }
  }
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.