### PR TITLE
fix(resourcemanager): random return value of string.Compare

### DIFF
--- a/sdk/core/Azure.Core/src/ResourceIdentifier.cs
+++ b/sdk/core/Azure.Core/src/ResourceIdentifier.cs
@@ -269,20 +269,15 @@ namespace Azure.Core
         /// Compre this resource identifier to the given resource identifier.
         /// </summary>
         /// <param name="other"> The resource identifier to compare to. </param>
-        /// <returns> 0 if the resource identifiers are equivalent, -1 if this resource identifier
-        /// should be ordered before the given resource identifier, 1 if this resource identifier
+        /// <returns> 0 if the resource identifiers are equivalent, less than 0 if this resource identifier
+        /// should be ordered before the given resource identifier, greater than 0 if this resource identifier
         /// should be ordered after the given resource identifier. </returns>
         public int CompareTo(ResourceIdentifier? other)
         {
             if (other is null)
                 return 1;
 
-            return string.Compare(StringValue, other.StringValue, StringComparison.OrdinalIgnoreCase) switch
-            {
-                > 0 => 1,
-                < 0 => -1,
-                _ => 0,
-            };
+            return string.Compare(StringValue, other.StringValue, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc/>

--- a/sdk/core/Azure.Core/src/ResourceIdentifier.cs
+++ b/sdk/core/Azure.Core/src/ResourceIdentifier.cs
@@ -277,7 +277,12 @@ namespace Azure.Core
             if (other is null)
                 return 1;
 
-            return string.Compare(StringValue, other.StringValue, StringComparison.OrdinalIgnoreCase);
+            return string.Compare(StringValue, other.StringValue, StringComparison.OrdinalIgnoreCase) switch
+            {
+                > 0 => 1,
+                < 0 => -1,
+                _ => 0,
+            };
         }
 
         /// <inheritdoc/>

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ApiVersionsBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ApiVersionsBase.cs
@@ -138,10 +138,22 @@ namespace Azure.ResourceManager.Core
                     return 1;
                 }
 
-                return string.Compare(thisPreviewPart, otherPreviewPart, StringComparison.InvariantCulture);
+                // string.Compare doesn't ensure the return value is 0, 1, -1, so here we need to normalize it
+                // see https://docs.microsoft.com/en-us/dotnet/api/system.string.compare?view=net-6.0#system-string-compare(system-string-system-string-system-stringcomparison)
+                return string.Compare(thisPreviewPart, otherPreviewPart, StringComparison.InvariantCulture) switch
+                {
+                    > 0 => 1,
+                    < 0 => -1,
+                    _ => 0,
+                };
             }
 
-            return string.Compare(thisDatePart, otherDatePart, StringComparison.InvariantCulture);
+            return string.Compare(thisDatePart, otherDatePart, StringComparison.InvariantCulture) switch
+            {
+                > 0 => 1,
+                < 0 => -1,
+                _ => 0,
+            };
         }
 
         /// <summary>

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ApiVersionsBase.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ApiVersionsBase.cs
@@ -102,7 +102,9 @@ namespace Azure.ResourceManager.Core
         /// Compares two API version values in string type.
         /// </summary>
         /// <param name="other"> The API version value to compare. </param>
-        /// <returns> Comparison result in integer. 1 for greater than, 0 for equals to, and -1 for less than. </returns>
+        /// <returns> 0 if the APIVersionBase are equivalent, less than 0 if this APIVersionBase
+        /// should be ordered before the given APIVersionBase, greater than 0 if this APIVersionBase
+        /// should be ordered after the given APIVersionBase.. </returns>
         public int CompareTo(string other)
         {
             if (other is null)
@@ -138,22 +140,10 @@ namespace Azure.ResourceManager.Core
                     return 1;
                 }
 
-                // string.Compare doesn't ensure the return value is 0, 1, -1, so here we need to normalize it
-                // see https://docs.microsoft.com/en-us/dotnet/api/system.string.compare?view=net-6.0#system-string-compare(system-string-system-string-system-stringcomparison)
-                return string.Compare(thisPreviewPart, otherPreviewPart, StringComparison.InvariantCulture) switch
-                {
-                    > 0 => 1,
-                    < 0 => -1,
-                    _ => 0,
-                };
+                return string.Compare(thisPreviewPart, otherPreviewPart, StringComparison.InvariantCulture);
             }
 
-            return string.Compare(thisDatePart, otherDatePart, StringComparison.InvariantCulture) switch
-            {
-                > 0 => 1,
-                < 0 => -1,
-                _ => 0,
-            };
+            return string.Compare(thisDatePart, otherDatePart, StringComparison.InvariantCulture);
         }
 
         /// <summary>


### PR DESCRIPTION
The docs of several `CompareTo` APIs says the return value is 0, 1, and -1. But actually for some use cases, the return value could be other numbers. The reason is that the one depending API `string.Compare` only ensure the return value will `Less than zero`, `Zero`, and `Greater than zero`. We've found under some environment, our test cases will fail because the return value is 10, -10, 8, etc.

The fix is to normalize the return value of `string.Compare` to 0, 1, and -1.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
