### PR TITLE
Default to 2s for standard size sessions.

### DIFF
--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (Unreleased)
+## 1.2.0-beta.1 (Unreleased)
 - The SDK now defaults to a 2s polling interval when waiting for a Standard sized rendering VM. For Premium, 10s is still used.
 
 ## 1.1.0 (2021-09-17)

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/CHANGELOG.md
@@ -1,14 +1,7 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+## 1.2.0 (Unreleased)
+- The SDK now defaults to a 2s polling interval when waiting for a Standard sized rendering VM. For Premium, 10s is still used.
 
 ## 1.1.0 (2021-09-17)
 - Ensure the MS-CV header is not redacted in logs. If you are logging an issue, it can be useful to quote this value.

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/StartRenderingSessionOperation.cs
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/src/StartRenderingSessionOperation.cs
@@ -91,7 +91,8 @@ namespace Azure.MixedReality.RemoteRendering
         /// <inheritdoc />
         public async override ValueTask<Response<RenderingSession>> WaitForCompletionAsync(CancellationToken cancellationToken = default)
         {
-            return await WaitForCompletionAsync(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
+            int pollingPeriodInSeconds = (_response.Value.Size == RenderingServerSize.Standard) ? 2 : 10;
+            return await WaitForCompletionAsync(TimeSpan.FromSeconds(pollingPeriodInSeconds), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
We don't test with premium sessions, but I have tested this manually for both session sizes.