### PR TITLE
Include API ref docs link in Monitor Query README

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -9,6 +9,7 @@ The Azure Monitor Query client library is used to execute read-only queries agai
 
 - [Source code][source]
 - [Package (NuGet)][package]
+- [API reference documentation][msdocs_apiref]
 - [Service documentation][azure_monitor_overview]
 - [Change log][changelog]
 
@@ -425,6 +426,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 [kusto_query_language]: https://docs.microsoft.com/azure/data-explorer/kusto/query/
 [logging]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md
 [monitor_rest_api]: https://docs.microsoft.com/rest/api/monitor/
+[msdocs_apiref]: https://docs.microsoft.com/dotnet/api/overview/azure/monitor/query?view=azure-dotnet
 [package]: https://www.nuget.org/packages/Azure.Monitor.Query
 [source]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/src
 


### PR DESCRIPTION
Add a link to the API ref to more closely align with the other languages' READMEs and to improve discoverability.