### PR TITLE
Merge autorest change to rename low-level-client flag to data-plane

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -146,7 +146,7 @@
     All should have PrivateAssets="All" set so they don't become package dependencies
   -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20211210.4" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.Azure.AutoRest.CSharp" Version="3.0.0-beta.20211213.3" PrivateAssets="All" />
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20210903.4" PrivateAssets="All" />
     <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="All" />

--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/autorest.md
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: FarmBeats
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/683e3f4849ee1d84629d0d0fa17789e80a9cee08/specification/agfood/data-plane/Microsoft.AgFoodPlatform/preview/2021-03-31-preview/agfood.json
 namespace: Azure.Verticals.AgriFood.Farming
-low-level-client: true
+data-plane: true
 security: AADToken
 security-scopes: https://farmbeats.azure.net/.default
 ```

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/autorest.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/src/autorest.md
@@ -15,7 +15,7 @@ batch:
 # TODO: Uncomment when we ship authoring support and remove ./ConversationsClientOptions.cs.
 # - input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/33138867cd88a4a8689feb591a98dda26d96a63e/specification/cognitiveservices/data-plane/Language/preview/2021-07-15-preview/analyzeconversations-authoring.json
 #   add-credentials: true
-#   low-level-client: true
+#   data-plane: true
 
 modelerfour:
   lenient-model-deduplication: true

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
@@ -15,7 +15,7 @@ batch:
 # TODO: Uncomment when we ship authoring support and remove ./QuestionAnsweringClientOptions.cs.
 # - input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/34a2c0723155d134311419fd997925ce96b85bec/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering-authoring.json
 #   add-credentials: true
-#   low-level-client: true
+#   data-plane: true
 
 modelerfour:
   lenient-model-deduplication: true

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/autorest.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/autorest.md
@@ -7,7 +7,7 @@ title: ConfidentialLedger
 namespace: Azure.Security.ConfidentialLedger 
 security: AADToken
 security-scopes: "https://confidential-ledger.azure.com/.default"
-low-level-client: true
+data-plane: true
 input-file:
     -  https://github.com/Azure/azure-rest-api-specs/blob/e34c5f11d61ca17fdc9fd0f70446dd54b94d67f1/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/0.1-preview/common.json
     -  https://github.com/Azure/azure-rest-api-specs/blob/e34c5f11d61ca17fdc9fd0f70446dd54b94d67f1/specification/confidentialledger/data-plane/Microsoft.ConfidentialLedger/preview/0.1-preview/confidentialledger.json

--- a/sdk/purview/Azure.Analytics.Purview.Account/src/autorest.md
+++ b/sdk/purview/Azure.Analytics.Purview.Account/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: PurviewAccount
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/b2bddfe2e59b5b14e559e0433b6e6d057bcff95d/specification/purview/data-plane/Azure.Analytics.Purview.Account/preview/2019-11-01-preview/account.json
 namespace: Azure.Analytics.Purview.Account
-low-level-client: true
+data-plane: true
 security: AADToken
 security-scopes:  https://purview.azure.net/.default
 ```

--- a/sdk/purview/Azure.Analytics.Purview.Administration/src/autorest.md
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/src/autorest.md
@@ -8,7 +8,7 @@ input-file:
   - https://github.com/Azure/azure-rest-api-specs/blob/b2bddfe2e59b5b14e559e0433b6e6d057bcff95d/specification/purview/data-plane/Azure.Analytics.Purview.Account/preview/2019-11-01-preview/account.json
   - https://github.com/Azure/azure-rest-api-specs/blob/1424fc4a1f82af852a626c6ab6d1d296b5fe4df1/specification/purview/data-plane/Azure.Analytics.Purview.MetadataPolicies/preview/2021-07-01/purviewMetadataPolicy.json
 namespace: Azure.Analytics.Purview.Administration
-low-level-client: true
+data-plane: true
 modelerfour:
     lenient-model-deduplication: true
 security: AADToken

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/src/autorest.md
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: PurviewCatalog
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d23ad89e8c3e98c4f941fd9ec3db6ab39951a494/specification/purview/data-plane/Azure.Analytics.Purview.Catalog/preview/2021-05-01-preview/purviewcatalog.json
 namespace: Azure.Analytics.Purview.Catalog
-low-level-client: true
+data-plane: true
 security: AADToken
 security-scopes:  https://purview.azure.net/.default
 ```

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/src/autorest.md
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: PurviewScanningService
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/1c7df99f6a84335cfd7bf5be8c800d72c1dddbc2/specification/purview/data-plane/Azure.Analytics.Purview.Scanning/preview/2018-12-01-preview/scanningService.json
 namespace: Azure.Analytics.Purview.Scanning
-low-level-client: true
+data-plane: true
 security: AADToken
 security-scopes:  https://purview.azure.net/.default
 modelerfour:

--- a/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/autorest.md
@@ -11,7 +11,7 @@ require:
     - https://github.com/Azure/azure-rest-api-specs/blob/37c4ff1612668f5acec62dea729ca3a66b591d7f/specification/synapse/data-plane/readme.md
 namespace: Azure.Analytics.Synapse.AccessControl
 public-clients: true
-low-level-client: true
+data-plane: true
 security: AADToken
 security-scopes: https://dev.azuresynapse.net/.default
 ```

--- a/sdk/template-dpg/Azure.Template.Generated/src/autorest.md
+++ b/sdk/template-dpg/Azure.Template.Generated/src/autorest.md
@@ -10,7 +10,7 @@ input-file:
 - $(this-folder)/swagger/swagger.json
 namespace: Azure.Template.Generated
 public-clients: true
-low-level-client: true
+data-plane: true
 security: AADToken
 security-scopes: https://dev.azuresdkgenerated.net/.default
 ```

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/autorest.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/autorest.md
@@ -10,7 +10,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 title: WebPubSubServiceClient
 input-file:
 - https://github.com/Azure/azure-rest-api-specs/blob/39c7d63c21b9a29efe3907d9b949d1c77b021907/specification/webpubsub/data-plane/WebPubSub/stable/2021-10-01/webpubsub.json
-low-level-client: true
+data-plane: true
 credential-types: AzureKeyCredential
 credential-header-name: Ocp-Apim-Subscription-Key
 ```


### PR DESCRIPTION
PR https://github.com/Azure/autorest.csharp/pull/1739 changed the name of the code generator flag used to generate clients with protocol methods from `low-level-client` to `data-plane` as part of an overall effort renaming "Low level client" to "Data plane code generation."