### PR TITLE
Add Azure.Core to solutions that have TestFramework

### DIFF
--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/Azure.Verticals.AgriFood.Farming.sln
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/Azure.Verticals.AgriFood.Farming.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Stress", "..\..\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{0ED9C8A0-9A19-4750-8DD3-61D086288283}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{7B24E7B3-64FD-4408-8B89-E9DBE54AD47A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{0ED9C8A0-9A19-4750-8DD3-61D086288283}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0ED9C8A0-9A19-4750-8DD3-61D086288283}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0ED9C8A0-9A19-4750-8DD3-61D086288283}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B24E7B3-64FD-4408-8B89-E9DBE54AD47A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B24E7B3-64FD-4408-8B89-E9DBE54AD47A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B24E7B3-64FD-4408-8B89-E9DBE54AD47A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B24E7B3-64FD-4408-8B89-E9DBE54AD47A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/Azure.AI.AnomalyDetector.sln
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/Azure.AI.AnomalyDetector.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.AnomalyDetector.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{439F1494-8E96-4931-AB0A-5BBA7EBA15D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{71C00248-3DEE-4C44-A2BB-4CCAF994DB32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{439F1494-8E96-4931-AB0A-5BBA7EBA15D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{439F1494-8E96-4931-AB0A-5BBA7EBA15D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{439F1494-8E96-4931-AB0A-5BBA7EBA15D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71C00248-3DEE-4C44-A2BB-4CCAF994DB32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71C00248-3DEE-4C44-A2BB-4CCAF994DB32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71C00248-3DEE-4C44-A2BB-4CCAF994DB32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71C00248-3DEE-4C44-A2BB-4CCAF994DB32}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/attestation/Azure.Security.Attestation/Azure.Security.Attestation.sln
+++ b/sdk/attestation/Azure.Security.Attestation/Azure.Security.Attestation.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Security.Attestation.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{8052009B-2126-44A3-88CD-4F3B17894C64}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{261AB245-22A3-48DF-8F7F-15868E60B872}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{8052009B-2126-44A3-88CD-4F3B17894C64}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8052009B-2126-44A3-88CD-4F3B17894C64}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8052009B-2126-44A3-88CD-4F3B17894C64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{261AB245-22A3-48DF-8F7F-15868E60B872}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{261AB245-22A3-48DF-8F7F-15868E60B872}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{261AB245-22A3-48DF-8F7F-15868E60B872}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{261AB245-22A3-48DF-8F7F-15868E60B872}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/communication/Azure.Communication.sln
+++ b/sdk/communication/Azure.Communication.sln
@@ -44,6 +44,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Communication.Calling
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Communication.CallingServer.Tests", "Azure.Communication.CallingServer\tests\Azure.Communication.CallingServer.Tests.csproj", "{B7C0269B-1809-4713-A7BD-390098AB7135}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{78638C36-A6ED-47CE-BC99-76BD8725DE92}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +120,10 @@ Global
 		{B7C0269B-1809-4713-A7BD-390098AB7135}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7C0269B-1809-4713-A7BD-390098AB7135}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B7C0269B-1809-4713-A7BD-390098AB7135}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78638C36-A6ED-47CE-BC99-76BD8725DE92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78638C36-A6ED-47CE-BC99-76BD8725DE92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78638C36-A6ED-47CE-BC99-76BD8725DE92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78638C36-A6ED-47CE-BC99-76BD8725DE92}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/Azure.Security.ConfidentialLedger.sln
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/Azure.Security.ConfidentialLedger.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Security.ConfidentialLedger.Tests", "tests\Azure.Security.ConfidentialLedger.Tests.csproj", "{953B33C8-42F0-45BF-B6A4-46D80D39A9E3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{EF8F81A5-B1E7-41B3-BBAD-819F10F3C501}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{953B33C8-42F0-45BF-B6A4-46D80D39A9E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{953B33C8-42F0-45BF-B6A4-46D80D39A9E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{953B33C8-42F0-45BF-B6A4-46D80D39A9E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF8F81A5-B1E7-41B3-BBAD-819F10F3C501}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF8F81A5-B1E7-41B3-BBAD-819F10F3C501}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF8F81A5-B1E7-41B3-BBAD-819F10F3C501}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF8F81A5-B1E7-41B3-BBAD-819F10F3C501}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/core/Azure.Core.TestFramework/Azure.Core.TestFramework.sln
+++ b/sdk/core/Azure.Core.TestFramework/Azure.Core.TestFramework.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "src\Azure.Core.TestFramework.csproj", "{961FD4FB-3CA1-4B33-B6FD-8396CF9280DF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\Azure.Core\src\Azure.Core.csproj", "{0654EC0E-12B8-44C6-9906-7CCE7A5697FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{961FD4FB-3CA1-4B33-B6FD-8396CF9280DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{961FD4FB-3CA1-4B33-B6FD-8396CF9280DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{961FD4FB-3CA1-4B33-B6FD-8396CF9280DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0654EC0E-12B8-44C6-9906-7CCE7A5697FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0654EC0E-12B8-44C6-9906-7CCE7A5697FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0654EC0E-12B8-44C6-9906-7CCE7A5697FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0654EC0E-12B8-44C6-9906-7CCE7A5697FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/Azure.IoT.DeviceUpdate.sln
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/Azure.IoT.DeviceUpdate.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceUpdateClientSample", "samples\DeviceUpdateClientSample\DeviceUpdateClientSample.csproj", "{4719AE90-2B90-4DBC-92DA-8CCE29D5B7F3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{9BD705AB-D378-4859-8DDE-3865C0893661}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{4719AE90-2B90-4DBC-92DA-8CCE29D5B7F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4719AE90-2B90-4DBC-92DA-8CCE29D5B7F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4719AE90-2B90-4DBC-92DA-8CCE29D5B7F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BD705AB-D378-4859-8DDE-3865C0893661}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BD705AB-D378-4859-8DDE-3865C0893661}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BD705AB-D378-4859-8DDE-3865C0893661}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BD705AB-D378-4859-8DDE-3865C0893661}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/Azure.DigitalTwins.Core.sln
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/Azure.DigitalTwins.Core.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{E685A401-AF9E-4196-975B-26C4A340256F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{4153CAAF-C1D5-4104-ABD9-7F010E6AAFAB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{15EF5B20-42F6-4280-BE8E-DAC973B572A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15EF5B20-42F6-4280-BE8E-DAC973B572A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{15EF5B20-42F6-4280-BE8E-DAC973B572A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4153CAAF-C1D5-4104-ABD9-7F010E6AAFAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4153CAAF-C1D5-4104-ABD9-7F010E6AAFAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4153CAAF-C1D5-4104-ABD9-7F010E6AAFAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4153CAAF-C1D5-4104-ABD9-7F010E6AAFAB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/Microsoft.Azure.WebJobs.Extensions.EventGrid.sln
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/Microsoft.Azure.WebJobs.Extensions.EventGrid.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventGrid",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{328250F6-39A2-489A-81E5-46C13C59D8F7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{C05E2889-0E7C-4942-8B6F-15DCAF817156}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{328250F6-39A2-489A-81E5-46C13C59D8F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{328250F6-39A2-489A-81E5-46C13C59D8F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{328250F6-39A2-489A-81E5-46C13C59D8F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C05E2889-0E7C-4942-8B6F-15DCAF817156}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C05E2889-0E7C-4942-8B6F-15DCAF817156}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C05E2889-0E7C-4942-8B6F-15DCAF817156}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C05E2889-0E7C-4942-8B6F-15DCAF817156}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/perf/Azure.Messaging.EventHubs.Processor.Perf.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/perf/Azure.Messaging.EventHubs.Processor.Perf.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{1F5EE4F0-7DE8-4E3E-819C-58F34D17C2A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\..\core\Azure.Core\src\Azure.Core.csproj", "{01AA6564-166A-411E-9B0D-6A2CABA246F7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{1F5EE4F0-7DE8-4E3E-819C-58F34D17C2A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F5EE4F0-7DE8-4E3E-819C-58F34D17C2A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1F5EE4F0-7DE8-4E3E-819C-58F34D17C2A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01AA6564-166A-411E-9B0D-6A2CABA246F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01AA6564-166A-411E-9B0D-6A2CABA246F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01AA6564-166A-411E-9B0D-6A2CABA246F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01AA6564-166A-411E-9B0D-6A2CABA246F7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/Microsoft.Azure.WebJobs.Extensions.EventHubs.sln
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/Microsoft.Azure.WebJobs.Extensions.EventHubs.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventHubs",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Azure", "..\..\extensions\Microsoft.Extensions.Azure\src\Microsoft.Extensions.Azure.csproj", "{E772769A-7CE1-4FBC-A084-C0936EB2C766}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{FD65B96F-855A-495C-AA82-03402336E96C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,5 +88,17 @@ Global
 		{E772769A-7CE1-4FBC-A084-C0936EB2C766}.Release|x64.Build.0 = Release|Any CPU
 		{E772769A-7CE1-4FBC-A084-C0936EB2C766}.Release|x86.ActiveCfg = Release|Any CPU
 		{E772769A-7CE1-4FBC-A084-C0936EB2C766}.Release|x86.Build.0 = Release|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Debug|x64.Build.0 = Debug|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Debug|x86.Build.0 = Debug|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Release|x64.ActiveCfg = Release|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Release|x64.Build.0 = Release|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Release|x86.ActiveCfg = Release|Any CPU
+		{FD65B96F-855A-495C-AA82-03402336E96C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/sdk/extensions/Azure.Extensions.sln
+++ b/sdk/extensions/Azure.Extensions.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.WebJobs.Ext
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Azure.Samples", "Microsoft.Extensions.Azure\samples\Microsoft.Extensions.Azure.Samples.csproj", "{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -243,6 +245,18 @@ Global
 		{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}.Release|x64.Build.0 = Release|Any CPU
 		{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}.Release|x86.ActiveCfg = Release|Any CPU
 		{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}.Release|x86.Build.0 = Release|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|x64.Build.0 = Debug|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Debug|x86.Build.0 = Debug|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|x64.ActiveCfg = Release|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|x64.Build.0 = Release|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|x86.ActiveCfg = Release|Any CPU
+		{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/Azure.AI.FormRecognizer.sln
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/Azure.AI.FormRecognizer.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.FormRecognizer.Perf", "perf\Azure.AI.FormRecognizer.Perf\Azure.AI.FormRecognizer.Perf.csproj", "{E11C4DF2-C78A-4EE3-B3FC-BE4F7C7A80F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{6C5E5550-A9AE-4B52-84E5-32E035AC4D40}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{E11C4DF2-C78A-4EE3-B3FC-BE4F7C7A80F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E11C4DF2-C78A-4EE3-B3FC-BE4F7C7A80F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E11C4DF2-C78A-4EE3-B3FC-BE4F7C7A80F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C5E5550-A9AE-4B52-84E5-32E035AC4D40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C5E5550-A9AE-4B52-84E5-32E035AC4D40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C5E5550-A9AE-4B52-84E5-32E035AC4D40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C5E5550-A9AE-4B52-84E5-32E035AC4D40}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/iot/Azure.IoT.Hub.Service/Azure.IoT.Hub.Service.sln
+++ b/sdk/iot/Azure.IoT.Hub.Service/Azure.IoT.Hub.Service.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IotHubClientSamples", "samples\IotHubClientSamples\IotHubClientSamples.csproj", "{8291D7B1-E485-4C04-9712-6DF1D4646C28}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{DE1EBB40-4BB4-491B-9FE2-FB82948333D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{8291D7B1-E485-4C04-9712-6DF1D4646C28}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8291D7B1-E485-4C04-9712-6DF1D4646C28}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8291D7B1-E485-4C04-9712-6DF1D4646C28}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE1EBB40-4BB4-491B-9FE2-FB82948333D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE1EBB40-4BB4-491B-9FE2-FB82948333D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE1EBB40-4BB4-491B-9FE2-FB82948333D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE1EBB40-4BB4-491B-9FE2-FB82948333D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/Azure.AI.MetricsAdvisor.sln
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/Azure.AI.MetricsAdvisor.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{DECB7564-96C8-413F-8F87-998C1E8C077F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{1715D99D-E5B4-4970-93FA-FEE2AA7573D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{DECB7564-96C8-413F-8F87-998C1E8C077F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DECB7564-96C8-413F-8F87-998C1E8C077F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DECB7564-96C8-413F-8F87-998C1E8C077F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1715D99D-E5B4-4970-93FA-FEE2AA7573D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1715D99D-E5B4-4970-93FA-FEE2AA7573D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1715D99D-E5B4-4970-93FA-FEE2AA7573D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1715D99D-E5B4-4970-93FA-FEE2AA7573D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/Azure.MixedReality.Authentication.sln
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/Azure.MixedReality.Authentication.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.Azure.MixedReality.A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.Azure.MixedReality.Authentication.Tests", "tests\Shared.Azure.MixedReality.Authentication.Tests\Shared.Azure.MixedReality.Authentication.Tests.csproj", "{A128CD7B-EABC-48C7-BAD2-216007EF130D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{CFD20568-B88B-4CA1-852B-E21F3ADFB12E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{A128CD7B-EABC-48C7-BAD2-216007EF130D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A128CD7B-EABC-48C7-BAD2-216007EF130D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A128CD7B-EABC-48C7-BAD2-216007EF130D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFD20568-B88B-4CA1-852B-E21F3ADFB12E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFD20568-B88B-4CA1-852B-E21F3ADFB12E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFD20568-B88B-4CA1-852B-E21F3ADFB12E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFD20568-B88B-4CA1-852B-E21F3ADFB12E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/Azure.IoT.ModelsRepository.sln
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/Azure.IoT.ModelsRepository.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModelsRepositoryClientSamples", "samples\ModelsRepositoryClientSamples\ModelsRepositoryClientSamples.csproj", "{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{D9CAD23D-60CF-4CA7-8683-3507A81DE2FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9CAD23D-60CF-4CA7-8683-3507A81DE2FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9CAD23D-60CF-4CA7-8683-3507A81DE2FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9CAD23D-60CF-4CA7-8683-3507A81DE2FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9CAD23D-60CF-4CA7-8683-3507A81DE2FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization", "tests\Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization\Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization.csproj", "{57A53135-3C1B-4106-B873-434B2F606B17}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{9816D6D4-AAF3-42F8-A358-962A8BE6FFC6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{57A53135-3C1B-4106-B873-434B2F606B17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57A53135-3C1B-4106-B873-434B2F606B17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{57A53135-3C1B-4106-B873-434B2F606B17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9816D6D4-AAF3-42F8-A358-962A8BE6FFC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9816D6D4-AAF3-42F8-A358-962A8BE6FFC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9816D6D4-AAF3-42F8-A358-962A8BE6FFC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9816D6D4-AAF3-42F8-A358-962A8BE6FFC6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/Azure.MixedReality.ObjectAnchors.Conversion.sln
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/Azure.MixedReality.ObjectAnchors.Conversion.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.MixedReality.ObjectAnchors.Conversion.Tests", "tests\Azure.MixedReality.ObjectAnchors.Conversion.Tests.csproj", "{FDE9619C-6A39-4A72-8E78-9ACB3B8C64FB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{557636BA-FB06-4AC6-B604-23ADB1ED1492}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{FDE9619C-6A39-4A72-8E78-9ACB3B8C64FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDE9619C-6A39-4A72-8E78-9ACB3B8C64FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDE9619C-6A39-4A72-8E78-9ACB3B8C64FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{557636BA-FB06-4AC6-B604-23ADB1ED1492}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{557636BA-FB06-4AC6-B604-23ADB1ED1492}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{557636BA-FB06-4AC6-B604-23ADB1ED1492}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{557636BA-FB06-4AC6-B604-23ADB1ED1492}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/personalizer/Azure.AI.Personalizer.sln
+++ b/sdk/personalizer/Azure.AI.Personalizer.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{0F88C67F-34D2-4C68-B5BF-08A547D4CC2E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{F788BE17-A662-4EA2-98DD-AA6423A7F3C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{0F88C67F-34D2-4C68-B5BF-08A547D4CC2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F88C67F-34D2-4C68-B5BF-08A547D4CC2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F88C67F-34D2-4C68-B5BF-08A547D4CC2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F788BE17-A662-4EA2-98DD-AA6423A7F3C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F788BE17-A662-4EA2-98DD-AA6423A7F3C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F788BE17-A662-4EA2-98DD-AA6423A7F3C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F788BE17-A662-4EA2-98DD-AA6423A7F3C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/purview/Azure.Analytics.Purview.Account/Azure.Analytics.Purview.Account.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Account/Azure.Analytics.Purview.Account.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Acc
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{1E9A1DB3-96FC-4EB4-B6E2-13FB057B050A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{002a0f15-402b-473d-8842-5507462920bf}*SharedItemsImports = 5
@@ -45,6 +47,10 @@ Global
 		{002A0F15-402B-473D-8842-5507462920BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{002A0F15-402B-473D-8842-5507462920BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{002A0F15-402B-473D-8842-5507462920BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E9A1DB3-96FC-4EB4-B6E2-13FB057B050A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E9A1DB3-96FC-4EB4-B6E2-13FB057B050A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E9A1DB3-96FC-4EB4-B6E2-13FB057B050A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E9A1DB3-96FC-4EB4-B6E2-13FB057B050A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/purview/Azure.Analytics.Purview.Administration/Azure.Analytics.Purview.Administration.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/Azure.Analytics.Purview.Administration.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{85677AD3-C214-42FA-AE6E-49B956CAC8DC}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{283cb4fe-a207-4d92-8431-6147f1ecbab7}*SharedItemsImports = 13
@@ -45,6 +47,10 @@ Global
 		{FA8BD3F1-8616-47B6-974C-7576CDF4717E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA8BD3F1-8616-47B6-974C-7576CDF4717E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FA8BD3F1-8616-47B6-974C-7576CDF4717E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85677AD3-C214-42FA-AE6E-49B956CAC8DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85677AD3-C214-42FA-AE6E-49B956CAC8DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85677AD3-C214-42FA-AE6E-49B956CAC8DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85677AD3-C214-42FA-AE6E-49B956CAC8DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/Azure.Analytics.Purview.Catalog.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/Azure.Analytics.Purview.Catalog.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Cat
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{B48EFD57-7500-4A8E-870B-46E3C511B9DF}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{002a0f15-402b-473d-8842-5507462920bf}*SharedItemsImports = 5
@@ -45,6 +47,10 @@ Global
 		{002A0F15-402B-473D-8842-5507462920BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{002A0F15-402B-473D-8842-5507462920BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{002A0F15-402B-473D-8842-5507462920BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B48EFD57-7500-4A8E-870B-46E3C511B9DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B48EFD57-7500-4A8E-870B-46E3C511B9DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B48EFD57-7500-4A8E-870B-46E3C511B9DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B48EFD57-7500-4A8E-870B-46E3C511B9DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/Azure.Analytics.Purview.Scanning.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/Azure.Analytics.Purview.Scanning.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Sca
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{546166BC-7440-407B-AD50-85C90190D0C1}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{283cb4fe-a207-4d92-8431-6147f1ecbab7}*SharedItemsImports = 13
@@ -45,6 +47,10 @@ Global
 		{41F48A9A-86CC-4855-AB01-3B2F94E6E8CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41F48A9A-86CC-4855-AB01-3B2F94E6E8CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41F48A9A-86CC-4855-AB01-3B2F94E6E8CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{546166BC-7440-407B-AD50-85C90190D0C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{546166BC-7440-407B-AD50-85C90190D0C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{546166BC-7440-407B-AD50-85C90190D0C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{546166BC-7440-407B-AD50-85C90190D0C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/quantum/Azure.Quantum.Jobs/Azure.Quantum.Jobs.sln
+++ b/sdk/quantum/Azure.Quantum.Jobs/Azure.Quantum.Jobs.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Quantum.Jobs.Samples", "samples\Azure.Quantum.Jobs.Samples.csproj", "{C48526E9-7F6A-494F-8193-3C050BD8E32E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{1953481F-8E50-406A-B1E6-51FFDFA43ECF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{C48526E9-7F6A-494F-8193-3C050BD8E32E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C48526E9-7F6A-494F-8193-3C050BD8E32E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C48526E9-7F6A-494F-8193-3C050BD8E32E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1953481F-8E50-406A-B1E6-51FFDFA43ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1953481F-8E50-406A-B1E6-51FFDFA43ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1953481F-8E50-406A-B1E6-51FFDFA43ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1953481F-8E50-406A-B1E6-51FFDFA43ECF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/Azure.MixedReality.RemoteRendering.sln
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/Azure.MixedReality.RemoteRendering.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.MixedReality.RemoteRe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{85271BAE-8B48-43B6-8A16-BBD3F14F7AA1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{44601A61-63BA-4251-88EE-3BFF39E8D05E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{85271BAE-8B48-43B6-8A16-BBD3F14F7AA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{85271BAE-8B48-43B6-8A16-BBD3F14F7AA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85271BAE-8B48-43B6-8A16-BBD3F14F7AA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44601A61-63BA-4251-88EE-3BFF39E8D05E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44601A61-63BA-4251-88EE-3BFF39E8D05E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44601A61-63BA-4251-88EE-3BFF39E8D05E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44601A61-63BA-4251-88EE-3BFF39E8D05E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/Azure.Data.SchemaRegistry.sln
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/Azure.Data.SchemaRegistry.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.SchemaRegistry.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{8052009B-2126-44A3-88CD-4F3B17894C64}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{6A8336DC-AE5F-4955-95E3-BF5010A4CE5D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{8052009B-2126-44A3-88CD-4F3B17894C64}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8052009B-2126-44A3-88CD-4F3B17894C64}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8052009B-2126-44A3-88CD-4F3B17894C64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A8336DC-AE5F-4955-95E3-BF5010A4CE5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A8336DC-AE5F-4955-95E3-BF5010A4CE5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A8336DC-AE5F-4955-95E3-BF5010A4CE5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A8336DC-AE5F-4955-95E3-BF5010A4CE5D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Microsoft.Azure.WebJobs.Extensions.ServiceBus.sln
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Microsoft.Azure.WebJobs.Extensions.ServiceBus.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.ServiceBus"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{E0274499-FD0C-4AC5-9CA9-F94379AA29CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{F589935A-C325-47C5-A1DE-4C42A735B1B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{E0274499-FD0C-4AC5-9CA9-F94379AA29CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0274499-FD0C-4AC5-9CA9-F94379AA29CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E0274499-FD0C-4AC5-9CA9-F94379AA29CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F589935A-C325-47C5-A1DE-4C42A735B1B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F589935A-C325-47C5-A1DE-4C42A735B1B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F589935A-C325-47C5-A1DE-4C42A735B1B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F589935A-C325-47C5-A1DE-4C42A735B1B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/sqlmanagement/Azure.ResourceManager.Sql/Azure.ResourceManager.Sql.sln
+++ b/sdk/sqlmanagement/Azure.ResourceManager.Sql/Azure.ResourceManager.Sql.sln
@@ -9,6 +9,8 @@ Project("{DCF1AD44-8A51-4851-93A8-0611F8D4DC61}") = "Azure.ResourceManager.Sql",
 EndProject
 Project("{DCF1AD44-8A51-4851-93A8-0611F8D4DC61}") = "Azure.ResourceManager.Sql.Tests", "tests\Azure.ResourceManager.Sql.Tests.csproj", "{BE6FF05E-1E3C-4C35-B18A-89A029B79999}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{23367795-CD08-4A70-929D-2164EE74D82A}"
+EndProject
 Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -61,5 +63,17 @@ Global
 		{BE6FF05E-1E3C-4C35-B18A-89A029B79999}.Release|x64.Build.0 = Release|Any CPU
 		{BE6FF05E-1E3C-4C35-B18A-89A029B79999}.Release|x86.ActiveCfg = Release|Any CPU
 		{BE6FF05E-1E3C-4C35-B18A-89A029B79999}.Release|x86.Build.0 = Release|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Debug|x64.Build.0 = Debug|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Debug|x86.Build.0 = Debug|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Release|x64.ActiveCfg = Release|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Release|x64.Build.0 = Release|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Release|x86.ActiveCfg = Release|Any CPU
+		{23367795-CD08-4A70-929D-2164EE74D82A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Azure.Storage.Files.DataLake.Perf.sln
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Azure.Storage.Files.DataLake.Perf.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{59CCD0D2-1F7B-4EB8-AAF5-A4CB01DD1BC6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\..\..\core\Azure.Core\src\Azure.Core.csproj", "{AB603D89-33D9-46D3-8135-3F582945A3B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{59CCD0D2-1F7B-4EB8-AAF5-A4CB01DD1BC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59CCD0D2-1F7B-4EB8-AAF5-A4CB01DD1BC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59CCD0D2-1F7B-4EB8-AAF5-A4CB01DD1BC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB603D89-33D9-46D3-8135-3F582945A3B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB603D89-33D9-46D3-8135-3F582945A3B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB603D89-33D9-46D3-8135-3F582945A3B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB603D89-33D9-46D3-8135-3F582945A3B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Ext
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Function.App", "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs\samples\functionapp\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Function.App.csproj", "{22D974DB-0B34-48F5-90EC-F65F9902E7D3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{03A5BF93-27C7-4923-B006-004DFD0795C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -116,6 +118,10 @@ Global
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22D974DB-0B34-48F5-90EC-F65F9902E7D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03A5BF93-27C7-4923-B006-004DFD0795C0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/tables/Azure.Data.Tables/Azure.Data.Tables.sln
+++ b/sdk/tables/Azure.Data.Tables/Azure.Data.Tables.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.Tables.Performance", "tests\perf\Azure.Data.Tables.Perf.csproj", "{3EA53995-C462-43F2-9413-72E29BE04DD4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{CDBB043B-8D26-4232-9FB7-F8A10D3D1DCF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{3EA53995-C462-43F2-9413-72E29BE04DD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EA53995-C462-43F2-9413-72E29BE04DD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EA53995-C462-43F2-9413-72E29BE04DD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDBB043B-8D26-4232-9FB7-F8A10D3D1DCF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDBB043B-8D26-4232-9FB7-F8A10D3D1DCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDBB043B-8D26-4232-9FB7-F8A10D3D1DCF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDBB043B-8D26-4232-9FB7-F8A10D3D1DCF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/Microsoft.Azure.WebJobs.Extensions.Tables.sln
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/Microsoft.Azure.WebJobs.Extensions.Tables.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.WebJobs.Ext
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{5153257C-C449-4776-B3CB-022C9ABB5543}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{B0D107B8-6BEE-4F9F-91BC-049721DF4620}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{5153257C-C449-4776-B3CB-022C9ABB5543}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5153257C-C449-4776-B3CB-022C9ABB5543}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5153257C-C449-4776-B3CB-022C9ABB5543}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0D107B8-6BEE-4F9F-91BC-049721DF4620}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0D107B8-6BEE-4F9F-91BC-049721DF4620}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0D107B8-6BEE-4F9F-91BC-049721DF4620}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0D107B8-6BEE-4F9F-91BC-049721DF4620}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/sdk/template-dpg/Azure.Template.Generated/Azure.Template.Generated.sln
+++ b/sdk/template-dpg/Azure.Template.Generated/Azure.Template.Generated.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Template.Generated", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Template.Generated.Tests", "tests\Azure.Template.Generated.Tests.csproj", "{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{40028299-DE93-48CA-969B-A100D555A1FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40028299-DE93-48CA-969B-A100D555A1FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40028299-DE93-48CA-969B-A100D555A1FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40028299-DE93-48CA-969B-A100D555A1FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40028299-DE93-48CA-969B-A100D555A1FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/template/Azure.Template/Azure.Template.sln
+++ b/sdk/template/Azure.Template/Azure.Template.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Template.Perf", "perf
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{0ED9C8A0-9A19-4750-8DD3-61D086288283}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{AA507C7F-F19A-48AB-A7FA-CB113314418F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{0ED9C8A0-9A19-4750-8DD3-61D086288283}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0ED9C8A0-9A19-4750-8DD3-61D086288283}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0ED9C8A0-9A19-4750-8DD3-61D086288283}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA507C7F-F19A-48AB-A7FA-CB113314418F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA507C7F-F19A-48AB-A7FA-CB113314418F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA507C7F-F19A-48AB-A7FA-CB113314418F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA507C7F-F19A-48AB-A7FA-CB113314418F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/Azure.IoT.TimeSeriesInsights.sln
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/Azure.IoT.TimeSeriesInsights.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TimeSeriesInsightsClientSample", "samples\TimeSeriesInsightsClientSample\TimeSeriesInsightsClientSample.csproj", "{D243481B-0944-4F60-9B1F-35EDFC7769BA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{7FE9FA2F-7793-4EB9-B8D0-26696536508B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{D243481B-0944-4F60-9B1F-35EDFC7769BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D243481B-0944-4F60-9B1F-35EDFC7769BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D243481B-0944-4F60-9B1F-35EDFC7769BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FE9FA2F-7793-4EB9-B8D0-26696536508B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FE9FA2F-7793-4EB9-B8D0-26696536508B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FE9FA2F-7793-4EB9-B8D0-26696536508B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FE9FA2F-7793-4EB9-B8D0-26696536508B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/translation/Azure.AI.Translation.Document/Azure.AI.Translation.Document.sln
+++ b/sdk/translation/Azure.AI.Translation.Document/Azure.AI.Translation.Document.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.AI.Translation.Document.Tests", "tests\Azure.AI.Translation.Document.Tests.csproj", "{764BFCBB-D8FD-401A-8075-B8F5F10B4991}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{D55A8124-3081-4F60-A2D7-744819FA0295}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{764BFCBB-D8FD-401A-8075-B8F5F10B4991}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{764BFCBB-D8FD-401A-8075-B8F5F10B4991}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{764BFCBB-D8FD-401A-8075-B8F5F10B4991}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D55A8124-3081-4F60-A2D7-744819FA0295}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D55A8124-3081-4F60-A2D7-744819FA0295}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D55A8124-3081-4F60-A2D7-744819FA0295}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D55A8124-3081-4F60-A2D7-744819FA0295}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/Azure.Media.VideoAnalyzer.Edge.sln
+++ b/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/Azure.Media.VideoAnalyzer.Edge.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Media.VideoAnalyzer.E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Media.VideoAnalyzer.Edge.Samples", "samples\Azure.Media.VideoAnalyzer.Edge.Samples.csproj", "{FE985514-0F2A-44AA-844A-F360A4475F21}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{B1DC71AF-5225-4E2E-A1C0-60C796D4B566}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{FE985514-0F2A-44AA-844A-F360A4475F21}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FE985514-0F2A-44AA-844A-F360A4475F21}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FE985514-0F2A-44AA-844A-F360A4475F21}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1DC71AF-5225-4E2E-A1C0-60C796D4B566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1DC71AF-5225-4E2E-A1C0-60C796D4B566}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1DC71AF-5225-4E2E-A1C0-60C796D4B566}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1DC71AF-5225-4E2E-A1C0-60C796D4B566}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/Azure.Messaging.WebPubSub.sln
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/Azure.Messaging.WebPubSub.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.WebPubSub",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.WebPubSub.Tests", "tests\Azure.Messaging.WebPubSub.Tests.csproj", "{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{96840387-72F6-45DC-A790-7E449523141B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96840387-72F6-45DC-A790-7E449523141B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96840387-72F6-45DC-A790-7E449523141B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96840387-72F6-45DC-A790-7E449523141B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96840387-72F6-45DC-A790-7E449523141B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The TestFramework has a dependency on Azure.Core project. The build fails in Visual Studio if the project is not part of the solution.