### PR TITLE
Ignore exportable key import errors

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.SecureKeyRelease.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.SecureKeyRelease.cs
@@ -89,11 +89,12 @@ namespace Azure.Security.KeyVault.Keys.Tests
                 },
             };
 
-            KeyVaultKey key = await Client.ImportKeyAsync(options);
+            // BUGBUG: Remove assert when https://github.com/Azure/azure-sdk-for-net/issues/22750 is resolved.
+            KeyVaultKey key = await AssertRequestSupported(async () => await Client.ImportKeyAsync(options));
             RegisterForCleanup(key.Name);
 
             // BUGBUG: Remove assert when https://github.com/Azure/azure-sdk-for-net/issues/22750 is resolved.
-            JwtSecurityToken jws = await AssertRequestSupported(async() => await ReleaseKeyAsync(keyName));
+            JwtSecurityToken jws = await AssertRequestSupported(async () => await ReleaseKeyAsync(keyName));
             Assert.IsTrue(jws.Payload.TryGetValue("response", out object response));
 
             JsonDocument doc = JsonDocument.Parse(response.ToString());


### PR DESCRIPTION
A recent change in Key Vault returned HTTP 400 when trying to import an exportable key, so ignore those errors for now as well.
