### PR TITLE
[FormRecognizer] Updated testing cloud to Public

### DIFF
--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -6,8 +6,11 @@ extends:
     ServiceDirectory: formrecognizer
     TimeoutInMinutes: 180
     CloudConfig:
+      Public:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        Location: 'canadacentral'
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'
-    Clouds: 'Canary'
-    SupportedClouds: 'Canary'
+    Clouds: 'Public'
+    SupportedClouds: 'Public, Canary'


### PR DESCRIPTION
Moving main testing region back to `Public`.