### PR TITLE
AOA Conversion cleanup

### DIFF
--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetConversionOperation.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetConversionOperation.cs
@@ -12,7 +12,7 @@ using Azure.Core.Pipeline;
 namespace Azure.MixedReality.ObjectAnchors.Conversion
 {
     /// <summary>
-    /// A long running asset conversion process for Object Anchors
+    /// A long running asset conversion process for Object Anchors.
     /// </summary>
     public class AssetConversionOperation : Operation<AssetConversionProperties>
     {
@@ -61,7 +61,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         public override bool HasValue => _lastConversionResponse != null;
 
         /// <summary>
-        /// Whether the operation has completed and has a successful final status
+        /// Whether the operation has completed and has a successful final status.
         /// </summary>
         public bool HasCompletedSuccessfully => HasCompleted && HasValue && (this.Value.ConversionStatus == AssetConversionStatus.Succeeded);
 

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileType.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileType.cs
@@ -8,7 +8,7 @@ using System.IO;
 namespace Azure.MixedReality.ObjectAnchors.Conversion
 {
     /// <summary>
-    /// An extensible enum representing the filetype of the asset
+    /// An extensible enum representing the filetype of the asset.
     /// </summary>
     public readonly struct AssetFileType : IEquatable<AssetFileType>
     {
@@ -22,44 +22,44 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// Initializes a new instance of the <see cref="AssetFileType"/> struct.
         /// </summary>
-        /// <param name="value">The asset file type</param>
+        /// <param name="value">The asset file type.</param>
         public AssetFileType(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
-        /// Returns an AssetFileType derived from the extension of a provided file name
+        /// Returns an AssetFileType derived from the extension of a provided file name.
         /// </summary>
-        /// <param name="assetFilePath">The asset file name</param>
-        /// <returns>The AssetFileType derived from the extension of a provided file name</returns>
+        /// <param name="assetFilePath">The asset file name.</param>
+        /// <returns>The AssetFileType derived from the extension of a provided file name.</returns>
         public static AssetFileType FromFilePath(string assetFilePath)
         {
             return new AssetFileType(Path.GetExtension(assetFilePath));
         }
 
         /// <summary>
-        /// Fbx
+        /// The FBX asset file type.
         /// </summary>
         public static AssetFileType Fbx { get; } = new AssetFileType(FbxValue);
 
         /// <summary>
-        /// Glb
+        /// The GLB asset file type.
         /// </summary>
         public static AssetFileType Glb { get; } = new AssetFileType(GlbValue);
 
         /// <summary>
-        /// Gltf
+        /// The GLTF asset file type.
         /// </summary>
         public static AssetFileType Gltf { get; } = new AssetFileType(GltfValue);
 
         /// <summary>
-        /// Obj
+        /// The OBJ asset file type.
         /// </summary>
         public static AssetFileType Obj { get; } = new AssetFileType(ObjValue);
 
         /// <summary>
-        /// Ply
+        /// The PLY asset file type.
         /// </summary>
         public static AssetFileType Ply { get; } = new AssetFileType(PlyValue);
 

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileTypeNotSupportedException.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/AssetFileTypeNotSupportedException.cs
@@ -9,12 +9,12 @@ using Azure.Core;
 namespace Azure.MixedReality.ObjectAnchors.Conversion
 {
     /// <summary>
-    /// An Exception thrown during an attempt to provide an unsupported asset file type in an asset conversion operation
+    /// An Exception thrown during an attempt to provide an unsupported asset file type in an asset conversion operation.
     /// </summary>
     public class AssetFileTypeNotSupportedException : Exception, ISerializable
     {
         /// <summary>
-        /// Creates an instance of the <see cref="AssetFileTypeNotSupportedException"/>
+        /// Creates an instance of the <see cref="AssetFileTypeNotSupportedException"/>.
         /// </summary>
         public AssetFileTypeNotSupportedException()
             : base($"The provided asset file type is unsupported by Azure Object Anchors for conversion.")
@@ -22,19 +22,19 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// Creates an instance of the <see cref="AssetFileTypeNotSupportedException"/>
+        /// Creates an instance of the <see cref="AssetFileTypeNotSupportedException"/>.
         /// </summary>
-        /// <param name="message">The message corresponding to the exception</param>
+        /// <param name="message">The message corresponding to the exception.</param>
         public AssetFileTypeNotSupportedException(string message)
             : base(message)
         {
         }
 
         /// <summary>
-        /// Creates an Exception thrown during an attempt to provide an unsupported asset file type in an asset conversion operation
+        /// Creates an Exception thrown during an attempt to provide an unsupported asset file type in an asset conversion operation.
         /// </summary>
-        /// <param name="message">The message corresponding to the exception</param>
-        /// <param name="inner">The inner exception</param>
+        /// <param name="message">The message corresponding to the exception.</param>
+        /// <param name="inner">The inner exception.</param>
         public AssetFileTypeNotSupportedException(string message, Exception inner)
             : base(message, inner)
         {
@@ -59,10 +59,10 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// An Exception thrown during an attempt to provide an unsupported asset file type in an asset conversion operation
+        /// An Exception thrown during an attempt to provide an unsupported asset file type in an asset conversion operation.
         /// </summary>
-        /// <param name="info">The SerializationInfo</param>
-        /// <param name="context">The StreamingContext</param>
+        /// <param name="info">The <see cref="SerializationInfo"/>.</param>
+        /// <param name="context">The <see cref="StreamingContext"/>.</param>
         protected AssetFileTypeNotSupportedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -71,12 +71,12 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// The unsupported filetype provided for asset conversion
+        /// The unsupported filetype provided for asset conversion.
         /// </summary>
         public AssetFileType AttemptedFileType { get; }
 
         /// <summary>
-        /// The list of file types supported by Azure Object Anchors Conversion
+        /// The list of file types supported by Azure Object Anchors Conversion.
         /// </summary>
         public IReadOnlyList<AssetFileType> SupportedAssetFileTypes { get; }
     }

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetConversionConfiguration.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetConversionConfiguration.cs
@@ -15,7 +15,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
     public partial class AssetConversionConfiguration
     {
         /// <summary>
-        /// Creates an asset conversion configuration from the gravity vector and a model scale
+        /// Creates an asset conversion configuration from the gravity vector and a model scale.
         /// </summary>
         /// <param name="gravity">Gravity vector with respect to object's nominal position.</param>
         /// <param name="scale">Scale of transformation of asset units into meter space.</param>
@@ -29,7 +29,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// Creates an asset conversion configuration from the gravity vector and a model scale
+        /// Creates an asset conversion configuration from the gravity vector and a model scale.
         /// </summary>
         /// <param name="gravityWrapper">Gravity vector with respect to object's nominal position.</param>
         /// <param name="scale">Scale of transformation of asset units into meter space.</param>

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetConversionProperties.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/AssetConversionProperties.cs
@@ -46,19 +46,19 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// The status of the AOA asset conversion job
+        /// The status of the AOA asset conversion job.
         /// </summary>
         [CodeGenMember("JobStatus")]
         public AssetConversionStatus? ConversionStatus { get; internal set; }
 
         /// <summary>
-        /// The configuration of the AOA asset conversion job
+        /// The configuration of the AOA asset conversion job.
         /// </summary>
         [CodeGenMember("IngestionConfiguration")]
         public AssetConversionConfiguration ConversionConfiguration { get; internal set; }
 
         /// <summary>
-        /// The error code of the AOA asset conversion job
+        /// The error code of the AOA asset conversion job.
         /// </summary>
         public ConversionErrorCode ErrorCode { get; }
 

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Quaternion.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Quaternion.cs
@@ -14,22 +14,22 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         private System.Numerics.Quaternion data;
 
         /// <summary>
-        /// Creates a autorest-defined Quaternion given its Numerics equivalent
+        /// Creates a autorest-defined Quaternion given its Numerics equivalent.
         /// </summary>
-        /// <param name="quaternion">The numerics quaternion</param>
+        /// <param name="quaternion">The numerics quaternion.</param>
         internal Quaternion(System.Numerics.Quaternion quaternion)
         {
             data = quaternion;
         }
 
         /// <summary>
-        /// Creates a autorest-defined Quaternion given its fields
+        /// Creates a autorest-defined Quaternion given its fields.
         /// </summary>
-        /// <param name="x">X component</param>
-        /// <param name="y">Y component</param>
-        /// <param name="z">Z component</param>
-        /// <param name="w">W component</param>
-        /// <param name="isIdentity">Unused</param>
+        /// <param name="x">X component.</param>
+        /// <param name="y">Y component.</param>
+        /// <param name="z">Z component.</param>
+        /// <param name="w">W component.</param>
+        /// <param name="isIdentity">Unused.</param>
 #pragma warning disable CA1801 // Review unused parameters
         internal Quaternion(float x, float y, float z, float w, bool isIdentity) : this(x, y, z, w)
 #pragma warning restore CA1801 // Review unused parameters
@@ -37,47 +37,47 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         }
 
         /// <summary>
-        /// Creates a autorest-defined Quaternion given its fields
+        /// Creates a autorest-defined Quaternion given its fields.
         /// </summary>
-        /// <param name="x">X component</param>
-        /// <param name="y">Y component</param>
-        /// <param name="z">Z component</param>
-        /// <param name="w">W component</param>
+        /// <param name="x">X component.</param>
+        /// <param name="y">Y component.</param>
+        /// <param name="z">Z component.</param>
+        /// <param name="w">W component.</param>
         internal Quaternion(float x, float y, float z, float w)
         {
             data = new System.Numerics.Quaternion(x, y, z, w);
         }
 
         /// <summary>
-        /// X component
+        /// X component.
         /// </summary>
         public float X { get { return data.X; } set { data.X = value; } }
 
         /// <summary>
-        /// Y component
+        /// Y component.
         /// </summary>
         public float Y { get { return data.Y; } set { data.Y = value; } }
 
         /// <summary>
-        /// Z component
+        /// Z component.
         /// </summary>
         public float Z { get { return data.Z; } set { data.Z = value; } }
 
         /// <summary>
-        /// W component
+        /// W component.
         /// </summary>
         public float W { get { return data.W; } set { data.W = value; } }
 
         /// <summary>
-        /// Gets a value that indicates whether the current instance is the identity quaternion
+        /// Gets a value that indicates whether the current instance is the identity quaternion.
         /// </summary>
         public bool IsIdentity { get => data.IsIdentity; }
 
         /// <summary>
-        /// Assesses equality with another quaternion
+        /// Assesses equality with another quaternion.
         /// </summary>
-        /// <param name="other">The other quaternion being compared to</param>
-        /// <returns>Whether the two are equal</returns>
+        /// <param name="other">The other quaternion being compared to.</param>
+        /// <returns>Whether the two are equal.</returns>
         public bool Equals(Quaternion other)
         {
             return this.data.Equals(other.data);

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/TrajectoryPose.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/TrajectoryPose.cs
@@ -15,20 +15,20 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
     public partial struct TrajectoryPose : IEquatable<TrajectoryPose>
     {
         /// <summary>
-        /// Creates the Pose of a trajectory
+        /// Creates the Pose of a trajectory.
         /// </summary>
-        /// <param name="rotation">The pose's rotation</param>
-        /// <param name="translation">The pose's translation</param>
+        /// <param name="rotation">The pose's rotation.</param>
+        /// <param name="translation">The pose's translation.</param>
         internal TrajectoryPose(System.Numerics.Quaternion rotation, System.Numerics.Vector3 translation)
             : this(new Quaternion(rotation), new Vector3(translation))
         {
         }
 
         /// <summary>
-        /// Creates the Pose of a trajectory
+        /// Creates the Pose of a trajectory.
         /// </summary>
-        /// <param name="rotationWrapper">The pose's rotation</param>
-        /// <param name="translationWrapper">The pose's translation</param>
+        /// <param name="rotationWrapper">The pose's rotation.</param>
+        /// <param name="translationWrapper">The pose's translation.</param>
         internal TrajectoryPose(Quaternion rotationWrapper, Vector3 translationWrapper)
         {
             RotationWrapper = rotationWrapper;
@@ -52,7 +52,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         internal readonly Vector3 TranslationWrapper;
 
         /// <summary>
-        /// Returns whether a Trajectory pose's content matches that of another
+        /// Returns whether a Trajectory pose's content matches that of another.
         /// </summary>
         public bool Equals(TrajectoryPose other)
         {

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Vector3.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Vector3.cs
@@ -14,45 +14,45 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         private System.Numerics.Vector3 data;
 
         /// <summary>
-        /// Creates a autorest-defined Vector3 given its Numerics equivalent
+        /// Creates a autorest-defined Vector3 given its Numerics equivalent.
         /// </summary>
-        /// <param name="vector">The numerics vector</param>
+        /// <param name="vector">The numerics vector.</param>
         internal Vector3(System.Numerics.Vector3 vector)
         {
             data = vector;
         }
 
         /// <summary>
-        /// Creates a autorest-defined Vector3 given its fields
+        /// Creates a autorest-defined Vector3 given its fields.
         /// </summary>
-        /// <param name="x">X component</param>
-        /// <param name="y">Y component</param>
-        /// <param name="z">Z component</param>
+        /// <param name="x">X component.</param>
+        /// <param name="y">Y component.</param>
+        /// <param name="z">Z component.</param>
         internal Vector3(float x, float y, float z)
         {
             data = new System.Numerics.Vector3(x, y, z);
         }
 
         /// <summary>
-        /// X component
+        /// X component.
         /// </summary>
         public float X { get { return data.X; } set { data.X = value; } }
 
         /// <summary>
-        /// Y component
+        /// Y component.
         /// </summary>
         public float Y { get { return data.Y; } set { data.Y = value; } }
 
         /// <summary>
-        /// Z component
+        /// Z component.
         /// </summary>
         public float Z { get { return data.Z; } set { data.Z = value; } }
 
         /// <summary>
-        /// Assesses equality with another vector
+        /// Assesses equality with another vector.
         /// </summary>
-        /// <param name="other">The other vector being compared to</param>
-        /// <returns>Whether the two are equal</returns>
+        /// <param name="other">The other vector being compared to.</param>
+        /// <returns>Whether the two are equal.</returns>
         public bool Equals(Vector3 other)
         {
             return this.data.Equals(other.data);

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Vector4.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/Customizations/Models/Vector4.cs
@@ -14,51 +14,51 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion.Models
         private System.Numerics.Vector4 data;
 
         /// <summary>
-        /// Creates a autorest-defined Vector4 given its Numerics equivalent
+        /// Creates a autorest-defined Vector4 given its Numerics equivalent.
         /// </summary>
-        /// <param name="vector">The numerics vector</param>
+        /// <param name="vector">The numerics vector.</param>
         internal Vector4(System.Numerics.Vector4 vector)
         {
             data = vector;
         }
 
         /// <summary>
-        /// Creates a autorest-defined Vector4 given its fields
+        /// Creates a autorest-defined Vector4 given its fields.
         /// </summary>
-        /// <param name="x">X component</param>
-        /// <param name="y">Y component</param>
-        /// <param name="z">Z component</param>
-        /// <param name="w">W component</param>
+        /// <param name="x">X component.</param>
+        /// <param name="y">Y component.</param>
+        /// <param name="z">Z component.</param>
+        /// <param name="w">W component.</param>
         internal Vector4(float x, float y, float z, float w)
         {
             data = new System.Numerics.Vector4(x, y, z, w);
         }
 
         /// <summary>
-        /// X component
+        /// X component.
         /// </summary>
         public float X { get { return data.X; } set { data.X = value; } }
 
         /// <summary>
-        /// Y component
+        /// Y component.
         /// </summary>
         public float Y { get { return data.Y; } set { data.Y = value; } }
 
         /// <summary>
-        /// Z component
+        /// Z component.
         /// </summary>
         public float Z { get { return data.Z; } set { data.Z = value; } }
 
         /// <summary>
-        /// W component
+        /// W component.
         /// </summary>
         public float W { get { return data.W; } set { data.W = value; } }
 
         /// <summary>
-        /// Assesses equality with another vector
+        /// Assesses equality with another vector.
         /// </summary>
-        /// <param name="other">The other vector being compared to</param>
-        /// <returns>Whether the two are equal</returns>
+        /// <param name="other">The other vector being compared to.</param>
+        /// <returns>Whether the two are equal.</returns>
         public bool Equals(Vector4 other)
         {
             return this.data.Equals(other.data);

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClient.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClient.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.MixedReality.Authentication;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Azure.MixedReality.ObjectAnchors.Conversion
 {
@@ -20,12 +20,12 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         private HashSet<AssetFileType> _supportedAssetFileTypesSet;
 
         /// <summary>
-        /// The Account ID to be used by the Client
+        /// The Account ID to be used by the Client.
         /// </summary>
         public Guid AccountId { get; }
 
         /// <summary>
-        /// The list of supported asset file types
+        /// The list of supported asset file types.
         /// </summary>
         public IReadOnlyList<AssetFileType> SupportedAssetFileTypes { get; private set; }
 
@@ -43,7 +43,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// The Account Domain to be used by the Client
+        /// The Account Domain to be used by the Client.
         /// </summary>
         public string AccountDomain { get; }
 
@@ -123,9 +123,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// Creates an Object Anchors asset conversion job request.
         /// </summary>
-        /// <param name="options">The asset conversion job creation options</param>
-        /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>The asset conversion operation</returns>
+        /// <param name="options">The asset conversion job creation options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The asset conversion operation.</returns>
         public virtual AssetConversionOperation StartAssetConversion(AssetConversionOptions options, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ObjectAnchorsConversionClient)}.{nameof(StartAssetConversion)}");
@@ -138,14 +138,14 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
                 }
 
                 AssetConversionProperties properties = new AssetConversionProperties
-            {
-                InputAssetFileType = options.InputAssetFileType,
-                ConversionConfiguration = options.ConversionConfiguration,
-                InputAssetUri = options.InputAssetUri
-            };
+                {
+                    InputAssetFileType = options.InputAssetFileType,
+                    ConversionConfiguration = options.ConversionConfiguration,
+                    InputAssetUri = options.InputAssetUri
+                };
 
-            _ingestionJobRestClient.Create(AccountId, options.JobId, body: properties, cancellationToken: cancellationToken);
-            return new AssetConversionOperation(options.JobId, this);
+                _ingestionJobRestClient.Create(AccountId, options.JobId, body: properties, cancellationToken: cancellationToken);
+                return new AssetConversionOperation(options.JobId, this);
             }
             catch (Exception ex)
             {
@@ -157,9 +157,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// <summary>
         /// Creates an Object Anchors asset conversion job request.
         /// </summary>
-        /// <param name="options">The asset conversion job creation options</param>
-        /// <param name="cancellationToken">The cancellation toke</param>
-        /// <returns>The asset conversion operation</returns>
+        /// <param name="options">The asset conversion job creation options.</param>
+        /// <param name="cancellationToken">The cancellation toke.</param>
+        /// <returns>The asset conversion operation.</returns>
         public virtual async Task<AssetConversionOperation> StartAssetConversionAsync(AssetConversionOptions options, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ObjectAnchorsConversionClient)}.{nameof(StartAssetConversion)}");
@@ -172,14 +172,14 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
                 }
 
                 AssetConversionProperties properties = new AssetConversionProperties
-            {
-                InputAssetFileType = options.InputAssetFileType,
-                ConversionConfiguration = options.ConversionConfiguration,
-                InputAssetUri = options.InputAssetUri
-            };
+                {
+                    InputAssetFileType = options.InputAssetFileType,
+                    ConversionConfiguration = options.ConversionConfiguration,
+                    InputAssetUri = options.InputAssetUri
+                };
 
-            await _ingestionJobRestClient.CreateAsync(AccountId, options.JobId, body: properties, cancellationToken: cancellationToken).ConfigureAwait(false);
-            return new AssetConversionOperation(options.JobId, this);
+                await _ingestionJobRestClient.CreateAsync(AccountId, options.JobId, body: properties, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return new AssetConversionOperation(options.JobId, this);
             }
             catch (Exception ex)
             {
@@ -189,9 +189,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// Retrieves an upload URI intended to house the model to be ingested
+        /// Retrieves an upload URI intended to house the model to be ingested.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns><see cref="Response{GetAssetUploadUriResult}"/>.</returns>
         public virtual Response<AssetUploadUriResult> GetAssetUploadUri(CancellationToken cancellationToken = default)
         {
@@ -209,9 +209,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// Retrieves an upload URI intended to house the model to be ingested
+        /// Retrieves an upload URI intended to house the model to be ingested.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns><see cref="Response{GetAssetUploadUriResult}"/>.</returns>
         public virtual async Task<Response<AssetUploadUriResult>> GetAssetUploadUriAsync(CancellationToken cancellationToken = default)
         {
@@ -219,7 +219,9 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
             scope.Start();
             try
             {
-                return await _getBlobUploadEndpointRestClient.GetAsync(AccountId, xMrcCv: GenerateCv(), cancellationToken: cancellationToken).ConfigureAwait(false);
+                return await _getBlobUploadEndpointRestClient
+                    .GetAsync(AccountId, xMrcCv: GenerateCv(), cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -229,10 +231,10 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// Gets the status of an Object Anchors asset conversion job
+        /// Gets the status of an Object Anchors asset conversion job.
         /// </summary>
-        /// <param name="JobId">The asset conversion job's ID</param>
-        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="JobId">The asset conversion job's ID.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns><see cref="Response{AssetConversionProperties}"/>.</returns>
         internal virtual Response<AssetConversionProperties> GetAssetConversionStatus(Guid JobId, CancellationToken cancellationToken = default)
         {
@@ -240,7 +242,8 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
             scope.Start();
             try
             {
-                var properties = _ingestionJobRestClient.Get(AccountId, JobId, xMrcCv: GenerateCv(), cancellationToken: cancellationToken);
+                ResponseWithHeaders<AssetConversionProperties, IngestionJobGetHeaders> properties = _ingestionJobRestClient
+                    .Get(AccountId, JobId, xMrcCv: GenerateCv(), cancellationToken: cancellationToken);
                 properties.Value.JobId = JobId;
                 properties.Value.AccountId = AccountId;
                 return properties;
@@ -253,14 +256,16 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         }
 
         /// <summary>
-        /// Gets the status of an Object Anchors asset conversion job
+        /// Gets the status of an Object Anchors asset conversion job.
         /// </summary>
-        /// <param name="JobId">The asset conversion job's ID</param>
-        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="JobId">The asset conversion job's ID.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns><see cref="Response{AssetConversionProperties}"/>.</returns>
         internal virtual async Task<Response<AssetConversionProperties>> GetAssetConversionStatusAsync(Guid JobId, CancellationToken cancellationToken = default)
         {
-            var properties = await _ingestionJobRestClient.GetAsync(AccountId, JobId, xMrcCv: GenerateCv(), cancellationToken: cancellationToken).ConfigureAwait(false);
+            ResponseWithHeaders<AssetConversionProperties, IngestionJobGetHeaders> properties = await _ingestionJobRestClient
+                .GetAsync(AccountId, JobId, xMrcCv: GenerateCv(), cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             properties.Value.JobId = JobId;
             properties.Value.AccountId = AccountId;
             return properties;

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionClientOptions.cs
@@ -19,7 +19,7 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         internal string Version { get; }
 
         /// <summary>
-        /// Gets the list of supported asset file types
+        /// Gets the list of supported asset file types.
         /// </summary>
         internal HashSet<AssetFileType> SupportedAssetFileTypes { get; }
 

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionModelFactory.cs
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/src/ObjectAnchorsConversionModelFactory.cs
@@ -44,14 +44,14 @@ namespace Azure.MixedReality.ObjectAnchors.Conversion
         /// </summary>
         /// <param name="clientErrorDetails"> Information about the cause of a ClientError AssetConversionStatus. </param>
         /// <param name="serverErrorDetails"> Information about the cause of a ServerError AssetConversionStatus. </param>
-        /// <param name="conversionErrorCode">The error code of the AOA asset conversion job</param>
+        /// <param name="conversionErrorCode">The error code of the AOA asset conversion job.</param>
         /// <param name="jobId"> Identifier for the AOA Asset Conversion Job. </param>
         /// <param name="outputModelUri"> The URI for downloading the generated AOA Model. </param>
-        /// <param name="assetConversionStatus"> The status of the AOA asset conversion job </param>
+        /// <param name="assetConversionStatus"> The status of the AOA asset conversion job. </param>
         /// <param name="assetFileType"> The file type of the original 3D asset. Examples include: &quot;ply&quot;, &quot;obj&quot;, &quot;fbx&quot;, &quot;glb&quot;, &quot;gltf&quot;, etc. </param>
         /// <param name="uploadedInputAssetUri"> The Uri to the Asset to be ingested by the AOA Asset Conversion Service. This asset needs to have been uploaded to the service using an endpoint provided from a call to the GetUploadUri API. </param>
         /// <param name="accountId"> Identifier for the Account owning the AOA asset conversion Job. </param>
-        /// <param name="assetConversionConfiguration"> The configuration of the AOA asset conversion job </param>
+        /// <param name="assetConversionConfiguration"> The configuration of the AOA asset conversion job. </param>
         /// <returns> A new instance of the <see cref="AssetConversionProperties"/> for mocking purposes. </returns>
         public static AssetConversionProperties AssetConversionProperties(
             string clientErrorDetails,


### PR DESCRIPTION
While looking at the code to understand our error handling, I noticed that analyzers were suggesting periods at the end of sentences, which make sense. The analyzer added all of those for me. I've also fixed the formatting in `AssetConversionOperation.cs` which appears to have been tweaked by some automated tooling.