### PR TITLE
Add nullable to Parent property and remove ctor warning suppression

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net461.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net461.cs
@@ -538,7 +538,7 @@ namespace Azure.Core
         public ResourceIdentifier(string resourceId) { }
         public Azure.Core.AzureLocation? Location { get { throw null; } }
         public string Name { get { throw null; } }
-        public Azure.Core.ResourceIdentifier Parent { get { throw null; } }
+        public Azure.Core.ResourceIdentifier? Parent { get { throw null; } }
         public string? Provider { get { throw null; } }
         public string? ResourceGroupName { get { throw null; } }
         public Azure.Core.ResourceType ResourceType { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net5.0.cs
@@ -538,7 +538,7 @@ namespace Azure.Core
         public ResourceIdentifier(string resourceId) { }
         public Azure.Core.AzureLocation? Location { get { throw null; } }
         public string Name { get { throw null; } }
-        public Azure.Core.ResourceIdentifier Parent { get { throw null; } }
+        public Azure.Core.ResourceIdentifier? Parent { get { throw null; } }
         public string? Provider { get { throw null; } }
         public string? ResourceGroupName { get { throw null; } }
         public Azure.Core.ResourceType ResourceType { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netcoreapp2.1.cs
@@ -538,7 +538,7 @@ namespace Azure.Core
         public ResourceIdentifier(string resourceId) { }
         public Azure.Core.AzureLocation? Location { get { throw null; } }
         public string Name { get { throw null; } }
-        public Azure.Core.ResourceIdentifier Parent { get { throw null; } }
+        public Azure.Core.ResourceIdentifier? Parent { get { throw null; } }
         public string? Provider { get { throw null; } }
         public string? ResourceGroupName { get { throw null; } }
         public Azure.Core.ResourceType ResourceType { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -538,7 +538,7 @@ namespace Azure.Core
         public ResourceIdentifier(string resourceId) { }
         public Azure.Core.AzureLocation? Location { get { throw null; } }
         public string Name { get { throw null; } }
-        public Azure.Core.ResourceIdentifier Parent { get { throw null; } }
+        public Azure.Core.ResourceIdentifier? Parent { get { throw null; } }
         public string? Provider { get { throw null; } }
         public string? ResourceGroupName { get { throw null; } }
         public Azure.Core.ResourceType ResourceType { get { throw null; } }

--- a/sdk/core/Azure.Core/src/ResourceIdentifier.cs
+++ b/sdk/core/Azure.Core/src/ResourceIdentifier.cs
@@ -36,19 +36,27 @@ namespace Azure.Core
         /// Initializes a new instance of the <see cref="ResourceIdentifier"/> class.
         /// </summary>
         /// <param name="resourceId"> The id string to create the ResourceIdentifier from. </param>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public ResourceIdentifier(string resourceId)
         {
             ResourceIdentifier id = Create(resourceId);
-            Init(id.Parent, id.ResourceType, id.Name, id.IsProviderResource);
+            Init(id.Parent, id.ResourceType, id.Name);
             _stringValue = resourceId;
+
+            //need to set init only properties in ctor
+            ResourceType = id.ResourceType;
+            Name = id.Name;
+            IsProviderResource = id.IsProviderResource;
         }
 
         private ResourceIdentifier(ResourceIdentifier? parent, ResourceType resourceType, string resourceName, bool idProviderResource)
         {
-            Init(parent ?? Root, resourceType, resourceName, idProviderResource);
+            Init(parent ?? Root, resourceType, resourceName);
+
+            //need to set init only properties in ctor
+            ResourceType = resourceType;
+            Name = resourceName;
+            IsProviderResource = idProviderResource;
         }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         private ResourceIdentifier(ResourceIdentifier parent, string resourceTypeName, string resourceName)
             : this(parent, ChooseResourceType(resourceTypeName, parent), resourceName, false)
@@ -60,7 +68,7 @@ namespace Azure.Core
         {
         }
 
-        private void Init(ResourceIdentifier parent, ResourceType resourceType, string resourceName, bool isProviderResource)
+        private void Init(ResourceIdentifier? parent, ResourceType resourceType, string resourceName)
         {
             if (parent is not null)
             {
@@ -86,13 +94,9 @@ namespace Azure.Core
             if (resourceType == ProviderResourceType)
                 Provider = resourceName;
 
-            ResourceType = resourceType;
-            Name = resourceName;
-            IsProviderResource = isProviderResource;
-            Parent = parent!;
-
             if (parent is null)
                 _stringValue = RootStringValue;
+            Parent = parent;
         }
 
         private static ResourceType ChooseResourceType(string resourceTypeName, ResourceIdentifier parent)
@@ -180,22 +184,22 @@ namespace Azure.Core
         /// <summary>
         /// The resource type of the resource.
         /// </summary>
-        public ResourceType ResourceType { get; private set; }
+        public ResourceType ResourceType { get; }
 
         /// <summary>
         /// The name of the resource.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// The immediate parent containing this resource.
         /// </summary>
-        public ResourceIdentifier Parent { get; private set; }
+        public ResourceIdentifier? Parent { get; private set; }
 
         /// <summary>
         /// Determines whether this resource is in the same namespace as its parent.
         /// </summary>
-        internal bool IsProviderResource { get; private set; }
+        internal bool IsProviderResource { get; }
 
         /// <summary>
         /// Gets the subscription id if it exists otherwise null.


### PR DESCRIPTION
remove ctor warning suppress

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
