### PR TITLE
[Messaging] AMQP Library Version Bump

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -96,7 +96,7 @@
     <PackageReference Update="Azure.ResourceManager" Version="1.0.0-beta.6" />
 
     <!-- Other approved packages -->
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.5.6" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.5.8" />
     <PackageReference Update="Microsoft.Identity.Client" Version="4.30.1" />
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.4" />
 
@@ -250,7 +250,7 @@
     <PackageReference Update="System.Security.Cryptography.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
-    <PackageDownload Include="Azure.Sdk.Tools.Testproxy" Version="[$(TestProxyVersion)]" />  
+    <PackageDownload Include="Azure.Sdk.Tools.Testproxy" Version="[$(TestProxyVersion)]" />
     <PackageReference Update="WindowsAzure.ServiceBus" Version="5.1.0" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Update="xunit" Version="2.4.1" />
@@ -260,8 +260,8 @@
     <PackageDownload Update="NETStandard.Library.Ref" Version="[2.1.0]" />
   </ItemGroup>
 
-   <PropertyGroup>
-     <TestProxyVersion>1.0.0-dev.20211202.1</TestProxyVersion>
-   </PropertyGroup>
+  <PropertyGroup>
+    <TestProxyVersion>1.0.0-dev.20211202.1</TestProxyVersion>
+  </PropertyGroup>
 
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -515,7 +515,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 if (ManagementLink?.TryGetOpenedObject(out var _) == true)
                 {
-                    await ManagementLink.CloseAsync().ConfigureAwait(false);
+                    await ManagementLink.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
 
                 ManagementLink?.Dispose();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -413,7 +413,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 if (ReceiveLink?.TryGetOpenedObject(out var _) == true)
                 {
-                    await ReceiveLink.CloseAsync().ConfigureAwait(false);
+                    await ReceiveLink.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
 
                 ReceiveLink?.Dispose();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -402,7 +402,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 if (SendLink?.TryGetOpenedObject(out var _) == true)
                 {
-                    await SendLink.CloseAsync().ConfigureAwait(false);
+                    await SendLink.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
 
                 SendLink?.Dispose();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -1305,13 +1305,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
             if (_receiveLink?.TryGetOpenedObject(out var _) == true)
             {
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-                await _receiveLink.CloseAsync().ConfigureAwait(false);
+                await _receiveLink.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
             if (_managementLink?.TryGetOpenedObject(out var _) == true)
             {
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-                await _managementLink.CloseAsync().ConfigureAwait(false);
+                await _managementLink.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
             _receiveLink?.Dispose();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -340,13 +340,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 if (_sendLink?.TryGetOpenedObject(out var _) == true)
                 {
                     cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-                    await _sendLink.CloseAsync().ConfigureAwait(false);
+                    await _sendLink.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
 
                 if (_managementLink?.TryGetOpenedObject(out var _) == true)
                 {
                     cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-                    await _managementLink.CloseAsync().ConfigureAwait(false);
+                    await _managementLink.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                 }
 
                 _sendLink?.Dispose();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpTransactionEnlistment.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpTransactionEnlistment.cs
@@ -7,6 +7,7 @@ using System.Transactions;
 using Microsoft.Azure.Amqp;
 using Microsoft.Azure.Amqp.Transaction;
 using Azure.Messaging.ServiceBus.Diagnostics;
+using System.Threading;
 
 namespace Azure.Messaging.ServiceBus.Amqp
 {
@@ -31,13 +32,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         public ArraySegment<byte> AmqpTransactionId { get; private set; }
 
-        protected override async Task<AmqpTransactionEnlistment> OnCreateAsync(TimeSpan timeout)
+        protected override async Task<AmqpTransactionEnlistment> OnCreateAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             try
             {
                 Controller controller = await GetController(timeout).ConfigureAwait(false);
 
-                AmqpTransactionId = await controller.DeclareAsync().ConfigureAwait(false);
+                AmqpTransactionId = await controller.DeclareAsync(cancellationToken).ConfigureAwait(false);
                 ServiceBusEventSource.Log.TransactionDeclared(_transactionId, AmqpTransactionId);
                 return this;
             }


### PR DESCRIPTION
# Summary 

The focus of these changes is to bump the version of the AMQP transport library used by Event Hubs and Service Bus to the latest GA version which includes:

- A fix for ensuring the TaskCompletionSource used internally by AMQP objects
runs continuations asynchronously.

- Support for cancellation tokens when performing CBS link authorization
and requesting a fault tolerant AMQP object.