### PR TITLE
Fix icon path

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -143,7 +143,7 @@
     <Authors>Microsoft</Authors>
     <Product>Azure .NET SDK</Product>
     <PackageIcon>pkgicon.png</PackageIcon>
-    <PackageIconPath>$(RepoEngPath)/images/pkgicon.png</PackageIconPath>  
+    <PackageIconPath>$(RepoEngPath)/images/$(PackageIcon)</PackageIconPath>  
     <RepositoryUrl>https://github.com/Azure/azure-sdk-for-net</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -142,7 +142,8 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
     <Product>Azure .NET SDK</Product>
-    <PackageIconPath>$(RepoEngPath)/images/pkgicon.png</PackageIconPath>
+    <PackageIcon>pkgicon.png</PackageIcon>
+    <PackageIconPath>$(RepoEngPath)/images/pkgicon.png</PackageIconPath>  
     <RepositoryUrl>https://github.com/Azure/azure-sdk-for-net</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -206,6 +207,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsClientLibrary)' == 'true'">
+    <PackageIcon>azureicon.png</PackageIcon>
     <PackageIconPath>$(RepoEngPath)/images/azureicon.png</PackageIconPath>
     <!-- Use a full key for the new client libraries and disable delay signing -->
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzureSDKClient.snk</AssemblyOriginatorKeyFile>

--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -208,7 +208,7 @@
 
   <PropertyGroup Condition="'$(IsClientLibrary)' == 'true'">
     <PackageIcon>azureicon.png</PackageIcon>
-    <PackageIconPath>$(RepoEngPath)/images/azureicon.png</PackageIconPath>
+    <PackageIconPath>$(RepoEngPath)/images/$(PackageIcon)</PackageIconPath>
     <!-- Use a full key for the new client libraries and disable delay signing -->
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzureSDKClient.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>


### PR DESCRIPTION
Verified that Track 2 library uses new icon, and Track 1 library still uses MS logo.