### PR TITLE
Update smoke test dependencies

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -16,15 +16,15 @@
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.0" />
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.3.0-beta.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.9.1" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.3" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.35.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.15.0" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.6" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.36.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.16.2" />
 
     <!-- This is needed to resolve a build conflict and force the correct version -->
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
 
     <!-- This is needed for non-nightly smoke test runs -->
-    <PackageReference Include="Azure.Template" Version="1.0.2" />
+    <PackageReference Include="Azure.Template" Version="1.0.3-beta.1218030" />
   </ItemGroup>
 
   <!-- Sample: IoT Hub Connection String Translation -->


### PR DESCRIPTION
This is a quick fix to update the smoke test dependencies outside of the feeds we auto-update from
as well as the hardcoded dependencies to enable `dotnet restore`. This should only be temporary as this project is
going to be superseded soon.
