### PR TITLE
[Storage][Files] OpenRead - mention exception thrown for other failures

### DIFF
--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -2124,6 +2124,8 @@ namespace Azure.Storage.Files.Shares
         /// <remarks>
         /// The stream returned might throw <see cref="ShareFileModifiedException"/>
         /// if the file is concurrently modified and <see cref="ShareFileOpenReadOptions"/> don't allow modification.
+        ///
+        /// A <see cref="RequestFailedException" /> will be thrown if other failures occur.
         /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual Stream OpenRead(
@@ -2157,6 +2159,8 @@ namespace Azure.Storage.Files.Shares
         /// <remarks>
         /// The stream returned might throw <see cref="ShareFileModifiedException"/>
         /// if the file is concurrently modified and <see cref="ShareFileOpenReadOptions"/> don't allow modification.
+        ///
+        /// A <see cref="RequestFailedException" /> will be thrown if other failures occur.
         /// </remarks>
 #pragma warning disable AZC0015 // Unexpected client method return type.
         public virtual async Task<Stream> OpenReadAsync(
@@ -2199,6 +2203,8 @@ namespace Azure.Storage.Files.Shares
         /// <remarks>
         /// The stream returned might throw <see cref="ShareFileModifiedException"/>
         /// if the file is concurrently modified.
+        ///
+        /// A <see cref="RequestFailedException" /> will be thrown if other failures occur.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0015 // Unexpected client method return type.
@@ -2243,6 +2249,8 @@ namespace Azure.Storage.Files.Shares
         /// <remarks>
         /// The stream returned might throw <see cref="ShareFileModifiedException"/>
         /// if the file is concurrently modified.
+        ///
+        /// A <see cref="RequestFailedException" /> will be thrown if other failures occur.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0015 // Unexpected client method return type.
@@ -2285,6 +2293,8 @@ namespace Azure.Storage.Files.Shares
         /// <remarks>
         /// The stream returned might throw <see cref="ShareFileModifiedException"/>
         /// if the file is concurrently modified.
+        ///
+        /// A <see cref="RequestFailedException" /> will be thrown if other failures occur.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0015 // Unexpected client method return type.
@@ -2329,6 +2339,8 @@ namespace Azure.Storage.Files.Shares
         /// <remarks>
         /// The stream returned might throw <see cref="ShareFileModifiedException"/>
         /// if the file is concurrently modified.
+        ///
+        /// A <see cref="RequestFailedException" /> will be thrown if other failures occur.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable AZC0015 // Unexpected client method return type.
@@ -2380,6 +2392,8 @@ namespace Azure.Storage.Files.Shares
         /// <remarks>
         /// The stream returned might throw <see cref="ShareFileModifiedException"/>
         /// if the file is concurrently modified and allowModifications is false.
+        ///
+        /// A <see cref="RequestFailedException" /> will be thrown if other failures occur.
         /// </remarks>
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         internal async Task<Stream> OpenReadInteral(


### PR DESCRIPTION
The docs for [`OpenRead`](https://docs.microsoft.com/en-us/dotnet/api/azure.storage.files.shares.sharefileclient.openread?view=azure-dotnet) and [`OpenReadAsync`](https://docs.microsoft.com/en-us/dotnet/api/azure.storage.files.shares.sharefileclient.openreadasync?view=azure-dotnet) don't mention the exception thrown for other failures like when a file is not present. This PR adds a mention of the exception, [`RequestFailedException`](https://docs.microsoft.com/en-us/dotnet/api/azure.requestfailedexception?view=azure-dotnet), which is thrown for such cases.

resolves #25662 