### PR TITLE
Add link to Monitor Query migration guide

### DIFF
--- a/sdk/monitor/Azure.Monitor.Query/MigrationGuide.md
+++ b/sdk/monitor/Azure.Monitor.Query/MigrationGuide.md
@@ -7,13 +7,13 @@ Familiarity with the `Microsoft.Azure.OperationalInsights` v1.1.0 package is ass
 ## Table of contents
 
 - [Migration benefits](#migration-benefits)
-    - [Cross-service SDK improvements](#cross-service-sdk-improvements)
-    - [New features](#new-features)
+  - [Cross-service SDK improvements](#cross-service-sdk-improvements)
+  - [New features](#new-features)
 - [Important changes](#important-changes)
-    - [The client](#the-client)
-    - [Client constructors and authentication](#client-constructors-and-authentication)
-    - [Send a single query request](#send-a-single-query-request)
-    - [Retrieve results from a table](#retrieve-results-from-a-table)
+  - [The client](#the-client)
+  - [Client constructors and authentication](#client-constructors-and-authentication)
+  - [Send a single query request](#send-a-single-query-request)
+  - [Retrieve results from a table](#retrieve-results-from-a-table)
 - [Additional samples](#additional-samples)
 
 ## Migration benefits
@@ -61,18 +61,18 @@ In `Microsoft.Azure.OperationalInsights` v1.1.0:
 using Microsoft.Azure.OperationalInsights;
 using Microsoft.Rest;
 using Microsoft.Rest.Azure.Authentication;
-	
+
 // code omitted for brevity
 
 var adSettings = new ActiveDirectoryServiceSettings
-	{
-	    AuthenticationEndpoint = new Uri("https://login.microsoftonline.com"),
-	    TokenAudience = new Uri("https://api.loganalytics.io/"),
-	    ValidateAuthority = true
-	};
-	
+{
+    AuthenticationEndpoint = new Uri("https://login.microsoftonline.com"),
+    TokenAudience = new Uri("https://api.loganalytics.io/"),
+    ValidateAuthority = true
+};
+
 ServiceClientCredentials credentials = ApplicationTokenProvider.LoginSilentAsync(
-	    "<domainId or tenantId>", "<clientId>", "<clientSecret>", adSettings).GetAwaiter().GetResult();
+    "<domainId or tenantId>", "<clientId>", "<clientSecret>", adSettings).GetAwaiter().GetResult();
 var client = new OperationalInsightsDataClient(credentials);
 ```
 
@@ -93,9 +93,9 @@ In `Microsoft.Azure.OperationalInsights` v1.1.0:
 
 ```csharp
 using Microsoft.Azure.OperationalInsights.Models;
-	
+
 // code omitted for brevity
-	
+
 QueryResults response = await client.QueryAsync("AzureActivity | top 10 by TimeGenerated");
 ```
 
@@ -108,9 +108,9 @@ In `Azure.Monitor.Query` v1.0.x:
 using Azure;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
-	
+
 // code omitted for brevity
-	
+
 Response<LogsQueryResult> response = await client.QueryWorkspaceAsync(
 	workspaceId,
 	"AzureActivity | top 10 by TimeGenerated",
@@ -124,17 +124,17 @@ In `Microsoft.Azure.OperationalInsights` v1.1.0:
 ```csharp
 using Microsoft.Azure.OperationalInsights;
 using Microsoft.Azure.OperationalInsights.Models;
-	
+
 // code omitted for brevity
 
 var client = new OperationalInsightsDataClient(credentials);
 QueryResults response = await client.QueryAsync("AzureActivity | top 10 by TimeGenerated");
 IList<Table> tables = response.Tables;
-	
+
 foreach (Table table in tables)
 {
 	IList<IList<string>> rows = table.Rows;
-	                
+
 	foreach (IList<string> row in rows)
 	{
 	    foreach (string element in row)
@@ -151,15 +151,16 @@ In `Azure.Monitor.Query` v1.0.x:
 using Azure;
 using Azure.Monitor.Query;
 using Azure.Monitor.Query.Models;
-	
+
 // code omitted for brevity
-	
+
 Response<LogsQueryResult> response = await client.QueryWorkspaceAsync(
 	workspaceId,
 	"AzureActivity | top 10 by TimeGenerated",
 	new QueryTimeRange(TimeSpan.FromDays(1)));
 LogsTable table = response.Value.Table;
 IReadOnlyList<LogsTableRow> rows = table.Rows;
+
 foreach (LogsTableRow row in rows)
 {
     Console.WriteLine(row.GetString(0)); // Access a particular element with index

--- a/sdk/monitor/Azure.Monitor.Query/README.md
+++ b/sdk/monitor/Azure.Monitor.Query/README.md
@@ -12,6 +12,7 @@ The Azure Monitor Query client library is used to execute read-only queries agai
 - [API reference documentation][msdocs_apiref]
 - [Service documentation][azure_monitor_overview]
 - [Change log][changelog]
+- [Migration guide][migration_guide]
 
 ## Getting started
 
@@ -425,6 +426,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 [changelog]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/CHANGELOG.md
 [kusto_query_language]: https://docs.microsoft.com/azure/data-explorer/kusto/query/
 [logging]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md
+[migration_guide]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/MigrationGuide.md
 [monitor_rest_api]: https://docs.microsoft.com/rest/api/monitor/
 [msdocs_apiref]: https://docs.microsoft.com/dotnet/api/overview/azure/monitor/query?view=azure-dotnet
 [package]: https://www.nuget.org/packages/Azure.Monitor.Query


### PR DESCRIPTION
**Summary of changes**
- Move the migration guide to the same level as the README.
- Link to the migration guide from the README.
- Apply minor formatting changes in the migration guide.