### PR TITLE
[Storage][Blobs] Fix null reference when overwriting binary data with client-side encryption enabled

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for BlobContainerClient.FilterBlobsByTag().
 - Added support for BlobContainerClient.OpenWriteAsync().
 - Fixed bug where BlobSasBuilder.SetPermissions(string rawPermissions) was not properly handling the Permanent Delete ('y') and set Immutability Policy ('i') permissions.
+- Fixed a bug where BlobClient.Upload() and UploadAsync() would result in a NullReferenceException when trying to overwrite a blob with client-side encryption enabled
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -1625,6 +1625,8 @@ namespace Azure.Storage.Blobs
             long? expectedContentLength = null;
             if (UsingClientSideEncryption)
             {
+                options ??= new BlobUploadOptions();
+
                 if (UsingClientSideEncryption && options.TransactionalHashingOptions != default)
                 {
                     throw Errors.TransactionalHashingNotSupportedWithClientSideEncryption();


### PR DESCRIPTION
When calling `Upload` or `UploadAsync` on `BlobClient` with `BinaryData` and Client-Side Encryption enabled to overwrite a blob, it results in a `NullReferenceException` since the `BlobUploadOptions` object is `null` when `overwrite: true` is passed. This PR resolves that by sending the default object instead of `null`.

resolves #26012