### PR TITLE
Revert "Use working region/subscription for search deployments"

### DIFF
--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -6,9 +6,7 @@ extends:
     ServiceDirectory: search
     TimeoutInMinutes: 240
     MaxParallel: 2
-    # TODO: change 'Preview' cloud back to public after search RP fixes deletion metadata issue
-    # https://github.com/Azure/azure-sdk-tools/issues/2216
-    Clouds: 'Preview'
-    SupportedClouds: 'Preview,UsGov,China'
+    UnsupportedClouds: 'Canary'
+    SupportedClouds: 'Public,UsGov,China'
     EnvVars:
       AZURE_SEARCH_TEST_MODE: Live


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#25113

The above PR was a temporary workaround fix for an RP deletion metadata issue. Checking to see if it is resolved now.