### PR TITLE
Add support for additional credential providers in ClientFactory

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.2.0-beta.1 (Unreleased)
 
+- The ability to use `AzureCliCredential` from the configuration using the `"credential": "azurecli"`
+- The ability to use `InteractiveBrowserCredential` from the configuration using the `"credential": "interactivebrowser"`
+- The ability to use `VisualStudioCredential` and `VisualStudioCodeCredential` from the configuration using the `"credential": "visualstudio"`
+
 ### Features Added
 
 ### Breaking Changes

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -100,8 +100,8 @@ namespace Microsoft.Extensions.Azure
 
             if (string.Equals(credentialType, "visualstudio", StringComparison.OrdinalIgnoreCase))
             {
-                // visual studio covers multiple token providers (VisualStudioCredentials & VisualStudioCodeCredentials)
-                // rely on DefaultAzureCredentialOptions and it's factory to build both.
+                // Visual Studio covers multiple token providers (VisualStudioCredentials & VisualStudioCodeCredentials)
+                // rely on DefaultAzureCredentialOptions and its factory to build both.
                 var credentialOptions = CopyTokenCredentialOptions<DefaultAzureCredentialOptions>(identityClientOptions);
                 ExcludeAllCredentialProviders(credentialOptions);
 


### PR DESCRIPTION
When developing solutions using Azure SDKs that uses Microsoft.Extensions.Azure for authentication, options are currently limited to shared secrets or certificates when developing and debugging locally.
This imposes limitations on developers and requires us to either maintain shared secrets or certificates, which needs to be handled in a secure manner.
When developing locally, there are several options for getting an AAD token for a target Azure cloud, either using the Visual Studio credential feature, the Azure Cli or interactive browser credentials.

Add new credential types to ClientFactory for using VisualStudio, AzureCLI and Interactive browser when running locally.

Proposed solution for #26117

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
