### PR TITLE
Clean-up conditions and continue on caching error

### DIFF
--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -8,7 +8,7 @@ steps:
     inputs:
       solution: eng/InstallDevopsLogger.proj
       msbuildArguments: /p:WorkFolder="$(Agent.WorkFolder)" /p:BuildDirectory="$(Agent.BuildDirectory)"
-  #Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
+  # Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'
     inputs:
@@ -16,14 +16,14 @@ steps:
       performMultiLevelLookup: true
   # test-proxy requires ASP.NET Core 5.0 runtime
   - task: UseDotNet@2
-    condition: ne(variables['Agent.OS'], 'Windows_NT') # Windows supports MultiLevelLookup and doesn't need explicit framework installation
+    condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT')) # Windows supports MultiLevelLookup and doesn't need explicit framework installation
     displayName: 'Use .NET Core 5.0 SDK'
     inputs:
       packageType: sdk
       performMultiLevelLookup: true
       version: "5.0.x"
   - task: UseDotNet@2
-    condition: ne(variables['Agent.OS'], 'Windows_NT') # Windows supports MultiLevelLookup and doesn't need explicit framework installation
+    condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT')) # Windows supports MultiLevelLookup and doesn't need explicit framework installation
     displayName: 'Use .NET Core 3.1 SDK'
     inputs:
       # AspNetCore runtime pack can't be installed outside of SDK and we need it for intergation tests
@@ -34,5 +34,6 @@ steps:
     inputs:
       key: 'nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/eng/Packages.Data.props | ${{parameters.NuGetCacheKey}}'
       path: $(NUGET_PACKAGES)
-    condition: ${{parameters.EnableNuGetCache}}
+    condition: and(succeeded(), ${{parameters.EnableNuGetCache}})
+    continueOnError: true
     displayName: Cache NuGet packages


### PR DESCRIPTION
There has been some recent issues with the caching tasks where it fails and blocks the build so setting it to continueOnError:true as it should never block the build. Also cleaned up some of the other conditions so they only run on successful builds instead of always.
