### PR TITLE
Local Test Timeouts

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/ClientTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientTestBase.cs
@@ -49,7 +49,7 @@ namespace Azure.Core.TestFramework
             {
                 executionContext.CurrentResult.SetResult(
                     ResultState.Failure,
-                    $"Test exceeded global time limit of {GLOBAL_TEST_TIMEOUT_IN_SECONDS} seconds. Duration: {duration}");
+                    $"Test exceeded global time limit of {timeout} seconds. Duration: {duration}");
             }
         }
 

--- a/sdk/core/Azure.Core.TestFramework/src/ClientTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientTestBase.cs
@@ -22,6 +22,7 @@ namespace Azure.Core.TestFramework
         private static readonly IInterceptor s_diagnosticScopeValidatingInterceptor = new DiagnosticScopeValidatingInterceptor();
         private static Dictionary<Type, Exception> s_clientValidation = new Dictionary<Type, Exception>();
         private const int GLOBAL_TEST_TIMEOUT_IN_SECONDS = 10;
+        private const int GLOBAL_LOCAL_TEST_TIMEOUT_IN_SECONDS = 5;
         public bool IsAsync { get; }
 
         public bool TestDiagnostics { get; set; } = true;
@@ -36,11 +37,18 @@ namespace Azure.Core.TestFramework
         [TearDown]
         public virtual void GlobalTimeoutTearDown()
         {
+            if (Debugger.IsAttached)
+            {
+                return;
+            }
+
             var executionContext = TestExecutionContext.CurrentContext;
             var duration = DateTime.UtcNow - TestStartTime;
-            if (duration > TimeSpan.FromSeconds(GLOBAL_TEST_TIMEOUT_IN_SECONDS) && !Debugger.IsAttached)
+            var timeout = TestEnvironment.GlobalIsRunningInCI ? GLOBAL_TEST_TIMEOUT_IN_SECONDS : GLOBAL_LOCAL_TEST_TIMEOUT_IN_SECONDS;
+            if (duration > TimeSpan.FromSeconds(timeout))
             {
-                executionContext.CurrentResult.SetResult(ResultState.Failure,
+                executionContext.CurrentResult.SetResult(
+                    ResultState.Failure,
                     $"Test exceeded global time limit of {GLOBAL_TEST_TIMEOUT_IN_SECONDS} seconds. Duration: {duration}");
             }
         }
@@ -52,7 +60,8 @@ namespace Azure.Core.TestFramework
 
         public TClient InstrumentClient<TClient>(TClient client) where TClient : class => (TClient)InstrumentClient(typeof(TClient), client, null);
 
-        protected TClient InstrumentClient<TClient>(TClient client, IEnumerable<IInterceptor> preInterceptors) where TClient : class => (TClient)InstrumentClient(typeof(TClient), client, preInterceptors);
+        protected TClient InstrumentClient<TClient>(TClient client, IEnumerable<IInterceptor> preInterceptors) where TClient : class =>
+            (TClient)InstrumentClient(typeof(TClient), client, preInterceptors);
 
         protected internal virtual object InstrumentClient(Type clientType, object client, IEnumerable<IInterceptor> preInterceptors)
         {
@@ -120,7 +129,7 @@ namespace Azure.Core.TestFramework
 
             return ProxyGenerator.CreateClassProxyWithTarget(
                 clientType,
-                new[] {typeof(IInstrumented)},
+                new[] { typeof(IInstrumented) },
                 client,
                 interceptors.ToArray());
         }
@@ -134,7 +143,7 @@ namespace Azure.Core.TestFramework
         {
             if (instrumented == null) throw new ArgumentNullException(nameof(instrumented));
             var i = instrumented as IInstrumented ?? throw new InvalidOperationException($"{instrumented.GetType()} is not an instrumented type");
-            return (T) i.Original;
+            return (T)i.Original;
         }
     }
 }


### PR DESCRIPTION
Implements a lower global test timeout value when tests are not running on a CI.