### PR TITLE
[TextAnalytics] Merge hotfix/textanalytics511 after releasing 5.1.1

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 ### Other Changes
 
+## 5.1.1 (2021-11-19)
+### Breaking changes
+- Enum `EntityCategory.IPAddress` now uses the underlying string `IPAddress` value instead of `IP` to align with the Text Analytics service behavior.
+
+### Bug Fixes
+- Long-Running operation rehydration has been patched to stop throwing a `NullReferenceException`. Issue [24692](https://github.com/Azure/azure-sdk-for-net/issues/24692).
+
 ## 5.2.0-beta.2 (2021-11-02)
 
 ### Features Added

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Features Added
 
 ### Breaking Changes
+- Enum `EntityCategory.IPAddress` now uses the underlying string `IPAddress` value instead of `IP` to align with the Text Analytics service behavior.
 
 ### Bugs Fixed
+- Long-Running operation rehydration has been patched to stop throwing a `NullReferenceException`. Issue [24692](https://github.com/Azure/azure-sdk-for-net/issues/24692).
 
 ### Other Changes
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -25,9 +25,9 @@ This table shows the relationship between SDK versions and supported API version
 |SDK version|Supported API version of service
 |-|- |
 |5.2.0-beta.2 | 3.0, 3.1, 3.2-preview.2 (default)
-|5.1.0  | 3.0, 3.1 (default)
+|5.1.X  | 3.0, 3.1 (default)
 |5.0.0  | 3.0
-|1.0.X | 3.0
+|1.0.X  | 3.0
 
 ### Prerequisites
 * An [Azure subscription][azure_sub].

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.TextAnalytics.Models;
@@ -116,6 +117,11 @@ namespace Azure.AI.TextAnalytics
         private bool? _showStats { get; }
 
         /// <summary>
+        /// Represents the job Id the service assigned to the operation.
+        /// </summary>
+        private string _jobId { get; }
+
+        /// <summary>
         /// Returns true if the long-running operation completed successfully and has produced final result (accessible by Value property).
         /// </summary>
         public override bool HasValue => _operationInternal.HasValue;
@@ -127,7 +133,22 @@ namespace Azure.AI.TextAnalytics
         /// <param name="client">The client used to check for completion.</param>
         public AnalyzeActionsOperation(string operationId, TextAnalyticsClient client)
         {
-            // TODO: Add argument validation here.
+            Argument.AssertNotNullOrEmpty(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
+
+            try
+            {
+                OperationContinuationToken token = OperationContinuationToken.Deserialize(operationId);
+
+                _jobId = token.JobId;
+                _showStats = token.ShowStats;
+                _idToIndexMap = token.InputDocumentOrder;
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"Invalid value. Please use the {nameof(AnalyzeActionsOperation)}.{nameof(Id)} property value.", nameof(operationId), e);
+            }
+
             Id = operationId;
             _serviceClient = client._serviceRestClient;
             _diagnostics = client._clientDiagnostics;
@@ -152,7 +173,9 @@ namespace Azure.AI.TextAnalytics
 
             // TODO: Add validation here
             // https://github.com/Azure/azure-sdk-for-net/issues/11505
-            Id = operationLocation.Split('/').Last();
+            _jobId = operationLocation.Split('/').Last();
+
+            Id = OperationContinuationToken.Serialize(_jobId, idToIndexMap, showStats);
         }
 
         /// <summary>
@@ -289,8 +312,8 @@ namespace Azure.AI.TextAnalytics
         async ValueTask<OperationState<AsyncPageable<AnalyzeActionsResult>>> IOperation<AsyncPageable<AnalyzeActionsResult>>.UpdateStateAsync(bool async, CancellationToken cancellationToken)
         {
             Response<AnalyzeJobState> response = async
-                ? await _serviceClient.AnalyzeStatusAsync(Id, _showStats, null, null, cancellationToken).ConfigureAwait(false)
-                : _serviceClient.AnalyzeStatus(Id, _showStats, null, null, cancellationToken);
+                ? await _serviceClient.AnalyzeStatusAsync(_jobId, _showStats, null, null, cancellationToken).ConfigureAwait(false)
+                : _serviceClient.AnalyzeStatus(_jobId, _showStats, null, null, cancellationToken);
 
             // Add lock to avoid race condition?
             _displayName = response.Value.DisplayName;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeActionsOperation.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.TextAnalytics.Models;
@@ -114,12 +113,12 @@ namespace Azure.AI.TextAnalytics
         /// Represents the desire of the user to request statistics.
         /// This is used in every GET request.
         /// </summary>
-        private bool? _showStats { get; }
+        private readonly bool? _showStats;
 
         /// <summary>
         /// Represents the job Id the service assigned to the operation.
         /// </summary>
-        private string _jobId { get; }
+        private readonly string _jobId;
 
         /// <summary>
         /// Returns true if the long-running operation completed successfully and has produced final result (accessible by Value property).

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.TextAnalytics.Models;
@@ -90,6 +91,11 @@ namespace Azure.AI.TextAnalytics
         private readonly bool? _showStats;
 
         /// <summary>
+        /// Represents the job Id the service assigned to the operation.
+        /// </summary>
+        private string _jobId { get; }
+
+        /// <summary>
         /// Time when the operation will expire.
         /// </summary>
         private DateTimeOffset? _expiresOn;
@@ -116,7 +122,21 @@ namespace Azure.AI.TextAnalytics
         /// <param name="client">The client used to check for completion.</param>
         public AnalyzeHealthcareEntitiesOperation(string operationId, TextAnalyticsClient client)
         {
-            // TODO: Add argument validation here.
+            Argument.AssertNotNullOrEmpty(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
+
+            try
+            {
+                OperationContinuationToken token = OperationContinuationToken.Deserialize(operationId);
+
+                _jobId = token.JobId;
+                _showStats = token.ShowStats;
+                _idToIndexMap = token.InputDocumentOrder;
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"Invalid value. Please use the {nameof(AnalyzeHealthcareEntitiesOperation)}.{nameof(Id)} property value.", nameof(operationId), e);
+            }
 
             Id = operationId;
             _serviceClient = client._serviceRestClient;
@@ -142,7 +162,9 @@ namespace Azure.AI.TextAnalytics
 
             // TODO: Add validation here
             // https://github.com/Azure/azure-sdk-for-net/issues/11505
-            Id = operationLocation.Split('/').Last();
+            _jobId = operationLocation.Split('/').Last();
+
+            Id = OperationContinuationToken.Serialize(_jobId, idToIndexMap, showStats);
         }
 
         /// <summary>
@@ -222,7 +244,7 @@ namespace Azure.AI.TextAnalytics
             scope.Start();
             try
             {
-                ResponseWithHeaders<TextAnalyticsCancelHealthJobHeaders> response = _serviceClient.CancelHealthJob(new Guid(Id), cancellationToken);
+                ResponseWithHeaders<TextAnalyticsCancelHealthJobHeaders> response = _serviceClient.CancelHealthJob(new Guid(_jobId), cancellationToken);
                 _operationInternal.RawResponse = response.GetRawResponse();
             }
             catch (Exception e)
@@ -244,7 +266,7 @@ namespace Azure.AI.TextAnalytics
 
             try
             {
-                ResponseWithHeaders<TextAnalyticsCancelHealthJobHeaders> response = await _serviceClient.CancelHealthJobAsync(new Guid(Id), cancellationToken).ConfigureAwait(false);
+                ResponseWithHeaders<TextAnalyticsCancelHealthJobHeaders> response = await _serviceClient.CancelHealthJobAsync(new Guid(_jobId), cancellationToken).ConfigureAwait(false);
                 _operationInternal.RawResponse = response.GetRawResponse();
             }
             catch (Exception e)
@@ -321,8 +343,8 @@ namespace Azure.AI.TextAnalytics
         async ValueTask<OperationState<AsyncPageable<AnalyzeHealthcareEntitiesResultCollection>>> IOperation<AsyncPageable<AnalyzeHealthcareEntitiesResultCollection>>.UpdateStateAsync(bool async, CancellationToken cancellationToken)
         {
             Response<HealthcareJobState> response = async
-                ? await _serviceClient.HealthStatusAsync(new Guid(Id), null, null, _showStats, cancellationToken).ConfigureAwait(false)
-                : _serviceClient.HealthStatus(new Guid(Id), null, null, _showStats, cancellationToken);
+                ? await _serviceClient.HealthStatusAsync(new Guid(_jobId), null, null, _showStats, cancellationToken).ConfigureAwait(false)
+                : _serviceClient.HealthStatus(new Guid(_jobId), null, null, _showStats, cancellationToken);
 
             // Add lock to avoid race condition?
             _status = response.Value.Status;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeHealthcareEntitiesOperation.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.AI.TextAnalytics.Models;
@@ -75,16 +74,6 @@ namespace Azure.AI.TextAnalytics
         private readonly ClientDiagnostics _diagnostics;
 
         /// <summary>
-        /// Represents the status of the long-running operation.
-        /// </summary>
-        private TextAnalyticsOperationStatus _status;
-
-        /// <summary>
-        /// Provides the results for the first page.
-        /// </summary>
-        private Page<AnalyzeHealthcareEntitiesResultCollection> _firstPage;
-
-        /// <summary>
         /// Represents the desire of the user to request statistics.
         /// This is used in every GET request.
         /// </summary>
@@ -93,7 +82,17 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Represents the job Id the service assigned to the operation.
         /// </summary>
-        private string _jobId { get; }
+        private readonly string _jobId;
+
+        /// <summary>
+        /// Represents the status of the long-running operation.
+        /// </summary>
+        private TextAnalyticsOperationStatus _status;
+
+        /// <summary>
+        /// Provides the results for the first page.
+        /// </summary>
+        private Page<AnalyzeHealthcareEntitiesResultCollection> _firstPage;
 
         /// <summary>
         /// Time when the operation will expire.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/Azure.AI.TextAnalytics.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Microsoft Azure.AI.TextAnalytics client library</AssemblyTitle>
     <Version>5.2.0-beta.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>5.1.0</ApiCompatVersion>
+    <ApiCompatVersion>5.1.1</ApiCompatVersion>
     <PackageTags>Microsoft Azure Text Analytics</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <!-- AZC0012 - Single word class names are too generic for Entity.cs class  -->

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/EntityCategory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/EntityCategory.cs
@@ -71,7 +71,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Specifies that the entity contains an Internet Protocol Address.
         /// </summary>
-        public static readonly EntityCategory IPAddress = new EntityCategory("IP");
+        public static readonly EntityCategory IPAddress = new EntityCategory("IPAddress");
 
         /// <summary>
         /// Specifies that the entity contains a number or numeric quantity.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/OperationContinuationToken.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/OperationContinuationToken.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+
+using ServiceVersion = Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion;
+
+namespace Azure.AI.TextAnalytics
+{
+    internal class OperationContinuationToken
+    {
+        private const ServiceVersion ContinuationTokenVersion = ServiceVersion.V3_1;
+
+        // Parameterless constructor required for JSON deserialization.
+        public OperationContinuationToken()
+        {
+            Version = TextAnalyticsClientOptions.GetVersionString(ContinuationTokenVersion);
+        }
+
+        public OperationContinuationToken(string jobId, IDictionary<string, int> inputDocumentOrder, bool? showStats)
+            : this()
+        {
+            JobId = jobId;
+            InputDocumentOrder = new Dictionary<string, int>(inputDocumentOrder);
+            ShowStats = showStats;
+        }
+
+        public string Version { get; set; }
+
+        public string JobId { get; set; }
+
+        public Dictionary<string, int> InputDocumentOrder { get; set; }
+
+        public bool? ShowStats { get; set; }
+
+        /// <exception cref="ArgumentException">Thrown when the <see cref="Version"/> of the deserialized token is not the expected <see cref="ContinuationTokenVersion"/>.</exception>
+        /// <exception cref="FormatException">Thrown when <paramref name="base64OperationId"/> is not a valid base-64 string.</exception>
+        /// <exception cref="JsonException">Thrown when <paramref name="base64OperationId"/> cannot be deserialized from JSON.</exception>
+        public static OperationContinuationToken Deserialize(string base64OperationId)
+        {
+            byte[] plainTextBytes = Convert.FromBase64String(base64OperationId);
+
+            var options = new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            OperationContinuationToken token = JsonSerializer.Deserialize<OperationContinuationToken>(plainTextBytes, options);
+
+            string currentTokenVersion = TextAnalyticsClientOptions.GetVersionString(ContinuationTokenVersion);
+
+            if (token.Version != currentTokenVersion)
+            {
+                throw new ArgumentException($"Unsupported continuation token version. Expected: '{currentTokenVersion}'. Actual: '{token.Version}'.");
+            }
+
+            Argument.AssertNotNull(token.JobId, nameof(JobId));
+            Argument.AssertNotNull(token.InputDocumentOrder, nameof(InputDocumentOrder));
+
+            return token;
+        }
+
+        public static string Serialize(string jobId, IDictionary<string, int> inputDocumentOrder, bool? showStats) =>
+            new OperationContinuationToken(jobId, inputDocumentOrder, showStats).Serialize();
+
+        public string Serialize()
+        {
+            var options = new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            string plainOperationId = JsonSerializer.Serialize(this, options);
+            byte[] plainTextBytes = Encoding.UTF8.GetBytes(plainOperationId);
+
+            return Convert.ToBase64String(plainTextBytes);
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationMockTests.cs
@@ -843,26 +843,7 @@ namespace Azure.AI.TextAnalytics.Tests
             var mockTransport = new MockTransport(new[] { mockResponse });
             var client = CreateTestClient(mockTransport);
 
-            var documents = new List<string>
-            {
-                "Elon Musk is the CEO of SpaceX and Tesla."
-            };
-
-            TextAnalyticsActions batchActions = new TextAnalyticsActions()
-            {
-                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
-                RecognizeEntitiesActions = new List<RecognizeEntitiesAction>() { new RecognizeEntitiesAction() },
-                RecognizePiiEntitiesActions = new List<RecognizePiiEntitiesAction>() { new RecognizePiiEntitiesAction() },
-                RecognizeLinkedEntitiesActions = new List<RecognizeLinkedEntitiesAction>() { new RecognizeLinkedEntitiesAction() },
-                AnalyzeSentimentActions = new List<AnalyzeSentimentAction>() { new AnalyzeSentimentAction() },
-                ExtractSummaryActions = new List<ExtractSummaryAction>() { new ExtractSummaryAction() },
-                RecognizeCustomEntitiesActions = new List<RecognizeCustomEntitiesAction>() { new RecognizeCustomEntitiesAction(FakeProjectName, FakeDeploymentName) },
-                SingleCategoryClassifyActions = new List<SingleCategoryClassifyAction> { new SingleCategoryClassifyAction(FakeProjectName, FakeDeploymentName)},
-                MultiCategoryClassifyActions = new List<MultiCategoryClassifyAction>() { new MultiCategoryClassifyAction(FakeProjectName, FakeDeploymentName) },
-                DisplayName = "AnalyzeOperationBatchWithErrorTest"
-            };
-
-            var operation = new AnalyzeActionsOperation("75d521bc-c2aa-4d8a-aabe-713e72d53a2d", client);
+            AnalyzeActionsOperation operation = CreateOperation(client);
             await operation.UpdateStatusAsync();
 
             Assert.AreEqual(9, operation.ActionsFailed);
@@ -953,18 +934,8 @@ namespace Azure.AI.TextAnalytics.Tests
             var mockTransport = new MockTransport(new[] { mockResponse });
             var client = CreateTestClient(mockTransport);
 
-            var documents = new List<string>
-            {
-                "Elon Musk is the CEO of SpaceX and Tesla."
-            };
+            var operation = CreateOperation(client);
 
-            TextAnalyticsActions batchActions = new TextAnalyticsActions()
-            {
-                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
-                DisplayName = "AnalyzeOperationBatchWithErrorTest"
-            };
-
-            var operation = new AnalyzeActionsOperation("75d521bc-c2aa-4d8a-aabe-713e72d53a2d", client);
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.UpdateStatusAsync());
             Assert.AreEqual("InternalServerError", ex.ErrorCode);
             Assert.IsTrue(ex.Message.Contains("Some error"));
@@ -1000,6 +971,14 @@ namespace Azure.AI.TextAnalytics.Tests
 
                 Assert.AreEqual(-1, contentString.IndexOf("show-stats"));
             }
+        }
+
+        private AnalyzeActionsOperation CreateOperation(TextAnalyticsClient client)
+        {
+            var inputOrder = new Dictionary<string, int>(1) { { "0", 0 } };
+            var operationId = OperationContinuationToken.Serialize("75d521bc-c2aa-4d8a-aabe-713e72d53a2d", inputOrder, null);
+
+            return new AnalyzeActionsOperation(operationId, client);
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsClientLiveTestBase.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/Infrastructure/TextAnalyticsClientLiveTestBase.cs
@@ -28,7 +28,11 @@ namespace Azure.AI.TextAnalytics.Tests
             Sanitizer = new TextAnalyticsRecordedTestSanitizer();
         }
 
+        protected TextAnalyticsClient GetClient(AzureKeyCredential credential = default, TextAnalyticsClientOptions options = default, bool useTokenCredential = default)
+            => GetClient(out _, credential, options, useTokenCredential);
+
         public TextAnalyticsClient GetClient(
+            out TextAnalyticsClient nonInstrumentedClient,
             AzureKeyCredential credential = default,
             TextAnalyticsClientOptions options = default,
             bool useTokenCredential = default)
@@ -43,13 +47,14 @@ namespace Azure.AI.TextAnalytics.Tests
 
             if (useTokenCredential)
             {
-                return InstrumentClient(new TextAnalyticsClient(endpoint, TestEnvironment.Credential, InstrumentClientOptions(options)));
+                nonInstrumentedClient = new TextAnalyticsClient(endpoint, TestEnvironment.Credential, InstrumentClientOptions(options));
             }
             else
             {
                 credential ??= new AzureKeyCredential(TestEnvironment.ApiKey);
-                return InstrumentClient(new TextAnalyticsClient(endpoint, credential, InstrumentClientOptions(options)));
+                nonInstrumentedClient = new TextAnalyticsClient(endpoint, credential, InstrumentClientOptions(options));
             }
+            return InstrumentClient(nonInstrumentedClient);
         }
 
         // This has been added to stop the custom tests to run forever while we

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/OperationLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/OperationLiveTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.TextAnalytics.Tests
+{
+    [ClientTestFixture(TextAnalyticsClientOptions.ServiceVersion.V3_1)]
+    public class OperationLiveTests : TextAnalyticsClientLiveTestBase
+    {
+        public OperationLiveTests(bool isAsync, TextAnalyticsClientOptions.ServiceVersion serviceVersion)
+            : base(isAsync, serviceVersion)
+        {
+        }
+
+        #region Analyze
+
+        [RecordedTest]
+        public async Task AnalyzeOperationCanPollFromNewObject()
+        {
+            TextAnalyticsClient client = GetClient(out var nonInstrumentedClient);
+
+            var documents = new List<TextDocumentInput>
+            {
+                new TextDocumentInput("1", "Elon Musk is the CEO of SpaceX and Tesla.")
+                {
+                     Language = "en",
+                },
+                new TextDocumentInput("2", "Tesla stock is up by 400% this year.")
+                {
+                     Language = "en",
+                }
+            };
+
+            TextAnalyticsActions batchActions = new()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+            };
+
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, batchActions);
+            var sameOperation = InstrumentOperation(new AnalyzeActionsOperation(operation.Id, nonInstrumentedClient));
+            await sameOperation.WaitForCompletionAsync();
+
+            Assert.IsTrue(sameOperation.HasValue);
+        }
+
+        [RecordedTest]
+        public async Task AnalyzeOperationConvenienceCanPollFromNewObject()
+        {
+            TextAnalyticsClient client = GetClient(out var nonInstrumentedClient);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla.",
+                "Tesla stock is up by 400% this year."
+            };
+
+            TextAnalyticsActions batchActions = new()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+            };
+
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, batchActions);
+            var sameOperation = InstrumentOperation(new AnalyzeActionsOperation(operation.Id, nonInstrumentedClient));
+            await sameOperation.WaitForCompletionAsync();
+
+            Assert.IsTrue(sameOperation.HasValue);
+        }
+
+        #endregion Analyze
+
+        #region Healthcare
+
+        [RecordedTest]
+        public async Task HealthcareOperationCanPollFromNewObject()
+        {
+            TextAnalyticsClient client = GetClient(out var nonInstrumentedClient);
+
+            var documents = new List<TextDocumentInput>
+            {
+                new TextDocumentInput("1", "Subject is taking 100mg of ibuprofen twice daily")
+                {
+                     Language = "en",
+                },
+                new TextDocumentInput("2", "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.")
+                {
+                     Language = "en",
+                }
+            };
+
+            AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(documents);
+            var sameOperation = InstrumentOperation(new AnalyzeHealthcareEntitiesOperation(operation.Id, nonInstrumentedClient));
+            await sameOperation.WaitForCompletionAsync();
+
+            Assert.IsTrue(sameOperation.HasValue);
+        }
+
+        [RecordedTest]
+        public async Task HealthcareOperationConvenienceCanPollFromNewObject()
+        {
+            TextAnalyticsClient client = GetClient(out var nonInstrumentedClient);
+
+            var documents = new List<string>
+            {
+                "Subject is taking 100mg of ibuprofen twice daily",
+                "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure."
+            };
+
+            AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(documents);
+            var sameOperation = InstrumentOperation(new AnalyzeHealthcareEntitiesOperation(operation.Id, nonInstrumentedClient));
+            await sameOperation.WaitForCompletionAsync();
+
+            Assert.IsTrue(sameOperation.HasValue);
+        }
+
+        #endregion Healthcare
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/OperationsMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/OperationsMockTests.cs
@@ -1,0 +1,304 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.TextAnalytics.Tests
+{
+    public class OperationsMockTests : ClientTestBase
+    {
+        private static readonly string s_endpoint = "https://contoso-textanalytics.cognitiveservices.azure.com/";
+        private static readonly string s_apiKey = "FakeapiKey";
+
+        public OperationsMockTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        private TextAnalyticsClient CreateTestClient(HttpPipelineTransport transport)
+        {
+            var options = new TextAnalyticsClientOptions
+            {
+                Transport = transport
+            };
+
+            return new TextAnalyticsClient(new Uri(s_endpoint), new AzureKeyCredential(s_apiKey), options);
+        }
+
+        #region Analyze
+
+        [Test]
+        public async Task CreateAnalyzeOperationConvenienceSetsOperationId()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Elon Musk is the CEO of SpaceX and Tesla.",
+                "Microsoft was founded by Bill Gates and Paul Allen.",
+                "My cat and my dog might need to see a veterinarian."
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+            };
+
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            OperationContinuationToken continuationToken = OperationContinuationToken.Deserialize(operation.Id);
+
+            Assert.IsNull(continuationToken.ShowStats);
+            Assert.AreEqual("2a96a91f-7edf-4931-a880-3fdee1d56f15", continuationToken.JobId);
+            Assert.AreEqual(3, continuationToken.InputDocumentOrder.Count);
+            Assert.AreEqual(0, continuationToken.InputDocumentOrder["0"]);
+            Assert.AreEqual(1, continuationToken.InputDocumentOrder["1"]);
+            Assert.AreEqual(2, continuationToken.InputDocumentOrder["2"]);
+        }
+
+        [Test]
+        public async Task CreateAnalyzeOperationSetsOperationId()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<TextDocumentInput>
+            {
+                new TextDocumentInput("134234", "Elon Musk is the CEO of SpaceX and Tesla.")
+                {
+                     Language = "en",
+                },
+                new TextDocumentInput("324232", "Tesla stock is up by 400% this year.")
+                {
+                     Language = "en",
+                }
+            };
+
+            TextAnalyticsActions batchActions = new TextAnalyticsActions()
+            {
+                ExtractKeyPhrasesActions = new List<ExtractKeyPhrasesAction>() { new ExtractKeyPhrasesAction() },
+            };
+
+            AnalyzeActionsOperation operation = await client.StartAnalyzeActionsAsync(documents, batchActions);
+
+            OperationContinuationToken continuationToken = OperationContinuationToken.Deserialize(operation.Id);
+
+            Assert.IsNull(continuationToken.ShowStats);
+            Assert.AreEqual("2a96a91f-7edf-4931-a880-3fdee1d56f15", continuationToken.JobId);
+            Assert.AreEqual(2, continuationToken.InputDocumentOrder.Count);
+            Assert.AreEqual(0, continuationToken.InputDocumentOrder["134234"]);
+            Assert.AreEqual(1, continuationToken.InputDocumentOrder["324232"]);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationFromFakeValidOperationId()
+        {
+            var jobId = "2a96a91f-7edf-4931-a880-3fdee1d56f15";
+
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", $"something/jobs/{jobId}"));
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var inputOrder = new Dictionary<string, int>(1) { { "0", 0 } };
+            string operationId = OperationContinuationToken.Serialize(jobId, inputOrder, true);
+
+            var operation = new AnalyzeActionsOperation(operationId, client);
+            Assert.AreEqual(operationId, operation.Id);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationWrongOperationId()
+        {
+            var client = CreateTestClient(new MockTransport());
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeActionsOperation("2a96a91f-7edf-4931-a880-3fdee1d56f15", client));
+            Assert.IsInstanceOf<FormatException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationWrongTokenVersion()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>() { { "0", 0 } };
+
+            var token = new OperationContinuationToken("2a96a91f-7edf-4931-a880-3fdee1d56f15", order, null);
+            token.Version = "wrong-version";
+
+            string operationId = token.Serialize();
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeActionsOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationMissingJobId()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>() { { "0", 0 } };
+
+            string operationId = OperationContinuationToken.Serialize(null, order, null);
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeActionsOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentNullException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateAnalyzeOperationMissingDocumentOrder()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>();
+
+            var token = new OperationContinuationToken("2a96a91f-7edf-4931-a880-3fdee1d56f15", order, null);
+            token.InputDocumentOrder = null;
+
+            string operationId = token.Serialize();
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeActionsOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentNullException>(ex.InnerException);
+        }
+
+        #endregion Analyze
+
+        #region Healthcare
+        [Test]
+        public async Task CreateHealthcareOperationConvenienceSetsOperationId()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<string>
+            {
+                "Subject is taking 100mg of ibuprofen twice daily",
+                "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure."
+            };
+
+            AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(documents);
+
+            OperationContinuationToken continuationToken = OperationContinuationToken.Deserialize(operation.Id);
+
+            Assert.IsFalse(continuationToken.ShowStats);
+            Assert.AreEqual("2a96a91f-7edf-4931-a880-3fdee1d56f15", continuationToken.JobId);
+            Assert.AreEqual(2, continuationToken.InputDocumentOrder.Count);
+            Assert.AreEqual(0, continuationToken.InputDocumentOrder["0"]);
+            Assert.AreEqual(1, continuationToken.InputDocumentOrder["1"]);
+        }
+
+        [Test]
+        public async Task CreateHealthcareOperationSetsOperationId()
+        {
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", "something/jobs/2a96a91f-7edf-4931-a880-3fdee1d56f15"));
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var documents = new List<TextDocumentInput>
+            {
+                new TextDocumentInput("134234", "Subject is taking 100mg of ibuprofen twice daily")
+                {
+                     Language = "en",
+                },
+                new TextDocumentInput("324232", "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.")
+                {
+                     Language = "en",
+                }
+            };
+
+            AnalyzeHealthcareEntitiesOperation operation = await client.StartAnalyzeHealthcareEntitiesAsync(documents);
+
+            OperationContinuationToken continuationToken = OperationContinuationToken.Deserialize(operation.Id);
+
+            Assert.IsFalse(continuationToken.ShowStats);
+            Assert.AreEqual("2a96a91f-7edf-4931-a880-3fdee1d56f15", continuationToken.JobId);
+            Assert.AreEqual(2, continuationToken.InputDocumentOrder.Count);
+            Assert.AreEqual(0, continuationToken.InputDocumentOrder["134234"]);
+            Assert.AreEqual(1, continuationToken.InputDocumentOrder["324232"]);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationFromFakeValidOperationId()
+        {
+            var jobId = "2a96a91f-7edf-4931-a880-3fdee1d56f15";
+
+            var mockResponse = new MockResponse(202);
+            mockResponse.AddHeader(new HttpHeader("Operation-Location", $"something/jobs/{jobId}"));
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var client = CreateTestClient(mockTransport);
+
+            var inputOrder = new Dictionary<string, int>(1) { { "0", 0 } };
+            string operationId = OperationContinuationToken.Serialize(jobId, inputOrder, true);
+
+            var operation = new AnalyzeHealthcareEntitiesOperation(operationId, client);
+            Assert.AreEqual(operationId, operation.Id);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationWrongOperationId()
+        {
+            var client = CreateTestClient(new MockTransport());
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeHealthcareEntitiesOperation("2a96a91f-7edf-4931-a880-3fdee1d56f15", client));
+            Assert.IsInstanceOf<FormatException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationWrongTokenVersion()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>() { { "0", 0 } };
+
+            var token = new OperationContinuationToken("2a96a91f-7edf-4931-a880-3fdee1d56f15", order, null);
+            token.Version = "wrong-version";
+
+            string operationId = token.Serialize();
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeHealthcareEntitiesOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationMissingJobId()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>() { { "0", 0 } };
+
+            string operationId = OperationContinuationToken.Serialize(null, order, null);
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeHealthcareEntitiesOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentNullException>(ex.InnerException);
+        }
+
+        [Test]
+        public void CreateHealthcareOperationMissingDocumentOrder()
+        {
+            var client = CreateTestClient(new MockTransport());
+            var order = new Dictionary<string, int>();
+
+            var token = new OperationContinuationToken("2a96a91f-7edf-4931-a880-3fdee1d56f15", order, null);
+            token.InputDocumentOrder = null;
+
+            string operationId = token.Serialize();
+
+            var ex = Assert.Throws<ArgumentException>(() => new AnalyzeHealthcareEntitiesOperation(operationId, client));
+            Assert.IsInstanceOf<ArgumentNullException>(ex.InnerException);
+        }
+
+        #endregion Healthcare
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/AnalyzeOperationCanPollFromNewObject.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/AnalyzeOperationCanPollFromNewObject.json
@@ -1,0 +1,288 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "241",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-298692d8d2d5b147a7ee9d1b117a749c-829797c73ed5bb4d-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0ef6b28d40dbb0b56cea1a20a33050d3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "1",
+              "text": "Elon Musk is the CEO of SpaceX and Tesla.",
+              "language": "en"
+            },
+            {
+              "id": "2",
+              "text": "Tesla stock is up by 400% this year.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": {
+          "keyPhraseExtractionTasks": [
+            {
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "apim-request-id": "e6beaa84-960f-4d2f-9e7c-81cf02c8c1ed",
+        "Content-Length": "314",
+        "Content-Type": "application/json",
+        "Date": "Thu, 04 Nov 2021 21:56:42 GMT",
+        "Retry-After": "1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff"
+      },
+      "ResponseBody": "{\u0022error\u0022:{\u0022code\u0022:\u0022429\u0022,\u0022message\u0022: \u0022Requests to the Submit analysis job Operation under Text Analytics API (v3.1) have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit.\u0022}}"
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "241",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-298692d8d2d5b147a7ee9d1b117a749c-829797c73ed5bb4d-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0ef6b28d40dbb0b56cea1a20a33050d3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "1",
+              "text": "Elon Musk is the CEO of SpaceX and Tesla.",
+              "language": "en"
+            },
+            {
+              "id": "2",
+              "text": "Tesla stock is up by 400% this year.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": {
+          "keyPhraseExtractionTasks": [
+            {
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "63d8ce4d-73a5-42dc-a4f6-6da0ed4ef49e",
+        "Date": "Thu, 04 Nov 2021 21:56:44 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/928eab91-dc74-474a-9cbc-2e737a2b8e93",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "136"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/928eab91-dc74-474a-9cbc-2e737a2b8e93",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6091f629c9f8373ea717a79e2233f2c9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "apim-request-id": "7e37badf-47b5-4625-990d-b8f390769f4a",
+        "Content-Length": "327",
+        "Content-Type": "application/json",
+        "Date": "Thu, 04 Nov 2021 21:56:44 GMT",
+        "Retry-After": "3",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff"
+      },
+      "ResponseBody": "{\u0022error\u0022:{\u0022code\u0022:\u0022429\u0022,\u0022message\u0022: \u0022Requests to the Get analysis status and results Operation under Text Analytics API (v3.1) have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 3 seconds. Please contact Azure support service if you would like to further increase the default rate limit.\u0022}}"
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/928eab91-dc74-474a-9cbc-2e737a2b8e93",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6091f629c9f8373ea717a79e2233f2c9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "apim-request-id": "3eaad648-a7ba-4c78-9499-e400fc1a6ba5",
+        "Content-Length": "327",
+        "Content-Type": "application/json",
+        "Date": "Thu, 04 Nov 2021 21:56:47 GMT",
+        "Retry-After": "2",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff"
+      },
+      "ResponseBody": "{\u0022error\u0022:{\u0022code\u0022:\u0022429\u0022,\u0022message\u0022: \u0022Requests to the Get analysis status and results Operation under Text Analytics API (v3.1) have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 2 seconds. Please contact Azure support service if you would like to further increase the default rate limit.\u0022}}"
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/928eab91-dc74-474a-9cbc-2e737a2b8e93",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "6091f629c9f8373ea717a79e2233f2c9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "44c47a4f-5f84-4275-bed0-185c4518f5ea",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 21:56:49 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "928eab91-dc74-474a-9cbc-2e737a2b8e93",
+        "lastUpdateDateTime": "2021-11-04T21:56:44Z",
+        "createdDateTime": "2021-11-04T21:56:44Z",
+        "expirationDateTime": "2021-11-05T21:56:44Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/928eab91-dc74-474a-9cbc-2e737a2b8e93",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0faca615a28905d991a5f1181e667ef5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "be03b763-ada7-4242-93e9-0cf6bc4fca8f",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 21:56:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "928eab91-dc74-474a-9cbc-2e737a2b8e93",
+        "lastUpdateDateTime": "2021-11-04T21:56:44Z",
+        "createdDateTime": "2021-11-04T21:56:44Z",
+        "expirationDateTime": "2021-11-05T21:56:44Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/928eab91-dc74-474a-9cbc-2e737a2b8e93",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8f5b4d86a41ec49974bf67c398178d39",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6cc0b9a7-fff8-45fb-8801-d2fb4fe4768e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 21:56:51 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "65"
+      },
+      "ResponseBody": {
+        "jobId": "928eab91-dc74-474a-9cbc-2e737a2b8e93",
+        "lastUpdateDateTime": "2021-11-04T21:56:52Z",
+        "createdDateTime": "2021-11-04T21:56:44Z",
+        "expirationDateTime": "2021-11-05T21:56:44Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-11-04T21:56:52.2503266Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "476228016",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/AnalyzeOperationCanPollFromNewObjectAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/AnalyzeOperationCanPollFromNewObjectAsync.json
@@ -1,0 +1,288 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "241",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f949bf97a9d04647ac611de8dba7e161-16959f452640a041-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bbc902a74d25aa41de5995e14fb2ba16",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "1",
+              "text": "Elon Musk is the CEO of SpaceX and Tesla.",
+              "language": "en"
+            },
+            {
+              "id": "2",
+              "text": "Tesla stock is up by 400% this year.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": {
+          "keyPhraseExtractionTasks": [
+            {
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "apim-request-id": "bda85146-83d9-4023-8e24-e7be03eb0503",
+        "Content-Length": "314",
+        "Content-Type": "application/json",
+        "Date": "Thu, 04 Nov 2021 21:56:52 GMT",
+        "Retry-After": "1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff"
+      },
+      "ResponseBody": "{\u0022error\u0022:{\u0022code\u0022:\u0022429\u0022,\u0022message\u0022: \u0022Requests to the Submit analysis job Operation under Text Analytics API (v3.1) have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit.\u0022}}"
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "241",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f949bf97a9d04647ac611de8dba7e161-16959f452640a041-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "bbc902a74d25aa41de5995e14fb2ba16",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "1",
+              "text": "Elon Musk is the CEO of SpaceX and Tesla.",
+              "language": "en"
+            },
+            {
+              "id": "2",
+              "text": "Tesla stock is up by 400% this year.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": {
+          "keyPhraseExtractionTasks": [
+            {
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "a451894b-effd-42c3-bb1b-1aedffa23211",
+        "Date": "Thu, 04 Nov 2021 21:56:54 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/0fb61d84-1170-449d-91ed-ecebce07caf8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "151"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/0fb61d84-1170-449d-91ed-ecebce07caf8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "c3b4cd86e8e3380786c1667c1f2659ca",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "95649460-2752-4f24-b67f-8b0b2c239475",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 21:56:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "0fb61d84-1170-449d-91ed-ecebce07caf8",
+        "lastUpdateDateTime": "2021-11-04T21:56:54Z",
+        "createdDateTime": "2021-11-04T21:56:54Z",
+        "expirationDateTime": "2021-11-05T21:56:54Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/0fb61d84-1170-449d-91ed-ecebce07caf8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ac70307ce424e04e57790590652dc3c2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8dce6baa-c1e6-48a4-9cf7-8ecc49fc923a",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 21:56:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "0fb61d84-1170-449d-91ed-ecebce07caf8",
+        "lastUpdateDateTime": "2021-11-04T21:56:54Z",
+        "createdDateTime": "2021-11-04T21:56:54Z",
+        "expirationDateTime": "2021-11-05T21:56:54Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/0fb61d84-1170-449d-91ed-ecebce07caf8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "69ce7040487ebe82fb903463e7c48bb8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "apim-request-id": "cc45ebf8-d7b3-4db8-ad0b-2f12338b924d",
+        "Content-Length": "326",
+        "Content-Type": "application/json",
+        "Date": "Thu, 04 Nov 2021 21:56:56 GMT",
+        "Retry-After": "1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff"
+      },
+      "ResponseBody": "{\u0022error\u0022:{\u0022code\u0022:\u0022429\u0022,\u0022message\u0022: \u0022Requests to the Get analysis status and results Operation under Text Analytics API (v3.1) have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit.\u0022}}"
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/0fb61d84-1170-449d-91ed-ecebce07caf8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "69ce7040487ebe82fb903463e7c48bb8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 429,
+      "ResponseHeaders": {
+        "apim-request-id": "f0317918-c732-4621-83dd-8a417e8b5abb",
+        "Content-Length": "326",
+        "Content-Type": "application/json",
+        "Date": "Thu, 04 Nov 2021 21:56:57 GMT",
+        "Retry-After": "1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff"
+      },
+      "ResponseBody": "{\u0022error\u0022:{\u0022code\u0022:\u0022429\u0022,\u0022message\u0022: \u0022Requests to the Get analysis status and results Operation under Text Analytics API (v3.1) have exceeded rate limit of your current TextAnalytics S pricing tier. Please retry after 1 second. Please contact Azure support service if you would like to further increase the default rate limit.\u0022}}"
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/0fb61d84-1170-449d-91ed-ecebce07caf8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "69ce7040487ebe82fb903463e7c48bb8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "14d75a64-9df8-45bf-bce6-0f0656153cf8",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 21:56:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "67"
+      },
+      "ResponseBody": {
+        "jobId": "0fb61d84-1170-449d-91ed-ecebce07caf8",
+        "lastUpdateDateTime": "2021-11-04T21:56:56Z",
+        "createdDateTime": "2021-11-04T21:56:54Z",
+        "expirationDateTime": "2021-11-05T21:56:54Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-11-04T21:56:56.5406821Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "2",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "661551377",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/AnalyzeOperationConvenienceCanPollFromNewObject.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/AnalyzeOperationConvenienceCanPollFromNewObject.json
@@ -1,0 +1,374 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "241",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-50113cf81457ee458b1432488f9998c0-471ebd2a898bce4c-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3231ab0d0fb9c9882461c15544e505bf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "Elon Musk is the CEO of SpaceX and Tesla.",
+              "language": "en"
+            },
+            {
+              "id": "1",
+              "text": "Tesla stock is up by 400% this year.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": {
+          "keyPhraseExtractionTasks": [
+            {
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "28eb5af2-1445-4d35-94fe-21d44641276d",
+        "Date": "Thu, 04 Nov 2021 22:01:16 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "255"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "31bc6d955c80778575568a4d6480377e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "567092f0-789c-4441-a027-b20a954bdbd3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
+      },
+      "ResponseBody": {
+        "jobId": "9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "lastUpdateDateTime": "2021-11-04T22:01:17Z",
+        "createdDateTime": "2021-11-04T22:01:17Z",
+        "expirationDateTime": "2021-11-05T22:01:17Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2fe030782dd201990a046a03d2c3e940",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0a7ebcc1-21d5-4d5c-8f05-29ade8bf30f8",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "lastUpdateDateTime": "2021-11-04T22:01:17Z",
+        "createdDateTime": "2021-11-04T22:01:17Z",
+        "expirationDateTime": "2021-11-05T22:01:17Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2c4c5001fae2b14625b9bd62853b65a4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5af4abf8-0584-43bb-b89a-bf6c0bcefe30",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "lastUpdateDateTime": "2021-11-04T22:01:17Z",
+        "createdDateTime": "2021-11-04T22:01:17Z",
+        "expirationDateTime": "2021-11-05T22:01:17Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "13dd4329d50467ecd4ba277bf181a4b2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9ebb2b71-2058-4f2c-8007-6f1172e7a695",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "jobId": "9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "lastUpdateDateTime": "2021-11-04T22:01:17Z",
+        "createdDateTime": "2021-11-04T22:01:17Z",
+        "expirationDateTime": "2021-11-05T22:01:17Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "134b496d0b337d9be92e0a1970367ccf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "45730486-4373-4308-87ce-8c7779ee1d1e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "9"
+      },
+      "ResponseBody": {
+        "jobId": "9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "lastUpdateDateTime": "2021-11-04T22:01:17Z",
+        "createdDateTime": "2021-11-04T22:01:17Z",
+        "expirationDateTime": "2021-11-05T22:01:17Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "8fdac69ed6e52c3c64e45728d3cac0a3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "27780066-8191-42a5-91fa-9476dd23f619",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "lastUpdateDateTime": "2021-11-04T22:01:17Z",
+        "createdDateTime": "2021-11-04T22:01:17Z",
+        "expirationDateTime": "2021-11-05T22:01:17Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "3bf50b1451ef1e70a75f2ad5cbd3f79e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e612693b-6c95-4974-b6da-aedd3a58e9d4",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "lastUpdateDateTime": "2021-11-04T22:01:17Z",
+        "createdDateTime": "2021-11-04T22:01:17Z",
+        "expirationDateTime": "2021-11-05T22:01:17Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2add573d15a797cc0d1faf4fb373aa1e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4c1924dc-1544-491d-83fd-0a707ab8ddf3",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "90"
+      },
+      "ResponseBody": {
+        "jobId": "9ec7b9cd-2445-4540-accc-fd66aacd1b03",
+        "lastUpdateDateTime": "2021-11-04T22:01:25Z",
+        "createdDateTime": "2021-11-04T22:01:17Z",
+        "expirationDateTime": "2021-11-05T22:01:17Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-11-04T22:01:25.1232257Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "789155774",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/AnalyzeOperationConvenienceCanPollFromNewObjectAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/AnalyzeOperationConvenienceCanPollFromNewObjectAsync.json
@@ -1,0 +1,230 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "241",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-350c86c4283e164391fbb05066c7c38b-a83b4a102894054c-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "62d19b31351b199604ad454be654679d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "analysisInput": {
+          "documents": [
+            {
+              "id": "0",
+              "text": "Elon Musk is the CEO of SpaceX and Tesla.",
+              "language": "en"
+            },
+            {
+              "id": "1",
+              "text": "Tesla stock is up by 400% this year.",
+              "language": "en"
+            }
+          ]
+        },
+        "tasks": {
+          "keyPhraseExtractionTasks": [
+            {
+              "parameters": {}
+            }
+          ]
+        }
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "d8724d34-2d91-4474-ad03-6d9240a4a9a4",
+        "Date": "Thu, 04 Nov 2021 22:01:25 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/18a69587-bc85-4b12-8c94-6219ba9abd2d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "175"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/18a69587-bc85-4b12-8c94-6219ba9abd2d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "9b0052f19d8a7fc2c3125f8dbb61219e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7f525317-abb5-4b30-9b2b-a3ede6d84a55",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "jobId": "18a69587-bc85-4b12-8c94-6219ba9abd2d",
+        "lastUpdateDateTime": "2021-11-04T22:01:25Z",
+        "createdDateTime": "2021-11-04T22:01:25Z",
+        "expirationDateTime": "2021-11-05T22:01:25Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/18a69587-bc85-4b12-8c94-6219ba9abd2d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f760db44749ff4fb012e3a4f85447ed5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "51974b78-4112-4e13-aa49-0a1c1bebad4b",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:26 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "27"
+      },
+      "ResponseBody": {
+        "jobId": "18a69587-bc85-4b12-8c94-6219ba9abd2d",
+        "lastUpdateDateTime": "2021-11-04T22:01:26Z",
+        "createdDateTime": "2021-11-04T22:01:25Z",
+        "expirationDateTime": "2021-11-05T22:01:25Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/18a69587-bc85-4b12-8c94-6219ba9abd2d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "afa06c6dbc3894c0d9519e09d6085da2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "06be45ef-9253-433f-bcb0-7a14acebb040",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "8"
+      },
+      "ResponseBody": {
+        "jobId": "18a69587-bc85-4b12-8c94-6219ba9abd2d",
+        "lastUpdateDateTime": "2021-11-04T22:01:26Z",
+        "createdDateTime": "2021-11-04T22:01:25Z",
+        "expirationDateTime": "2021-11-05T22:01:25Z",
+        "status": "running",
+        "errors": [],
+        "tasks": {
+          "completed": 0,
+          "failed": 0,
+          "inProgress": 1,
+          "total": 1
+        }
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/analyze/jobs/18a69587-bc85-4b12-8c94-6219ba9abd2d",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0b06a68c6ff37cfd570b995c6273fa7e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5ab2ba0f-7bfc-4a4c-b577-37ddd44fe9ed",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:01:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "179"
+      },
+      "ResponseBody": {
+        "jobId": "18a69587-bc85-4b12-8c94-6219ba9abd2d",
+        "lastUpdateDateTime": "2021-11-04T22:01:28Z",
+        "createdDateTime": "2021-11-04T22:01:25Z",
+        "expirationDateTime": "2021-11-05T22:01:25Z",
+        "status": "succeeded",
+        "errors": [],
+        "tasks": {
+          "completed": 1,
+          "failed": 0,
+          "inProgress": 0,
+          "total": 1,
+          "keyPhraseExtractionTasks": [
+            {
+              "lastUpdateDateTime": "2021-11-04T22:01:28.1675821Z",
+              "state": "succeeded",
+              "results": {
+                "documents": [
+                  {
+                    "id": "0",
+                    "keyPhrases": [
+                      "Elon Musk",
+                      "CEO",
+                      "SpaceX",
+                      "Tesla"
+                    ],
+                    "warnings": []
+                  },
+                  {
+                    "id": "1",
+                    "keyPhrases": [
+                      "Tesla stock"
+                    ],
+                    "warnings": []
+                  }
+                ],
+                "errors": [],
+                "modelVersion": "2021-06-01"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "712164189",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/HealthcareOperationCanPollFromNewObject.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/HealthcareOperationCanPollFromNewObject.json
@@ -1,0 +1,1053 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "223",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-11e995b294441240ae3d5cc9cf4ec9a4-194b785f9e8e694d-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "96ed0b15321b0dde2af775c023652325",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "id": "1",
+            "text": "Subject is taking 100mg of ibuprofen twice daily",
+            "language": "en"
+          },
+          {
+            "id": "2",
+            "text": "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.",
+            "language": "en"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "b04a267d-7009-4448-ba23-929930907648",
+        "Date": "Thu, 04 Nov 2021 22:28:20 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/021f1c83-8909-4b88-aa22-a26784ac5b7d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "147"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/021f1c83-8909-4b88-aa22-a26784ac5b7d?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "785a48dd5a5c03ab8b7fd3f6d86227d8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a15db183-f783-4576-b2aa-69dc091d77f9",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:28:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "86"
+      },
+      "ResponseBody": {
+        "jobId": "021f1c83-8909-4b88-aa22-a26784ac5b7d",
+        "lastUpdateDateTime": "2021-11-04T22:28:21Z",
+        "createdDateTime": "2021-11-04T22:28:21Z",
+        "expirationDateTime": "2021-11-05T22:28:21Z",
+        "status": "succeeded",
+        "errors": [],
+        "results": {
+          "documents": [
+            {
+              "id": "1",
+              "entities": [
+                {
+                  "offset": 18,
+                  "length": 5,
+                  "text": "100mg",
+                  "category": "Dosage",
+                  "confidenceScore": 1.0
+                },
+                {
+                  "offset": 27,
+                  "length": 9,
+                  "text": "ibuprofen",
+                  "category": "MedicationName",
+                  "confidenceScore": 1.0,
+                  "name": "ibuprofen",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0020740"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000019879"
+                    },
+                    {
+                      "dataSource": "ATC",
+                      "id": "M01AE01"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "0046165"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000006519"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "2270-2077"
+                    },
+                    {
+                      "dataSource": "DRUGBANK",
+                      "id": "DB01050"
+                    },
+                    {
+                      "dataSource": "GS",
+                      "id": "1611"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh97005926"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP16165-0"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "40458"
+                    },
+                    {
+                      "dataSource": "MMSL",
+                      "id": "d00015"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D007052"
+                    },
+                    {
+                      "dataSource": "MTHSPL",
+                      "id": "WK2XYI10QM"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C561"
+                    },
+                    {
+                      "dataSource": "NCI_CTRP",
+                      "id": "C561"
+                    },
+                    {
+                      "dataSource": "NCI_DCP",
+                      "id": "00803"
+                    },
+                    {
+                      "dataSource": "NCI_DTP",
+                      "id": "NSC0256857"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "WK2XYI10QM"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000613511"
+                    },
+                    {
+                      "dataSource": "NDDF",
+                      "id": "002377"
+                    },
+                    {
+                      "dataSource": "PDQ",
+                      "id": "CDR0000040475"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "x02MO"
+                    },
+                    {
+                      "dataSource": "RXNORM",
+                      "id": "5640"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "E-7772"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "C-603C0"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "387207008"
+                    },
+                    {
+                      "dataSource": "USP",
+                      "id": "m39860"
+                    },
+                    {
+                      "dataSource": "USPMG",
+                      "id": "MTHU000060"
+                    },
+                    {
+                      "dataSource": "VANDF",
+                      "id": "4017840"
+                    }
+                  ]
+                },
+                {
+                  "offset": 37,
+                  "length": 11,
+                  "text": "twice daily",
+                  "category": "Frequency",
+                  "confidenceScore": 1.0
+                }
+              ],
+              "relations": [
+                {
+                  "relationType": "DosageOfMedication",
+                  "entities": [
+                    {
+                      "ref": "#/results/documents/0/entities/0",
+                      "role": "Dosage"
+                    },
+                    {
+                      "ref": "#/results/documents/0/entities/1",
+                      "role": "Medication"
+                    }
+                  ]
+                },
+                {
+                  "relationType": "FrequencyOfMedication",
+                  "entities": [
+                    {
+                      "ref": "#/results/documents/0/entities/1",
+                      "role": "Medication"
+                    },
+                    {
+                      "ref": "#/results/documents/0/entities/2",
+                      "role": "Frequency"
+                    }
+                  ]
+                }
+              ],
+              "warnings": []
+            },
+            {
+              "id": "2",
+              "entities": [
+                {
+                  "offset": 10,
+                  "length": 5,
+                  "text": "rapid",
+                  "category": "SymptomOrSign",
+                  "confidenceScore": 0.93,
+                  "name": "Rapid",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0456962"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000002744"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000034666"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA24868-4"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C65069"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X78xZ"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "255358001"
+                    }
+                  ]
+                },
+                {
+                  "offset": 19,
+                  "length": 19,
+                  "text": "irregular heartbeat",
+                  "category": "SymptomOrSign",
+                  "confidenceScore": 1.0,
+                  "name": "Cardiac Arrhythmia",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0003811"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000005346"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00057"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1017785"
+                    },
+                    {
+                      "dataSource": "CCS",
+                      "id": "7.2.9"
+                    },
+                    {
+                      "dataSource": "CCSR_10",
+                      "id": "CIR017"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000001440"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "153"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "1393-3277"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "ARRHYTHMIA"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0011675"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "427.9"
+                    },
+                    {
+                      "dataSource": "ICPC",
+                      "id": "K80"
+                    },
+                    {
+                      "dataSource": "ICPC2EENG",
+                      "id": "K80"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU033639"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "K80012"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U000359"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85007430"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA15419-7"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10003119"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "35851"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "147"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D001145"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "153"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "427.9"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "00126"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "1721"
+                    },
+                    {
+                      "dataSource": "NCI_GDC",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "040520"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "115000"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "03790"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X77BB"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-73102"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D3-30010"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "698247007"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0433"
+                    }
+                  ]
+                },
+                {
+                  "offset": 40,
+                  "length": 8,
+                  "text": "delirium",
+                  "category": "Diagnosis",
+                  "confidenceScore": 0.97,
+                  "name": "Delirium",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0011206"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000004328"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1017884"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000003670"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "U000178"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "5003-0016"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "DELIRIUM"
+                    },
+                    {
+                      "dataSource": "DSM-5",
+                      "id": "780.09"
+                    },
+                    {
+                      "dataSource": "DXP",
+                      "id": "U000937"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0031258"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "F05.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "F05.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "R41.0"
+                    },
+                    {
+                      "dataSource": "ICNP",
+                      "id": "10022091"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU022150"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U001289"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85036579"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP89856-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10012218"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "677"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "5562"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D003693"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "02157"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E12898"
+                    },
+                    {
+                      "dataSource": "NCI_CTRP",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000450100"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "091213"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU035152"
+                    },
+                    {
+                      "dataSource": "PDQ",
+                      "id": "CDR0000042226"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "13360"
+                    },
+                    {
+                      "dataSource": "QMR",
+                      "id": "Q0200089"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "XE1Xv"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-85720"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D9-20100"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "2776000"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0099"
+                    }
+                  ]
+                },
+                {
+                  "offset": 50,
+                  "length": 5,
+                  "text": "panic",
+                  "category": "Diagnosis",
+                  "confidenceScore": 1.0,
+                  "name": "Panic",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0030318"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000023911"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000009234"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "AGITATION"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "F41.0"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU057222"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U003458"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85097438"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10033670"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D010200"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "551"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "300.01"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C94438"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000454704"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "121346"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "36260"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "Xa3Vj"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-90880"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "F-92560"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "79823003"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0163"
+                    }
+                  ]
+                },
+                {
+                  "offset": 57,
+                  "length": 9,
+                  "text": "psychosis",
+                  "category": "Diagnosis",
+                  "confidenceScore": 0.91,
+                  "name": "Psychotic Disorders",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0033975"
+                    },
+                    {
+                      "dataSource": "AIR",
+                      "id": "PSYCH"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000004324"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00688"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1018204"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000010350"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "089"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "2484-8182"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "PSYCHOSIS"
+                    },
+                    {
+                      "dataSource": "DXP",
+                      "id": "U003257"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0000709"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "298.9"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU070382"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "P98004"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85108502"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA7534-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10061920"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "364298"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "4180"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D011618"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "089"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "298.9"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "03128"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NCI_CELLOSAURUS",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E12954"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000450115"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "061619"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU002910"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "41910"
+                    },
+                    {
+                      "dataSource": "QMR",
+                      "id": "Q0200208"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X00S6"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "D-9200"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D9-72000"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "69322001"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0193"
+                    }
+                  ]
+                },
+                {
+                  "offset": 72,
+                  "length": 13,
+                  "text": "heart failure",
+                  "category": "Diagnosis",
+                  "confidenceScore": 1.0,
+                  "name": "Heart failure",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0018801"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000005308"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00019"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "0017571"
+                    },
+                    {
+                      "dataSource": "CCS",
+                      "id": "7.2.11.2"
+                    },
+                    {
+                      "dataSource": "CCSR_10",
+                      "id": "CIR019"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000005877"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "U000338"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "1393-3587"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "HEART FAIL"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0001635"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "428.9"
+                    },
+                    {
+                      "dataSource": "ICPC",
+                      "id": "K77"
+                    },
+                    {
+                      "dataSource": "ICPC2EENG",
+                      "id": "K77"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU027668"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "K77011"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U005616"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85059745"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP269421-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10007554"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "95724"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "199"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D006333"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "428.9"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C50577"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E10124"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "2206"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C50577"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU009472"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "G58.."
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "D-7050"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D3-16000"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "84114007"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0496"
+                    }
+                  ]
+                }
+              ],
+              "relations": [],
+              "warnings": []
+            }
+          ],
+          "errors": [],
+          "modelVersion": "2021-05-15"
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "436145447",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/HealthcareOperationCanPollFromNewObjectAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/HealthcareOperationCanPollFromNewObjectAsync.json
@@ -1,0 +1,1083 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "223",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cfa280846838b446b612ace0a545a38a-5b87ab29f88dde45-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "77f1c0b25526bbcedab018b3f7227419",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "id": "1",
+            "text": "Subject is taking 100mg of ibuprofen twice daily",
+            "language": "en"
+          },
+          {
+            "id": "2",
+            "text": "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.",
+            "language": "en"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "66c27f0c-7e22-4899-b6ad-dbdd47e9618a",
+        "Date": "Thu, 04 Nov 2021 22:28:27 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/147d1443-bb94-4deb-bf2c-71dfd75526f9",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "261"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/147d1443-bb94-4deb-bf2c-71dfd75526f9?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f90fbc550c1cd02539d127274bfe0c9b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fbf199fc-b48a-40dd-8661-28c019c0eaba",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:28:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "13"
+      },
+      "ResponseBody": {
+        "jobId": "147d1443-bb94-4deb-bf2c-71dfd75526f9",
+        "lastUpdateDateTime": "2021-11-04T22:28:27Z",
+        "createdDateTime": "2021-11-04T22:28:27Z",
+        "expirationDateTime": "2021-11-05T22:28:27Z",
+        "status": "notStarted",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/147d1443-bb94-4deb-bf2c-71dfd75526f9?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2932d5aa10c5a00f2946509dd32ef816",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f3c1df1e-ac0d-43dc-a171-c5350be51f74",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:28:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "70"
+      },
+      "ResponseBody": {
+        "jobId": "147d1443-bb94-4deb-bf2c-71dfd75526f9",
+        "lastUpdateDateTime": "2021-11-04T22:28:28Z",
+        "createdDateTime": "2021-11-04T22:28:27Z",
+        "expirationDateTime": "2021-11-05T22:28:27Z",
+        "status": "succeeded",
+        "errors": [],
+        "results": {
+          "documents": [
+            {
+              "id": "1",
+              "entities": [
+                {
+                  "offset": 18,
+                  "length": 5,
+                  "text": "100mg",
+                  "category": "Dosage",
+                  "confidenceScore": 1.0
+                },
+                {
+                  "offset": 27,
+                  "length": 9,
+                  "text": "ibuprofen",
+                  "category": "MedicationName",
+                  "confidenceScore": 1.0,
+                  "name": "ibuprofen",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0020740"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000019879"
+                    },
+                    {
+                      "dataSource": "ATC",
+                      "id": "M01AE01"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "0046165"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000006519"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "2270-2077"
+                    },
+                    {
+                      "dataSource": "DRUGBANK",
+                      "id": "DB01050"
+                    },
+                    {
+                      "dataSource": "GS",
+                      "id": "1611"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh97005926"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP16165-0"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "40458"
+                    },
+                    {
+                      "dataSource": "MMSL",
+                      "id": "d00015"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D007052"
+                    },
+                    {
+                      "dataSource": "MTHSPL",
+                      "id": "WK2XYI10QM"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C561"
+                    },
+                    {
+                      "dataSource": "NCI_CTRP",
+                      "id": "C561"
+                    },
+                    {
+                      "dataSource": "NCI_DCP",
+                      "id": "00803"
+                    },
+                    {
+                      "dataSource": "NCI_DTP",
+                      "id": "NSC0256857"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "WK2XYI10QM"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000613511"
+                    },
+                    {
+                      "dataSource": "NDDF",
+                      "id": "002377"
+                    },
+                    {
+                      "dataSource": "PDQ",
+                      "id": "CDR0000040475"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "x02MO"
+                    },
+                    {
+                      "dataSource": "RXNORM",
+                      "id": "5640"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "E-7772"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "C-603C0"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "387207008"
+                    },
+                    {
+                      "dataSource": "USP",
+                      "id": "m39860"
+                    },
+                    {
+                      "dataSource": "USPMG",
+                      "id": "MTHU000060"
+                    },
+                    {
+                      "dataSource": "VANDF",
+                      "id": "4017840"
+                    }
+                  ]
+                },
+                {
+                  "offset": 37,
+                  "length": 11,
+                  "text": "twice daily",
+                  "category": "Frequency",
+                  "confidenceScore": 1.0
+                }
+              ],
+              "relations": [
+                {
+                  "relationType": "DosageOfMedication",
+                  "entities": [
+                    {
+                      "ref": "#/results/documents/0/entities/0",
+                      "role": "Dosage"
+                    },
+                    {
+                      "ref": "#/results/documents/0/entities/1",
+                      "role": "Medication"
+                    }
+                  ]
+                },
+                {
+                  "relationType": "FrequencyOfMedication",
+                  "entities": [
+                    {
+                      "ref": "#/results/documents/0/entities/1",
+                      "role": "Medication"
+                    },
+                    {
+                      "ref": "#/results/documents/0/entities/2",
+                      "role": "Frequency"
+                    }
+                  ]
+                }
+              ],
+              "warnings": []
+            },
+            {
+              "id": "2",
+              "entities": [
+                {
+                  "offset": 10,
+                  "length": 5,
+                  "text": "rapid",
+                  "category": "SymptomOrSign",
+                  "confidenceScore": 0.93,
+                  "name": "Rapid",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0456962"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000002744"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000034666"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA24868-4"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C65069"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X78xZ"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "255358001"
+                    }
+                  ]
+                },
+                {
+                  "offset": 19,
+                  "length": 19,
+                  "text": "irregular heartbeat",
+                  "category": "SymptomOrSign",
+                  "confidenceScore": 1.0,
+                  "name": "Cardiac Arrhythmia",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0003811"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000005346"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00057"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1017785"
+                    },
+                    {
+                      "dataSource": "CCS",
+                      "id": "7.2.9"
+                    },
+                    {
+                      "dataSource": "CCSR_10",
+                      "id": "CIR017"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000001440"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "153"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "1393-3277"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "ARRHYTHMIA"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0011675"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "427.9"
+                    },
+                    {
+                      "dataSource": "ICPC",
+                      "id": "K80"
+                    },
+                    {
+                      "dataSource": "ICPC2EENG",
+                      "id": "K80"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU033639"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "K80012"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U000359"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85007430"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA15419-7"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10003119"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "35851"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "147"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D001145"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "153"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "427.9"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "00126"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "1721"
+                    },
+                    {
+                      "dataSource": "NCI_GDC",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "040520"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "115000"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "03790"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X77BB"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-73102"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D3-30010"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "698247007"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0433"
+                    }
+                  ]
+                },
+                {
+                  "offset": 40,
+                  "length": 8,
+                  "text": "delirium",
+                  "category": "Diagnosis",
+                  "confidenceScore": 0.97,
+                  "name": "Delirium",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0011206"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000004328"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1017884"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000003670"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "U000178"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "5003-0016"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "DELIRIUM"
+                    },
+                    {
+                      "dataSource": "DSM-5",
+                      "id": "780.09"
+                    },
+                    {
+                      "dataSource": "DXP",
+                      "id": "U000937"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0031258"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "F05.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "F05.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "R41.0"
+                    },
+                    {
+                      "dataSource": "ICNP",
+                      "id": "10022091"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU022150"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U001289"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85036579"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP89856-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10012218"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "677"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "5562"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D003693"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "02157"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E12898"
+                    },
+                    {
+                      "dataSource": "NCI_CTRP",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000450100"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "091213"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU035152"
+                    },
+                    {
+                      "dataSource": "PDQ",
+                      "id": "CDR0000042226"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "13360"
+                    },
+                    {
+                      "dataSource": "QMR",
+                      "id": "Q0200089"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "XE1Xv"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-85720"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D9-20100"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "2776000"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0099"
+                    }
+                  ]
+                },
+                {
+                  "offset": 50,
+                  "length": 5,
+                  "text": "panic",
+                  "category": "Diagnosis",
+                  "confidenceScore": 1.0,
+                  "name": "Panic",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0030318"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000023911"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000009234"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "AGITATION"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "F41.0"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU057222"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U003458"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85097438"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10033670"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D010200"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "551"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "300.01"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C94438"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000454704"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "121346"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "36260"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "Xa3Vj"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-90880"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "F-92560"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "79823003"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0163"
+                    }
+                  ]
+                },
+                {
+                  "offset": 57,
+                  "length": 9,
+                  "text": "psychosis",
+                  "category": "Diagnosis",
+                  "confidenceScore": 0.91,
+                  "name": "Psychotic Disorders",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0033975"
+                    },
+                    {
+                      "dataSource": "AIR",
+                      "id": "PSYCH"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000004324"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00688"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1018204"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000010350"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "089"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "2484-8182"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "PSYCHOSIS"
+                    },
+                    {
+                      "dataSource": "DXP",
+                      "id": "U003257"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0000709"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "298.9"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU070382"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "P98004"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85108502"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA7534-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10061920"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "364298"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "4180"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D011618"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "089"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "298.9"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "03128"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NCI_CELLOSAURUS",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E12954"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000450115"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "061619"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU002910"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "41910"
+                    },
+                    {
+                      "dataSource": "QMR",
+                      "id": "Q0200208"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X00S6"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "D-9200"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D9-72000"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "69322001"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0193"
+                    }
+                  ]
+                },
+                {
+                  "offset": 72,
+                  "length": 13,
+                  "text": "heart failure",
+                  "category": "Diagnosis",
+                  "confidenceScore": 1.0,
+                  "name": "Heart failure",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0018801"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000005308"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00019"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "0017571"
+                    },
+                    {
+                      "dataSource": "CCS",
+                      "id": "7.2.11.2"
+                    },
+                    {
+                      "dataSource": "CCSR_10",
+                      "id": "CIR019"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000005877"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "U000338"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "1393-3587"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "HEART FAIL"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0001635"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "428.9"
+                    },
+                    {
+                      "dataSource": "ICPC",
+                      "id": "K77"
+                    },
+                    {
+                      "dataSource": "ICPC2EENG",
+                      "id": "K77"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU027668"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "K77011"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U005616"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85059745"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP269421-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10007554"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "95724"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "199"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D006333"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "428.9"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C50577"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E10124"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "2206"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C50577"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU009472"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "G58.."
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "D-7050"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D3-16000"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "84114007"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0496"
+                    }
+                  ]
+                }
+              ],
+              "relations": [],
+              "warnings": []
+            }
+          ],
+          "errors": [],
+          "modelVersion": "2021-05-15"
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "911811260",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/HealthcareOperationConvenienceCanPollFromNewObject.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/HealthcareOperationConvenienceCanPollFromNewObject.json
@@ -1,0 +1,1083 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "223",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3f6480cf580200409af3824500a65cc9-d1f0c57be1767941-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "325037f399b208433e5dbc4e3c7935e1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "id": "0",
+            "text": "Subject is taking 100mg of ibuprofen twice daily",
+            "language": "en"
+          },
+          {
+            "id": "1",
+            "text": "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.",
+            "language": "en"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "60a2a7e6-4aea-4a85-81a2-ad430f4ab31f",
+        "Date": "Thu, 04 Nov 2021 22:28:24 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/472a5c27-3ac7-4a5f-a1c1-933f13034ced",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "356"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/472a5c27-3ac7-4a5f-a1c1-933f13034ced?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "2038ff6ea39ce483790d5bd904005a91",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0cbbcb54-842c-4c40-8efc-42ae4ceb4f5e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:28:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
+      },
+      "ResponseBody": {
+        "jobId": "472a5c27-3ac7-4a5f-a1c1-933f13034ced",
+        "lastUpdateDateTime": "2021-11-04T22:28:24Z",
+        "createdDateTime": "2021-11-04T22:28:24Z",
+        "expirationDateTime": "2021-11-05T22:28:24Z",
+        "status": "notStarted",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/472a5c27-3ac7-4a5f-a1c1-933f13034ced?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ad97f40c4e8c84a4f1fb2131ea2a002b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b142c53d-9d61-4e53-9176-e394dbe1623c",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:28:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "80"
+      },
+      "ResponseBody": {
+        "jobId": "472a5c27-3ac7-4a5f-a1c1-933f13034ced",
+        "lastUpdateDateTime": "2021-11-04T22:28:25Z",
+        "createdDateTime": "2021-11-04T22:28:24Z",
+        "expirationDateTime": "2021-11-05T22:28:24Z",
+        "status": "succeeded",
+        "errors": [],
+        "results": {
+          "documents": [
+            {
+              "id": "0",
+              "entities": [
+                {
+                  "offset": 18,
+                  "length": 5,
+                  "text": "100mg",
+                  "category": "Dosage",
+                  "confidenceScore": 1.0
+                },
+                {
+                  "offset": 27,
+                  "length": 9,
+                  "text": "ibuprofen",
+                  "category": "MedicationName",
+                  "confidenceScore": 1.0,
+                  "name": "ibuprofen",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0020740"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000019879"
+                    },
+                    {
+                      "dataSource": "ATC",
+                      "id": "M01AE01"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "0046165"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000006519"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "2270-2077"
+                    },
+                    {
+                      "dataSource": "DRUGBANK",
+                      "id": "DB01050"
+                    },
+                    {
+                      "dataSource": "GS",
+                      "id": "1611"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh97005926"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP16165-0"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "40458"
+                    },
+                    {
+                      "dataSource": "MMSL",
+                      "id": "d00015"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D007052"
+                    },
+                    {
+                      "dataSource": "MTHSPL",
+                      "id": "WK2XYI10QM"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C561"
+                    },
+                    {
+                      "dataSource": "NCI_CTRP",
+                      "id": "C561"
+                    },
+                    {
+                      "dataSource": "NCI_DCP",
+                      "id": "00803"
+                    },
+                    {
+                      "dataSource": "NCI_DTP",
+                      "id": "NSC0256857"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "WK2XYI10QM"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000613511"
+                    },
+                    {
+                      "dataSource": "NDDF",
+                      "id": "002377"
+                    },
+                    {
+                      "dataSource": "PDQ",
+                      "id": "CDR0000040475"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "x02MO"
+                    },
+                    {
+                      "dataSource": "RXNORM",
+                      "id": "5640"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "E-7772"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "C-603C0"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "387207008"
+                    },
+                    {
+                      "dataSource": "USP",
+                      "id": "m39860"
+                    },
+                    {
+                      "dataSource": "USPMG",
+                      "id": "MTHU000060"
+                    },
+                    {
+                      "dataSource": "VANDF",
+                      "id": "4017840"
+                    }
+                  ]
+                },
+                {
+                  "offset": 37,
+                  "length": 11,
+                  "text": "twice daily",
+                  "category": "Frequency",
+                  "confidenceScore": 1.0
+                }
+              ],
+              "relations": [
+                {
+                  "relationType": "DosageOfMedication",
+                  "entities": [
+                    {
+                      "ref": "#/results/documents/0/entities/0",
+                      "role": "Dosage"
+                    },
+                    {
+                      "ref": "#/results/documents/0/entities/1",
+                      "role": "Medication"
+                    }
+                  ]
+                },
+                {
+                  "relationType": "FrequencyOfMedication",
+                  "entities": [
+                    {
+                      "ref": "#/results/documents/0/entities/1",
+                      "role": "Medication"
+                    },
+                    {
+                      "ref": "#/results/documents/0/entities/2",
+                      "role": "Frequency"
+                    }
+                  ]
+                }
+              ],
+              "warnings": []
+            },
+            {
+              "id": "1",
+              "entities": [
+                {
+                  "offset": 10,
+                  "length": 5,
+                  "text": "rapid",
+                  "category": "SymptomOrSign",
+                  "confidenceScore": 0.93,
+                  "name": "Rapid",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0456962"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000002744"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000034666"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA24868-4"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C65069"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X78xZ"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "255358001"
+                    }
+                  ]
+                },
+                {
+                  "offset": 19,
+                  "length": 19,
+                  "text": "irregular heartbeat",
+                  "category": "SymptomOrSign",
+                  "confidenceScore": 1.0,
+                  "name": "Cardiac Arrhythmia",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0003811"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000005346"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00057"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1017785"
+                    },
+                    {
+                      "dataSource": "CCS",
+                      "id": "7.2.9"
+                    },
+                    {
+                      "dataSource": "CCSR_10",
+                      "id": "CIR017"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000001440"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "153"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "1393-3277"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "ARRHYTHMIA"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0011675"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "427.9"
+                    },
+                    {
+                      "dataSource": "ICPC",
+                      "id": "K80"
+                    },
+                    {
+                      "dataSource": "ICPC2EENG",
+                      "id": "K80"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU033639"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "K80012"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U000359"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85007430"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA15419-7"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10003119"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "35851"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "147"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D001145"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "153"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "427.9"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "00126"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "1721"
+                    },
+                    {
+                      "dataSource": "NCI_GDC",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "040520"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "115000"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "03790"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X77BB"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-73102"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D3-30010"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "698247007"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0433"
+                    }
+                  ]
+                },
+                {
+                  "offset": 40,
+                  "length": 8,
+                  "text": "delirium",
+                  "category": "Diagnosis",
+                  "confidenceScore": 0.97,
+                  "name": "Delirium",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0011206"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000004328"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1017884"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000003670"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "U000178"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "5003-0016"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "DELIRIUM"
+                    },
+                    {
+                      "dataSource": "DSM-5",
+                      "id": "780.09"
+                    },
+                    {
+                      "dataSource": "DXP",
+                      "id": "U000937"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0031258"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "F05.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "F05.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "R41.0"
+                    },
+                    {
+                      "dataSource": "ICNP",
+                      "id": "10022091"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU022150"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U001289"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85036579"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP89856-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10012218"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "677"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "5562"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D003693"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "02157"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E12898"
+                    },
+                    {
+                      "dataSource": "NCI_CTRP",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000450100"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "091213"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU035152"
+                    },
+                    {
+                      "dataSource": "PDQ",
+                      "id": "CDR0000042226"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "13360"
+                    },
+                    {
+                      "dataSource": "QMR",
+                      "id": "Q0200089"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "XE1Xv"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-85720"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D9-20100"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "2776000"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0099"
+                    }
+                  ]
+                },
+                {
+                  "offset": 50,
+                  "length": 5,
+                  "text": "panic",
+                  "category": "Diagnosis",
+                  "confidenceScore": 1.0,
+                  "name": "Panic",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0030318"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000023911"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000009234"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "AGITATION"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "F41.0"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU057222"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U003458"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85097438"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10033670"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D010200"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "551"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "300.01"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C94438"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000454704"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "121346"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "36260"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "Xa3Vj"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-90880"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "F-92560"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "79823003"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0163"
+                    }
+                  ]
+                },
+                {
+                  "offset": 57,
+                  "length": 9,
+                  "text": "psychosis",
+                  "category": "Diagnosis",
+                  "confidenceScore": 0.91,
+                  "name": "Psychotic Disorders",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0033975"
+                    },
+                    {
+                      "dataSource": "AIR",
+                      "id": "PSYCH"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000004324"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00688"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1018204"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000010350"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "089"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "2484-8182"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "PSYCHOSIS"
+                    },
+                    {
+                      "dataSource": "DXP",
+                      "id": "U003257"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0000709"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "298.9"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU070382"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "P98004"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85108502"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA7534-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10061920"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "364298"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "4180"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D011618"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "089"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "298.9"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "03128"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NCI_CELLOSAURUS",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E12954"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000450115"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "061619"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU002910"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "41910"
+                    },
+                    {
+                      "dataSource": "QMR",
+                      "id": "Q0200208"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X00S6"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "D-9200"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D9-72000"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "69322001"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0193"
+                    }
+                  ]
+                },
+                {
+                  "offset": 72,
+                  "length": 13,
+                  "text": "heart failure",
+                  "category": "Diagnosis",
+                  "confidenceScore": 1.0,
+                  "name": "Heart failure",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0018801"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000005308"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00019"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "0017571"
+                    },
+                    {
+                      "dataSource": "CCS",
+                      "id": "7.2.11.2"
+                    },
+                    {
+                      "dataSource": "CCSR_10",
+                      "id": "CIR019"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000005877"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "U000338"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "1393-3587"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "HEART FAIL"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0001635"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "428.9"
+                    },
+                    {
+                      "dataSource": "ICPC",
+                      "id": "K77"
+                    },
+                    {
+                      "dataSource": "ICPC2EENG",
+                      "id": "K77"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU027668"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "K77011"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U005616"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85059745"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP269421-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10007554"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "95724"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "199"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D006333"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "428.9"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C50577"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E10124"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "2206"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C50577"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU009472"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "G58.."
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "D-7050"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D3-16000"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "84114007"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0496"
+                    }
+                  ]
+                }
+              ],
+              "relations": [],
+              "warnings": []
+            }
+          ],
+          "errors": [],
+          "modelVersion": "2021-05-15"
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1508913074",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/HealthcareOperationConvenienceCanPollFromNewObjectAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/OperationLiveTests/HealthcareOperationConvenienceCanPollFromNewObjectAsync.json
@@ -1,0 +1,1083 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs?stringIndexType=Utf16CodeUnit",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "223",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f2627f2bc2bcd44aa820b424771b4d97-1b40a5adb734eb4b-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "ec2a9eac4c8fcc197b578e753b878d18",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "id": "0",
+            "text": "Subject is taking 100mg of ibuprofen twice daily",
+            "language": "en"
+          },
+          {
+            "id": "1",
+            "text": "Can cause rapid or irregular heartbeat, delirium, panic, psychosis, and heart failure.",
+            "language": "en"
+          }
+        ]
+      },
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "8fc5ab7d-fae2-4ba3-9cb1-9e5b5a5a8132",
+        "Date": "Thu, 04 Nov 2021 22:28:29 GMT",
+        "operation-location": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/b7d36e97-4779-403b-8cb7-f748d5d03589",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "183"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/b7d36e97-4779-403b-8cb7-f748d5d03589?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "f3733ed36c6d694ab3cc1fc753f4f752",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bfcff355-a4e4-436a-a2b0-e7cd79f22dca",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:28:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "7"
+      },
+      "ResponseBody": {
+        "jobId": "b7d36e97-4779-403b-8cb7-f748d5d03589",
+        "lastUpdateDateTime": "2021-11-04T22:28:29Z",
+        "createdDateTime": "2021-11-04T22:28:29Z",
+        "expirationDateTime": "2021-11-05T22:28:29Z",
+        "status": "notStarted",
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.1/entities/health/jobs/b7d36e97-4779-403b-8cb7-f748d5d03589?showStats=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20211104.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "x-ms-client-request-id": "0181b5254a7391100de2348e019cac2a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "322c6032-ae9f-42de-b157-8dbecc96cf33",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 04 Nov 2021 22:28:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "62"
+      },
+      "ResponseBody": {
+        "jobId": "b7d36e97-4779-403b-8cb7-f748d5d03589",
+        "lastUpdateDateTime": "2021-11-04T22:28:30Z",
+        "createdDateTime": "2021-11-04T22:28:29Z",
+        "expirationDateTime": "2021-11-05T22:28:29Z",
+        "status": "succeeded",
+        "errors": [],
+        "results": {
+          "documents": [
+            {
+              "id": "0",
+              "entities": [
+                {
+                  "offset": 18,
+                  "length": 5,
+                  "text": "100mg",
+                  "category": "Dosage",
+                  "confidenceScore": 1.0
+                },
+                {
+                  "offset": 27,
+                  "length": 9,
+                  "text": "ibuprofen",
+                  "category": "MedicationName",
+                  "confidenceScore": 1.0,
+                  "name": "ibuprofen",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0020740"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000019879"
+                    },
+                    {
+                      "dataSource": "ATC",
+                      "id": "M01AE01"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "0046165"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000006519"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "2270-2077"
+                    },
+                    {
+                      "dataSource": "DRUGBANK",
+                      "id": "DB01050"
+                    },
+                    {
+                      "dataSource": "GS",
+                      "id": "1611"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh97005926"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP16165-0"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "40458"
+                    },
+                    {
+                      "dataSource": "MMSL",
+                      "id": "d00015"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D007052"
+                    },
+                    {
+                      "dataSource": "MTHSPL",
+                      "id": "WK2XYI10QM"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C561"
+                    },
+                    {
+                      "dataSource": "NCI_CTRP",
+                      "id": "C561"
+                    },
+                    {
+                      "dataSource": "NCI_DCP",
+                      "id": "00803"
+                    },
+                    {
+                      "dataSource": "NCI_DTP",
+                      "id": "NSC0256857"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "WK2XYI10QM"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000613511"
+                    },
+                    {
+                      "dataSource": "NDDF",
+                      "id": "002377"
+                    },
+                    {
+                      "dataSource": "PDQ",
+                      "id": "CDR0000040475"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "x02MO"
+                    },
+                    {
+                      "dataSource": "RXNORM",
+                      "id": "5640"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "E-7772"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "C-603C0"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "387207008"
+                    },
+                    {
+                      "dataSource": "USP",
+                      "id": "m39860"
+                    },
+                    {
+                      "dataSource": "USPMG",
+                      "id": "MTHU000060"
+                    },
+                    {
+                      "dataSource": "VANDF",
+                      "id": "4017840"
+                    }
+                  ]
+                },
+                {
+                  "offset": 37,
+                  "length": 11,
+                  "text": "twice daily",
+                  "category": "Frequency",
+                  "confidenceScore": 1.0
+                }
+              ],
+              "relations": [
+                {
+                  "relationType": "DosageOfMedication",
+                  "entities": [
+                    {
+                      "ref": "#/results/documents/0/entities/0",
+                      "role": "Dosage"
+                    },
+                    {
+                      "ref": "#/results/documents/0/entities/1",
+                      "role": "Medication"
+                    }
+                  ]
+                },
+                {
+                  "relationType": "FrequencyOfMedication",
+                  "entities": [
+                    {
+                      "ref": "#/results/documents/0/entities/1",
+                      "role": "Medication"
+                    },
+                    {
+                      "ref": "#/results/documents/0/entities/2",
+                      "role": "Frequency"
+                    }
+                  ]
+                }
+              ],
+              "warnings": []
+            },
+            {
+              "id": "1",
+              "entities": [
+                {
+                  "offset": 10,
+                  "length": 5,
+                  "text": "rapid",
+                  "category": "SymptomOrSign",
+                  "confidenceScore": 0.93,
+                  "name": "Rapid",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0456962"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000002744"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000034666"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA24868-4"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C65069"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X78xZ"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "255358001"
+                    }
+                  ]
+                },
+                {
+                  "offset": 19,
+                  "length": 19,
+                  "text": "irregular heartbeat",
+                  "category": "SymptomOrSign",
+                  "confidenceScore": 1.0,
+                  "name": "Cardiac Arrhythmia",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0003811"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000005346"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00057"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1017785"
+                    },
+                    {
+                      "dataSource": "CCS",
+                      "id": "7.2.9"
+                    },
+                    {
+                      "dataSource": "CCSR_10",
+                      "id": "CIR017"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000001440"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "153"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "1393-3277"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "ARRHYTHMIA"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0011675"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "I49.9"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "427.9"
+                    },
+                    {
+                      "dataSource": "ICPC",
+                      "id": "K80"
+                    },
+                    {
+                      "dataSource": "ICPC2EENG",
+                      "id": "K80"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU033639"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "K80012"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U000359"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85007430"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA15419-7"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10003119"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "35851"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "147"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D001145"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "153"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "427.9"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "00126"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "1721"
+                    },
+                    {
+                      "dataSource": "NCI_GDC",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C2881"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "040520"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "115000"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "03790"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X77BB"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-73102"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D3-30010"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "698247007"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0433"
+                    }
+                  ]
+                },
+                {
+                  "offset": 40,
+                  "length": 8,
+                  "text": "delirium",
+                  "category": "Diagnosis",
+                  "confidenceScore": 0.97,
+                  "name": "Delirium",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0011206"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000004328"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1017884"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000003670"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "U000178"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "5003-0016"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "DELIRIUM"
+                    },
+                    {
+                      "dataSource": "DSM-5",
+                      "id": "780.09"
+                    },
+                    {
+                      "dataSource": "DXP",
+                      "id": "U000937"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0031258"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "F05.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "F05.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "R41.0"
+                    },
+                    {
+                      "dataSource": "ICNP",
+                      "id": "10022091"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU022150"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U001289"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85036579"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP89856-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10012218"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "677"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "5562"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D003693"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "02157"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E12898"
+                    },
+                    {
+                      "dataSource": "NCI_CTRP",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000450100"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C2981"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "091213"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU035152"
+                    },
+                    {
+                      "dataSource": "PDQ",
+                      "id": "CDR0000042226"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "13360"
+                    },
+                    {
+                      "dataSource": "QMR",
+                      "id": "Q0200089"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "XE1Xv"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-85720"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D9-20100"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "2776000"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0099"
+                    }
+                  ]
+                },
+                {
+                  "offset": 50,
+                  "length": 5,
+                  "text": "panic",
+                  "category": "Diagnosis",
+                  "confidenceScore": 1.0,
+                  "name": "Panic",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0030318"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000023911"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000009234"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "AGITATION"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "F41.0"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU057222"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U003458"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85097438"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10033670"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D010200"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "551"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "300.01"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C94438"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000454704"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "121346"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "36260"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "Xa3Vj"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "F-90880"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "F-92560"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "79823003"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0163"
+                    }
+                  ]
+                },
+                {
+                  "offset": 57,
+                  "length": 9,
+                  "text": "psychosis",
+                  "category": "Diagnosis",
+                  "confidenceScore": 0.91,
+                  "name": "Psychotic Disorders",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0033975"
+                    },
+                    {
+                      "dataSource": "AIR",
+                      "id": "PSYCH"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000004324"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00688"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "1018204"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000010350"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "089"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "2484-8182"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "PSYCHOSIS"
+                    },
+                    {
+                      "dataSource": "DXP",
+                      "id": "U003257"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0000709"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "298.9"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU070382"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "P98004"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85108502"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LA7534-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10061920"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "364298"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "4180"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D011618"
+                    },
+                    {
+                      "dataSource": "MTH",
+                      "id": "089"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "298.9"
+                    },
+                    {
+                      "dataSource": "NANDA-I",
+                      "id": "03128"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NCI_CELLOSAURUS",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E12954"
+                    },
+                    {
+                      "dataSource": "NCI_NCI-GLOSS",
+                      "id": "CDR0000450115"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C78576"
+                    },
+                    {
+                      "dataSource": "NOC",
+                      "id": "061619"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU002910"
+                    },
+                    {
+                      "dataSource": "PSY",
+                      "id": "41910"
+                    },
+                    {
+                      "dataSource": "QMR",
+                      "id": "Q0200208"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "X00S6"
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "D-9200"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D9-72000"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "69322001"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0193"
+                    }
+                  ]
+                },
+                {
+                  "offset": 72,
+                  "length": 13,
+                  "text": "heart failure",
+                  "category": "Diagnosis",
+                  "confidenceScore": 1.0,
+                  "name": "Heart failure",
+                  "links": [
+                    {
+                      "dataSource": "UMLS",
+                      "id": "C0018801"
+                    },
+                    {
+                      "dataSource": "AOD",
+                      "id": "0000005308"
+                    },
+                    {
+                      "dataSource": "BI",
+                      "id": "BI00019"
+                    },
+                    {
+                      "dataSource": "CCPSS",
+                      "id": "0017571"
+                    },
+                    {
+                      "dataSource": "CCS",
+                      "id": "7.2.11.2"
+                    },
+                    {
+                      "dataSource": "CCSR_10",
+                      "id": "CIR019"
+                    },
+                    {
+                      "dataSource": "CHV",
+                      "id": "0000005877"
+                    },
+                    {
+                      "dataSource": "COSTAR",
+                      "id": "U000338"
+                    },
+                    {
+                      "dataSource": "CSP",
+                      "id": "1393-3587"
+                    },
+                    {
+                      "dataSource": "CST",
+                      "id": "HEART FAIL"
+                    },
+                    {
+                      "dataSource": "HPO",
+                      "id": "HP:0001635"
+                    },
+                    {
+                      "dataSource": "ICD10",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD10AM",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD10CM",
+                      "id": "I50.9"
+                    },
+                    {
+                      "dataSource": "ICD9CM",
+                      "id": "428.9"
+                    },
+                    {
+                      "dataSource": "ICPC",
+                      "id": "K77"
+                    },
+                    {
+                      "dataSource": "ICPC2EENG",
+                      "id": "K77"
+                    },
+                    {
+                      "dataSource": "ICPC2ICD10ENG",
+                      "id": "MTHU027668"
+                    },
+                    {
+                      "dataSource": "ICPC2P",
+                      "id": "K77011"
+                    },
+                    {
+                      "dataSource": "LCH",
+                      "id": "U005616"
+                    },
+                    {
+                      "dataSource": "LCH_NW",
+                      "id": "sh85059745"
+                    },
+                    {
+                      "dataSource": "LNC",
+                      "id": "LP269421-6"
+                    },
+                    {
+                      "dataSource": "MDR",
+                      "id": "10007554"
+                    },
+                    {
+                      "dataSource": "MEDCIN",
+                      "id": "95724"
+                    },
+                    {
+                      "dataSource": "MEDLINEPLUS",
+                      "id": "199"
+                    },
+                    {
+                      "dataSource": "MSH",
+                      "id": "D006333"
+                    },
+                    {
+                      "dataSource": "MTHICD9",
+                      "id": "428.9"
+                    },
+                    {
+                      "dataSource": "NCI",
+                      "id": "C50577"
+                    },
+                    {
+                      "dataSource": "NCI_CTCAE",
+                      "id": "E10124"
+                    },
+                    {
+                      "dataSource": "NCI_FDA",
+                      "id": "2206"
+                    },
+                    {
+                      "dataSource": "NCI_NICHD",
+                      "id": "C50577"
+                    },
+                    {
+                      "dataSource": "OMIM",
+                      "id": "MTHU009472"
+                    },
+                    {
+                      "dataSource": "RCD",
+                      "id": "G58.."
+                    },
+                    {
+                      "dataSource": "SNM",
+                      "id": "D-7050"
+                    },
+                    {
+                      "dataSource": "SNMI",
+                      "id": "D3-16000"
+                    },
+                    {
+                      "dataSource": "SNOMEDCT_US",
+                      "id": "84114007"
+                    },
+                    {
+                      "dataSource": "WHO",
+                      "id": "0496"
+                    }
+                  ]
+                }
+              ],
+              "relations": [],
+              "warnings": []
+            }
+          ],
+          "errors": [],
+          "modelVersion": "2021-05-15"
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1167203386",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategories.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategories.json
@@ -1,43 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?model-version=2020-02-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?model-version=2020-02-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Content-Length": "87",
+        "Accept": "application/json, text/json",
+        "Content-Length": "99",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b10eba0253d934894dcfd1f23ca1fa4-ae2e2f752dda764e-00",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
-          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "2bbb7414e3ce80e03f8df0adf3eb7d0c",
+        "traceparent": "00-b1821b291a3a7e44b687b7403c62b8d1-d1848ef4b0efd348-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211119.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.22000 )",
+        "x-ms-client-request-id": "98390f07b746e4e2f8901f49bf56b44f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "documents": [
           {
             "id": "0",
-            "text": "Bill Gates | Microsoft | New Mexico",
+            "text": "Bill Gates | Microsoft | New Mexico | 127.0.0.1",
             "language": "en"
           }
         ]
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2f87c194-0f90-462e-9a9d-4e374c5925fe",
+        "apim-request-id": "4f6d9b27-8eab-4e73-bafb-d9699fd13aa5",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Mon, 25 Oct 2021 21:23:50 GMT",
+        "Date": "Sat, 20 Nov 2021 00:57:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "70"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "71"
       },
       "ResponseBody": {
         "documents": [
@@ -64,7 +58,14 @@
                 "subcategory": "GPE",
                 "offset": 25,
                 "length": 10,
-                "confidenceScore": 0.63
+                "confidenceScore": 0.56
+              },
+              {
+                "text": "127.0.0.1",
+                "category": "IPAddress",
+                "offset": 38,
+                "length": 9,
+                "confidenceScore": 0.8
               }
             ],
             "warnings": []
@@ -76,8 +77,8 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "1654409937",
+    "RandomSeed": "1312952948",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategoriesAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/EntitiesCategoriesAsync.json
@@ -1,43 +1,37 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://javatextanalyticstestresources.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?model-version=2020-02-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.2-preview.2/entities/recognition/general?model-version=2020-02-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
-        "Content-Length": "87",
+        "Accept": "application/json, text/json",
+        "Content-Length": "99",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fae5a92312fcdc459d3b7f002e781cae-945f084b854bfb4c-00",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211025.1",
-          "(.NET Core 3.1.20; Microsoft Windows 10.0.19043)"
-        ],
-        "x-ms-client-request-id": "6470d4cf3910c27ceead9bc2cf6c8aa0",
+        "traceparent": "00-415ed741b38c27468b19ab5cd296853f-8f24a457a53daf46-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.2.0-alpha.20211119.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.22000 )",
+        "x-ms-client-request-id": "3b09106f973efe8efad9aad5561cc5ca",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "documents": [
           {
             "id": "0",
-            "text": "Bill Gates | Microsoft | New Mexico",
+            "text": "Bill Gates | Microsoft | New Mexico | 127.0.0.1",
             "language": "en"
           }
         ]
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b43903a0-e7ed-41eb-951b-ecb0510156c2",
+        "apim-request-id": "45d54ccf-100f-4c56-9307-7c21c752c0e1",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1,CognitiveServices.TextAnalytics.TextRecords=1",
-        "Date": "Mon, 25 Oct 2021 21:23:52 GMT",
+        "Date": "Sat, 20 Nov 2021 00:57:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "68"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "92"
       },
       "ResponseBody": {
         "documents": [
@@ -64,7 +58,14 @@
                 "subcategory": "GPE",
                 "offset": 25,
                 "length": 10,
-                "confidenceScore": 0.63
+                "confidenceScore": 0.56
+              },
+              {
+                "text": "127.0.0.1",
+                "category": "IPAddress",
+                "offset": 38,
+                "length": 9,
+                "confidenceScore": 0.8
               }
             ],
             "warnings": []
@@ -76,8 +77,8 @@
     }
   ],
   "Variables": {
-    "RandomSeed": "62086103",
+    "RandomSeed": "235833771",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://javatextanalyticstestresources.cognitiveservices.azure.com/"
+    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -65,18 +65,20 @@ namespace Azure.AI.TextAnalytics.Tests
         public async Task EntitiesCategories()
         {
             TextAnalyticsClient client = GetClient();
-            const string document = "Bill Gates | Microsoft | New Mexico";
+            const string document = "Bill Gates | Microsoft | New Mexico | 127.0.0.1";
 
             RecognizeEntitiesResultCollection response = await client.RecognizeEntitiesBatchAsync(new List<string>() { document }, "en", new TextAnalyticsRequestOptions() { ModelVersion = "2020-02-01" });
             var entities = response.FirstOrDefault().Entities.ToList();
 
-            Assert.AreEqual(3, entities.Count);
+            Assert.AreEqual(4, entities.Count);
 
             Assert.AreEqual(EntityCategory.Person, entities[0].Category);
 
             Assert.AreEqual(EntityCategory.Organization, entities[1].Category);
 
             Assert.AreEqual(EntityCategory.Location, entities[2].Category);
+
+            Assert.AreEqual(EntityCategory.IPAddress, entities[3].Category);
         }
 
         [RecordedTest]


### PR DESCRIPTION
Merging the fixes we released in 5.1.1 into our main branch. Changes are:
- Enum `EntityCategory.IPAddress` now uses the underlying string `IPAddress` value instead of `IP` to align with the Text Analytics service behavior.
- Long-Running operation rehydration has been patched to stop throwing a `NullReferenceException`. Issue [24692](https://github.com/Azure/azure-sdk-for-net/issues/24692).
- Added tests and recordings.

Had to address some rebase conflicts. Other than that, all code has already been reviewed.