### PR TITLE
Fix inadvertent build break to Storage in main

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/README.md
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/README.md
@@ -39,7 +39,7 @@ In order to interact with the Azure Blobs Storage service for batch operations, 
 // Create a BlobServiceClient that will authenticate through Active Directory
 Uri accountUri = new Uri("https://MYSTORAGEACCOUNT.blob.core.windows.net/");
 BlobServiceClient client = new BlobServiceClient(accountUri, new DefaultAzureCredential());
-BlobBatchClient batch = service.GetBlobBatchClient();
+BlobBatchClient batch = client.GetBlobBatchClient();
 ```
 
 ## Key concepts

--- a/sdk/storage/Azure.Storage.Blobs.Batch/samples/Sample03a_Batching.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/samples/Sample03a_Batching.cs
@@ -188,7 +188,7 @@ namespace Azure.Storage.Blobs.Samples
             // Create a BlobServiceClient that will authenticate through Active Directory
             Uri accountUri = new Uri("https://MYSTORAGEACCOUNT.blob.core.windows.net/");
             BlobServiceClient client = new BlobServiceClient(accountUri, new DefaultAzureCredential());
-            BlobBatchClient batch = service.GetBlobBatchClient();
+            BlobBatchClient batch = client.GetBlobBatchClient();
             #endregion
         }
     }

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/samples/Sample01b_HelloWorldAsync.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/samples/Sample01b_HelloWorldAsync.cs
@@ -119,7 +119,6 @@ namespace Azure.Storage.Blobs.ChangeFeed.Samples
             BlobChangeFeedClient changeFeedClient = new BlobChangeFeedClient(connectionString);
             List<BlobChangeFeedEvent> changeFeedEvents = new List<BlobChangeFeedEvent>();
 
-            #region Snippet:SampleSnippetsChangeFeed_PollForEventsWithCursor
             // Create the start time.  The change feed client will round start time down to
             // the nearest hour if you provide DateTimeOffsets
             // with minutes and seconds.
@@ -153,7 +152,6 @@ namespace Azure.Storage.Blobs.ChangeFeed.Samples
                 // Resume from last continuation token and fetch latest set of events.
                 pages = changeFeedClient.GetChangesAsync(continuationToken).AsPages();
             }
-            #endregion
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/samples/Sample01a_HelloWorld.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/samples/Sample01a_HelloWorld.cs
@@ -359,9 +359,7 @@ namespace Azure.Storage.Files.DataLake.Samples
 
                 // Download the DataLake file's directly to a file.
                 // For larger files, ReadTo() will download the file in multiple sequential requests.
-                #region Snippet:SampleSnippetDataLakeFileClient_ReadTo
                 file.ReadTo(downloadPath);
-                #endregion Snippet:SampleSnippetDataLakeFileClient_ReadTo
 
                 // Verify the contents
                 Assert.AreEqual(SampleFileContent, File.ReadAllText(downloadPath));


### PR DESCRIPTION
It is unclear why the change [passed CI](https://github.com/Azure/azure-sdk-for-net/pull/25905) when it broke the build.