### PR TITLE
ADT: Update Bicep Template

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/Azure.DigitalTwins.Core.sln
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/Azure.DigitalTwins.Core.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29806.167
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.31911.260
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.DigitalTwins.Core", "src\Azure.DigitalTwins.Core.csproj", "{E33D09D9-D809-472C-82E6-6A26BDB86FC2}"
 EndProject
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\ci.yml = ..\ci.yml
 		..\Export-AdtApis.ps1 = ..\Export-AdtApis.ps1
 		..\remove-test-resources-pre.ps1 = ..\remove-test-resources-pre.ps1
+		..\test-resources.bicep = ..\test-resources.bicep
 		..\test-resources.json = ..\test-resources.json
 		..\tests.yml = ..\tests.yml
 	EndProjectSection
@@ -27,7 +28,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{E685A401-AF9E-4196-975B-26C4A340256F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{4153CAAF-C1D5-4104-ABD9-7F010E6AAFAB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{4153CAAF-C1D5-4104-ABD9-7F010E6AAFAB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/prerequisite readme.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/prerequisite readme.md
@@ -13,7 +13,7 @@
 
 ### Install Bicep
 
-- Install using the instructions in [bicep](https://github.com/Azure/bicep/blob/main/docs/installing.md)
+- Install using the instructions in [bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/install#install-manually)
 - Note that to deploy Bicep files, use Bicep CLI version 0.4.1124 or later. To check your Bicep CLI version, run:
 
 ```bash

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/prerequisite readme.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/prerequisite readme.md
@@ -13,7 +13,7 @@
 
 ### Install Bicep
 
-- Install using the instructions in [bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/install#install-manually)
+- Install using the instructions in [bicep](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install#install-manually)
 - Note that to deploy Bicep files, use Bicep CLI version 0.4.1124 or later. To check your Bicep CLI version, run:
 
 ```bash

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/prerequisite readme.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/prerequisites/prerequisite readme.md
@@ -14,7 +14,7 @@
 ### Install Bicep
 
 - Install using the instructions in [bicep](https://github.com/Azure/bicep/blob/main/docs/installing.md)
-- Note that to deploy Bicep files, use Bicep CLI version 0.3.1 or later. To check your Bicep CLI version, run:
+- Note that to deploy Bicep files, use Bicep CLI version 0.4.1124 or later. To check your Bicep CLI version, run:
 
 ```bash
 bicep --version

--- a/sdk/digitaltwins/test-resources.bicep
+++ b/sdk/digitaltwins/test-resources.bicep
@@ -9,23 +9,24 @@ param baseName string = resourceGroup().name
 @description('The location of the resource. By default, this is the same as the resource group.')
 param location string = resourceGroup().location
 
+@description('A new GUID used to identify the role assignment')
+param roleNameGuid string = newGuid()
+
 var adtOwnerRoleDefinitionId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/bcd981a7-7f74-457b-83e1-cceb9e632ffe'
 
-resource digitaltwin 'Microsoft.DigitalTwins/digitalTwinsInstances@2020-03-01-preview' = {
+resource digitaltwin 'Microsoft.DigitalTwins/digitalTwinsInstances@2020-12-01' = {
     name: baseName
     location: location
-    sku: {
-        name: 'S1'
-    }
     properties: {}
 }
 
-resource digitaltwinRoleAssignment 'Microsoft.DigitalTwins/digitalTwinsInstances/providers/roleAssignments@2020-03-01-preview' = {
-    name: '${digitaltwin.name}/Microsoft.Authorization/${guid(uniqueString(baseName))}'
+resource digitaltwinRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+    name: roleNameGuid
     properties: {
         roleDefinitionId: adtOwnerRoleDefinitionId
         principalId: testApplicationOid
     }
+    scope: digitaltwin
 }
 
 resource eventHubNamespace 'Microsoft.EventHub/namespaces@2018-01-01-preview' = {
@@ -75,12 +76,13 @@ resource eventHubNamespaceEventHubAuthRules 'Microsoft.EventHub/namespaces/event
     }
 }
 
-resource digitaltwinEndpoints 'Microsoft.DigitalTwins/digitalTwinsInstances/endpoints@2020-03-01-preview' = {
+resource digitaltwinEndpoints 'Microsoft.DigitalTwins/digitalTwinsInstances/endpoints@2020-12-01' = {
     name: '${digitaltwin.name}/someEventHubEndpoint'
     properties: {
         endpointType: 'EventHub'
-        'connectionString-PrimaryKey': listKeys(eventHubNamespaceEventHubAuthRules.id, '2017-04-01').primaryConnectionString
-        'connectionString-SecondaryKey': listKeys(eventHubNamespaceEventHubAuthRules.id, '2017-04-01').secondaryConnectionString
+        authenticationType: 'KeyBased'
+        connectionStringPrimaryKey: listKeys(eventHubNamespaceEventHubAuthRules.id, '2017-04-01').primaryConnectionString
+        connectionStringSecondaryKey: listKeys(eventHubNamespaceEventHubAuthRules.id, '2017-04-01').secondaryConnectionString
     }
 }
 


### PR DESCRIPTION
* Updates ADT management plane version to latest stable version
* Uses new bicep syntax for setting scope when performing role assignments
* Removes sku from ADT deployment payload since no longer used by service
* Fixes connection string parameters since these no longer contain dashes and adds authentication type in endpoint creation
* Fixes role assignment name

Proof of live tests succeeding:

![image](https://user-images.githubusercontent.com/20584629/148485949-abb7e7dd-7f37-4274-b540-40ff7f8ebf56.png)

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
