### PR TITLE
Fix CanSetContentLengthOverMaxInt

### DIFF
--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -112,6 +112,7 @@ namespace Azure.Core.Tests
                 // Sending the request would fail because of length mismatch
             }
 
+            // InfiniteStream has a length of long.MaxValue check that it got sent correctly
             Assert.AreEqual(long.MaxValue, contentLength);
         }
 

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -94,15 +94,14 @@ namespace Azure.Core.Tests
                 context =>
                 {
                     contentLength = context.Request.ContentLength.Value;
+                    context.Abort();
                 });
 
-            var requestContentLength = long.MaxValue;
             var transport = GetTransport();
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Post;
             request.Uri.Reset(testServer.Address);
-            request.Content = RequestContent.Create(new byte[10]);
-            request.Headers.Add("Content-Length", requestContentLength.ToString());
+            request.Content = RequestContent.Create(new InfiniteStream());
 
             try
             {
@@ -113,7 +112,7 @@ namespace Azure.Core.Tests
                 // Sending the request would fail because of length mismatch
             }
 
-            Assert.AreEqual(requestContentLength, requestContentLength);
+            Assert.AreEqual(long.MaxValue, contentLength);
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -101,7 +101,8 @@ namespace Azure.Core.Tests
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Post;
             request.Uri.Reset(testServer.Address);
-            request.Content = RequestContent.Create(new InfiniteStream());
+            var infiniteStream = new InfiniteStream();
+            request.Content = RequestContent.Create(infiniteStream);
 
             try
             {
@@ -113,7 +114,8 @@ namespace Azure.Core.Tests
             }
 
             // InfiniteStream has a length of long.MaxValue check that it got sent correctly
-            Assert.AreEqual(long.MaxValue, contentLength);
+            Assert.AreEqual(infiniteStream.Length, contentLength);
+            Assert.Greater(infiniteStream.Length, int.MaxValue);
         }
 
         [Test]


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/25401