### PR TITLE
Add multi-subscriber listener test

### DIFF
--- a/sdk/core/Azure.Core/tests/AzureEventSourceListenerTests.cs
+++ b/sdk/core/Azure.Core/tests/AzureEventSourceListenerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using Azure.Core.Diagnostics;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -30,6 +31,27 @@ namespace Azure.Core.Tests
 
             Assert.AreEqual("Request", singleInvocation.Item1.EventName);
             Assert.NotNull(singleInvocation.Item2);
+        }
+
+        [Test]
+        public void FiltersMessagesUsingLevel()
+        {
+            var warningInvocations = new List<(EventWrittenEventArgs, string)>();
+            var verboseInvocations = new List<(EventWrittenEventArgs, string)>();
+            using var verboseListener = new AzureEventSourceListener((args, s) => verboseInvocations.Add((args, s)), EventLevel.Verbose);
+            using var warningListener = new AzureEventSourceListener((args, s) => warningInvocations.Add((args, s)), EventLevel.Warning);
+
+            AzureCoreEventSource.Singleton.ErrorResponse("id", 500, "GET", "http", 5);
+            AzureCoreEventSource.Singleton.Request("id", "GET", "http", "header", "Test-SDK");
+
+            Assert.AreEqual(1, warningInvocations.Count);
+            var warningInvocation = warningInvocations.Single();
+            Assert.AreEqual("ErrorResponse", warningInvocation.Item1.EventName);
+            Assert.NotNull(warningInvocation.Item2);
+
+            Assert.AreEqual(2, verboseInvocations.Count);
+            Assert.True(verboseInvocations.Any(c=>c.Item1.EventName == "ErrorResponse"));
+            Assert.True(verboseInvocations.Any(c=>c.Item1.EventName == "Request"));
         }
 
         [Test]


### PR DESCRIPTION
I thought there was a bug but there was none. It's still a good test.