### PR TITLE
[Event Hubs] Fix Snippet Syntax

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_IdentityAndSharedAccessCredentials.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_IdentityAndSharedAccessCredentials.md
@@ -262,7 +262,7 @@ In some scenarios, it may be preferable to supplement token-based authorization 
 This example illustrates parsing the fully qualified namespace and, optionally, the Event Hub name from the connection string and using it with identity-based authorization.
 
 ```C# Snippet:EventHubs_Processor_Sample05_ConnectionStringParse
-TokenCredential credential = new DefaultAzureCredential();
+var credential = new DefaultAzureCredential();
 
 var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
 var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
@@ -272,8 +272,11 @@ var eventHubName = "<< NAME OF THE EVENT HUB >>";
 var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
 
 var storageEndpoint = new BlobServiceClient(storageConnectionString).Uri;
-var blobUriBuilder = new BlobUriBuilder(storageEndpoint);
-blobUriBuilder.BlobContainerName = blobContainerName;
+
+var blobUriBuilder = new BlobUriBuilder(storageEndpoint)
+{
+    BlobContainerName = blobContainerName
+};
 
 var storageClient = new BlobContainerClient(
     blobUriBuilder.ToUri(),

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_IdentityAndSharedAccessCredentials.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_IdentityAndSharedAccessCredentials.md
@@ -264,13 +264,12 @@ This example illustrates parsing the fully qualified namespace and, optionally, 
 ```C# Snippet:EventHubs_Processor_Sample05_ConnectionStringParse
 var credential = new DefaultAzureCredential();
 
-var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
-var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
-
 var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
 
+var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
 var storageEndpoint = new BlobServiceClient(storageConnectionString).Uri;
 
 var blobUriBuilder = new BlobUriBuilder(storageEndpoint)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample05_IdentityAndSharedAccessCredentialsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample05_IdentityAndSharedAccessCredentialsLiveTests.cs
@@ -309,26 +309,30 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             #region Snippet:EventHubs_Processor_Sample05_ConnectionStringParse
 
-            TokenCredential credential = new DefaultAzureCredential();
+#if SNIPPET
+            var credential = new DefaultAzureCredential();
 
             var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
             var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
-            /*@@*/
-            /*@@*/ storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
-            /*@@*/ blobContainerName = storageScope.ContainerName;
 
             var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
             var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
-            /*@@*/
-            /*@@*/ eventHubsConnectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
-            /*@@*/ eventHubName = eventHubScope.EventHubName;
-            /*@@*/ consumerGroup = eventHubScope.ConsumerGroups.First();
-            /*@@*/ credential = EventHubsTestEnvironment.Instance.Credential;
+#else
+            var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
+            var blobContainerName = storageScope.ContainerName;
+            var eventHubsConnectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+            var eventHubName = eventHubScope.EventHubName;
+            var consumerGroup = eventHubScope.ConsumerGroups.First();
+            var credential = EventHubsTestEnvironment.Instance.Credential;
+#endif
 
             var storageEndpoint = new BlobServiceClient(storageConnectionString).Uri;
-            var blobUriBuilder = new BlobUriBuilder(storageEndpoint);
-            blobUriBuilder.BlobContainerName = blobContainerName;
+
+            var blobUriBuilder = new BlobUriBuilder(storageEndpoint)
+            {
+                BlobContainerName = blobContainerName
+            };
 
             var storageClient = new BlobContainerClient(
                 blobUriBuilder.ToUri(),

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample05_IdentityAndSharedAccessCredentialsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample05_IdentityAndSharedAccessCredentialsLiveTests.cs
@@ -312,21 +312,20 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 #if SNIPPET
             var credential = new DefaultAzureCredential();
 
-            var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
-            var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
-
             var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
             var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+
+            var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+            var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
 #else
-            var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
-            var blobContainerName = storageScope.ContainerName;
+            var credential = EventHubsTestEnvironment.Instance.Credential;
             var eventHubsConnectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
             var eventHubName = eventHubScope.EventHubName;
             var consumerGroup = eventHubScope.ConsumerGroups.First();
-            var credential = EventHubsTestEnvironment.Instance.Credential;
+            var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
+            var blobContainerName = storageScope.ContainerName;
 #endif
-
             var storageEndpoint = new BlobServiceClient(storageConnectionString).Uri;
 
             var blobUriBuilder = new BlobUriBuilder(storageEndpoint)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
@@ -84,9 +84,6 @@ Global
 		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x64.ActiveCfg = Release|Any CPU
 		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x64.Build.0 = Release|Any CPU
 		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x86.ActiveCfg = Release|Any CPU
-<<<<<<< HEAD
-		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x86.Build.0 = Release|Any CPU		
-=======
 		{FB10A6B3-88DD-4296-9241-53ECDF942842}.Release|x86.Build.0 = Release|Any CPU
 		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
@@ -100,19 +97,14 @@ Global
 		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|x64.Build.0 = Release|Any CPU
 		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|x86.ActiveCfg = Release|Any CPU
 		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA}.Release|x86.Build.0 = Release|Any CPU
->>>>>>> b3d9d8605d ([Event Hubs Client] Idempotent Error Handling)
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
-<<<<<<< HEAD
-		{6C67B4C6-0ABF-4E10-8BAF-FCF2AD053DE3} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
-=======
 		{FB10A6B3-88DD-4296-9241-53ECDF942842} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
 		{79B7DF40-239D-4360-A1C3-D4F92A2E75EA} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
->>>>>>> b3d9d8605d ([Event Hubs Client] Idempotent Error Handling)
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {509F2EE0-3348-4506-8AC7-9945B602CB43}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md
@@ -312,6 +312,7 @@ In the `Microsoft.Azure.EventHubs` library, to publish events and allow the Even
 ```C# Snippet:EventHubs_Migrate_T1_PublishToSpecificPartition
 var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
+
 var builder = new EventHubsConnectionStringBuilder(connectionString);
 builder.EntityPath = eventHubName;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md
@@ -312,7 +312,6 @@ In the `Microsoft.Azure.EventHubs` library, to publish events and allow the Even
 ```C# Snippet:EventHubs_Migrate_T1_PublishToSpecificPartition
 var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
-
 var builder = new EventHubsConnectionStringBuilder(connectionString);
 builder.EntityPath = eventHubName;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_IdentityAndSharedAccessCredentials.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_IdentityAndSharedAccessCredentials.md
@@ -54,7 +54,7 @@ var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName,
 
 try
 {
-    using var eventBatch = await producer.CreateBatchAsync();
+    using EventDataBatch eventBatch = await producer.CreateBatchAsync();
 
     for (var index = 0; index < 5; ++index)
     {
@@ -87,7 +87,7 @@ var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName,
 
 try
 {
-    using var eventBatch = await producer.CreateBatchAsync();
+    using EventDataBatch eventBatch = await producer.CreateBatchAsync();
 
     for (var index = 0; index < 5; ++index)
     {
@@ -120,7 +120,7 @@ var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName,
 
 try
 {
-    using var eventBatch = await producer.CreateBatchAsync();
+    using EventDataBatch eventBatch = await producer.CreateBatchAsync();
 
     for (var index = 0; index < 5; ++index)
     {
@@ -148,13 +148,13 @@ In some scenarios, it may be preferable to supplement token-based authorization 
 This example illustrates parsing the fully qualified namespace and, optionally, the Event Hub name from the connection string and using it with identity-based authorization.
 
 ```C# Snippet:EventHubs_Sample06_ConnectionStringParse
+var credential = new DefaultAzureCredential();
+
 var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 
 EventHubsConnectionStringProperties properties =
     EventHubsConnectionStringProperties.Parse(connectionString);
-
-TokenCredential credential = new DefaultAzureCredential();
 
 var producer = new EventHubProducerClient(
     properties.FullyQualifiedNamespace,
@@ -163,7 +163,7 @@ var producer = new EventHubProducerClient(
 
 try
 {
-    using var eventBatch = await producer.CreateBatchAsync();
+    using EventDataBatch eventBatch = await producer.CreateBatchAsync();
 
     for (var index = 0; index < 5; ++index)
     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample06_IdentityAndSharedAccessCredentialsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample06_IdentityAndSharedAccessCredentialsLiveTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Identity;
 using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Producer;
@@ -49,7 +48,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             try
             {
-                using var eventBatch = await producer.CreateBatchAsync();
+                using EventDataBatch eventBatch = await producer.CreateBatchAsync();
 
                 for (var index = 0; index < 5; ++index)
                 {
@@ -101,7 +100,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             try
             {
-                using var eventBatch = await producer.CreateBatchAsync();
+                using EventDataBatch eventBatch = await producer.CreateBatchAsync();
 
                 for (var index = 0; index < 5; ++index)
                 {
@@ -150,7 +149,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             try
             {
-                using var eventBatch = await producer.CreateBatchAsync();
+                using EventDataBatch eventBatch = await producer.CreateBatchAsync();
 
                 for (var index = 0; index < 5; ++index)
                 {
@@ -185,19 +184,18 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
             #region Snippet:EventHubs_Sample06_ConnectionStringParse
 
 #if SNIPPET
+            var credential = new DefaultAzureCredential();
+
             var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
 #else
             var connectionString = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
             var eventHubName = scope.EventHubName;
+            var credential = EventHubsTestEnvironment.Instance.Credential;
 #endif
 
             EventHubsConnectionStringProperties properties =
                 EventHubsConnectionStringProperties.Parse(connectionString);
-
-            TokenCredential credential = new DefaultAzureCredential();
-            /*@@*/
-            /*@@*/ credential = EventHubsTestEnvironment.Instance.Credential;
 
             var producer = new EventHubProducerClient(
                 properties.FullyQualifiedNamespace,
@@ -206,7 +204,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
 
             try
             {
-                using var eventBatch = await producer.CreateBatchAsync();
+                using EventDataBatch eventBatch = await producer.CreateBatchAsync();
 
                 for (var index = 0; index < 5; ++index)
                 {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Snippets/MigrationGuideSnippets.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Snippets/MigrationGuideSnippets.cs
@@ -30,12 +30,13 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
         public void CreateWithConnectionString()
         {
             #region Snippet:EventHubs_Migrate_T1_CreateWithConnectionString
-
+#if SNIPPET
             var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
-            /*@@*/
-            /*@@*/ connectionString = TestUtility.EventHubsConnectionString;
-            /*@@*/ eventHubName = "fake";
+#else
+            var connectionString = TestUtility.EventHubsConnectionString;
+            var eventHubName = "fake";
+#endif
 
             var builder = new EventHubsConnectionStringBuilder(connectionString);
             builder.EntityPath = eventHubName;
@@ -55,20 +56,20 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
             await using var scope = await EventHubScope.CreateAsync(1);
 
             #region Snippet:EventHubs_Migrate_T1_CreateWithAzureActiveDirectory
-
+#if SNIPPET
             var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
-            /*@@*/
-            /*@@*/ fullyQualifiedNamespace = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString).Endpoint.ToString();
-            /*@@*/ eventHubName = scope.EventHubName;
 
             var authority = "<< NAME OF THE AUTHORITY TO ASSOCIATE WITH THE TOKEN >>";
             var aadAppId = "<< THE AZURE ACTIVE DIRECTORY APPLICATION ID TO REQUEST A TOKEN FOR >>";
             var aadAppSecret = "<< THE AZURE ACTIVE DIRECTORY SECRET TO USE FOR THE TOKEN >>";
-            /*@@*/
-            /*@@*/ authority = "";     // Needed for manual run
-            /*@@*/ aadAppId = "";      // Needed for manual run
-            /*@@*/ aadAppSecret = "";  // Needed for manual run
+#else
+            var fullyQualifiedNamespace = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString).Endpoint.ToString();
+            var eventHubName = scope.EventHubName;
+            var authority = "";     // Needed for manual run
+            var aadAppId = "";      // Needed for manual run
+            var aadAppSecret = "";  // Needed for manual run
+#endif
 
             AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback =
                 async (audience, authority, state) =>
@@ -99,12 +100,13 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
             await using var scope = await EventHubScope.CreateAsync(1);
 
             #region Snippet:EventHubs_Migrate_T1_ManagedIdentity
-
+#if SNIPPET
             var fullyQualifiedNamespace = "<< NAMESPACE (likely similar to {your-namespace}.servicebus.windows.net) >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
-            /*@@*/
-            /*@@*/ fullyQualifiedNamespace = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString).Endpoint.ToString();
-            /*@@*/ eventHubName = scope.EventHubName;
+#else
+            var fullyQualifiedNamespace = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString).Endpoint.ToString();
+            var eventHubName = scope.EventHubName;
+#endif
 
             EventHubClient client = EventHubClient.CreateWithManagedIdentity(
                 new Uri(fullyQualifiedNamespace),
@@ -123,12 +125,13 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
             await using var scope = await EventHubScope.CreateAsync(1);
 
             #region Snippet:EventHubs_Migrate_T1_PublishWithAutomaticRouting
-
+#if SNIPPET
             var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
-            /*@@*/
-            /*@@*/ connectionString = TestUtility.EventHubsConnectionString;
-            /*@@*/ eventHubName = scope.EventHubName;
+#else
+            var connectionString = TestUtility.EventHubsConnectionString;
+            var eventHubName = scope.EventHubName;
+#endif
 
             var builder = new EventHubsConnectionStringBuilder(connectionString);
             builder.EntityPath = eventHubName;
@@ -167,12 +170,13 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
             await using var scope = await EventHubScope.CreateAsync(1);
 
             #region Snippet:EventHubs_Migrate_T1_PublishWithAPartitionKey
-
+#if SNIPPET
             var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
-            /*@@*/
-            /*@@*/ connectionString = TestUtility.EventHubsConnectionString;
-            /*@@*/ eventHubName = scope.EventHubName;
+#else
+            var connectionString = TestUtility.EventHubsConnectionString;
+            var eventHubName = scope.EventHubName;
+#endif
 
             var builder = new EventHubsConnectionStringBuilder(connectionString);
             builder.EntityPath = eventHubName;
@@ -216,13 +220,13 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
             await using var scope = await EventHubScope.CreateAsync(1);
 
             #region Snippet:EventHubs_Migrate_T1_PublishToSpecificPartition
-
+#if SNIPPET
             var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
-            /*@@*/
-            /*@@*/ connectionString = TestUtility.EventHubsConnectionString;
-            /*@@*/ eventHubName = scope.EventHubName;
-
+#else
+            var connectionString = TestUtility.EventHubsConnectionString;
+            var eventHubName = scope.EventHubName;
+#endif
             var builder = new EventHubsConnectionStringBuilder(connectionString);
             builder.EntityPath = eventHubName;
 
@@ -265,14 +269,15 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
             await using var scope = await EventHubScope.CreateAsync(1);
 
             #region Snippet:EventHubs_Migrate_T1_ReadFromSpecificPartition
-
+#if SNIPPET
             var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
             var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
-            /*@@*/
-            /*@@*/ connectionString = TestUtility.EventHubsConnectionString;
-            /*@@*/ eventHubName = scope.EventHubName;
-            /*@@*/ consumerGroup = PartitionReceiver.DefaultConsumerGroupName;
+#else
+            var connectionString = TestUtility.EventHubsConnectionString;
+            var eventHubName = scope.EventHubName;
+            var consumerGroup = PartitionReceiver.DefaultConsumerGroupName;
+#endif
 
             var builder = new EventHubsConnectionStringBuilder(connectionString);
             builder.EntityPath = eventHubName;
@@ -309,20 +314,21 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
             await using var scope = await EventHubScope.CreateAsync(1);
 
             #region Snippet:EventHubs_Migrate_T1_BasicEventProcessorHost
-
+#if SNIPPET
             var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
             var blobContainerName = "<< NAME OF THE BLOB CONTAINER >>";
-            /*@@*/
-            /*@@*/ storageConnectionString = TestUtility.StorageConnectionString;
-            /*@@*/ blobContainerName = "migragionsample";
 
             var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
             var eventHubName = "<< NAME OF THE EVENT HUB >>";
             var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
-            /*@@*/
-            /*@@*/ eventHubsConnectionString = TestUtility.EventHubsConnectionString;
-            /*@@*/ eventHubName = scope.EventHubName;
-            /*@@*/ consumerGroup = PartitionReceiver.DefaultConsumerGroupName;
+#else
+            var storageConnectionString = TestUtility.StorageConnectionString;
+            var blobContainerName = "migragionsample";
+
+            var eventHubsConnectionString = TestUtility.EventHubsConnectionString;
+            var eventHubName = scope.EventHubName;
+            var consumerGroup = PartitionReceiver.DefaultConsumerGroupName;
+#endif
 
             var eventProcessorHost = new EventProcessorHost(
                 eventHubName,

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Snippets/MigrationGuideSnippets.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Snippets/MigrationGuideSnippets.cs
@@ -227,6 +227,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Snippets
             var connectionString = TestUtility.EventHubsConnectionString;
             var eventHubName = scope.EventHubName;
 #endif
+
             var builder = new EventHubsConnectionStringBuilder(connectionString);
             builder.EntityPath = eventHubName;
 


### PR DESCRIPTION
# Summary

The focus of these changes is to update the snippet syntax from the legacy comment style (/*@@*/) to the compiler conditional for a few instances that were overlooked in the initial migration.   Riding along is a fix for a merge error that snuck into the solution file.