### PR TITLE
[Service Bus Functions Extensions] Session Actions Mock Support

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/api/Microsoft.Azure.WebJobs.Extensions.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/api/Microsoft.Azure.WebJobs.Extensions.ServiceBus.netstandard2.0.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
     }
     public partial class ServiceBusSessionMessageActions : Microsoft.Azure.WebJobs.ServiceBus.ServiceBusMessageActions
     {
-        internal ServiceBusSessionMessageActions() { }
+        protected ServiceBusSessionMessageActions() { }
         public virtual System.Threading.Tasks.Task<System.BinaryData> GetSessionStateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SetSessionStateAsync(System.BinaryData sessionState, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/ServiceBusSessionMessageActions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Primitives/ServiceBusSessionMessageActions.cs
@@ -27,6 +27,17 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             _receiver = receiver;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusSessionMessageActions"/> class for mocking use in testing.
+        /// </summary>
+        /// <remarks>
+        /// This constructor exists only to support mocking. When used, class state is not fully initialized, and
+        /// will not function correctly; virtual members are meant to be mocked.
+        ///</remarks>
+        protected ServiceBusSessionMessageActions()
+        {
+        }
+
         /// <inheritdoc cref="ServiceBusSessionReceiver.GetSessionStateAsync(CancellationToken)"/>
         public virtual async Task<BinaryData> GetSessionStateAsync(
             CancellationToken cancellationToken = default)


### PR DESCRIPTION
# Summary

The focus of these changes is to add a protected constructor to the `ServiceBusSessionMessageActions` class to support mocking for test scenarios.

# References and Related

- [Twitter thread discussing mocking difficulties](https://twitter.com/rolandkru/status/1462756372651593733)
- [[Service Bus Functions Extensions] Actions Mock Support (#25489)](https://github.com/Azure/azure-sdk-for-net/pull/25489)