### PR TITLE
Migrate form recognizer to test-proxy

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestRecording.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestRecording.cs
@@ -329,7 +329,7 @@ namespace Azure.Core.TestFramework
         {
             if (!_useLegacyTransport && Mode != RecordedTestMode.Live)
             {
-                return new ProxyTransport(_proxy, currentTransport, this);
+                return new ProxyTransport(_proxy, currentTransport, this, () => _disableRecording.Value);
             }
             return Mode switch
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DocumentAnalysisLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DocumentAnalysisLiveTestBase.cs
@@ -19,7 +19,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
         private readonly DocumentAnalysisClientOptions.ServiceVersion _serviceVersion;
 
         public DocumentAnalysisLiveTestBase(bool isAsync, DocumentAnalysisClientOptions.ServiceVersion serviceVersion)
-            : base(isAsync, useLegacyTransport: true)
+            : base(isAsync)
         {
             _serviceVersion = serviceVersion;
             Sanitizer = new DocumentAnalysisRecordedTestSanitizer();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.FormRecognizer.Tests
         private readonly FormRecognizerClientOptions.ServiceVersion _serviceVersion;
 
         public FormRecognizerLiveTestBase(bool isAsync, FormRecognizerClientOptions.ServiceVersion serviceVersion)
-            : base(isAsync, useLegacyTransport: true)
+            : base(isAsync)
         {
             _serviceVersion = serviceVersion;
             Sanitizer = new FormRecognizerRecordedTestSanitizer();


### PR DESCRIPTION
For now, leaving the filter body request in Test Framework. Issue tracking addition to Test Proxy - https://github.com/Azure/azure-sdk-tools/issues/2434

Contributes to https://github.com/Azure/azure-sdk-for-net/issues/24167