### PR TITLE
Make HttpPipeline.CreateMessage overload throw when context is null

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -767,7 +767,7 @@ namespace Azure.Core.Pipeline
         public static System.IDisposable CreateClientRequestIdScope(string? clientRequestId) { throw null; }
         public static System.IDisposable CreateHttpMessagePropertiesScope(System.Collections.Generic.IDictionary<string, object?> messageProperties) { throw null; }
         public Azure.Core.HttpMessage CreateMessage() { throw null; }
-        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext context) { throw null; }
+        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext? context) { throw null; }
         public Azure.Core.Request CreateRequest() { throw null; }
         public void Send(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SendAsync(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -767,7 +767,7 @@ namespace Azure.Core.Pipeline
         public static System.IDisposable CreateClientRequestIdScope(string? clientRequestId) { throw null; }
         public static System.IDisposable CreateHttpMessagePropertiesScope(System.Collections.Generic.IDictionary<string, object?> messageProperties) { throw null; }
         public Azure.Core.HttpMessage CreateMessage() { throw null; }
-        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext context) { throw null; }
+        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext? context) { throw null; }
         public Azure.Core.Request CreateRequest() { throw null; }
         public void Send(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SendAsync(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -767,7 +767,7 @@ namespace Azure.Core.Pipeline
         public static System.IDisposable CreateClientRequestIdScope(string? clientRequestId) { throw null; }
         public static System.IDisposable CreateHttpMessagePropertiesScope(System.Collections.Generic.IDictionary<string, object?> messageProperties) { throw null; }
         public Azure.Core.HttpMessage CreateMessage() { throw null; }
-        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext context) { throw null; }
+        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext? context) { throw null; }
         public Azure.Core.Request CreateRequest() { throw null; }
         public void Send(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SendAsync(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -767,7 +767,7 @@ namespace Azure.Core.Pipeline
         public static System.IDisposable CreateClientRequestIdScope(string? clientRequestId) { throw null; }
         public static System.IDisposable CreateHttpMessagePropertiesScope(System.Collections.Generic.IDictionary<string, object?> messageProperties) { throw null; }
         public Azure.Core.HttpMessage CreateMessage() { throw null; }
-        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext context) { throw null; }
+        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext? context) { throw null; }
         public Azure.Core.Request CreateRequest() { throw null; }
         public void Send(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask SendAsync(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/sdk/core/Azure.Core/src/HttpMessage.cs
+++ b/sdk/core/Azure.Core/src/HttpMessage.cs
@@ -80,9 +80,9 @@ namespace Azure.Core
         /// </summary>
         public TimeSpan? NetworkTimeout { get; set; }
 
-        internal void AddPolicies(RequestContext context)
+        internal void AddPolicies(RequestContext? context)
         {
-            if (context.Policies == null || context.Policies.Count == 0)
+            if (context == null || context.Policies == null || context.Policies.Count == 0)
             {
                 return;
             }

--- a/sdk/core/Azure.Core/src/HttpMessage.cs
+++ b/sdk/core/Azure.Core/src/HttpMessage.cs
@@ -82,7 +82,7 @@ namespace Azure.Core
 
         internal void AddPolicies(RequestContext context)
         {
-            if (context == null || context.Policies == null || context.Policies.Count == 0)
+            if (context.Policies == null || context.Policies.Count == 0)
             {
                 return;
             }

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -101,9 +101,8 @@ namespace Azure.Core.Pipeline
         /// </summary>
         /// <param name="context">Context specifying the message options.</param>
         /// <returns>The message.</returns>
-        public HttpMessage CreateMessage(RequestContext context)
+        public HttpMessage CreateMessage(RequestContext? context)
         {
-            Argument.AssertNotNull(context, nameof(context));
             var message = CreateMessage();
             message.AddPolicies(context);
             return message;

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -103,6 +103,7 @@ namespace Azure.Core.Pipeline
         /// <returns>The message.</returns>
         public HttpMessage CreateMessage(RequestContext context)
         {
+            Argument.AssertNotNull(context, nameof(context));
             var message = CreateMessage();
             message.AddPolicies(context);
             return message;

--- a/sdk/core/Azure.Core/tests/HttpPipelineTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineTests.cs
@@ -216,7 +216,7 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public async Task ThrowsIfUsePipelineConstructor()
+        public void ThrowsIfUsePipelineConstructor()
         {
             HttpPipeline pipeline = new HttpPipeline(new MockTransport());
 
@@ -224,18 +224,14 @@ namespace Azure.Core.Tests
             context.AddPolicy(new AddHeaderPolicy("PerCallHeader", "Value"), HttpPipelinePosition.PerCall);
 
             var message = pipeline.CreateMessage(context);
+            Assert.CatchAsync<InvalidOperationException>(async () => await pipeline.SendAsync(message, context.CancellationToken));
+        }
 
-            bool throws = false;
-            try
-            {
-                await pipeline.SendAsync(message, context.CancellationToken);
-            }
-            catch (InvalidOperationException)
-            {
-                throws = true;
-            }
-
-            Assert.IsTrue(throws);
+        [Test]
+        public void CreateMessage_ThrowsOnNullContext()
+        {
+            var pipeline = new HttpPipeline(new MockTransport());
+            Assert.Throws<ArgumentNullException>(() => pipeline.CreateMessage(null));
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/HttpPipelineTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineTests.cs
@@ -228,10 +228,10 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        public void CreateMessage_ThrowsOnNullContext()
+        public void CreateMessage_AllowsNullContext()
         {
             var pipeline = new HttpPipeline(new MockTransport());
-            Assert.Throws<ArgumentNullException>(() => pipeline.CreateMessage(null));
+            Assert.DoesNotThrow(() => pipeline.CreateMessage(null));
         }
 
         [Test]


### PR DESCRIPTION
Right now, `context` parameter in `HttpPipeline.CreateMessage` is declared as non-nullable. However, its implementation assumes that it is. This inconsistency creates an issue from the calling side. If nullable refs are enabled, `pipeline.CreateMessage(null)` will produce a compilation error. The same will happen if calling method passes a nullable parameter:
```cs
CreateOperationRequest(RequestContext? context = null) 
{
    var message = _pipeline.CreateMessage(context);
```

We need to either declare parameter as nullable or make `CreateMessage` throw on null.
