### PR TITLE
Don't enforce global timeout when debugging

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/ClientTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using Castle.DynamicProxy;
 using NUnit.Framework;
@@ -35,7 +36,7 @@ namespace Azure.Core.TestFramework
         {
             var executionContext = TestExecutionContext.CurrentContext;
             var duration = DateTime.UtcNow - executionContext.StartTime;
-            if (duration > TimeSpan.FromSeconds(GLOBAL_TEST_TIMEOUT_IN_SECONDS))
+            if (duration > TimeSpan.FromSeconds(GLOBAL_TEST_TIMEOUT_IN_SECONDS) && !Debugger.IsAttached)
             {
                 executionContext.CurrentResult.SetResult(ResultState.Failure, $"Test exceeded global time limit of {GLOBAL_TEST_TIMEOUT_IN_SECONDS} seconds. Duration: {duration}");
             }

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -102,8 +102,8 @@ namespace Azure.Core.TestFramework
 
         public override void GlobalTimeoutTearDown()
         {
-            // Only enforce the timeout on playback.
-            if (Mode == RecordedTestMode.Playback)
+            // Only enforce the timeout on playback when debugger is not attached.
+            if (Mode == RecordedTestMode.Playback && !Debugger.IsAttached)
             {
                 base.GlobalTimeoutTearDown();
             }

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -102,8 +102,8 @@ namespace Azure.Core.TestFramework
 
         public override void GlobalTimeoutTearDown()
         {
-            // Only enforce the timeout on playback when debugger is not attached.
-            if (Mode == RecordedTestMode.Playback && !Debugger.IsAttached)
+            // Only enforce the timeout on playback.
+            if (Mode == RecordedTestMode.Playback)
             {
                 base.GlobalTimeoutTearDown();
             }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/25454