### PR TITLE
Remove canary from default weekly live testing clouds

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -7,7 +7,7 @@ parameters:
   default: 'Public'
 - name: SupportedClouds
   type: string
-  default: 'Public,Canary'
+  default: 'Public'
 - name: UnsupportedClouds
   type: string
   default: ''
@@ -102,9 +102,6 @@ variables:
 
 stages:
 - ${{ each cloud in parameters.CloudConfig }}:
-  # TODO: re-enable tests-weekly allow filter once sovereign cloud live tests are stable: https://github.com/Azure/azure-sdk/issues/2074
-  # Run all clouds by default for weekly test pipeline, except for clouds specifically unsupported by the calling pipeline
-  # - ${{ if or(contains(parameters.Clouds, cloud.key), contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
   - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'tests-weekly'), contains(parameters.SupportedClouds, cloud.key))) }}:
     - ${{ if not(contains(parameters.UnsupportedClouds, cloud.key)) }}:
       - stage: ${{ cloud.key }}


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-tools/issues/1781

@weshaggard related to the discussion in ^^, I think it adds too much complexity to have a separate "additional clouds" parameter. We already have a bunch of parameters like this where you can pick one to override the default, or the other to append to the default, and it trips people up from time to time. I think in this case given that the set is very static (it will only be changed if we add another sovereign cloud to Azure), the tradeoff is in favor of a single parameter. It also makes it clear at to the tests.yml reader which clouds will actually be tested vs. having to dig into the pipeline template to get the full set.

If this PR goes through on tests and reviews, I'll put ones up for the other repos.