### PR TITLE
Fixed a bug in the SubscriptionData class - displayName and subscriptonId were specified in the wrong order.

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/SubscriptionData.Serialization.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/PsuedoGenerated/Resources/Models/SubscriptionData.Serialization.cs
@@ -99,7 +99,7 @@ namespace Azure.ResourceManager.Resources
                     continue;
                 }
             }
-            return new SubscriptionData(id.Value, subscriptionId.Value, displayName.Value, tenantId.Value, Optional.ToNullable(state), subscriptionPolicies.Value, authorizationSource.Value, Optional.ToList(managedByTenants), Optional.ToDictionary(tags));
+            return new SubscriptionData(id.Value, displayName.Value, subscriptionId.Value, tenantId.Value, Optional.ToNullable(state), subscriptionPolicies.Value, authorizationSource.Value, Optional.ToList(managedByTenants), Optional.ToDictionary(tags));
         }
     }
 }


### PR DESCRIPTION
displayName and subscriptonId parameters were specified in the wrong order.

Sample program that shows the issue:
```
using Azure.Identity;
using Azure.ResourceManager;
using Azure.ResourceManager.Resources;

namespace HelloAzureResourceManager
{
    class Program
    {
        static async Task Main(string[] args)
        {
            ArmClient armClient = new ArmClient(new DefaultAzureCredential());
            SubscriptionCollection subscriptions = armClient.GetSubscriptions();

            await foreach (Subscription sub in subscriptions)
            {
                Console.WriteLine($"Id: {sub.Data.SubscriptionGuid}, Display Name: {sub.Data.DisplayName}");
            }
        }
    }
}
```
sub.Data.SubscriptionGuid is set to subscription name and sub.Data.DisplayName is set to subscription id.