### PR TITLE
`ShareFileClient` uses `PartitionedUploader`

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
@@ -15,7 +15,7 @@ using Azure.Storage.Shared;
 
 namespace Azure.Storage
 {
-    internal class PartitionedUploader<TServiceSpecificArgs, TCompleteUploadReturn>
+    internal class PartitionedUploader<TServiceSpecificData, TCompleteUploadReturn>
     {
         #region Definitions
         // delegte for getting a partition from a stream based on the selected data management stragegy
@@ -29,10 +29,10 @@ namespace Azure.Storage
 
         // injected behaviors for services to use partitioned uploads
         public delegate DiagnosticScope CreateScope(string operationName);
-        public delegate Task InitializeDestinationInternal(TServiceSpecificArgs args, bool async, CancellationToken cancellationToken);
+        public delegate Task InitializeDestinationInternal(TServiceSpecificData args, bool async, CancellationToken cancellationToken);
         public delegate Task<Response<TCompleteUploadReturn>> SingleUploadInternal(
             Stream contentStream,
-            TServiceSpecificArgs args,
+            TServiceSpecificData args,
             IProgress<long> progressHandler,
             UploadTransactionalHashingOptions hashingOptions,
             string operationName,
@@ -40,14 +40,14 @@ namespace Azure.Storage
             CancellationToken cancellationToken);
         public delegate Task UploadPartitionInternal(Stream contentStream,
             long offset,
-            TServiceSpecificArgs args,
+            TServiceSpecificData args,
             IProgress<long> progressHandler,
             UploadTransactionalHashingOptions hashingOptions,
             bool async,
             CancellationToken cancellationToken);
         public delegate Task<Response<TCompleteUploadReturn>> CommitPartitionedUploadInternal(
             List<(long Offset, long Size)> partitions,
-            TServiceSpecificArgs args,
+            TServiceSpecificData args,
             bool async,
             CancellationToken cancellationToken);
 
@@ -165,7 +165,7 @@ namespace Azure.Storage
         public async Task<Response<TCompleteUploadReturn>> UploadInternal(
             Stream content,
             long? expectedContentLength,
-            TServiceSpecificArgs args,
+            TServiceSpecificData args,
             IProgress<long> progressHandler,
             bool async,
             CancellationToken cancellationToken = default)
@@ -270,7 +270,7 @@ namespace Azure.Storage
             Stream content,
             long? contentLength,
             long partitionSize,
-            TServiceSpecificArgs args,
+            TServiceSpecificData args,
             IProgress<long> progressHandler,
             bool async,
             CancellationToken cancellationToken)
@@ -364,7 +364,7 @@ namespace Azure.Storage
             Stream content,
             long? contentLength,
             long blockSize,
-            TServiceSpecificArgs args,
+            TServiceSpecificData args,
             IProgress<long> progressHandler,
             CancellationToken cancellationToken)
         {
@@ -466,7 +466,7 @@ namespace Azure.Storage
         private async Task StagePartitionAndDisposeInternal(
             SlicedStream partition,
             long offset,
-            TServiceSpecificArgs args,
+            TServiceSpecificData args,
             IProgress<long> progressHandler,
             bool async,
             CancellationToken cancellationToken)

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.Test.Shared
         }
 
         public StorageTestBase(bool async, RecordedTestMode? mode = null)
-            : base(async, RecordedTestMode.Playback)
+            : base(async, mode)
         {
             Sanitizer = new StorageRecordedTestSanitizer();
             Tenants = new TenantConfigurationBuilder(this);

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.Test.Shared
         }
 
         public StorageTestBase(bool async, RecordedTestMode? mode = null)
-            : base(async, mode)
+            : base(async, RecordedTestMode.Playback)
         {
             Sanitizer = new StorageRecordedTestSanitizer();
             Tenants = new TenantConfigurationBuilder(this);

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed a memory leak in ShareFileClient.UploadAsync().
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
@@ -57,6 +57,7 @@
     <Compile Include="$(AzureStorageSharedSources)IHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonCryptographicHashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonDisposingStream.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)PartitionedUploader.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PooledMemoryStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ProgressIncrementingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)SasExtensions.cs" LinkBase="Shared" />
@@ -81,6 +82,7 @@
     <Compile Include="$(AzureStorageSharedSources)StreamPartition.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)UriQueryParamsCollection.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)WindowStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)StorageWriteStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)LazyLoadingReadOnlyStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)\StorageBearerTokenChallengeAuthorizationPolicy.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -4833,115 +4833,89 @@ namespace Azure.Storage.Files.Shares
             bool async,
             CancellationToken cancellationToken)
         {
-            Errors.VerifyStreamPosition(content, nameof(content));
-
-            // partitioned uploads don't support pre-calculated hashes
-            if (hashingOptions?.PrecalculatedHash != default)
-            {
-                throw Errors.PrecalculatedHashNotSupportedOnSplit();
-            }
-
-            DiagnosticScope scope = ClientConfiguration.ClientDiagnostics.CreateScope($"{nameof(ShareFileClient)}.{nameof(Upload)}");
-            try
-            {
-                scope.Start();
-
-                // Try to upload the file as a single range
-                Debug.Assert(singleRangeThreshold <= Constants.File.MaxFileUpdateRange);
-                var length = content?.Length - content?.Position;
-                if (length <= singleRangeThreshold)
+            var uploader = GetPartitionedUploader(
+                new StorageTransferOptions
                 {
-                    return await UploadRangeInternal(
-                        new HttpRange(0, length),
-                        content,
+                    // shares can't suppot parallel upload
+                    MaximumConcurrency = 1,
+                    MaximumTransferSize = singleRangeThreshold,
+                    InitialTransferSize = singleRangeThreshold
+                },
+                hashingOptions,
+                operationName: $"{nameof(ShareFileClient)}.{nameof(Upload)}");
+
+            return await uploader.UploadInternal(
+                content,
+                expectedContentLength: default,
+                new ShareFileUploadData
+                {
+                    Conditions = conditions,
+                },
+                progressHandler,
+                async,
+                cancellationToken)
+                .ConfigureAwait(false);
+        }
+        #endregion Upload
+
+        #region PartitionedUploader
+        internal class ShareFileUploadData
+        {
+            public ShareFileRequestConditions Conditions { get; set; }
+            public Response<ShareFileUploadInfo> LastUploadRangeResponse { get; set; }
+        }
+
+        internal PartitionedUploader<ShareFileUploadData, ShareFileUploadInfo> GetPartitionedUploader(
+            StorageTransferOptions transferOptions,
+            UploadTransactionalHashingOptions hashingOptions,
+            ArrayPool<byte> arrayPool = null,
+            string operationName = null)
+            => new PartitionedUploader<ShareFileUploadData, ShareFileUploadInfo>(
+                GetPartitionedUploaderBehaviors(this),
+                transferOptions,
+                hashingOptions,
+                arrayPool,
+                operationName);
+
+        // static because it makes mocking easier in tests
+        internal static PartitionedUploader<ShareFileUploadData, ShareFileUploadInfo>.Behaviors GetPartitionedUploaderBehaviors(ShareFileClient client)
+            => new PartitionedUploader<ShareFileUploadData, ShareFileUploadInfo>.Behaviors
+            {
+                SingleUpload = async (stream, data, progressHandler, hashingOptions, operationName, async, cancellationToken) =>
+                {
+                    return await client.UploadRangeInternal(
+                        new HttpRange(offset: 0, length: stream.Length),
+                        stream,
                         new ShareFileUploadRangeOptions
                         {
-                            TransactionalHashingOptions = hashingOptions,
+                            Conditions = data.Conditions,
                             ProgressHandler = progressHandler,
-                            Conditions = conditions
+                            TransactionalHashingOptions = hashingOptions,
                         },
                         async,
                         cancellationToken)
                         .ConfigureAwait(false);
-                }
-
-                // Otherwise naively split the file into ranges and upload them individually
-                var response = default(Response<ShareFileUploadInfo>);
-                var pool = default(MemoryPool<byte>);
-                // erase potential precalculated hash now that we're splitting; we'll have to recalculate.
-                hashingOptions = hashingOptions == default
-                    ? default
-                    : new UploadTransactionalHashingOptions
-                    {
-                        Algorithm = hashingOptions.Algorithm
-                    };
-
-                long initalPosition = content.Position;
-
-                try
+                },
+                UploadPartition = async (stream, offset, data, progressHandler, hashingOptions, async, cancellationToken) =>
                 {
-                    pool = (singleRangeThreshold < MemoryPool<byte>.Shared.MaxBufferSize) ?
-                        MemoryPool<byte>.Shared :
-                        new StorageMemoryPool(singleRangeThreshold, 1);
-                    for (; ; )
-                    {
-                        // Get the next chunk of content
-                        var parentPosition = content.Position;
-                        IMemoryOwner<byte> buffer = pool.Rent(singleRangeThreshold);
-                        if (!MemoryMarshal.TryGetArray<byte>(buffer.Memory, out ArraySegment<byte> segment))
+                    data.LastUploadRangeResponse = await client.UploadRangeInternal(
+                        new HttpRange(offset: offset, length: stream.Length),
+                        stream,
+                        new ShareFileUploadRangeOptions
                         {
-                            throw Errors.UnableAccessArray();
-                        }
-                        var count = async ?
-                            await content.ReadAsync(segment.Array, 0, singleRangeThreshold, cancellationToken).ConfigureAwait(false) :
-                            content.Read(segment.Array, 0, singleRangeThreshold);
-
-                        // Stop when we've exhausted the content
-                        if (count <= 0)
-                        { break; }
-
-                        // Upload the chunk
-                        var partition = new StreamPartition(
-                            buffer.Memory,
-                            parentPosition,
-                            count,
-                            () => buffer.Dispose(),
-                            cancellationToken);
-                        response = await UploadRangeInternal(
-                            new HttpRange(partition.ParentPosition - initalPosition, partition.Length),
-                            partition,
-                            new ShareFileUploadRangeOptions
-                            {
-                                TransactionalHashingOptions = hashingOptions,
-                                ProgressHandler = progressHandler,
-                                Conditions = conditions
-                            },
-                            async,
-                            cancellationToken)
-                            .ConfigureAwait(false);
-                    }
-                }
-                finally
-                {
-                    if (pool is StorageMemoryPool)
-                    {
-                        pool.Dispose();
-                    }
-                }
-                return response;
-            }
-            catch (Exception ex)
-            {
-                ClientConfiguration.Pipeline.LogException(ex);
-                scope.Failed(ex);
-                throw;
-            }
-            finally
-            {
-                scope.Dispose();
-            }
-        }
-        #endregion Upload
+                            Conditions = data.Conditions,
+                            ProgressHandler = progressHandler,
+                            TransactionalHashingOptions = hashingOptions,
+                        },
+                        async,
+                        cancellationToken)
+                        .ConfigureAwait(false);
+                },
+                CommitPartitionedUpload = (partitions, data, async, cancellationToken) => Task.FromResult(data.LastUploadRangeResponse),
+                Scope = operationName => client.ClientConfiguration.ClientDiagnostics.CreateScope(operationName ??
+                    $"{nameof(Azure)}.{nameof(Storage)}.{nameof(Files)}.{nameof(Shares)}.{nameof(ShareFileClient)}.{nameof(ShareFileClient.Upload)}")
+            };
+        #endregion
 
         #region GetRangeList
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -4543,6 +4543,7 @@ namespace Azure.Storage.Files.Shares
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
+        [ForwardsClientCalls]
         public virtual Response<ShareFileUploadInfo> Upload(
             Stream stream,
             ShareFileUploadOptions options,
@@ -4583,6 +4584,7 @@ namespace Azure.Storage.Files.Shares
         /// A <see cref="RequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
+        [ForwardsClientCalls]
         public virtual async Task<Response<ShareFileUploadInfo>> UploadAsync(
             Stream stream,
             ShareFileUploadOptions options,


### PR DESCRIPTION
Resolves #16816

`ShareFileClient` custom upload implementation had a memory leak and provided no real benefit over shared implementation. This moves `ShareFileClient` to shared implementation. Memory leak is no longer present. Tests match current recordings exactly.