### PR TITLE
[Signal] Hotfix: Resolve "package restore problem"

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -115,6 +115,7 @@
     <PackageReference Update="CloudNative.CloudEvents" Version="2.0.0" />
     <PackageReference Update="CloudNative.CloudEvents.SystemTextJson" Version="2.0.0" />
     <PackageReference Update="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Update="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="5.0.1" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Update="Microsoft.Azure.SignalR" Version="1.13.0" />
     <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.13.0" />
     <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.13.0" />

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md
@@ -7,4 +7,5 @@
 
 ### Bugs Fixed
 * Fixed the bug that the function host could not be shutdown locally on Functions V3 runtime.
+* Fixed the package restoring issue on .NET 5 and above.
 

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/DefaultSecurityTokenValidator.cs
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Auth/DefaultSecurityTokenValidator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
@@ -28,7 +29,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.SignalRService
         {
             try
             {
-                if (request?.Headers.TryGetValue(AuthHeaderName, out var authHeader) == true)
+                var authHeader = default(StringValues);
+                if (request?.Headers.TryGetValue(AuthHeaderName, out authHeader) == true)
                 {
                     var authHeaderValue = authHeader.ToString();
                     if (authHeaderValue.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))

--- a/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
+++ b/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/src/Microsoft.Azure.WebJobs.Extensions.SignalRService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.SignalRService</PackageId>
     <Version>1.7.0-beta.1</Version>
     <SignAssembly>true</SignAssembly>
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.Azure.SignalR.Protocols" />
     <PackageReference Include="Microsoft.Azure.SignalR.Serverless.Protocols" />
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->


## Description
Fix https://github.com/Azure/azure-functions-signalrservice-extension/issues/280

Try to resolve the package restore error on .NET 5 or above. 
error NU1605:  InstallationCheck -> Microsoft.Azure.WebJobs.Extensions.SignalRService 1.7.0-beta.1 -> Microsoft.Azure.SignalR.Management 1.13.0 -> Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson (>= 5.0.1)

error NU1605:  InstallationCheck -> Microsoft.Azure.WebJobs.Extensions.SignalRService 1.7.0-beta.1 -> Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson (>= 3.0.0)

In the long term, the dependency for `Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson` should be removed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

