### PR TITLE
[WebPubSub] Error handling of non-sdk states set.

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/ConnectionStatesNewtonsoftConverter.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/ConnectionStatesNewtonsoftConverter.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             var jDict = JToken.Load(reader).ToObject<Dictionary<string, JToken>>();
             foreach (var item in jDict)
             {
+                // Pairing with WriteJson of always write RawValue
                 dict.Add(item.Key, BinaryData.FromString(JsonConvert.SerializeObject(item.Value)));
             }
 
@@ -33,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 foreach (KeyValuePair<string, BinaryData> pair in value)
                 {
                     writer.WritePropertyName(pair.Key);
+                    // Pairing with ReadJson of always stringify value.
                     writer.WriteRawValue(pair.Value.ToString());
                 }
             }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Services/WebPubSubRequestExtensions.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Services/WebPubSubRequestExtensions.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 connectionContext = new WebPubSubConnectionContext(eventType, eventName, hub, connectionId, userId, signature, origin, states, headers);
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 connectionContext = null;
                 return false;
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 dataType = mediaType.GetDataType();
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 dataType = WebPubSubDataType.Binary;
                 return false;

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerDispatcher.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerDispatcher.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 context = new WebPubSubConnectionContext(eventType, eventName, hub, connectionId, userId, signature, origin, states, headers);
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 context = null;
                 return false;

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Utilities.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Utilities.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 dataType = GetDataType(mediaType);
                 return true;
             }
-            catch (Exception)
+            catch
             {
                 dataType = WebPubSubDataType.Binary;
                 return false;

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/JObjectTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/JObjectTests.cs
@@ -536,6 +536,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
         }
 
         [TestCase]
+        public void TestConnectionStatesConverter_SystemText_InvalidReturnEmpty()
+        {
+            var jsonOption = new SystemJson.JsonSerializerOptions();
+            jsonOption.Converters.Add(new ConnectionStatesConverter());
+            var input = new Dictionary<string, string>
+                {
+                    { "aKey", "aValue" },
+                    { "bKey", "123" },
+                    { "cKey", DateTime.Now.ToString() }
+                };
+            var serialized = SystemJson.JsonSerializer.Serialize(input);
+            var deserialized = SystemJson.JsonSerializer.Deserialize<IReadOnlyDictionary<string, BinaryData>>(serialized, jsonOption);
+
+            Assert.NotNull(deserialized);
+            Assert.AreEqual(0, deserialized.Count);
+        }
+
+        [TestCase]
         public void TestConnectionStatesEncodeDecode()
         {
             var testTime = DateTime.Parse("2021-11-10 4:23:55");

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Request/ConnectEventRequest.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Request/ConnectEventRequest.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Azure.WebPubSub.Common
 
         /// <summary>
         /// Create <see cref="EventErrorResponse"/>.
+        /// Methods works for Function Extensions. And AspNetCore SDK Hub methods can directly throw exception for error cases.
         /// </summary>
         /// <param name="code"><see cref="WebPubSubErrorCode"/>.</param>
         /// <param name="message">Detail error message.</param>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Request/UserEventRequest.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Request/UserEventRequest.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.WebPubSub.Common
 
         /// <summary>
         /// Create <see cref="EventErrorResponse"/>.
+        /// Methods works for Function Extensions. And AspNetCore SDK Hub methods can directly throw exception for error cases.
         /// </summary>
         /// <param name="code"><see cref="WebPubSubErrorCode"/>.</param>
         /// <param name="message">Detail error message.</param>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Shared/ConnectionStatesConverter.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Shared/ConnectionStatesConverter.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.WebPubSub.Common
     /// </summary>
     internal class ConnectionStatesConverter : JsonConverter<IReadOnlyDictionary<string, BinaryData>>
     {
+        private static readonly Dictionary<string, BinaryData> _defaultDict = new();
+
         public static JsonSerializerOptions Options = RegisterSerializerOptions();
 
         /// <inheritdoc/>
@@ -23,21 +25,21 @@ namespace Microsoft.Azure.WebPubSub.Common
         {
             try
             {
-                var dic = new Dictionary<string, BinaryData>();
+                var dict = new Dictionary<string, BinaryData>();
                 var element = JsonDocument.ParseValue(ref reader).RootElement;
                 foreach (var elementInfo in element.EnumerateObject())
                 {
                     // Use Base64 decode mapping to encode to avoid data loss.
                     var decoded = elementInfo.Value.GetBytesFromBase64();
-                    dic.Add(elementInfo.Name, BinaryData.FromBytes(decoded));
+                    dict.Add(elementInfo.Name, BinaryData.FromBytes(decoded));
                 }
-                return dic;
+                return dict;
             }
             catch
             {
                 // States not set via SDK and users need to read from Header themselves.
                 // Avoid partial results and return a non-null value.
-                return default;
+                return _defaultDict;
             }
         }
 

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Shared/ConnectionStatesConverter.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Shared/ConnectionStatesConverter.cs
@@ -25,9 +25,18 @@ namespace Microsoft.Azure.WebPubSub.Common
             var element = JsonDocument.ParseValue(ref reader).RootElement;
             foreach (var elementInfo in element.EnumerateObject())
             {
-                // Use Base64 decode mapping to encode to avoid data loss.
-                var decoded = elementInfo.Value.GetBytesFromBase64();
-                dic.Add(elementInfo.Name, BinaryData.FromBytes(decoded));
+                try
+                {
+                    // Use Base64 decode mapping to encode to avoid data loss.
+                    var decoded = elementInfo.Value.GetBytesFromBase64();
+                    dic.Add(elementInfo.Name, BinaryData.FromBytes(decoded));
+                }
+                catch (Exception)
+                {
+                    // States not set via SDK and users need to read from Header themselves.
+                    // Avoid partial results and return a non-null value.
+                    return new Dictionary<string, BinaryData>();
+                }
             }
             return dic;
         }

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Shared/ConnectionStatesConverter.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Shared/ConnectionStatesConverter.cs
@@ -21,24 +21,24 @@ namespace Microsoft.Azure.WebPubSub.Common
         /// <inheritdoc/>
         public override IReadOnlyDictionary<string, BinaryData> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var dic = new Dictionary<string, BinaryData>();
-            var element = JsonDocument.ParseValue(ref reader).RootElement;
-            foreach (var elementInfo in element.EnumerateObject())
+            try
             {
-                try
+                var dic = new Dictionary<string, BinaryData>();
+                var element = JsonDocument.ParseValue(ref reader).RootElement;
+                foreach (var elementInfo in element.EnumerateObject())
                 {
                     // Use Base64 decode mapping to encode to avoid data loss.
                     var decoded = elementInfo.Value.GetBytesFromBase64();
                     dic.Add(elementInfo.Name, BinaryData.FromBytes(decoded));
                 }
-                catch (Exception)
-                {
-                    // States not set via SDK and users need to read from Header themselves.
-                    // Avoid partial results and return a non-null value.
-                    return new Dictionary<string, BinaryData>();
-                }
+                return dic;
             }
-            return dic;
+            catch
+            {
+                // States not set via SDK and users need to read from Header themselves.
+                // Avoid partial results and return a non-null value.
+                return default;
+            }
         }
 
         /// <inheritdoc/>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Shared/ConnectionStatesConverter.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.Common/src/Shared/ConnectionStatesConverter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebPubSub.Common
     /// </summary>
     internal class ConnectionStatesConverter : JsonConverter<IReadOnlyDictionary<string, BinaryData>>
     {
-        private static readonly Dictionary<string, BinaryData> _defaultDict = new();
+        private static readonly Dictionary<string, BinaryData> EmptyDictionary = new();
 
         public static JsonSerializerOptions Options = RegisterSerializerOptions();
 
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebPubSub.Common
             {
                 // States not set via SDK and users need to read from Header themselves.
                 // Avoid partial results and return a non-null value.
-                return _defaultDict;
+                return EmptyDictionary;
             }
         }
 


### PR DESCRIPTION
Not throw exception when states not applied to SDK deserialization logic. Users can read from headers themselves.