### PR TITLE
Better error message for Response<T> implicit cast from null

### DIFF
--- a/sdk/core/Azure.Core/src/ResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/ResponseOfT.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -32,7 +33,17 @@ namespace Azure
         /// Returns the value of this <see cref="Response{T}"/> object.
         /// </summary>
         /// <param name="response">The <see cref="Response{T}"/> instance.</param>
-        public static implicit operator T(Response<T> response) => response.Value;
+        public static implicit operator T(Response<T> response)
+        {
+            if (response == null)
+            {
+#pragma warning disable CA1065 // Don't throw from cast operators
+                throw new ArgumentNullException(nameof(response), $"The implicit cast from Response<{typeof(T)}> to {typeof(T)} failed because the Response<{typeof(T)}> was null.");
+#pragma warning restore CA1065
+            }
+
+            return response.Value;
+        }
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/core/Azure.Core/tests/ResponseTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseTests.cs
@@ -35,7 +35,10 @@ namespace Azure.Core.Tests
         public void ImplicitCastFromResponseTToNullFails()
         {
             Response<string> response = null;
-            var exception = Assert.Throws<ArgumentNullException>(() => _ = (string)response);
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                string s = response;
+            });
             StringAssert.StartsWith("The implicit cast from Response<System.String> to System.String failed because the Response<System.String> was null.", exception.Message);
         }
 

--- a/sdk/core/Azure.Core/tests/ResponseTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseTests.cs
@@ -32,6 +32,14 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public void ImplicitCastFromResponseTToNullFails()
+        {
+            Response<string> response = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => _ = (string)response);
+            StringAssert.StartsWith("The implicit cast from Response<System.String> to System.String failed because the Response<System.String> was null.", exception.Message);
+        }
+
+        [Test]
         public void ToStringsFormatsStatusAndValue()
         {
             var response = Response.FromValue(new TestPayload("test_name"), response: new MockResponse(200));


### PR DESCRIPTION
Makes the exception clearer for situations like https://github.com/Azure/azure-sdk-for-net/issues/25528