### PR TITLE
[Event Hubs Client] Idempotent Error Handling

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Azure.Messaging.EventHubs.Processor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29215.179
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.Processor", "src\Azure.Messaging.EventHubs.Processor.csproj", "{B9C4A45A-BD10-4C4C-B7BF-EE4F601AE7FC}"
 EndProject
@@ -13,7 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{79
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{87A3ED70-190D-4E6B-A568-40DF5B9F3939}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{0BFCCE8E-85FD-4DF7-8E5D-A6CE9ACDB175}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{00EBD345-7146-442E-8FC7-106FA5FC2A1A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{B0B9A0F1-50DE-4059-9A2D-51059D9A477C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,10 +39,14 @@ Global
 		{87A3ED70-190D-4E6B-A568-40DF5B9F3939}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{87A3ED70-190D-4E6B-A568-40DF5B9F3939}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{87A3ED70-190D-4E6B-A568-40DF5B9F3939}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0BFCCE8E-85FD-4DF7-8E5D-A6CE9ACDB175}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0BFCCE8E-85FD-4DF7-8E5D-A6CE9ACDB175}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0BFCCE8E-85FD-4DF7-8E5D-A6CE9ACDB175}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0BFCCE8E-85FD-4DF7-8E5D-A6CE9ACDB175}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00EBD345-7146-442E-8FC7-106FA5FC2A1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00EBD345-7146-442E-8FC7-106FA5FC2A1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00EBD345-7146-442E-8FC7-106FA5FC2A1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00EBD345-7146-442E-8FC7-106FA5FC2A1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0B9A0F1-50DE-4059-9A2D-51059D9A477C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0B9A0F1-50DE-4059-9A2D-51059D9A477C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0B9A0F1-50DE-4059-9A2D-51059D9A477C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0B9A0F1-50DE-4059-9A2D-51059D9A477C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -48,7 +54,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{7DFF0E65-DC9A-410D-9A11-AD6A06860FE1} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
 		{87A3ED70-190D-4E6B-A568-40DF5B9F3939} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
-		{0BFCCE8E-85FD-4DF7-8E5D-A6CE9ACDB175} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
+		{00EBD345-7146-442E-8FC7-106FA5FC2A1A} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
+		{B0B9A0F1-50DE-4059-9A2D-51059D9A477C} = {797FF941-76FD-45FD-AC17-A73DFE2BA621}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {44BD3BD5-61DF-464D-8627-E00B0BC4B3A3}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -13,11 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--    
-        TEMP: Move Core to a project reference until the
-              MessageWithMetadata are shipped in Azure.Core.
+    <!--
+        TEMP: Move Core to a project reference until the MessageWithMetadata are shipped in Azure.Core.
+
     <PackageReference Include="Azure.Core" />
     -->
+    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
+    <!-- END TEMP -->
 
     <!--
       TEMP: Move Event Hubs to a project reference until the

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/Azure.Messaging.EventHubs.Shared.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/Azure.Messaging.EventHubs.Shared.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29519.87
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Messaging.EventHubs.Shared", "src\Azure.Messaging.EventHubs.Shared.shproj", "{905C204B-E043-4219-84E1-DC90139EA643}"
 EndProject
@@ -13,9 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{10
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{870D6ACA-B778-40AA-93B5-43CF1D25235E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{07A39A33-E454-4404-85DC-42B603AEBD6D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{07A39A33-E454-4404-85DC-42B603AEBD6D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{E3B14DB9-48E1-4B7D-A384-3247163A1421}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{E3B14DB9-48E1-4B7D-A384-3247163A1421}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -94,6 +94,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{1AC14D43-837B-412F-BE15-F506B351CE72} = {10D9CACA-DDF6-4A56-8633-8595F9805837}
 		{870D6ACA-B778-40AA-93B5-43CF1D25235E} = {10D9CACA-DDF6-4A56-8633-8595F9805837}
+		{07A39A33-E454-4404-85DC-42B603AEBD6D} = {10D9CACA-DDF6-4A56-8633-8595F9805837}
+		{E3B14DB9-48E1-4B7D-A384-3247163A1421} = {10D9CACA-DDF6-4A56-8633-8595F9805837}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F5A1E14E-F9E2-4A0C-9EB0-F91C44298DC8}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
@@ -11,9 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{2DB233D3-E757-423C-8F8D-742B0AFF4713}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{6C67B4C6-0ABF-4E10-8BAF-FCF2AD053DE3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{FB10A6B3-88DD-4296-9241-53ECDF942842}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{FB10A6B3-88DD-4296-9241-53ECDF942842}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -84,14 +84,35 @@ Global
 		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x64.ActiveCfg = Release|Any CPU
 		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x64.Build.0 = Release|Any CPU
 		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x86.ActiveCfg = Release|Any CPU
+<<<<<<< HEAD
 		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x86.Build.0 = Release|Any CPU		
+=======
+		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x86.Build.0 = Release|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Debug|x64.Build.0 = Debug|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Debug|x86.Build.0 = Debug|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|x64.ActiveCfg = Release|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|x64.Build.0 = Release|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|x86.ActiveCfg = Release|Any CPU
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|x86.Build.0 = Release|Any CPU
+>>>>>>> b3d9d8605d ([Event Hubs Client] Idempotent Error Handling)
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
+<<<<<<< HEAD
 		{6C67B4C6-0ABF-4E10-8BAF-FCF2AD053DE3} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
+=======
+		{FB10A6B3-88DD-4296-9241-53ECDF942842} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
+		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
+>>>>>>> b3d9d8605d ([Event Hubs Client] Idempotent Error Handling)
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {509F2EE0-3348-4506-8AC7-9945B602CB43}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue for publishing with idempotent retries enabled where the client and service state could become out-of-sync for error scenarios with ambiguous outcomes. When this occurred, callers had no way to detect or correct the condition and it was possible that new events would fail to publish or be incorrectly identified as duplicates by the service. 
+
 ### Other Changes
 
 - Based on a new series of profiling and testing in real-world application scenarios, the default values for `EventProcessor<T>` load balancing are being updated to provide better performance and stability.  The default load balancing interval was changed from 10 seconds to 30 seconds.  The default ownership expiration interval was changed from 30 seconds to 2 minutes.  The default load balancing strategy has been changed from balanced to greedy.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf.csproj
@@ -13,9 +13,9 @@
 
    <ItemGroup>
     <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Management.EventHub" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="Polly" />
   </ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -258,7 +258,6 @@ namespace Azure.Messaging.EventHubs.Amqp
                         // again after the operation completes to provide best efforts in respecting it.
 
                         EventHubsEventSource.Log.EventReceiveStart(EventHubName, ConsumerGroup, PartitionId, operationId);
-                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                         link = await ReceiveLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout)).ConfigureAwait(false);
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -417,6 +416,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 return;
             }
 
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             _closed = true;
 
             var clientId = GetHashCode().ToString(CultureInfo.InvariantCulture);
@@ -425,7 +425,6 @@ namespace Azure.Messaging.EventHubs.Amqp
             try
             {
                 EventHubsEventSource.Log.ClientCloseStart(clientType, EventHubName, clientId);
-                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 if (ReceiveLink?.TryGetOpenedObject(out var _) == true)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -337,8 +337,6 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             // Initialize the properties by forcing the link to be opened.
 
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-
             var failedAttemptCount = 0;
             var tryTimeout = RetryPolicy.CalculateTryTimeout(0);
 
@@ -392,6 +390,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 return;
             }
 
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             _closed = true;
 
             var clientId = GetHashCode().ToString(CultureInfo.InvariantCulture);
@@ -400,7 +399,6 @@ namespace Azure.Messaging.EventHubs.Amqp
             try
             {
                 EventHubsEventSource.Log.ClientCloseStart(clientType, EventHubName, clientId);
-                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 if (SendLink?.TryGetOpenedObject(out var _) == true)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -14,11 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-     <!--    
-        TEMP: Move Core to a project reference until the
-              MessageWithMetadata are shipped in Azure.Core.
-            <PackageReference Include="Azure.Core" />
+     <!--
+        TEMP: Move Core to a project reference until the MessageWithMetadata are shipped in Azure.Core.
+
+    <PackageReference Include="Azure.Core" />
     -->
+    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
+    <!-- END TEMP -->
+
     <PackageReference Include="Azure.Core.Amqp" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
@@ -62,8 +65,5 @@
       <Link>Resources.resx</Link>
       <CustomToolNamespace>Azure.Messaging.EventHubs</CustomToolNamespace>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -7,8 +7,8 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 using Azure.Core;
-using Azure.Core.Serialization;
 using Azure.Core.Amqp;
+using Azure.Core.Serialization;
 using Azure.Messaging.EventHubs.Amqp;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Producer;
@@ -46,17 +46,6 @@ namespace Azure.Messaging.EventHubs
         {
             get => _amqpMessage.GetEventBody();
             set => _amqpMessage.Body = AmqpMessageBody.FromData(MessageBody.FromReadOnlyMemorySegment(value.ToMemory()));
-        }
-
-        /// <summary>
-        /// Hidden property that shadows the <see cref="EventBody"/> property. This is added
-        /// in order to inherit from <see cref="MessageWithMetadata"/>.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override BinaryData Data
-        {
-            get => EventBody;
-            set => EventBody = value;
         }
 
         /// <summary>
@@ -108,9 +97,22 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        /// Hidden property that indicates that the <see cref="EventData"/> is not read-only. This is part of
-        /// the <see cref="MessageWithMetadata"/> abstraction.
+        ///   Hidden property that shadows the <see cref="EventBody"/> property. This is added
+        ///   in order to inherit from <see cref="MessageWithMetadata"/>.
         /// </summary>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override BinaryData Data
+        {
+            get => EventBody;
+            set => EventBody = value;
+        }
+
+        /// <summary>
+        ///   Hidden property that indicates that the <see cref="EventData"/> is not read-only. This is part of
+        ///   the <see cref="MessageWithMetadata"/> abstraction.
+        /// </summary>
+        ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool IsReadOnly => false;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -352,6 +352,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <param name="connection">The connection to use as the basis for delegation of client-type operations.</param>
         /// <param name="transportProducer">The transport producer instance to use as the basis for service communication.</param>
         /// <param name="partitionProducerPool">A <see cref="TransportProducerPool" /> used to manage a set of partition specific <see cref="TransportProducer" />.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the producer.</param>
         ///
         /// <remarks>
         ///   This constructor is intended to be used internally for functional
@@ -360,7 +361,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         internal EventHubProducerClient(EventHubConnection connection,
                                         TransportProducer transportProducer,
-                                        TransportProducerPool partitionProducerPool = default)
+                                        TransportProducerPool partitionProducerPool = default,
+                                        EventHubProducerClientOptions clientOptions = default)
         {
             Argument.AssertNotNull(connection, nameof(connection));
             Argument.AssertNotNull(transportProducer, nameof(transportProducer));
@@ -368,7 +370,7 @@ namespace Azure.Messaging.EventHubs.Producer
             OwnsConnection = false;
             Connection = connection;
             RetryPolicy = new EventHubsRetryOptions().ToRetryPolicy();
-            Options = new EventHubProducerClientOptions();
+            Options = clientOptions?.Clone() ?? new EventHubProducerClientOptions();
             Identifier = Guid.NewGuid().ToString();
             PartitionProducerPool = partitionProducerPool ?? new TransportProducerPool(partitionId => transportProducer);
 
@@ -498,7 +500,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// </remarks>
         ///
         internal virtual async Task<PartitionPublishingPropertiesInternal> GetPartitionPublishingPropertiesAsync(string partitionId,
-                                                                                                         CancellationToken cancellationToken = default)
+                                                                                                                 CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubProducerClient));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
@@ -957,20 +959,24 @@ namespace Azure.Messaging.EventHubs.Producer
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 EventHubsEventSource.Log.IdempotentPublishStart(EventHubName, options.PartitionId);
 
+                var resetStateOnError = false;
+                var releaseGuard = false;
                 var partitionState = PartitionState.GetOrAdd(options.PartitionId, new PartitionPublishingState(options.PartitionId));
 
                 try
                 {
-                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                    if (!partitionState.PublishingGuard.Wait(100, cancellationToken))
+                    {
+                        await partitionState.PublishingGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
 
-                    await partitionState.PublishingGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    releaseGuard = true;
                     EventHubsEventSource.Log.IdempotentSynchronizationAcquire(EventHubName, options.PartitionId);
 
                     // Ensure that the partition state has been initialized.
 
                     if (!partitionState.IsInitialized)
                     {
-                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                         await InitializePartitionStateAsync(partitionState, cancellationToken).ConfigureAwait(false);
                     }
 
@@ -989,7 +995,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                     // Publish the events.
 
-                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                    resetStateOnError = true;
 
                     EventHubsEventSource.Log.IdempotentSequencePublish(EventHubName, options.PartitionId, firstSequence, lastSequence);
                     await SendInternalAsync(eventSet, options, cancellationToken).ConfigureAwait(false);
@@ -1013,12 +1019,40 @@ namespace Azure.Messaging.EventHubs.Producer
                         eventData.ClearPublishingState();
                     }
 
+                    if (resetStateOnError)
+                    {
+                        // Reset the partition state and options to ensure that future attempts
+                        // are safe and do not risk data loss by reusing the same producer group identifier.
+
+                        if (!Options.PartitionOptions.TryGetValue(options.PartitionId, out var partitionOptions))
+                        {
+                            partitionOptions = new PartitionPublishingOptionsInternal();
+                            Options.PartitionOptions[options.PartitionId] = partitionOptions;
+                        }
+
+                        partitionOptions.ProducerGroupId = null;
+                        partitionOptions.OwnerLevel = null;
+                        partitionOptions.StartingSequenceNumber = null;
+
+                        partitionState.ProducerGroupId = null;
+                        partitionState.OwnerLevel = null;
+                        partitionState.LastPublishedSequenceNumber = null;
+
+                        // Expire the transport producer associated with the partition, to ensure
+                        // that the new idempotent state is used for the next publishing operation.
+
+                        await PartitionProducerPool.ExpirePooledProducerAsync(options.PartitionId, forceClose: true).ConfigureAwait(false);
+                    }
+
                     throw;
                 }
                 finally
                 {
-                    partitionState.PublishingGuard.Release();
-                    EventHubsEventSource.Log.IdempotentSynchronizationRelease(EventHubName, options.PartitionId);
+                    if (releaseGuard)
+                    {
+                        partitionState.PublishingGuard.Release();
+                        EventHubsEventSource.Log.IdempotentSynchronizationRelease(EventHubName, options.PartitionId);
+                    }
                 }
             }
             catch (Exception ex)
@@ -1052,6 +1086,8 @@ namespace Azure.Messaging.EventHubs.Producer
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 EventHubsEventSource.Log.IdempotentPublishStart(EventHubName, options.PartitionId);
 
+                var resetStateOnError = false;
+                var releaseGuard = false;
                 var partitionState = PartitionState.GetOrAdd(options.PartitionId, new PartitionPublishingState(options.PartitionId));
 
                 var eventSet = eventBatch.AsEnumerable<EventData>() switch
@@ -1062,16 +1098,18 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 try
                 {
-                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                    if (!partitionState.PublishingGuard.Wait(100, cancellationToken))
+                    {
+                        await partitionState.PublishingGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
 
-                    await partitionState.PublishingGuard.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    releaseGuard = true;
                     EventHubsEventSource.Log.IdempotentSynchronizationAcquire(EventHubName, options.PartitionId);
 
                     // Ensure that the partition state has been initialized.
 
                     if (!partitionState.IsInitialized)
                     {
-                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                         await InitializePartitionStateAsync(partitionState, cancellationToken).ConfigureAwait(false);
                     }
 
@@ -1090,7 +1128,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                     // Publish the events.
 
-                    cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                    resetStateOnError = true;
 
                     EventHubsEventSource.Log.IdempotentSequencePublish(EventHubName, options.PartitionId, firstSequence, lastSequence);
                     await SendInternalAsync(eventBatch, cancellationToken).ConfigureAwait(false);
@@ -1111,12 +1149,40 @@ namespace Azure.Messaging.EventHubs.Producer
                         eventData.ClearPublishingState();
                     }
 
+                    if (resetStateOnError)
+                    {
+                        // Reset the partition state and options to ensure that future attempts
+                        // are safe and do not risk data loss by reusing the same producer group identifier.
+
+                            if (!Options.PartitionOptions.TryGetValue(options.PartitionId, out var partitionOptions))
+                        {
+                            partitionOptions = new PartitionPublishingOptionsInternal();
+                            Options.PartitionOptions[options.PartitionId] = partitionOptions;
+                        }
+
+                        partitionOptions.ProducerGroupId = null;
+                        partitionOptions.OwnerLevel = null;
+                        partitionOptions.StartingSequenceNumber = null;
+
+                        partitionState.ProducerGroupId = null;
+                        partitionState.OwnerLevel = null;
+                        partitionState.LastPublishedSequenceNumber = null;
+
+                        // Expire the transport producer associated with the partition, to ensure
+                        // that the new idempotent state is used for the next publishing operation.
+
+                        await PartitionProducerPool.ExpirePooledProducerAsync(options.PartitionId, forceClose: true).ConfigureAwait(false);
+                    }
+
                     throw;
                 }
                 finally
                 {
-                    partitionState.PublishingGuard.Release();
-                    EventHubsEventSource.Log.IdempotentSynchronizationRelease(EventHubName, options.PartitionId);
+                    if (releaseGuard)
+                    {
+                        partitionState.PublishingGuard.Release();
+                        EventHubsEventSource.Log.IdempotentSynchronizationRelease(EventHubName, options.PartitionId);
+                    }
                 }
             }
             catch (Exception ex)
@@ -1361,7 +1427,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static PartitionPublishingPropertiesInternal CreatePublishingPropertiesFromPartitionState(EventHubProducerClientOptions options,
-                                                                                                  PartitionPublishingState state) =>
+                                                                                                          PartitionPublishingState state) =>
                     new PartitionPublishingPropertiesInternal(options.EnableIdempotentPartitions,
                                                       state.ProducerGroupId,
                                                       state.OwnerLevel,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -1141,7 +1141,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            await producer.SendAsync(events, sendOptions);
+            await producer.SendAsync(events, sendOptions, cancellationSource.Token);
 
             for (var index = 0; index < events.Length; ++index)
             {
@@ -1190,7 +1190,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            Assert.That(async () => await producer.SendAsync(events, sendOptions), Throws.Exception, "The send operation should have failed.");
+            Assert.That(async () => await producer.SendAsync(events, sendOptions, cancellationSource.Token), Throws.Exception, "The send operation should have failed.");
 
             for (var index = 0; index < events.Length; ++index)
             {
@@ -1201,7 +1201,82 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionStateCollection = GetPartitionState(producer);
             Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
             Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
-            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence), "The sequence number for partition state should have been rolled back.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.Null, "The sequence number for partition state should have been reset.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentUpdatesProducerGroupIdOnFailure()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingPropertiesInternal(true, 123, 456, startingSequence);
+            var events = EventGenerator.CreateEvents(eventCount).ToArray();
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new OverflowException()));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            Assert.That(async () => await producer.SendAsync(events, sendOptions, cancellationSource.Token), Throws.Exception, "The send operation should have failed.");
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.ProducerGroupId, Is.Not.EqualTo(expectedProperties.ProducerGroupId), "The producer group identifier in partition state should have been changed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentExpiresTheTransportProducerOnFailure()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingPropertiesInternal(true, 123, 456, startingSequence);
+            var events = EventGenerator.CreateEvents(eventCount).ToArray();
+            var sendOptions = new SendEventOptions { PartitionId = expectedPartition };
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+            var mockTransportProducerPool = new MockTransportProducerPool(mockTransport.Object, connection, new BasicRetryPolicy(new EventHubsRetryOptions()));
+            var producer = new EventHubProducerClient(connection, mockTransport.Object, mockTransportProducerPool, new EventHubProducerClientOptions { EnableIdempotentPartitions = true });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new OverflowException()));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            Assert.That(async () => await producer.SendAsync(events, sendOptions, cancellationSource.Token), Throws.Exception, "The send operation should have failed.");
+            Assert.That(mockTransportProducerPool.ExpirePooledProducerAsyncWasCalled, Is.True, "The transport producer should have been expired.");
         }
 
         /// <summary>
@@ -1644,7 +1719,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            await producer.SendAsync(batch);
+            await producer.SendAsync(batch, cancellationSource.Token);
             Assert.That(batch.StartingPublishedSequenceNumber, Is.EqualTo(startingSequence + 1), "The batch did not have the correct starting sequence number.");
 
             var partitionStateCollection = GetPartitionState(producer);
@@ -1687,13 +1762,86 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
-            Assert.That(async () => await producer.SendAsync(batch), Throws.Exception, "The send operation should have failed.");
+            Assert.That(async () => await producer.SendAsync(batch, cancellationSource.Token), Throws.Exception, "The send operation should have failed.");
             Assert.That(batch.StartingPublishedSequenceNumber, Is.Null, "The batch should not have a starting sequence number.");
 
             var partitionStateCollection = GetPartitionState(producer);
             Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
             Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
-            Assert.That(partitionState.LastPublishedSequenceNumber, Is.EqualTo(startingSequence), "The sequence number for partition state should have been rolled back.");
+            Assert.That(partitionState.LastPublishedSequenceNumber, Is.Null, "The sequence number for partition state should have been reset.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentUpdatesProducerGroupIdOnFailureWithABatch()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingPropertiesInternal(true, 123, 456, startingSequence);
+            var batch = new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = true
+            });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new OverflowException()));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            Assert.That(async () => await producer.SendAsync(batch, cancellationSource.Token), Throws.Exception, "The send operation should have failed.");
+
+            var partitionStateCollection = GetPartitionState(producer);
+            Assert.That(partitionStateCollection, Is.Not.Null, "The collection for partition state should have been initialized with the client.");
+            Assert.That(partitionStateCollection.TryGetValue(expectedPartition, out var partitionState), Is.True, "The state collection should have an entry for the partition.");
+            Assert.That(partitionState.ProducerGroupId, Is.Not.EqualTo(expectedProperties.ProducerGroupId), "The producer group identifier in partition state should have been changed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendIdempotentExpiresTheTransportProducerOnFailureWithABatch()
+        {
+            var expectedPartition = "5";
+            var eventCount = 5;
+            var startingSequence = 435;
+            var expectedProperties = new PartitionPublishingPropertiesInternal(true, 123, 456, startingSequence);
+            var batch = new EventDataBatch(new MockTransportBatch(eventCount), "ns", "eh", new CreateBatchOptions { PartitionId = expectedPartition });
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+            var mockTransportProducerPool = new MockTransportProducerPool(mockTransport.Object, connection, new BasicRetryPolicy(new EventHubsRetryOptions()));
+            var producer = new EventHubProducerClient(connection, mockTransport.Object, mockTransportProducerPool, new EventHubProducerClientOptions { EnableIdempotentPartitions = true });
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedProperties);
+
+            mockTransport
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new OverflowException()));
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            Assert.That(async () => await producer.SendAsync(batch, cancellationSource.Token), Throws.Exception, "The send operation should have failed.");
+            Assert.That(mockTransportProducerPool.ExpirePooledProducerAsyncWasCalled, Is.True, "The transport producer should have been expired.");
         }
 
         /// <summary>
@@ -2829,6 +2977,7 @@ namespace Azure.Messaging.EventHubs.Tests
         private class MockTransportProducerPool : TransportProducerPool
         {
             public bool GetPooledProducerWasCalled { get; set; }
+            public bool ExpirePooledProducerAsyncWasCalled { get; set; }
 
             public MockPooledProducer MockPooledProducer { get; }
 
@@ -2846,6 +2995,12 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 GetPooledProducerWasCalled = true;
                 return MockPooledProducer;
+            }
+
+            public override Task ExpirePooledProducerAsync(string partitionId, bool forceClose = false)
+            {
+                ExpirePooledProducerAsyncWasCalled = true;
+                return Task.CompletedTask;
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -52,6 +52,121 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   The pool periodically removes and closes expired items.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ExpireRemovesTheRequestedItem()
+        {
+            var wasFactoryCalled = false;
+            var transportProducer = new ObservableTransportProducerMock();
+
+            var startingPool = new ConcurrentDictionary<string, TransportProducerPool.PoolItem>
+            {
+                ["0"] = new TransportProducerPool.PoolItem("0", transportProducer),
+                ["1"] = new TransportProducerPool.PoolItem("1", transportProducer),
+                ["2"] = new TransportProducerPool.PoolItem("2", transportProducer),
+            };
+
+            Func<string, TransportProducer> producerFactory = partition =>
+            {
+                wasFactoryCalled = true;
+                return transportProducer;
+            };
+
+            var transportProducerPool = new TransportProducerPool(producerFactory, pool: startingPool, eventHubProducer: transportProducer);
+
+            // Validate the initial state.
+
+            Assert.That(startingPool.TryGetValue("0", out _), Is.True, "The requested partition should appear in the pool.");
+            Assert.That(wasFactoryCalled, Is.False, "No producer should not have been created.");
+            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(0), "The producer should not have been closed.");
+
+            // Expire the producer and validate the removal state.
+
+            await transportProducerPool.ExpirePooledProducerAsync("0");
+
+            Assert.That(startingPool.TryGetValue("0", out _), Is.False, "The requested partition should have been removed.");
+            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(1), "The producer should have been closed.");
+            Assert.That(wasFactoryCalled, Is.False, "The requested partition should not have been created.");
+
+            // Request the producer again and validate a new producer is created.
+
+            Assert.That(transportProducerPool.GetPooledProducer("0"), Is.Not.Null, "The requested partition should be available.");
+            Assert.That(wasFactoryCalled, Is.True, "A new producer for the requested partition should have been created.");
+        }
+
+        /// <summary>
+        ///   The pool periodically removes and closes expired items.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ExpireCoseNotCloseTheRemovedItemWhenInUse()
+        {
+            var transportProducer = new ObservableTransportProducerMock();
+
+            var startingPool = new ConcurrentDictionary<string, TransportProducerPool.PoolItem>
+            {
+                ["0"] = new TransportProducerPool.PoolItem("0", transportProducer),
+                ["1"] = new TransportProducerPool.PoolItem("1", transportProducer),
+                ["2"] = new TransportProducerPool.PoolItem("2", transportProducer),
+            };
+
+            var transportProducerPool = new TransportProducerPool(partition => transportProducer, pool: startingPool, eventHubProducer: transportProducer);
+
+            // Validate the initial state.
+
+            Assert.That(startingPool.TryGetValue("0", out _), Is.True, "The requested partition should appear in the pool.");
+            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(0), "The producer should not have been closed.");
+
+            // Request the producer and hold the reference to ensure that it is flagged as being in use.
+
+            await using var poolItem = transportProducerPool.GetPooledProducer("0");
+
+            // Expire the producer and validate the removal state.
+
+            await transportProducerPool.ExpirePooledProducerAsync("0", forceClose: false);
+
+            Assert.That(startingPool.TryGetValue("0", out _), Is.False, "The requested partition should have been removed.");
+            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(0), "The producer should not have been closed.");
+        }
+
+        /// <summary>
+        ///   The pool periodically removes and closes expired items.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ExpireClosesTheRemovedItemWhenForced()
+        {
+            var transportProducer = new ObservableTransportProducerMock();
+
+            var startingPool = new ConcurrentDictionary<string, TransportProducerPool.PoolItem>
+            {
+                ["0"] = new TransportProducerPool.PoolItem("0", transportProducer),
+                ["1"] = new TransportProducerPool.PoolItem("1", transportProducer),
+                ["2"] = new TransportProducerPool.PoolItem("2", transportProducer),
+            };
+
+            var transportProducerPool = new TransportProducerPool(partition => transportProducer, pool: startingPool, eventHubProducer: transportProducer);
+
+            // Validate the initial state.
+
+            Assert.That(startingPool.TryGetValue("0", out _), Is.True, "The requested partition should appear in the pool.");
+            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(0), "The producer should not have been closed.");
+
+            // Request the producer and hold the reference to ensure that it is flagged as being in use.
+
+            await using var poolItem = transportProducerPool.GetPooledProducer("0");
+
+            // Expire the producer and validate the removal state.
+
+            await transportProducerPool.ExpirePooledProducerAsync("0", forceClose: true);
+
+            Assert.That(startingPool.TryGetValue("0", out _), Is.False, "The requested partition should have been removed.");
+            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(1), "The producer should have been closed.");
+        }
+
+        /// <summary>
         ///   When a <see cref="TransportProducerPool.PoolItem" /> is requested
         ///   its <see cref="TransportProducerPool.PoolItem.RemoveAfter" /> will be increased.
         /// </summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to ensure that the AMQP connection and link states are fully reset on any exception after retries are exhausted in order to ensure no data loss.

In error scenarios with ambiguous outcomes, it is possible for the client and service state for idempotent sequencing to become out-of-sync with no way to detect or correct the problem.  When this happens, it is possible that events being published are incorrectly identified by the service as duplicates and their receipt acknowledged.  This leads the client to signal to callers that publishing was successful, though the events were ignored by the service and will never be available to be read.

By resetting the connection and forcing the client to use a new publisher identifier, the service will reset state and perform the initial handshake with the client, ensuring that state is properly synchronized between them.