### PR TITLE
[Event Hubs] Restore Experimental GA Package Reference

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/src/Azure.Messaging.EventHubs.Experimental.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Experimental/src/Azure.Messaging.EventHubs.Experimental.csproj
@@ -12,9 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- TEMP: Override the central version until the 5.7.x line goes GA.-->
-    <PackageReference Include="Azure.Messaging.EventHubs" OverrideVersion = "5.7.0-beta.1" />
-
+    <PackageReference Include="Azure.Messaging.EventHubs" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />


### PR DESCRIPTION
# Summary

The focus of these changes is to restore the GA package reference used for Event Hubs.