### PR TITLE
Azure.Identity adding authentication broker support to InteractiveBrowserCredential

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -97,8 +97,9 @@
 
     <!-- Other approved packages -->
     <PackageReference Update="Microsoft.Azure.Amqp" Version="2.5.6" />
-    <PackageReference Update="Microsoft.Identity.Client" Version="4.30.1" />
+    <PackageReference Update="Microsoft.Identity.Client" Version="4.39.0" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.4" />
+    <PackageReference Update="Microsoft.Identity.Client.Desktop" Version="4.39.0" />
 
     <!-- TODO: Make sure this package is arch-board approved -->
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.6.0-beta.1 (Unreleased)
 
 ### Features Added
+- Added authentication broker support to the `InteractiveBrowserCredential`
+    - Added the `PreferBroker` property on `InteractiveBrowserCredentialOptions`
 
 ### Breaking Changes
 

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -214,6 +214,7 @@ namespace Azure.Identity
         public string ClientId { get { throw null; } set { } }
         public bool DisableAutomaticAuthentication { get { throw null; } set { } }
         public string LoginHint { get { throw null; } set { } }
+        public bool PreferBroker { get { throw null; } set { } }
         public System.Uri RedirectUri { get { throw null; } set { } }
         public string TenantId { get { throw null; } set { } }
         public Azure.Identity.TokenCachePersistenceOptions TokenCachePersistenceOptions { get { throw null; } set { } }

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -1,13 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the implementation of the Azure SDK Client Library for Azure Identity</Description>
     <AssemblyTitle>Microsoft Azure.Identity Component</AssemblyTitle>
     <Version>1.6.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.5.0</ApiCompatVersion>
+    <ApiCompatVersion Condition="('$(TargetFramework)' != 'net461')" >1.5.0</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks);net461</TargetFrameworks>
     <PackageTags>Microsoft Azure Identity;$(PackageCommonTags)</PackageTags>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -20,8 +19,8 @@
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
-  <!--Only Add Microsoft.Identity.Client.Desktop when compiled for desktop-->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <!--Only Add Microsoft.Identity.Client.Desktop when compiled for desktop or net core 3.1-->
+  <ItemGroup Condition="('$(TargetFramework)' == 'net461')">
     <PackageReference Include="Microsoft.Identity.Client.Desktop" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -5,6 +5,7 @@
     <Version>1.6.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.0</ApiCompatVersion>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net461</TargetFrameworks>
     <PackageTags>Microsoft Azure Identity;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>
@@ -18,6 +19,10 @@
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
+  </ItemGroup>
+  <!--Only Add Microsoft.Identity.Client.Desktop when compiled for desktop-->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
@@ -23,6 +23,7 @@ namespace Azure.Identity
         internal MsalPublicClient Client { get; }
         internal CredentialPipeline Pipeline { get; }
         internal bool DisableAutomaticAuthentication { get; }
+
         internal AuthenticationRecord Record { get; private set; }
 
         private const string AuthenticationRequiredMessage = "Interactive authentication is needed to acquire token. Call Authenticate to interactively authenticate.";
@@ -80,7 +81,8 @@ namespace Azure.Identity
             Pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
             LoginHint = (options as InteractiveBrowserCredentialOptions)?.LoginHint;
             var redirectUrl = (options as InteractiveBrowserCredentialOptions)?.RedirectUri?.AbsoluteUri ?? Constants.DefaultRedirectUrl;
-            Client = client ?? new MsalPublicClient(Pipeline, tenantId, clientId, redirectUrl, options as ITokenCacheOptions, options?.IsLoggingPIIEnabled ?? false);
+            var preferBroker = (options as InteractiveBrowserCredentialOptions)?.PreferBroker ?? false;
+            Client = client ?? new MsalPublicClient(Pipeline, tenantId, clientId, redirectUrl, options as ITokenCacheOptions, options?.IsLoggingPIIEnabled ?? false, preferBroker);
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
@@ -53,5 +53,10 @@ namespace Azure.Identity
         /// Avoids the account prompt and pre-populates the username of the account to login.
         /// </summary>
         public string LoginHint { get; set; }
+
+        /// <summary>
+        /// When set to true the <see cref="InteractiveBrowserCredential"/> will use the system authentication broker instead of the system browser when available.
+        /// </summary>
+        public bool PreferBroker { get; set; }
     }
 }

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -15,13 +15,16 @@ namespace Azure.Identity
     {
         internal string RedirectUrl { get; }
 
+        internal bool EnableBroker { get; }
+
         protected MsalPublicClient()
         { }
 
-        public MsalPublicClient(CredentialPipeline pipeline, string tenantId, string clientId, string redirectUrl, ITokenCacheOptions cacheOptions, bool isPiiLoggingEnabled)
+        public MsalPublicClient(CredentialPipeline pipeline, string tenantId, string clientId, string redirectUrl, ITokenCacheOptions cacheOptions, bool isPiiLoggingEnabled, bool enableBroker = false)
             : base(pipeline, tenantId, clientId, isPiiLoggingEnabled, cacheOptions)
         {
             RedirectUrl = redirectUrl;
+            EnableBroker = enableBroker;
         }
 
         protected override ValueTask<IPublicClientApplication> CreateClientAsync(bool async, CancellationToken cancellationToken)
@@ -46,6 +49,11 @@ namespace Azure.Identity
             if (!string.IsNullOrEmpty(RedirectUrl))
             {
                 pubAppBuilder = pubAppBuilder.WithRedirectUri(RedirectUrl);
+            }
+
+            if (EnableBroker)
+            {
+                pubAppBuilder = pubAppBuilder.WithBroker();
             }
 
             if (clientCapabilities.Length > 0)

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -9,6 +9,9 @@ using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
+#if (NETFRAMEWORK)
+using Microsoft.Identity.Client.Desktop;
+#endif
 
 namespace Azure.Identity
 {
@@ -54,10 +57,11 @@ namespace Azure.Identity
 
             if (EnableBroker)
             {
-#if NET45
-                pubAppBuilder.WithDesktopFeatures();
-#endif
+#if (NETFRAMEWORK)
+                pubAppBuilder.WithWindowsBroker();
+#else
                 pubAppBuilder = pubAppBuilder.WithBroker();
+#endif
             }
 
             if (clientCapabilities.Length > 0)

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,6 +54,9 @@ namespace Azure.Identity
 
             if (EnableBroker)
             {
+#if NET45
+                pubAppBuilder.WithDesktopFeatures();
+#endif
                 pubAppBuilder = pubAppBuilder.WithBroker();
             }
 

--- a/sdk/identity/Azure.Identity/tests/Azure.Identity.Tests.csproj
+++ b/sdk/identity/Azure.Identity/tests/Azure.Identity.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);netcoreapp3.1;</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialLiveTests.cs
@@ -22,7 +22,6 @@ namespace Azure.Identity.Tests
         public void ClearDiscoveryCache()
         {
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
-            StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();
         }
 
         [TestCase(true)]

--- a/sdk/identity/Azure.Identity/tests/ClientSecretCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientSecretCredentialLiveTests.cs
@@ -21,7 +21,6 @@ namespace Azure.Identity.Tests
         public void ClearDiscoveryCache()
         {
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
-            StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();
         }
 
         [Test]

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -148,7 +148,6 @@ namespace Azure.Identity.Tests
             await client.AcquireTokenByUsernamePassword(new[] { testEnvironment.KeyvaultScope }, username, password.ToSecureString()).ExecuteAsync();
 
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
-            StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();
             return retriever.RefreshToken;
         }
 

--- a/sdk/identity/Azure.Identity/tests/IdentityRecordedTestBase.cs
+++ b/sdk/identity/Azure.Identity/tests/IdentityRecordedTestBase.cs
@@ -26,6 +26,8 @@ namespace Azure.Identity.Tests
             Matcher.LegacyExcludedHeaders.Add("x-client-SKU");
             Matcher.LegacyExcludedHeaders.Add("x-client-CPU");
             Matcher.LegacyExcludedHeaders.Add("x-client-Ver");
+            Matcher.LegacyExcludedHeaders.Add("x-client-current-telemetry");
+            Matcher.LegacyExcludedHeaders.Add("x-client-last-telemetry");
             // x-ms-PKeyAuth is only added on MAC and Linux so recordings made on windows will fail on these platforms and vice-versa
             // ignoring this header as CI must run on all platforms
             Matcher.LegacyExcludedHeaders.Add("x-ms-PKeyAuth");

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
@@ -29,6 +29,18 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
+        public async Task AuthenticateWithBrokerAsync()
+        {
+            // to fully manually verify the InteractiveBrowserCredential this test should be run both authenticating with a
+            // school / organization account as well as a personal live account, i.e. a @outlook.com, @live.com, or @hotmail.com
+            var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { PreferBroker = true });
+
+            AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" })).ConfigureAwait(false);
+
+            Assert.NotNull(token.Token);
+        }
+
+        [Test]
         [Ignore("This test is an integration test which can only be run with user interaction")]
         public void AuthenticateBrowserCancellationAsync()
         {

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        //[Ignore("This test is an integration test which can only be run with user interaction")]
+        [Ignore("This test is an integration test which can only be run with user interaction")]
         public async Task AuthenticateWithBrokerAsync()
         {
             var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { PreferBroker = true });

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        [Ignore("This test is an integration test which can only be run with user interaction")]
+        //[Ignore("This test is an integration test which can only be run with user interaction")]
         public async Task AuthenticateWithBrokerAsync()
         {
             var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { PreferBroker = true });

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialLiveTests.cs
@@ -29,10 +29,9 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
+        [Ignore("This test is an integration test which can only be run with user interaction")]
         public async Task AuthenticateWithBrokerAsync()
         {
-            // to fully manually verify the InteractiveBrowserCredential this test should be run both authenticating with a
-            // school / organization account as well as a personal live account, i.e. a @outlook.com, @live.com, or @hotmail.com
             var cred = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { PreferBroker = true });
 
             AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" })).ConfigureAwait(false);

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
@@ -48,6 +48,15 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
+        public void RespectsPreferBroker([Values(true, false)] bool preferBroker)
+        {
+            var credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { PreferBroker = preferBroker });
+
+            Assert.NotNull(credential.Client);
+            Assert.AreEqual(preferBroker, credential.Client.EnableBroker);
+        }
+
+        [Test]
         public async Task InteractiveBrowserAcquireTokenSilentException()
         {
             string expInnerExMessage = Guid.NewGuid().ToString();

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialFederatedTokenLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialFederatedTokenLiveTests.cs
@@ -26,7 +26,6 @@ namespace Azure.Identity.Tests
         public void ClearDiscoveryCache()
         {
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
-            StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();
         }
 
         [NonParallelizable]

--- a/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialLiveTests.cs
@@ -50,7 +50,6 @@ namespace Azure.Identity.Tests
         public void ClearDiscoveryCache()
         {
             StaticCachesUtilities.ClearStaticMetadataProviderCache();
-            StaticCachesUtilities.ClearAuthorityEndpointResolutionManagerCache();
         }
 
         // !!!!!! WARNING !!!!!


### PR DESCRIPTION
Adds support for authenticating through the platform authentication broker when availble.
 Adds `PreferBroker` property to `InteractiveBrowserCredentialOptions`
