### PR TITLE
[BUG FIX] Client-side encryption respects `StorageTransferOptions.InitialTransferSize`

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for listing system containers with BlobServiceClient.GetBlobContainers() and .GetBlobContainersAsync().
 - Added support for blob names container invalid XML characters.
 - Fixed a bug where BlobClient.Upload() and UploadAsync() when using client-side encryption would modify the Dictionary instance passed by the caller for blob metadata.
+- Fixed a bug where BlobClient.Upload() and UploadAsync() when using client-side encryption would not respect StorageTransferOptions.InitialTransferSize.
 
 ## 12.11.0-beta.1 (2021-11-03)
 - Added support for service version 2020-12-06.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -533,6 +533,7 @@ namespace Azure.Storage.Blobs.Specialized
 
             return uploader.UploadInternal(
                 content,
+                expectedContentLength: default,
                 options,
                 options.ProgressHandler,
                 async: false,
@@ -589,6 +590,7 @@ namespace Azure.Storage.Blobs.Specialized
 
             return await uploader.UploadInternal(
                 content,
+                expectedContentLength: default,
                 options,
                 options.ProgressHandler,
                 async: true,

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.InternalOnly.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.InternalOnly.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Storage.Blobs.Specialized;
+using BlobsClientBuilder = Azure.Storage.Test.Shared.ClientBuilder<
+    Azure.Storage.Blobs.BlobServiceClient,
+    Azure.Storage.Blobs.BlobClientOptions>;
+
+/**
+ * Azure.Storage.Blobs.Batch (and any other sub-package of blobs) finds itself in the situation
+ * where it cannot have access to Azure.Storage.Blobs internals. It requires access to
+ * Azure.Storage.Blobs.Batch internals, which shares compile-includes with Azure.Storage.Blobs.
+ * Some client builder extensions require access to the internals of blobs, but batch needs
+ * general access to client builder extensions. This file contains extensions that require access
+ * to blobs internals, and would cause compile conflicts were other packages to have access to those
+ * internals.
+ */
+namespace Azure.Storage.Blobs.Tests
+{
+    public static partial class ClientBuilderExtensions
+    {
+        public static BlockBlobClient ToBlockBlobClient(
+            this BlobsClientBuilder clientBuilder,
+            BlobBaseClient client)
+            => clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(new BlockBlobClient(client.Uri, client.ClientConfiguration));
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Test.Shared;
 using BlobsClientBuilder = Azure.Storage.Test.Shared.ClientBuilder<
     Azure.Storage.Blobs.BlobServiceClient,
@@ -87,5 +88,10 @@ namespace Azure.Storage.Blobs.Tests
             await container.CreateIfNotExistsAsync(metadata: metadata, publicAccessType: publicAccessType.Value);
             return new DisposingContainer(container);
         }
+
+        public static BlockBlobClient ToBlockBlobClient(
+            this BlobsClientBuilder clientBuilder,
+            BlobBaseClient client)
+            => clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(new BlockBlobClient(client.Uri, client.ClientConfiguration));
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientBuilderExtensions.cs
@@ -12,7 +12,7 @@ using BlobsClientBuilder = Azure.Storage.Test.Shared.ClientBuilder<
 
 namespace Azure.Storage.Blobs.Tests
 {
-    public static class ClientBuilderExtensions
+    public static partial class ClientBuilderExtensions
     {
         /// <summary>
         /// Creates a new <see cref="ClientBuilder{TServiceClient, TServiceClientOptions}"/>
@@ -88,10 +88,5 @@ namespace Azure.Storage.Blobs.Tests
             await container.CreateIfNotExistsAsync(metadata: metadata, publicAccessType: publicAccessType.Value);
             return new DisposingContainer(container);
         }
-
-        public static BlockBlobClient ToBlockBlobClient(
-            this BlobsClientBuilder clientBuilder,
-            BlobBaseClient client)
-            => clientBuilder.AzureCoreRecordedTestBase.InstrumentClient(new BlockBlobClient(client.Uri, client.ClientConfiguration));
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -1016,6 +1016,61 @@ namespace Azure.Storage.Blobs.Test
             }
         }
 
+        [Test]
+        [LiveOnly]
+        /// <summary>
+        /// Crypto transform streams are unseekable and have no <see cref="Stream.Length"/>.
+        /// When length is unknown, <see cref="PartitionedUploader{TServiceSpecificArgs, TCompleteUploadReturn}"/>
+        /// doesn't even attempt a one-shot upload.
+        /// This tests if we correctly inform the uploader of an expected stream length so it
+        /// can respect the given <see cref="StorageTransferOptions"/>.
+        /// </summary>
+        public async Task PutBlobPutBlockSwitch([Values(true, false)] bool oneshot)
+        {
+            const int dataSize = 1 * Constants.KB;
+
+            // Arrange
+            byte[] data = GetRandomBuffer(dataSize);
+            int transferSize = oneshot
+                    ? 2 * dataSize // big enough for put blob even after AES-CBC PKCS7 padding
+                    : dataSize / 2;
+            StorageTransferOptions transferOptions = new StorageTransferOptions
+            {
+                InitialTransferSize = transferSize,
+                MaximumTransferSize = transferSize
+            };
+
+            IKeyEncryptionKey key = GetIKeyEncryptionKey().Object;
+            await using var disposable = await GetTestContainerEncryptionAsync(
+                new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
+                {
+                    KeyEncryptionKey = key,
+                    KeyWrapAlgorithm = s_algorithmName
+                });
+            var blob = disposable.Container.GetBlobClient(GetNewBlobName());
+
+            // Act
+            await blob.UploadAsync(
+                new MemoryStream(data),
+                new BlobUploadOptions { TransferOptions = transferOptions },
+                cancellationToken: s_cancellationToken);
+
+            // Assert
+            Assert.IsTrue(await blob.ExistsAsync());
+            Assert.Greater((await blob.GetPropertiesAsync()).Value.ContentLength, 0);
+            // block list will return empty when putblob was used
+            BlockList blockList = await BlobsClientBuilder.ToBlockBlobClient(blob).GetBlockListAsync();
+            Assert.IsEmpty(blockList.UncommittedBlocks);
+            if (oneshot)
+            {
+                Assert.IsEmpty(blockList.CommittedBlocks);
+            }
+            else
+            {
+                Assert.IsNotEmpty(blockList.CommittedBlocks);
+            }
+        }
+
         [RecordedTest]
         public void CanGenerateSas_WithClientSideEncryptionOptions_True()
         {

--- a/sdk/storage/Azure.Storage.Blobs/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PartitionedUploaderTests.cs
@@ -318,6 +318,7 @@ namespace Azure.Storage.Blobs.Test
         {
             return await uploader.UploadInternal(
                 content,
+                expectedContentLength: default,
                 new BlobUploadOptions
                 {
                     HttpHeaders = s_blobHttpHeaders,

--- a/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideEncryptor.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/ClientsideEncryption/ClientSideEncryptor.cs
@@ -21,6 +21,14 @@ namespace Azure.Storage.Cryptography
             _keyWrapAlgorithm = options.KeyWrapAlgorithm;
         }
 
+        public static long ExpectedCiphertextLength(long plaintextLength)
+        {
+            const int aesBlockSizeBytes = 16;
+
+            // pkcs7 padding output length algorithm
+            return plaintextLength + (aesBlockSizeBytes - (plaintextLength % aesBlockSizeBytes));
+        }
+
         /// <summary>
         /// Wraps the given read-stream in a CryptoStream and provides the metadata used to create
         /// that stream.

--- a/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
@@ -148,7 +148,7 @@ namespace Azure.Storage.Tests
             const int dataSize = Constants.KB;
             const int numPartitions = 2;
             var data = TestHelper.GetRandomBuffer(dataSize);
-            int blockSize = oneshot ? dataSize : dataSize / numPartitions;
+            int blockSize = oneshot ? dataSize * 2 : dataSize / numPartitions;
 
             var stream = new Mock<MemoryStream>(MockBehavior.Loose, data);
             stream.CallBase = true;

--- a/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
@@ -134,7 +134,7 @@ namespace Azure.Storage.Tests
                 s_hashingOptions,
                 operationName: s_operationName);
 
-            Response<object> result = await partitionedUploader.UploadInternal(stream.Object, s_objectArgs, s_progress, IsAsync, s_cancellation).ConfigureAwait(false);
+            Response<object> result = await partitionedUploader.UploadInternal(stream.Object, default, s_objectArgs, s_progress, IsAsync, s_cancellation).ConfigureAwait(false);
 
             // assert streams were actually sent to delegates; the delegates themselves threw if conditions weren't met
             Assert.Greater(singleUpload.Invocations.Count + uploadPartition.Invocations.Count, 0);

--- a/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/PartitionedUploaderTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
 using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
@@ -138,6 +139,71 @@ namespace Azure.Storage.Tests
 
             // assert streams were actually sent to delegates; the delegates themselves threw if conditions weren't met
             Assert.Greater(singleUpload.Invocations.Count + uploadPartition.Invocations.Count, 0);
+        }
+
+        [Test]
+        public async Task InterpretsLengthNonSeekableStream([Values(true, false)] bool oneshot)
+        {
+            // Arrange
+            const int dataSize = Constants.KB;
+            const int numPartitions = 2;
+            var data = TestHelper.GetRandomBuffer(dataSize);
+            int blockSize = oneshot ? dataSize : dataSize / numPartitions;
+
+            var stream = new Mock<MemoryStream>(MockBehavior.Loose, data);
+            stream.CallBase = true;
+
+            // make stream unseekable (can't get length from stream)
+            stream.SetupGet(s => s.CanSeek).Returns(false);
+            stream.SetupGet(s => s.Position).Throws(new NotSupportedException());
+            stream.SetupSet(s => s.Position = default).Throws(new NotSupportedException());
+            stream.Setup(s => s.Seek(It.IsAny<long>(), It.IsAny<SeekOrigin>())).Throws(new NotSupportedException());
+            stream.SetupGet(s => s.Length).Throws(new NotSupportedException());
+            stream.Setup(s => s.SetLength(It.IsAny<long>())).Throws(new NotSupportedException());
+
+            // confirm our stream cannot give a length
+            Assert.Throws<NotSupportedException>(() => _ = stream.Object.Length);
+
+            var createScope = GetMockCreateScope();
+            var initializeDestination = GetMockInitializeDestinationInternal();
+            var singleUpload = GetMockSingleUploadInternal(dataSize);
+            var uploadPartition = GetMockUploadPartitionInternal(blockSize);
+            var commitPartitions = GetMockCommitPartitionedUploadInternal();
+            var partitionedUploader = new PartitionedUploader<object, object>(
+                new PartitionedUploader<object, object>.Behaviors
+                {
+                    Scope = createScope.Object,
+                    InitializeDestination = initializeDestination.Object,
+                    SingleUpload = singleUpload.Object,
+                    UploadPartition = uploadPartition.Object,
+                    CommitPartitionedUpload = commitPartitions.Object
+                },
+                new StorageTransferOptions()
+                {
+                    InitialTransferSize = blockSize,
+                    MaximumTransferSize = blockSize,
+                    MaximumConcurrency = 1
+                },
+                s_hashingOptions,
+                operationName: s_operationName);
+
+            // Act
+            // give uploader an expected content length for unseekable stream
+            Response<object> result = await partitionedUploader.UploadInternal(stream.Object, dataSize, s_objectArgs, s_progress, IsAsync, s_cancellation);
+
+            // Assert
+            if (oneshot)
+            {
+                Assert.AreEqual(1, singleUpload.Invocations.Count);
+                Assert.IsEmpty(uploadPartition.Invocations);
+                Assert.IsEmpty(commitPartitions.Invocations);
+            }
+            else
+            {
+                Assert.IsEmpty(singleUpload.Invocations);
+                Assert.AreEqual(numPartitions, uploadPartition.Invocations.Count);
+                Assert.AreEqual(1, commitPartitions.Invocations.Count);
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -3934,6 +3934,7 @@ namespace Azure.Storage.Files.DataLake
 
             return await uploader.UploadInternal(
                 content,
+                expectedContentLength: default,
                 options,
                 options.ProgressHandler,
                 async,

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakePartitionedUploaderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakePartitionedUploaderTests.cs
@@ -264,6 +264,7 @@ namespace Azure.Storage.Files.DataLake.Tests
         private async Task<Response<PathInfo>> InvokeUploadAsync(PartitionedUploader<DataLakeFileUploadOptions, PathInfo> uploader, Stream content)
             => await uploader.UploadInternal(
                 content,
+                expectedContentLength: default,
                 new DataLakeFileUploadOptions
                 {
                     HttpHeaders = s_pathHttpHeaders,


### PR DESCRIPTION
Introduced `long? expectedContentLength` to `PartitionedUploader`, allowing it to make decisions based on a known stream length even when the stream itself cannot supply that length. This is not exposed in the public API, but `BlobClient` uses it on upload to get the stream length of a seekable stream before wrapping it in an unseekable crypto transform. Now, toggling client-side encryption does not prevent the partitioned uploader from respecting transfer options.

Resolves #23860