### PR TITLE
Enable e2e tracing in EventGrid WebJobs extension

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
@@ -67,7 +67,7 @@ namespace Azure.Core.Tests
                     {
                         Name = name,
                         Activity = Activity.Current,
-                        Links = links.Select(a => a.ParentId).ToList(),
+                        Links = links.Select(a => new ProducedLink(a.ParentId, a.TraceStateString)).ToList(),
                         LinkedActivities = links.ToList()
                     };
 
@@ -234,13 +234,31 @@ namespace Azure.Core.Tests
             public bool IsCompleted { get; set; }
             public bool IsFailed => Exception != null;
             public Exception Exception { get; set; }
-            public List<string> Links { get; set; } = new List<string>();
+            public List<ProducedLink> Links { get; set; } = new List<ProducedLink>();
             public List<Activity> LinkedActivities { get; set; } = new List<Activity>();
 
             public override string ToString()
             {
                 return Name;
             }
+        }
+
+        public struct ProducedLink
+        {
+            public ProducedLink(string id)
+            {
+                Traceparent = id;
+                Tracestate = null;
+            }
+
+            public ProducedLink(string traceparent, string tracestate)
+            {
+                Traceparent = traceparent;
+                Tracestate = tracestate;
+            }
+
+            public string Traceparent { get; set; }
+            public string Tracestate { get; set; }
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -87,9 +87,9 @@ namespace Azure.Core.Pipeline
             }
         }
 
-        public void AddLink(string id, IDictionary<string, string>? attributes = null)
+        public void AddLink(string traceparent, string tracestate, IDictionary<string, string>? attributes = null)
         {
-            _activityAdapter?.AddLink(id, attributes);
+            _activityAdapter?.AddLink(traceparent, tracestate, attributes);
         }
 
         public void Start()
@@ -246,11 +246,12 @@ namespace Azure.Core.Pipeline
                 return linkCollection;
             }
 
-            public void AddLink(string id, IDictionary<string, string>? attributes)
+            public void AddLink(string traceparent, string tracestate, IDictionary<string, string>? attributes)
             {
                 var linkedActivity = new Activity("LinkedActivity");
                 linkedActivity.SetW3CFormat();
-                linkedActivity.SetParentId(id);
+                linkedActivity.SetParentId(traceparent);
+                linkedActivity.TraceStateString = tracestate;
 
                 if (attributes != null)
                 {

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -174,7 +174,7 @@ namespace Azure.Core.Tests
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
 
-            scope.AddLink("test", null);
+            scope.AddLink("test", "ignored");
 
             scope.Start();
             scope.Dispose();

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.Net50.cs
@@ -67,8 +67,8 @@ namespace Azure.Core.Tests
                 scope.AddAttribute("Attribute2", 2, i => i.ToString());
                 scope.AddAttribute("Attribute3", 3);
 
-                scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00");
-                scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b2-2899ebfdbdce904b-00", new Dictionary<string, string>()
+                scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00", "foo=bar");
+                scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b2-2899ebfdbdce904b-00", null, new Dictionary<string, string>()
                 {
                     {"linkAttribute", "linkAttributeValue"}
                 });
@@ -88,7 +88,7 @@ namespace Azure.Core.Tests
 
                 var links = activity.Links.ToArray();
                 Assert.AreEqual(2, links.Length);
-                Assert.AreEqual(ActivityContext.Parse("00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00", null), links[0].Context);
+                Assert.AreEqual(ActivityContext.Parse("00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00", "foo=bar"), links[0].Context);
                 Assert.AreEqual(ActivityContext.Parse("00-6e76af18746bae4eadc3581338bbe8b2-2899ebfdbdce904b-00", null), links[1].Context);
 
                 Assert.AreEqual(ActivityIdFormat.W3C, activity.IdFormat);
@@ -174,7 +174,7 @@ namespace Azure.Core.Tests
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ClientName.ActivityName");
 
-            scope.AddLink("test");
+            scope.AddLink("test", null);
 
             scope.Start();
             scope.Dispose();

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -102,8 +102,8 @@ namespace Azure.Core.Tests
 
             DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
 
-            scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00");
-            scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b2-2899ebfdbdce904b-00");
+            scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00", "foo=bar");
+            scope.AddLink("00-6e76af18746bae4eadc3581338bbe8b2-2899ebfdbdce904b-00", null);
             scope.Start();
 
             (string Key, object Value, DiagnosticListener) startEvent = testListener.Events.Dequeue();
@@ -131,9 +131,11 @@ namespace Azure.Core.Tests
 
             Assert.AreEqual(ActivityIdFormat.W3C, linkedActivity1.IdFormat);
             Assert.AreEqual("00-6e76af18746bae4eadc3581338bbe8b1-2899ebfdbdce904b-00", linkedActivity1.ParentId);
+            Assert.AreEqual("foo=bar", linkedActivity1.TraceStateString);
 
             Assert.AreEqual(ActivityIdFormat.W3C, linkedActivity2.IdFormat);
             Assert.AreEqual("00-6e76af18746bae4eadc3581338bbe8b2-2899ebfdbdce904b-00", linkedActivity2.ParentId);
+            Assert.Null(linkedActivity2.TraceStateString);
 
             Assert.AreEqual(0, testListener.Events.Count);
         }
@@ -152,7 +154,7 @@ namespace Azure.Core.Tests
                 {"key2", "value2"}
             };
 
-            scope.AddLink("id", expectedTags);
+            scope.AddLink("id", null, expectedTags);
             scope.Start();
 
             (string Key, object Value, DiagnosticListener) startEvent = testListener.Events.Dequeue();

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
         private readonly DiagnosticScopeFactory _diagnosticScopeFactory;
 
         // ApplicationInsights SDK listens to all Azure SDK sources that look like 'Azure.*'
-        private const string DiagnosticScopeNamespace = "Azure.WebJobs.Extensions.EventGrid";
+        private const string DiagnosticScopeNamespace = "Azure.Messaging.EventGrid";
         private const string ResourceProviderNamespace = "Microsoft.EventGrid";
 
         // for end to end testing
@@ -214,8 +214,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
         private static void AddLinkIfEventHasContext(DiagnosticScope scope, JToken evnt)
         {
             if (evnt is JObject eventObj &&
-                    eventObj.TryGetValue("traceparent", out JToken traceparent) &&
-                    traceparent.Type == JTokenType.String)
+                eventObj.TryGetValue("traceparent", out JToken traceparent) &&
+                traceparent.Type == JTokenType.String)
             {
                 string tracestateStr = null;
                 if (eventObj.TryGetValue("tracestate", out JToken tracestate) &&

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
         // ApplicationInsights SDK listens to all Azure SDK sources that look like 'Azure.*'
         private const string DiagnosticScopeNamespace = "Azure.Messaging.EventGrid";
         private const string ResourceProviderNamespace = "Microsoft.EventGrid";
+        private const string DiagnosticScopeName = "EventGrid.Process";
 
         // for end to end testing
         internal EventGridExtensionConfigProvider(
@@ -185,7 +186,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
 
         private async Task<FunctionResult> ExecuteWithTracingAsync(string functionName, TriggeredFunctionData triggerData)
         {
-            using DiagnosticScope scope = _diagnosticScopeFactory.CreateScope(functionName, DiagnosticScope.ActivityKind.Consumer);
+            using DiagnosticScope scope = _diagnosticScopeFactory.CreateScope(DiagnosticScopeName, DiagnosticScope.ActivityKind.Consumer);
             if (scope.IsEnabled)
             {
                 if (triggerData.TriggerValue is JArray evntArray)

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
@@ -203,20 +203,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
 
             scope.Start();
 
-            try
+            FunctionResult result = await _listeners[functionName].Executor.TryExecuteAsync(triggerData, CancellationToken.None).ConfigureAwait(false);
+            if (result.Exception != null)
             {
-                FunctionResult result = await _listeners[functionName].Executor.TryExecuteAsync(triggerData, CancellationToken.None).ConfigureAwait(false);
-                if (result.Exception != null)
-                {
-                    scope.Failed(result.Exception);
-                }
-                return result;
+                scope.Failed(result.Exception);
             }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
+            return result;
         }
 
         private static void AddLinkIfEventHasContext(DiagnosticScope scope, JToken evnt)

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -14,4 +14,14 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
+  </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj
@@ -17,11 +17,7 @@
 
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared" />
-    <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared" />
-    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="Shared" />
-    <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />
-    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
   </ItemGroup>
 </Project>

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestListener.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestListener.cs
@@ -16,6 +16,7 @@ using Azure.Core.Tests;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
+using Azure.Messaging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
@@ -139,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
-            using var testListener = new ClientDiagnosticListener("Azure.WebJobs.Extensions.EventGrid");
+            using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
             const string functionName = "TestEventGrid";
             const string traceparent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             var request = CreateSingleRequest(functionName,
@@ -165,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
-            using var testListener = new ClientDiagnosticListener("Azure.WebJobs.Extensions.EventGrid");
+            using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
             const string functionName = "TestEventGrid";
             const string traceparent1 = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             const string tracestate1 = "foo1=bar1";
@@ -217,7 +218,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             var host = TestHelpers.NewHost<MyProg4>(ext);
             await host.StartAsync(); // add listener
 
-            using var testListener = new ClientDiagnosticListener("Azure.WebJobs.Extensions.EventGrid");
+            using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
             const string functionName = "EventGridMultiple";
             const string traceparent1 = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             const string tracestate1 = "foo1=bar1";
@@ -251,7 +252,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             var host = TestHelpers.NewHost<MyProg3>(ext);
             await host.StartAsync(); // add listener
 
-            using var testListener = new ClientDiagnosticListener("Azure.WebJobs.Extensions.EventGrid");
+            using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
             const string functionName = "EventGridThrowsExceptionMultiple";
             const string traceparent1 = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             const string traceparent2 = "00-1123456789abcdef0123456789abcdef-1123456789abcdef-01";

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestListener.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestListener.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using Azure.Messaging;
+using Azure.Messaging.EventGrid;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
@@ -51,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             "'dataVersion': '2'" +
             "}]";
 
+        private const string CloudEventRequiredFields = @"'id':'1','source':'one','type':'t','data':'','specversion':'1.0'";
         [SetUp]
         public void SetupTestListener()
         {
@@ -58,15 +60,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         }
 
         [Test]
-        [TestCase(CloudEventSubscription)]
-        [TestCase(EventGridEventSubscription)]
-        public async Task TestSubscribe(string evt)
+        [TestCase(CloudEventSubscription, "TestJObject")]
+        [TestCase(CloudEventSubscription, "TestCloudEvent")]
+        [TestCase(EventGridEventSubscription, "TestJObject")]
+        [TestCase(EventGridEventSubscription, "TestEventGrid")]
+        public async Task TestSubscribe(string evt, string functionName)
         {
             var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
-            var request = CreateEventSubscribeRequest("TestEventGrid", evt);
+            var request = CreateEventSubscribeRequest(functionName, evt);
             var response = await ext.ConvertAsync(request, CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -92,21 +96,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         // and that each instance has correct binding data.
         // This is the fundamental difference between a regular HTTP trigger and a EventGrid trigger.
         [Test]
-        public async Task TestDispatch()
+        [TestCase("TestJObject")]
+        [TestCase("TestEventGrid")]
+        public async Task TestDispatch(string functionName)
         {
             var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
-            var request = CreateDispatchRequest("TestEventGrid",
-                JObject.Parse(@"{'subject':'one','data':{'prop':'alpha'}}"),
-                JObject.Parse(@"{'subject':'two','data':{'prop':'beta'}}"));
+            var request = CreateDispatchRequest(functionName,
+                JObject.Parse(@"{'subject':'one','id':'one','source':'one','eventType':'t','specversion':'1.0','dataVersion':'0','data':{'prop':'alpha'}}"),
+                JObject.Parse(@"{'subject':'two','id':'two','source':'two','eventType':'t','specversion':'1.0','dataVersion':'0','data':{'prop':'beta'}}"));
             var response = await ext.ConvertAsync(request, CancellationToken.None);
 
             // Verify that the user function was dispatched twice, NOT necessarily in order
             // Also verifies each instance gets its own proper binding data (from FakePayload.Prop)
             _log.TryGetValue("one", out string alpha);
             _log.TryGetValue("two", out string beta);
+            Assert.AreEqual(2, _log.Count);
             Assert.AreEqual("alpha", alpha);
             Assert.AreEqual("beta", beta);
             // TODO - Verify that we return from webhook before the dispatch is finished
@@ -122,14 +129,72 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
-            var request = CreateSingleRequest("TestEventGrid",
-                JObject.Parse(@"{'subject':'one','data':{'prop':'alpha'}}"));
+            var request = CreateSingleRequest("TestCloudEvent",
+                JObject.Parse(@"{'id':'one','source':'one','type':'t','data':'','specversion':'1.0','data':{'prop':'alpha'}}"));
             var response = await ext.ConvertAsync(request, CancellationToken.None);
 
             // verifies each instance gets its own proper binding data (from FakePayload.Prop)
             _log.TryGetValue("one", out string alpha);
             Assert.AreEqual("alpha", alpha);
+            Assert.AreEqual(1, _log.Count);
             Assert.AreEqual(HttpStatusCode.Accepted, response.StatusCode);
+        }
+
+        [Test]
+        [TestCase("TestJObject")]
+        [TestCase("TestEventGrid")]
+        public async Task TestEventGridEventWithTracingSingleDispatch(string functionName)
+        {
+            // individual elements
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
+            var host = TestHelpers.NewHost<MyProg1>(ext);
+            await host.StartAsync(); // add listener
+
+            using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
+            var request = CreateDispatchRequest(functionName,
+                JObject.Parse(@"{'subject':'one','eventType':'1','id':'1','dataVersion':'0','data':{'prop':'alpha'}}"),
+                JObject.Parse(@"{'subject':'one','eventType':'2','id':'1','dataVersion':'0','data':{'prop':'alpha'}}"));
+            var response = await ext.ConvertAsync(request, CancellationToken.None);
+
+            Assert.AreEqual(2, testListener.Scopes.Count);
+
+            // one of executions will fail because of dup subject
+            Assert.AreEqual(1, testListener.Scopes.Count(s => s.Exception != null));
+
+            for (int i = 0; i < 2; i++)
+            {
+                var executionScope = testListener.AssertAndRemoveScope("EventGrid.Process", new KeyValuePair<string, string>("az.namespace", "Microsoft.EventGrid"));
+                Assert.IsEmpty(executionScope.Links);
+                Assert.True(_log.TryGetValue(executionScope.Activity.Id, out var activityName));
+                Assert.AreEqual("EventGrid.Process", activityName);
+            }
+        }
+
+        [Test]
+        [TestCase("TestJObjectMultiple")]
+        [TestCase("TestEventGridMultiple")]
+        public async Task TestEventGridEventBatchDispatchWithTracing(string functionName)
+        {
+            // individual elements
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
+            var host = TestHelpers.NewHost<MyProg1>(ext);
+            await host.StartAsync(); // add listener
+
+            using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
+            var request = CreateDispatchRequest(functionName,
+                JObject.Parse(@"{'subject':'one','eventType':'1','id':'1','dataVersion':'0','data':{'prop':'alpha'}}"),
+                JObject.Parse(@"{'subject':'two','eventType':'2','id':'2','dataVersion':'0','data':{'prop':'alpha'}}"));
+
+            var response = await ext.ConvertAsync(request, CancellationToken.None);
+
+            Assert.AreEqual(1, testListener.Scopes.Count);
+            var executionScope = testListener.AssertScope("EventGrid.Process",
+                new KeyValuePair<string, string>("az.namespace", "Microsoft.EventGrid"));
+
+            Assert.IsEmpty(executionScope.Links);
+            Assert.Null(executionScope.Exception);
+            Assert.True(_log.TryGetValue(executionScope.Activity.Id, out var activityName));
+            Assert.AreEqual("EventGrid.Process", activityName);
         }
 
         [Test]
@@ -141,21 +206,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             await host.StartAsync(); // add listener
 
             using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
-            const string functionName = "TestEventGrid";
+            const string functionName = "TestCloudEvent";
             const string traceparent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             var request = CreateSingleRequest(functionName,
-                JObject.Parse($"{{'subject':'one','data':{{'prop':'alpha'}}, 'traceparent':'{traceparent}'}}"));
+                JObject.Parse($"{{{CloudEventRequiredFields},'traceparent':'{traceparent}','data':{{'prop':'1'}}}}"));
             var response = await ext.ConvertAsync(request, CancellationToken.None);
 
             Assert.AreEqual(1, testListener.Scopes.Count);
-            var executionScope = testListener.AssertScope(functionName,
+            var executionScope = testListener.AssertScope("EventGrid.Process",
                 new KeyValuePair<string, string>("az.namespace", "Microsoft.EventGrid"));
 
             var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink(traceparent) };
             Assert.That(executionScope.Links, Is.EquivalentTo(expectedLinks));
             Assert.Null(executionScope.Exception);
             Assert.True(_log.TryGetValue(executionScope.Activity.Id, out var activityName));
-            Assert.AreEqual(functionName, activityName);
+            Assert.AreEqual("EventGrid.Process", activityName);
         }
 
         [Test]
@@ -167,14 +232,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             await host.StartAsync(); // add listener
 
             using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
-            const string functionName = "TestEventGrid";
+            const string functionName = "TestCloudEvent";
             const string traceparent1 = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             const string tracestate1 = "foo1=bar1";
             const string traceparent2 = "00-1123456789abcdef0123456789abcdef-1123456789abcdef-01";
 
             var request = CreateDispatchRequest(functionName,
-                JObject.Parse($"{{'subject':'one','data':{{'prop':'alpha'}},'traceparent':'{traceparent1}','tracestate':'{tracestate1}'}}"),
-                JObject.Parse($"{{'subject':'one','data':{{'prop':'alpha'}},'traceparent':'{traceparent2}'}}"));
+                JObject.Parse($"{{{CloudEventRequiredFields},'data':{{'prop':'1'}},'traceparent':'{traceparent1}','tracestate':'{tracestate1}'}}"),
+                JObject.Parse($"{{{CloudEventRequiredFields},'data':{{'prop':'2'}},'traceparent':'{traceparent2}'}}"));
 
             var response = await ext.ConvertAsync(request, CancellationToken.None);
 
@@ -186,10 +251,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             bool fullFound = false, parentOnlyFound = false;
             for (int i = 0; i < 2; i++)
             {
-                var executionScope = testListener.AssertAndRemoveScope(functionName, new KeyValuePair<string, string>("az.namespace", "Microsoft.EventGrid"));
+                var executionScope = testListener.AssertAndRemoveScope("EventGrid.Process", new KeyValuePair<string, string>("az.namespace", "Microsoft.EventGrid"));
                 Assert.AreEqual(1, executionScope.Links.Count);
                 Assert.True(_log.TryGetValue(executionScope.Activity.Id, out var activityName));
-                Assert.AreEqual(functionName, activityName);
+                Assert.AreEqual("EventGrid.Process", activityName);
 
                 var link = executionScope.Links.Single();
                 if (link.Traceparent == traceparent1)
@@ -215,24 +280,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         {
             // individual elements
             var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
-            var host = TestHelpers.NewHost<MyProg4>(ext);
+            var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
             using var testListener = new ClientDiagnosticListener("Azure.Messaging.EventGrid");
-            const string functionName = "EventGridMultiple";
+            const string functionName = "TestCloudEventMultiple";
             const string traceparent1 = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
             const string tracestate1 = "foo1=bar1";
             const string traceparent2 = "00-1123456789abcdef0123456789abcdef-1123456789abcdef-01";
 
             var request = CreateDispatchRequest(functionName,
-                JObject.Parse($"{{'subject':'one','data':{{'prop':'alpha'}},'traceparent':'{traceparent1}','tracestate':'{tracestate1}'}}"),
-                JObject.Parse($"{{'subject':'two','data':{{'prop':'alpha'}},'traceparent':'{traceparent2}'}}"),
-                JObject.Parse($"{{'subject':'two','data':{{'prop':'alpha'}},'tracestate':'ignored'}}"));
+                JObject.Parse($"{{{CloudEventRequiredFields},'traceparent':'{traceparent1}','tracestate':'{tracestate1}'}}"),
+                JObject.Parse($"{{{CloudEventRequiredFields},'traceparent':'{traceparent2}'}}"),
+                JObject.Parse($"{{{CloudEventRequiredFields},'tracestate':'ignored'}}"));
 
             var response = await ext.ConvertAsync(request, CancellationToken.None);
 
             Assert.AreEqual(1, testListener.Scopes.Count);
-            var executionScope = testListener.AssertScope(functionName,
+            var executionScope = testListener.AssertScope("EventGrid.Process",
                 new KeyValuePair<string, string>("az.namespace", "Microsoft.EventGrid"));
 
             var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink(traceparent1, tracestate1),
@@ -241,7 +306,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             Assert.That(executionScope.Links, Is.EquivalentTo(expectedLinks));
             Assert.Null(executionScope.Exception);
             Assert.True(_log.TryGetValue(executionScope.Activity.Id, out var activityName));
-            Assert.AreEqual(functionName, activityName);
+            Assert.AreEqual("EventGrid.Process", activityName);
         }
 
         [Test]
@@ -264,7 +329,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             var response = await ext.ConvertAsync(request, CancellationToken.None);
 
             Assert.AreEqual(1, testListener.Scopes.Count);
-            var executionScope = testListener.AssertScope(functionName,
+            var executionScope = testListener.AssertScope("EventGrid.Process",
                 new KeyValuePair<string, string>("az.namespace", "Microsoft.EventGrid"));
 
             var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink(traceparent1, null),
@@ -273,7 +338,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             Assert.That(executionScope.Links, Is.EquivalentTo(expectedLinks));
             Assert.NotNull(executionScope.Exception);
             Assert.True(_log.TryGetValue(executionScope.Activity.Id, out var activityName));
-            Assert.AreEqual(functionName, activityName);
+            Assert.AreEqual("EventGrid.Process", activityName);
         }
 
         [Test]
@@ -367,8 +432,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 
         public class MyProg1
         {
-            [FunctionName("TestEventGrid")]
-            public void Run(
+            [FunctionName("TestJObject")]
+            public void RunSingleJObject(
                 [EventGridTrigger] JObject value,
                 [BindingData("{data.prop}")] string prop)
             {
@@ -381,6 +446,67 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
                 if (!_log.TryAdd((string)value["subject"], prop))
                 {
                     throw new InvalidOperationException($"duplicate subject '{(string)value["subject"]}'");
+                }
+            }
+
+            [FunctionName("TestEventGrid")]
+            public void RunSingleEgEvent(
+                [EventGridTrigger] EventGridEvent value,
+                [BindingData("{data.prop}")] string prop)
+            {
+                if (Activity.Current != null)
+                {
+                    _log.TryAdd(Activity.Current.Id, Activity.Current.OperationName);
+                }
+
+                // if the key already exists, we should error
+                if (!_log.TryAdd(value.Subject, prop))
+                {
+                    throw new InvalidOperationException($"duplicate subject '{value.Subject}'");
+                }
+            }
+
+            [FunctionName("TestJObjectMultiple")]
+            public void RunMultipleObjects([EventGridTrigger] JObject[] values)
+            {
+                if (Activity.Current != null)
+                {
+                    _log.TryAdd(Activity.Current.Id, Activity.Current.OperationName);
+                }
+            }
+
+            [FunctionName("TestEventGridMultiple")]
+            public void RunMultipleEvents([EventGridTrigger] EventGridEvent[] values)
+            {
+                if (Activity.Current != null)
+                {
+                    _log.TryAdd(Activity.Current.Id, Activity.Current.OperationName);
+                }
+            }
+
+            [FunctionName("TestCloudEvent")]
+            public void RunSingle(
+                [EventGridTrigger] CloudEvent value,
+                [BindingData("{data.prop}")] string prop)
+            {
+                if (Activity.Current != null)
+                {
+                    _log.TryAdd(Activity.Current.Id, Activity.Current.OperationName);
+                }
+
+                // if the key already exists, we should error
+                if (!_log.TryAdd(value.Id, prop))
+                {
+                    throw new InvalidOperationException($"duplicate subject '{value.Id}'");
+                }
+            }
+
+            [FunctionName("TestCloudEventMultiple")]
+            public void RunBatch([EventGridTrigger] JObject[] values)
+            {
+                if (Activity.Current != null)
+                {
+                    _log.TryAdd(Activity.Current.Id, Activity.Current.OperationName);
                 }
             }
         }
@@ -405,18 +531,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
                 }
 
                 throw new InvalidOperationException($"failed with {value.ToString()}");
-            }
-        }
-
-        public class MyProg4
-        {
-            [FunctionName("EventGridMultiple")]
-            public void Run([EventGridTrigger] JObject[] values)
-            {
-                if (Activity.Current != null)
-                {
-                    _log.TryAdd(Activity.Current.Id, Activity.Current.OperationName);
-                }
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -603,7 +603,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                             { DiagnosticProperty.EnqueuedTimeAttribute, eventData.EnqueuedTime.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture) }
                         };
 
-                        diagnosticScope.AddLink(diagnosticId, attributes);
+                        diagnosticScope.AddLink(diagnosticId, null, attributes);
                     }
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -1282,7 +1282,7 @@ namespace Azure.Messaging.EventHubs.Producer
             {
                 foreach (var identifier in diagnosticIdentifiers)
                 {
-                    scope.AddLink(identifier);
+                    scope.AddLink(identifier, null);
                 }
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -276,7 +276,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             ClientDiagnosticListener.ProducedDiagnosticScope sendScope = testListener.Scopes.Single(s => s.Name == DiagnosticProperty.ProducerActivityName);
 
-            var expectedLinks = new List<string>() { "id", "id2" };
+            var expectedLinks = new [] { new ClientDiagnosticListener.ProducedLink("id"), new ClientDiagnosticListener.ProducedLink("id2") };
             var links = sendScope.Links.ToList();
 
             Assert.That(links.Count, Is.EqualTo(expectedLinks.Count), "The amount of links should be the same as the amount of events that were sent.");
@@ -334,7 +334,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             ClientDiagnosticListener.ProducedDiagnosticScope sendScope = testListener.Scopes.Single(s => s.Name == DiagnosticProperty.ProducerActivityName);
 
-            var expectedLinks = new List<string>() { "id", "id2" };
+            var expectedLinks = new [] { new ClientDiagnosticListener.ProducedLink("id"), new ClientDiagnosticListener.ProducedLink("id2") };
             var links = sendScope.Links.ToList();
 
             Assert.That(links.Count, Is.EqualTo(expectedLinks.Count), "The amount of links should be the same as the amount of events that were sent.");
@@ -388,7 +388,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             for (var index = 0; index < eventBatch.Count; ++index)
             {
-                var targetId = (++diagnosticId).ToString();
+                var targetId = new ClientDiagnosticListener.ProducedLink((++diagnosticId).ToString());
                 Assert.That(scopes.SelectMany(scope => scope.Links), Has.One.EqualTo(targetId), $"There should have been a link for the diagnostic identifier: { targetId }");
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -276,10 +276,10 @@ namespace Azure.Messaging.EventHubs.Tests
 
             ClientDiagnosticListener.ProducedDiagnosticScope sendScope = testListener.Scopes.Single(s => s.Name == DiagnosticProperty.ProducerActivityName);
 
-            var expectedLinks = new [] { new ClientDiagnosticListener.ProducedLink("id"), new ClientDiagnosticListener.ProducedLink("id2") };
+            var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink("id"), new ClientDiagnosticListener.ProducedLink("id2") };
             var links = sendScope.Links.ToList();
 
-            Assert.That(links.Count, Is.EqualTo(expectedLinks.Count), "The amount of links should be the same as the amount of events that were sent.");
+            Assert.That(links.Count, Is.EqualTo(expectedLinks.Length), "The amount of links should be the same as the amount of events that were sent.");
             Assert.That(links, Is.EquivalentTo(expectedLinks), "The links should be identical to the diagnostic ids in the events that were sent.");
         }
 
@@ -334,10 +334,10 @@ namespace Azure.Messaging.EventHubs.Tests
 
             ClientDiagnosticListener.ProducedDiagnosticScope sendScope = testListener.Scopes.Single(s => s.Name == DiagnosticProperty.ProducerActivityName);
 
-            var expectedLinks = new [] { new ClientDiagnosticListener.ProducedLink("id"), new ClientDiagnosticListener.ProducedLink("id2") };
+            var expectedLinks = new[] { new ClientDiagnosticListener.ProducedLink("id"), new ClientDiagnosticListener.ProducedLink("id2") };
             var links = sendScope.Links.ToList();
 
-            Assert.That(links.Count, Is.EqualTo(expectedLinks.Count), "The amount of links should be the same as the amount of events that were sent.");
+            Assert.That(links.Count, Is.EqualTo(expectedLinks.Length), "The amount of links should be the same as the amount of events that were sent.");
             Assert.That(links, Is.EquivalentTo(expectedLinks), "The links should be identical to the diagnostic ids in the events that were sent.");
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticExtensions.cs
@@ -54,7 +54,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 properties,
                 out string diagnosticId))
             {
-                scope.AddLink(diagnosticId);
+                scope.AddLink(diagnosticId, null);
             }
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
@@ -168,7 +168,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         [Test]
         public async Task ProcessorActivities()
         {
-            string[] messageActivities = null;
+            ClientDiagnosticListener.ProducedLink[] messageActivities = null;
             int messageProcessedCt = 0;
             bool callbackExecuted = false;
             _listener = new ClientDiagnosticListener(
@@ -192,7 +192,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var msgs = ServiceBusTestUtilities.GetMessages(messageCt);
                 await sender.SendMessagesAsync(msgs);
                 Activity[] sendActivities = AssertSendActivities(false, sender, msgs);
-                messageActivities = sendActivities.Select(a => a.ParentId).ToArray();
+                messageActivities = sendActivities.Select(a => new ClientDiagnosticListener.ProducedLink(a.ParentId, a.TraceStateString)).ToArray();
 
                 ServiceBusProcessor processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
                 {
@@ -226,7 +226,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
         [Test]
         public async Task SessionProcessorActivities()
         {
-            string[] messageActivities = null;
+            ClientDiagnosticListener.ProducedLink[] messageActivities = null;
             int messageProcessedCt = 0;
             bool callbackExecuted = false;
             _listener = new ClientDiagnosticListener(
@@ -250,7 +250,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var msgs = ServiceBusTestUtilities.GetMessages(messageCt, "sessionId");
                 await sender.SendMessagesAsync(msgs);
                 Activity[] sendActivities = AssertSendActivities(false, sender, msgs);
-                messageActivities = sendActivities.Select(a => a.ParentId).ToArray();
+                messageActivities = sendActivities.Select(a => new ClientDiagnosticListener.ProducedLink(a.ParentId, a.TraceStateString)).ToArray();
 
                 ServiceBusSessionProcessor processor = client.CreateSessionProcessor(scope.QueueName,
                     new ServiceBusSessionProcessorOptions


### PR DESCRIPTION
Adds correlation between Azure Function `EventGridTrigger` and producer for `CloudEvents` in Azure Monitor.

Before this PR, users need to do something like that: https://github.com/Azure/azure-sdk-blog/blob/96bf3d5e2cb7b16e7425be5cbe5d425176b09e6d/posts/2022/2022-01-05-distributed-tracing-event-grid-functions.md#cloudevents-schema

With this PR, correlation works out of the box - no custom code needed

![image](https://user-images.githubusercontent.com/2347409/146123214-202b75cd-2cf5-4661-af78-fc2ebbf73b65.png)


