### PR TITLE
Prepare packages for release based on Core 1.22.0 package

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -83,7 +83,7 @@
     <PackageReference Update="Azure.Communication.Common" Version="1.0.1" />
     <PackageReference Update="Azure.Core" Version="1.22.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.2.0" />
-    <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.18" />
+    <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.19" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.0.0" />
     <PackageReference Update="Azure.Data.Tables" Version="12.3.0" />
     <PackageReference Update="Azure.Messaging.EventHubs" Version="5.6.2" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -81,7 +81,7 @@
 
     <!-- Azure SDK packages -->
     <PackageReference Update="Azure.Communication.Common" Version="1.0.1" />
-    <PackageReference Update="Azure.Core" Version="1.21.0" />
+    <PackageReference Update="Azure.Core" Version="1.22.0" />
     <PackageReference Update="Azure.Core.Amqp" Version="1.2.0" />
     <PackageReference Update="Azure.Core.Experimental" Version="0.1.0-preview.18" />
     <PackageReference Update="Azure.Data.SchemaRegistry" Version="1.0.0" />

--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/Azure.Verticals.AgriFood.Farming.sln
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/Azure.Verticals.AgriFood.Farming.sln
@@ -13,8 +13,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Stress", "..\..\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{0ED9C8A0-9A19-4750-8DD3-61D086288283}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{7B24E7B3-64FD-4408-8B89-E9DBE54AD47A}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/Azure.Verticals.AgriFood.Farming.csproj
+++ b/sdk/agrifood/Azure.Verticals.AgriFood.Farming/src/Azure.Verticals.AgriFood.Farming.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Core.Experimental" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
@@ -30,10 +32,6 @@
     <Compile Include="$(AzureCoreSharedSources)OperationInternalBase.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)OperationInternalOfT.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/Azure.AI.AnomalyDetector.sln
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/Azure.AI.AnomalyDetector.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.AnomalyDetector.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{439F1494-8E96-4931-AB0A-5BBA7EBA15D2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{71C00248-3DEE-4C44-A2BB-4CCAF994DB32}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/Azure.Data.AppConfiguration.sln
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/Azure.Data.AppConfiguration.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.AppConfiguration
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.AppConfiguration.Tests", "tests\Azure.Data.AppConfiguration.Tests.csproj", "{AAA761F4-D037-46AC-BF7A-496C15310F66}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{019A28FC-EFEA-4431-872C-AB8F9C0049BF}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.AppConfiguration.Performance", "tests\Performance\Azure.Data.AppConfiguration.Performance.csproj", "{2F3CC223-2357-4D24-BCE7-92835C62A201}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Identity", "..\..\identity\Azure.Identity\src\Azure.Identity.csproj", "{042736B0-D082-4366-BD2B-02D49FEC6073}"

--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/Azure.ResourceManager.AppConfiguration.sln
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/Azure.ResourceManager.AppConfiguration.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{EA9DBCE0-4918-4683-A2D1-68992BDAF1E3}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{086D0FD3-FA19-4C72-9E3A-B8570A2BAD11}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.AppConfiguration", "src\Azure.ResourceManager.AppConfiguration.csproj", "{A0135DBA-F25A-4BAB-BA73-D82CEC252937}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.AppConfiguration.Tests", "tests\Azure.ResourceManager.AppConfiguration.Tests.csproj", "{4711F6AE-14AB-4910-A524-80C54F539791}"

--- a/sdk/attestation/Azure.Security.Attestation/Azure.Security.Attestation.sln
+++ b/sdk/attestation/Azure.Security.Attestation/Azure.Security.Attestation.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Security.Attestation.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{8052009B-2126-44A3-88CD-4F3B17894C64}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{261AB245-22A3-48DF-8F7F-15868E60B872}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/cdn/Azure.ResourceManager.Cdn/Azure.ResourceManager.Cdn.sln
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/Azure.ResourceManager.Cdn.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Cdn",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Cdn.Tests", "tests\Azure.ResourceManager.Cdn.Tests.csproj", "{81C5B5DB-D408-44BA-B0F9-F6975C26ECD4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{5AC4A8F7-791D-4635-8F24-0D8B55197E25}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{5404EE57-8CD8-46F3-B7CA-200F5FD8A4B8}"
 EndProject
 Global

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Azure.AI.Language.QuestionAnswering.csproj
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Azure.AI.Language.QuestionAnswering.csproj
@@ -34,9 +34,4 @@
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
   </ItemGroup>
 
-  <!--TODO: Switch out project reference with .core package reference when package is ready.-->
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/sdk/cognitivelanguage/Azure.AI.Language.sln
+++ b/sdk/cognitivelanguage/Azure.AI.Language.sln
@@ -14,8 +14,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.Language.QuestionA
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{056BF4D1-3319-4026-A370-46E8F52C10A4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{8DAB9728-0F12-40DF-A5B7-EFD602AF3C0E}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{82AED6B1-C502-4802-B1D5-7A52C29BF9D3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.Language.Conversations", "Azure.AI.Language.Conversations\src\Azure.AI.Language.Conversations.csproj", "{EC6C5FCC-020D-4E85-A8B8-47A6F5623066}"

--- a/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
@@ -37,7 +37,7 @@
     <Compile Include="$(AzureCoreSharedSources)OperationInternalOfT.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../../core/Azure.Core/src/Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Communication.Common" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/sdk/communication/Azure.Communication.sln
+++ b/sdk/communication/Azure.Communication.sln
@@ -44,8 +44,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Communication.Calling
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Communication.CallingServer.Tests", "Azure.Communication.CallingServer\tests\Azure.Communication.CallingServer.Tests.csproj", "{B7C0269B-1809-4713-A7BD-390098AB7135}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{78638C36-A6ED-47CE-BC99-76BD8725DE92}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/communication/Azure.ResourceManager.Communication/Azure.ResourceManager.Communication.sln
+++ b/sdk/communication/Azure.ResourceManager.Communication/Azure.ResourceManager.Communication.sln
@@ -6,8 +6,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Commu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Communication.Tests", "tests\Azure.ResourceManager.Communication.Tests.csproj", "{738C0769-57F8-439C-8078-54498A030BA0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{EF7D6C71-0600-4A71-BEC9-297DAF6C7966}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{DF15D10D-3646-447E-B00B-49506D142322}"
 EndProject
 Global

--- a/sdk/compute/Azure.ResourceManager.Compute/Azure.ResourceManager.Compute.sln
+++ b/sdk/compute/Azure.ResourceManager.Compute/Azure.ResourceManager.Compute.sln
@@ -6,8 +6,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Compu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Compute.Tests", "tests\Azure.ResourceManager.Compute.Tests.csproj", "{738C0769-57F8-439C-8078-54498A030BA0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{EF7D6C71-0600-4A71-BEC9-297DAF6C7966}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{DF15D10D-3646-447E-B00B-49506D142322}"
 EndProject
 Global

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/Azure.Security.ConfidentialLedger.sln
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/Azure.Security.ConfidentialLedger.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Security.ConfidentialLedger.Tests", "tests\Azure.Security.ConfidentialLedger.Tests.csproj", "{953B33C8-42F0-45BF-B6A4-46D80D39A9E3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{EF8F81A5-B1E7-41B3-BBAD-819F10F3C501}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
@@ -13,14 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- TODO: uncomment when Azure.Core ships
     <PackageReference Include="Azure.Core" />
-    end TODO -->
-    <!-- TODO: revert when Azure.Core ships -->
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
-    <!--  end TODO-->
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Azure.Core.Experimental" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 <!-- Shared source from Azure.Core -->

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/Azure.Containers.ContainerRegistry.sln
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/Azure.Containers.ContainerRegistry.sln
@@ -13,8 +13,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Containers.ContainerRegistry.Tests", "tests\Azure.Containers.ContainerRegistry.Tests.csproj", "{3AEC1467-61D0-4A91-93FA-2BD391122D21}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{F62DCD51-5101-4427-B6C9-C24974F9DD3F}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Containers.ContainerRegistry.Perf", "perf\Azure.Containers.ContainerRegistry.Perf\Azure.Containers.ContainerRegistry.Perf.csproj", "{D8B4B378-8339-44AB-BBEC-056B82A15A0A}"
 EndProject
 Global

--- a/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
+++ b/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Azure.Core\src\Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/sdk/core/Azure.Core.TestFramework/Azure.Core.TestFramework.sln
+++ b/sdk/core/Azure.Core.TestFramework/Azure.Core.TestFramework.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "src\Azure.Core.TestFramework.csproj", "{961FD4FB-3CA1-4B33-B6FD-8396CF9280DF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\Azure.Core\src\Azure.Core.csproj", "{0654EC0E-12B8-44C6-9906-7CCE7A5697FC}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -4,7 +4,7 @@
     <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../Azure.Core/src/Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NUnit" />

--- a/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/Azure.ResourceManager.CosmosDB.sln
+++ b/sdk/cosmosdb/Azure.ResourceManager.CosmosDB/Azure.ResourceManager.CosmosDB.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31630.363
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{856C6092-55EB-4C02-B7D0-9846EDD70745}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{62AF7C88-CE3F-416E-B18E-BC6F884C89E2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.CosmosDB", "src\Azure.ResourceManager.CosmosDB.csproj", "{7C8507C6-BFAE-4DD2-B4AD-FE1A49B8E246}"

--- a/sdk/deviceupdate/Azure.IoT.DeviceUpdate/Azure.IoT.DeviceUpdate.sln
+++ b/sdk/deviceupdate/Azure.IoT.DeviceUpdate/Azure.IoT.DeviceUpdate.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceUpdateClientSample", "samples\DeviceUpdateClientSample\DeviceUpdateClientSample.csproj", "{4719AE90-2B90-4DBC-92DA-8CCE29D5B7F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{9BD705AB-D378-4859-8DDE-3865C0893661}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/deviceupdate/Azure.ResourceManager.DeviceUpdate/Azure.ResourceManager.DeviceUpdate.sln
+++ b/sdk/deviceupdate/Azure.ResourceManager.DeviceUpdate/Azure.ResourceManager.DeviceUpdate.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Devic
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.DeviceUpdate.Tests", "tests\Azure.ResourceManager.DeviceUpdate.Tests.csproj", "{06361970-B817-48D4-9803-48BE26523ED8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{5F64CEC1-7D66-4855-A59D-FD41728DBF89}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{02452114-797D-4E64-B049-CAFE98594AAA}"
 EndProject
 Global

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/Azure.DigitalTwins.Core.sln
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/Azure.DigitalTwins.Core.sln
@@ -28,8 +28,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{E685A401-AF9E-4196-975B-26C4A340256F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{4153CAAF-C1D5-4104-ABD9-7F010E6AAFAB}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/dns/Azure.ResourceManager.Dns/Azure.ResourceManager.Dns.sln
+++ b/sdk/dns/Azure.ResourceManager.Dns/Azure.ResourceManager.Dns.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31630.363
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{856C6092-55EB-4C02-B7D0-9846EDD70745}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Dns", "src\Azure.ResourceManager.Dns.csproj", "{334FB216-0D38-4370-92DB-65BC85EBFDB5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Dns.Tests", "tests\Azure.ResourceManager.Dns.Tests.csproj", "{B27A3240-EDB9-4C64-ABD4-02F492C27D64}"

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/Azure.Messaging.EventGrid.sln
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/Azure.Messaging.EventGrid.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventGrid",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventGrid.Tests", "tests\Azure.Messaging.EventGrid.Tests.csproj", "{779EF7D4-B9C1-4177-BAA7-CF7CBDEF6A5C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{21CF4B4A-5027-46D0-B50A-976BF8483095}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents", "..\Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents\src\Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj", "{A24C8A1C-B6A0-4F50-A690-9B1D3DF9228C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.Tests", "..\Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents\tests\Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.Tests.csproj", "{28B77D76-084F-4C7E-8A1B-631444EED6A2}"

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/Microsoft.Azure.WebJobs.Extensions.EventGrid.sln
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/Microsoft.Azure.WebJobs.Extensions.EventGrid.sln
@@ -11,8 +11,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventGrid",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{328250F6-39A2-489A-81E5-46C13C59D8F7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{C05E2889-0E7C-4942-8B6F-15DCAF817156}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="Azure.Core" />
     -->
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
+    <PackageReference Include="Azure.Core.Experimental" />
     <!-- END TEMP -->
 
     <!--

--- a/sdk/eventhub/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{4C209B69-98C3-4B12-B777-111EFF0E6F66}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{C8B54BA3-8FAE-4F54-B0F8-D528B2AA4996}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{327A0C67-D9B6-4831-A53F-BFE059934787}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs", "Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{F33BE6F6-AEC4-4D10-BB4B-05C7C0BB06C0}"

--- a/sdk/eventhub/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{4C209B69-98C3-4B12-B777-111EFF0E6F66}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{6221D9A4-8563-4B8B-86B2-73585D54F840}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{C8B54BA3-8FAE-4F54-B0F8-D528B2AA4996}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{327A0C67-D9B6-4831-A53F-BFE059934787}"

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -19,7 +19,7 @@
 
     <PackageReference Include="Azure.Core" />
     -->
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
+    <PackageReference Include="Azure.Core.Experimental" />
     <!-- END TEMP -->
 
     <PackageReference Include="Azure.Core.Amqp" />

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/Azure.ResourceManager.EventHubs.sln
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/Azure.ResourceManager.EventHubs.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Event
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{5AFADD62-1535-4E51-959F-A49DE0F0AA66}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{2E71CF58-760E-4C2F-BAB0-4697D6D21F54}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/Microsoft.Azure.WebJobs.Extensions.EventHubs.sln
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/Microsoft.Azure.WebJobs.Extensions.EventHubs.sln
@@ -13,8 +13,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventHubs",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Azure", "..\..\extensions\Microsoft.Extensions.Azure\src\Microsoft.Extensions.Azure.csproj", "{E772769A-7CE1-4FBC-A084-C0936EB2C766}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{FD65B96F-855A-495C-AA82-03402336E96C}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/extensions/Azure.Extensions.sln
+++ b/sdk/extensions/Azure.Extensions.sln
@@ -41,8 +41,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.WebJobs.Ext
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Azure.Samples", "Microsoft.Extensions.Azure\samples\Microsoft.Extensions.Azure.Samples.csproj", "{D131D37E-9E4E-4511-BBB1-28F9DC8C76CC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{D0D83FD0-44E7-4F8E-939F-8D8FDB2CCBAD}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/Azure.AI.FormRecognizer.sln
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/Azure.AI.FormRecognizer.sln
@@ -13,8 +13,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.FormRecognizer.Perf", "perf\Azure.AI.FormRecognizer.Perf\Azure.AI.FormRecognizer.Perf.csproj", "{E11C4DF2-C78A-4EE3-B3FC-BE4F7C7A80F1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{6C5E5550-A9AE-4B52-84E5-32E035AC4D40}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/identity/Azure.Identity/Azure.Identity.sln
+++ b/sdk/identity/Azure.Identity/Azure.Identity.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Identity", "src\Azure.Identity.csproj", "{8A856C05-8CC7-4A1A-A3DC-DD628ECD3E2A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{3A2D1187-6EC5-4B03-A8A1-68DADC20BA83}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Identity.Tests", "tests\Azure.Identity.Tests.csproj", "{CD0BE1AA-F99E-48E7-9FFD-F1B288E62B4F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8F748B65-7779-4A71-B2EC-9BA8B9526AB0}"

--- a/sdk/insights/Azure.ResourceManager.Insights/Azure.ResourceManager.Insights.sln
+++ b/sdk/insights/Azure.ResourceManager.Insights/Azure.ResourceManager.Insights.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Insig
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Insights.Tests", "tests\Azure.ResourceManager.Insights.Tests.csproj", "{EAF9B53D-8C1D-4D7D-AAB7-9E3553590332}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{45E8DC21-0B24-4982-9CB2-F282596FDF62}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{E614ED91-3025-4CE7-9A64-450869A28C69}"
 EndProject
 Global

--- a/sdk/iot/Azure.IoT.Hub.Service/Azure.IoT.Hub.Service.sln
+++ b/sdk/iot/Azure.IoT.Hub.Service/Azure.IoT.Hub.Service.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IotHubClientSamples", "samples\IotHubClientSamples\IotHubClientSamples.csproj", "{8291D7B1-E485-4C04-9712-6DF1D4646C28}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{DE1EBB40-4BB4-491B-9FE2-FB82948333D2}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/Azure.ResourceManager.KeyVault.sln
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/Azure.ResourceManager.KeyVault.sln
@@ -8,8 +8,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.KeyVa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{D834F7AA-20E1-4A74-8474-6E367332E3EB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{91F4FCC0-AEB7-4FEC-B3C2-7A3F9764CB51}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/keyvault/Azure.Security.KeyVault.sln
+++ b/sdk/keyvault/Azure.Security.KeyVault.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28927.53
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{8AEC7876-E05F-479C-91A2-AA12F95CC9E4}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Security.KeyVault.Secrets", "Azure.Security.KeyVault.Secrets\src\Azure.Security.KeyVault.Secrets.csproj", "{AA1C6FB6-7176-400E-B556-B04253A69949}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Security.KeyVault.Secrets.Tests", "Azure.Security.KeyVault.Secrets\tests\Azure.Security.KeyVault.Secrets.Tests.csproj", "{6BEF56A3-A6B2-4F21-A4B6-895764A384F3}"

--- a/sdk/machinelearningservices/Azure.ResourceManager.MachineLearningServices/Azure.ResourceManager.MachineLearningServices.sln
+++ b/sdk/machinelearningservices/Azure.ResourceManager.MachineLearningServices/Azure.ResourceManager.MachineLearningServices.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Machi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Compute.Tests", "tests\Azure.ResourceManager.MachineLearningServices.Tests.csproj", "{738C0769-57F8-439C-8078-54498A030BA0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{EF7D6C71-0600-4A71-BEC9-297DAF6C7966}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{8052009B-2126-44A3-88CD-4F3B17894C64}"
 EndProject
 Global

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/Azure.AI.MetricsAdvisor.sln
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/Azure.AI.MetricsAdvisor.sln
@@ -13,8 +13,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{DECB7564-96C8-413F-8F87-998C1E8C077F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{1715D99D-E5B4-4970-93FA-FEE2AA7573D1}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/Azure.MixedReality.Authentication.sln
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/Azure.MixedReality.Authentication.sln
@@ -13,8 +13,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.Azure.MixedReality.A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.Azure.MixedReality.Authentication.Tests", "tests\Shared.Azure.MixedReality.Authentication.Tests\Shared.Azure.MixedReality.Authentication.Tests.csproj", "{A128CD7B-EABC-48C7-BAD2-216007EF130D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{CFD20568-B88B-4CA1-852B-E21F3ADFB12E}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/modelsrepository/Azure.IoT.ModelsRepository/Azure.IoT.ModelsRepository.sln
+++ b/sdk/modelsrepository/Azure.IoT.ModelsRepository/Azure.IoT.ModelsRepository.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModelsRepositoryClientSamples", "samples\ModelsRepositoryClientSamples\ModelsRepositoryClientSamples.csproj", "{51E4AB9E-46F3-450C-B52A-C4C6378E8BA3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{D9CAD23D-60CF-4CA7-8683-3507A81DE2FB}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
@@ -19,8 +19,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization", "tests\Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization\Azure.Monitor.OpenTelemetry.Exporter.Tracing.Customization.csproj", "{57A53135-3C1B-4106-B873-434B2F606B17}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{9816D6D4-AAF3-42F8-A358-962A8BE6FFC6}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/monitor/Azure.Monitor.Query/Azure.Monitor.Query.sln
+++ b/sdk/monitor/Azure.Monitor.Query/Azure.Monitor.Query.sln
@@ -15,8 +15,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Monitor.Query.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{F630F933-5163-4878-B107-3D664FA8B89B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{753CF76A-180D-483D-93B8-BA7F243C5100}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Monitor.Query.Perf", "perf\Azure.Monitor.Query.Perf.csproj", "{E05FEA47-C575-44E1-83DA-A269A30122B1}"
 EndProject
 Global

--- a/sdk/monitor/Azure.Monitor.Query/Azure.Monitor.Query.sln
+++ b/sdk/monitor/Azure.Monitor.Query/Azure.Monitor.Query.sln
@@ -13,8 +13,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Monitor.Query", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Monitor.Query.Tests", "tests\Azure.Monitor.Query.Tests.csproj", "{57982C70-975B-475E-B4F4-D20E9EC9F7FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{F630F933-5163-4878-B107-3D664FA8B89B}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Monitor.Query.Perf", "perf\Azure.Monitor.Query.Perf.csproj", "{E05FEA47-C575-44E1-83DA-A269A30122B1}"
 EndProject
 Global

--- a/sdk/network/Azure.ResourceManager.Network/Azure.ResourceManager.Network.sln
+++ b/sdk/network/Azure.ResourceManager.Network/Azure.ResourceManager.Network.sln
@@ -6,8 +6,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Netwo
 EndProject
 Project("{B4FB44D3-B154-4769-8B0D-1F9BD7BB7001}") = "Azure.ResourceManager.Network.Tests", "tests\Azure.ResourceManager.Network.Tests.csproj", "{D0F09556-CA4C-43A1-8996-1BC2D99AD264}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{612DC74D-90C6-41CD-9C0A-D7E543D6D857}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{F76CA6E1-2957-4E0D-9164-1ADE84C762A3}"
 EndProject
 Global

--- a/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/Azure.MixedReality.ObjectAnchors.Conversion.sln
+++ b/sdk/objectanchors/Azure.MixedReality.ObjectAnchors.Conversion/Azure.MixedReality.ObjectAnchors.Conversion.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.MixedReality.ObjectAnchors.Conversion.Tests", "tests\Azure.MixedReality.ObjectAnchors.Conversion.Tests.csproj", "{FDE9619C-6A39-4A72-8E78-9ACB3B8C64FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{557636BA-FB06-4AC6-B604-23ADB1ED1492}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/personalizer/Azure.AI.Personalizer.sln
+++ b/sdk/personalizer/Azure.AI.Personalizer.sln
@@ -17,8 +17,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{0F88C67F-34D2-4C68-B5BF-08A547D4CC2E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{F788BE17-A662-4EA2-98DD-AA6423A7F3C9}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/purview/Azure.Analytics.Purview.Account/Azure.Analytics.Purview.Account.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Account/Azure.Analytics.Purview.Account.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Acc
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{1E9A1DB3-96FC-4EB4-B6E2-13FB057B050A}"
-EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{002a0f15-402b-473d-8842-5507462920bf}*SharedItemsImports = 5

--- a/sdk/purview/Azure.Analytics.Purview.Account/src/Azure.Analytics.Purview.Account.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.Account/src/Azure.Analytics.Purview.Account.csproj
@@ -27,8 +27,7 @@
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Core.Experimental" />
   </ItemGroup>
-
 </Project>

--- a/sdk/purview/Azure.Analytics.Purview.Administration/Azure.Analytics.Purview.Administration.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/Azure.Analytics.Purview.Administration.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{85677AD3-C214-42FA-AE6E-49B956CAC8DC}"
-EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{283cb4fe-a207-4d92-8431-6147f1ecbab7}*SharedItemsImports = 13

--- a/sdk/purview/Azure.Analytics.Purview.Administration/src/Azure.Analytics.Purview.Administration.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.Administration/src/Azure.Analytics.Purview.Administration.csproj
@@ -27,8 +27,8 @@
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Core.Experimental" />
   </ItemGroup>
 
 </Project>

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/Azure.Analytics.Purview.Catalog.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/Azure.Analytics.Purview.Catalog.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Cat
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{B48EFD57-7500-4A8E-870B-46E3C511B9DF}"
-EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{002a0f15-402b-473d-8842-5507462920bf}*SharedItemsImports = 5

--- a/sdk/purview/Azure.Analytics.Purview.Catalog/src/Azure.Analytics.Purview.Catalog.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.Catalog/src/Azure.Analytics.Purview.Catalog.csproj
@@ -27,8 +27,8 @@
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core.Experimental" />
+    <PackageReference Include="Azure.Core" />
   </ItemGroup>
 
 </Project>

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/Azure.Analytics.Purview.Scanning.sln
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/Azure.Analytics.Purview.Scanning.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Purview.Sca
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Azure.Analytics.Purview.Shared.Tests", "..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.shproj", "{283CB4FE-A207-4D92-8431-6147F1ECBAB7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{546166BC-7440-407B-AD50-85C90190D0C1}"
-EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\Azure.Analytics.Purview.Shared\tests\Azure.Analytics.Purview.Shared.Tests.projitems*{283cb4fe-a207-4d92-8431-6147f1ecbab7}*SharedItemsImports = 13

--- a/sdk/purview/Azure.Analytics.Purview.Scanning/src/Azure.Analytics.Purview.Scanning.csproj
+++ b/sdk/purview/Azure.Analytics.Purview.Scanning/src/Azure.Analytics.Purview.Scanning.csproj
@@ -27,8 +27,8 @@
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core.Experimental" />
+    <PackageReference Include="Azure.Core" />
   </ItemGroup>
 
 </Project>

--- a/sdk/quantum/Azure.Quantum.Jobs/Azure.Quantum.Jobs.sln
+++ b/sdk/quantum/Azure.Quantum.Jobs/Azure.Quantum.Jobs.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Quantum.Jobs.Samples", "samples\Azure.Quantum.Jobs.Samples.csproj", "{C48526E9-7F6A-494F-8193-3C050BD8E32E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{1953481F-8E50-406A-B1E6-51FFDFA43ECF}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/remoterendering/Azure.MixedReality.RemoteRendering/Azure.MixedReality.RemoteRendering.sln
+++ b/sdk/remoterendering/Azure.MixedReality.RemoteRendering/Azure.MixedReality.RemoteRendering.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.MixedReality.RemoteRe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{85271BAE-8B48-43B6-8A16-BBD3F14F7AA1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{44601A61-63BA-4251-88EE-3BFF39E8D05E}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/resourcemanager/Azure.ResourceManager/Azure.ResourceManager.sln
+++ b/sdk/resourcemanager/Azure.ResourceManager/Azure.ResourceManager.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31820.362
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{856C6092-55EB-4C02-B7D0-9846EDD70745}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{62AF7C88-CE3F-416E-B18E-BC6F884C89E2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager", "src\Azure.ResourceManager.csproj", "{010FE057-7BB5-4F8C-BB9A-6378144F4CA8}"

--- a/sdk/resources/Azure.ResourceManager.Resources/Azure.ResourceManager.Resources.sln
+++ b/sdk/resources/Azure.ResourceManager.Resources/Azure.ResourceManager.Resources.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{856C6092-55EB-4C02-B7D0-9846EDD70745}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{62AF7C88-CE3F-416E-B18E-BC6F884C89E2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Resources", "src\Azure.ResourceManager.Resources.csproj", "{DEFF4395-FBD0-4205-95DE-7992E79015FA}"

--- a/sdk/schemaregistry/Azure.Data.SchemaRegistry/Azure.Data.SchemaRegistry.sln
+++ b/sdk/schemaregistry/Azure.Data.SchemaRegistry/Azure.Data.SchemaRegistry.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.SchemaRegistry.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{8052009B-2126-44A3-88CD-4F3B17894C64}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{6A8336DC-AE5F-4955-95E3-BF5010A4CE5D}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.sln
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.SchemaRegistry", "..\Azure.Data.SchemaRegistry\src\Azure.Data.SchemaRegistry.csproj", "{D451EE68-ADE4-4780-A002-2D13DEA888A2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{8A0A0FBB-2B12-49B3-951E-5402D64075DD}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventHubs", "..\..\eventhub\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj", "{FDC382B3-7255-4D33-AAA9-1168B7D01E94}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.ServiceBus", "..\..\servicebus\Azure.Messaging.ServiceBus\src\Azure.Messaging.ServiceBus.csproj", "{69E3D417-F0A9-4C6B-B9C5-8C29E9F2A660}"

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.sln
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.sln
@@ -17,8 +17,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventHubs",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.ServiceBus", "..\..\servicebus\Azure.Messaging.ServiceBus\src\Azure.Messaging.ServiceBus.csproj", "{69E3D417-F0A9-4C6B-B9C5-8C29E9F2A660}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{9138F20C-DB99-455C-8F0C-D455FCAF8928}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.csproj
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.csproj
@@ -21,7 +21,7 @@
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
+    <PackageReference Include="Azure.Core.Experimental" />
     <ProjectReference Include="..\..\Azure.Data.SchemaRegistry\src\Azure.Data.SchemaRegistry.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests.csproj
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core.Experimental" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -20,7 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
     <ProjectReference Include="..\..\..\eventhub\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
     <ProjectReference Include="..\..\..\servicebus\Azure.Messaging.ServiceBus\src\Azure.Messaging.ServiceBus.csproj" />
     <ProjectReference Include="..\src\Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.csproj" />

--- a/sdk/search/Azure.Search.Documents/Azure.Search.Documents.sln
+++ b/sdk/search/Azure.Search.Documents/Azure.Search.Documents.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Search.Documents.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Search.Documents.Perf", "perf\Azure.Search.Documents.Perf\Azure.Search.Documents.Perf.csproj", "{CA130CB5-4B52-4B86-8208-C4DD7F1DED69}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{1C1494BE-FB17-4F53-BA6C-9A4EDD761DEE}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{06C87DE1-98A8-418E-AF01-FEFF9CFFA788}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{32F92309-FF56-4E48-81FF-ADC7318F6DA5}"

--- a/sdk/search/Azure.Search.Documents/Azure.Search.Documents.sln
+++ b/sdk/search/Azure.Search.Documents/Azure.Search.Documents.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Search.Documents.Perf
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{06C87DE1-98A8-418E-AF01-FEFF9CFFA788}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{32F92309-FF56-4E48-81FF-ADC7318F6DA5}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Core.Spatial.NewtonsoftJson", "..\..\core\Microsoft.Azure.Core.Spatial.NewtonsoftJson\src\Microsoft.Azure.Core.Spatial.NewtonsoftJson.csproj", "{C2A3FECA-1696-4EDD-ABA1-30F1E3D6CE1D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Core.NewtonsoftJson", "..\..\core\Microsoft.Azure.Core.NewtonsoftJson\src\Microsoft.Azure.Core.NewtonsoftJson.csproj", "{CB1DED0F-0E3E-4370-9351-58E025BFEAB4}"

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/Azure.Messaging.ServiceBus.sln
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/Azure.Messaging.ServiceBus.sln
@@ -40,8 +40,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.ServiceBus.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{A6A7CEAE-C1F9-4B9B-A19F-4AA38ADF5209}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.Experimental", "..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{B42578D2-76CD-4F4E-9999-CDB466477488}"
-EndProject
+
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/Azure.Messaging.ServiceBus.sln
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/Azure.Messaging.ServiceBus.sln
@@ -32,8 +32,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{8B8C
 		samples\Sample10_ClaimCheck.md = samples\Sample10_ClaimCheck.md
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{9CD1905A-19B9-4F71-8BE6-D25CF49DA5B3}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Amqp", "..\..\core\Azure.Core.Amqp\src\Azure.Core.Amqp.csproj", "{2ADA26CA-77E5-4793-927A-A6185FD8AA29}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Amqp.Tests", "..\..\core\Azure.Core.Amqp\tests\Azure.Core.Amqp.Tests.csproj", "{0C1C6691-FC09-4507-92B8-1406251A1273}"

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -62,7 +62,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
+    <PackageReference Include="Azure.Core.Experimental" />
   </ItemGroup>
 
 </Project>

--- a/sdk/servicebus/Azure.ResourceManager.ServiceBus/Azure.ResourceManager.ServiceBus.sln
+++ b/sdk/servicebus/Azure.ResourceManager.ServiceBus/Azure.ResourceManager.ServiceBus.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Servi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.ServiceBus.Tests", "tests\Azure.ResourceManager.ServiceBus.Tests.csproj", "{8623B4A2-A202-43DB-9403-25B9095296C7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{63F627CD-0743-4CA4-9729-A9FF8650D661}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{54396122-5CDD-40BE-B539-6BA0B5B7D981}"
 EndProject
 Global

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Microsoft.Azure.WebJobs.Extensions.ServiceBus.sln
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/Microsoft.Azure.WebJobs.Extensions.ServiceBus.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.ServiceBus"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{E0274499-FD0C-4AC5-9CA9-F94379AA29CB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{F589935A-C325-47C5-A1DE-4C42A735B1B0}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/sqlmanagement/Azure.ResourceManager.Sql/Azure.ResourceManager.Sql.sln
+++ b/sdk/sqlmanagement/Azure.ResourceManager.Sql/Azure.ResourceManager.Sql.sln
@@ -9,8 +9,6 @@ Project("{DCF1AD44-8A51-4851-93A8-0611F8D4DC61}") = "Azure.ResourceManager.Sql",
 EndProject
 Project("{DCF1AD44-8A51-4851-93A8-0611F8D4DC61}") = "Azure.ResourceManager.Sql.Tests", "tests\Azure.ResourceManager.Sql.Tests.csproj", "{BE6FF05E-1E3C-4C35-B18A-89A029B79999}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{23367795-CD08-4A70-929D-2164EE74D82A}"
-EndProject
 Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/storage/Azure.ResourceManager.Storage/Azure.ResourceManager.Storage.sln
+++ b/sdk/storage/Azure.ResourceManager.Storage/Azure.ResourceManager.Storage.sln
@@ -2,8 +2,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31630.363
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{94E23818-B4C6-4E73-A3B5-7BFE379999CD}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{EE26B4BC-37DB-4C5C-8519-4B8081012AF8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Storage", "src\Azure.ResourceManager.Storage.csproj", "{864272B5-4611-4FD0-9E18-D3152DE32270}"

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Azure.Storage.Files.DataLake.Perf.sln
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Azure.Storage.Files.DataLake.Perf.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{59CCD0D2-1F7B-4EB8-AAF5-A4CB01DD1BC6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\..\..\core\Azure.Core\src\Azure.Core.csproj", "{AB603D89-33D9-46D3-8135-3F582945A3B9}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/storage/Azure.Storage.sln
+++ b/sdk/storage/Azure.Storage.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{9056EE3A-9ED4-441A-9A88-A567ED07DDDD}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Storage.Common", "Azure.Storage.Common\src\Azure.Storage.Common.csproj", "{6890AA6B-C71C-48A0-BE49-E0D5AD4E914F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Storage.Common.Tests", "Azure.Storage.Common\tests\Azure.Storage.Common.Tests.csproj", "{6D68AF55-B0AF-435E-A943-9F53F1A062E0}"

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.sln
@@ -42,8 +42,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Ext
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Function.App", "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs\samples\functionapp\Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Function.App.csproj", "{22D974DB-0B34-48F5-90EC-F65F9902E7D3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{03A5BF93-27C7-4923-B006-004DFD0795C0}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/storagepool/Azure.ResourceManager.StoragePool/Azure.ResourceManager.StoragePool.sln
+++ b/sdk/storagepool/Azure.ResourceManager.StoragePool/Azure.ResourceManager.StoragePool.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Stora
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.StoragePool.Tests", "tests\Azure.ResourceManager.StoragePool.Tests.csproj", "{A2E97E59-7545-4FC3-9A2D-E9FE415077F5}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{69D7E497-C275-4AC9-A078-DAAA4B9B95B8}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{77EE59F4-F06D-4FAE-974B-F6DF9B566575}"
 EndProject
 Global

--- a/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/Azure.Analytics.Synapse.AccessControl.csproj
+++ b/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/Azure.Analytics.Synapse.AccessControl.csproj
@@ -18,6 +18,7 @@
   <Import Project="..\..\Azure.Analytics.Synapse.Shared\src\Azure.Analytics.Synapse.Shared.projitems" Label="Shared" />
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
@@ -39,9 +40,6 @@
     <Compile Include="$(AzureCoreSharedSources)OperationInternalOfT.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/synapse/Azure.Analytics.Synapse.sln
+++ b/sdk/synapse/Azure.Analytics.Synapse.sln
@@ -29,8 +29,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Synapse.Mon
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Synapse.Monitoring.Tests", "Azure.Analytics.Synapse.Monitoring\tests\Azure.Analytics.Synapse.Monitoring.Tests.csproj", "{729E92B7-E47B-442C-836F-27B8A7806D2F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{02A34436-0CB1-43C3-8CD5-4EC450171055}"
-EndProject
+
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Azure.Analytics.Synapse.Shared\tests\Azure.Analytics.Synapse.Shared.Tests.projitems*{1afa2644-a1d9-419f-b87d-9b519b673f24}*SharedItemsImports = 13

--- a/sdk/synapse/Azure.Analytics.Synapse.sln
+++ b/sdk/synapse/Azure.Analytics.Synapse.sln
@@ -29,8 +29,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Synapse.Mon
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Analytics.Synapse.Monitoring.Tests", "Azure.Analytics.Synapse.Monitoring\tests\Azure.Analytics.Synapse.Monitoring.Tests.csproj", "{729E92B7-E47B-442C-836F-27B8A7806D2F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\core\Azure.Core\src\Azure.Core.csproj", "{C97510BD-D704-4FE5-8B04-80BD267DFC51}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Experimental", "..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj", "{02A34436-0CB1-43C3-8CD5-4EC450171055}"
 EndProject
 Global

--- a/sdk/tables/Azure.Data.Tables/Azure.Data.Tables.sln
+++ b/sdk/tables/Azure.Data.Tables/Azure.Data.Tables.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Data.Tables.Performance", "tests\perf\Azure.Data.Tables.Perf.csproj", "{3EA53995-C462-43F2-9413-72E29BE04DD4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{CDBB043B-8D26-4232-9FB7-F8A10D3D1DCF}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/Microsoft.Azure.WebJobs.Extensions.Tables.sln
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/Microsoft.Azure.WebJobs.Extensions.Tables.sln
@@ -11,8 +11,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Data.Tables", "..\Azure.Data.Tables\src\Azure.Data.Tables.csproj", "{1E730DCF-CE91-4590-AF52-1F302225D10A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{B0D107B8-6BEE-4F9F-91BC-049721DF4620}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/template-dpg/Azure.Template.Generated/Azure.Template.Generated.sln
+++ b/sdk/template-dpg/Azure.Template.Generated/Azure.Template.Generated.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Template.Generated", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Template.Generated.Tests", "tests\Azure.Template.Generated.Tests.csproj", "{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{40028299-DE93-48CA-969B-A100D555A1FE}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/template-dpg/Azure.Template.Generated/src/Azure.Template.Generated.csproj
+++ b/sdk/template-dpg/Azure.Template.Generated/src/Azure.Template.Generated.csproj
@@ -32,7 +32,7 @@
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core" />
   </ItemGroup>
 
 </Project>

--- a/sdk/template/Azure.Template/Azure.Template.sln
+++ b/sdk/template/Azure.Template/Azure.Template.sln
@@ -17,8 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Template.Perf", "perf
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{0ED9C8A0-9A19-4750-8DD3-61D086288283}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{AA507C7F-F19A-48AB-A7FA-CB113314418F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/Azure.AI.TextAnalytics.sln
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/Azure.AI.TextAnalytics.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.TextAnalytics.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{FD1CFA70-4C03-42AF-9D95-E3E974F9AC9A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{EB0781C6-6C18-4C2A-8BDB-D61A1460AB09}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Test.Perf", "..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj", "{44C5D4FF-7404-4D7A-977B-8E1EAADA7D1D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.AI.TextAnalytics.Perf", "perf\Azure.AI.TextAnalytics.Perf\Azure.AI.TextAnalytics.Perf.csproj", "{2EE6085E-A0D6-4D25-B6E1-E5BA579E7D7C}"

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/Azure.IoT.TimeSeriesInsights.sln
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/Azure.IoT.TimeSeriesInsights.sln
@@ -22,8 +22,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TimeSeriesInsightsClientSample", "samples\TimeSeriesInsightsClientSample\TimeSeriesInsightsClientSample.csproj", "{D243481B-0944-4F60-9B1F-35EDFC7769BA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{7FE9FA2F-7793-4EB9-B8D0-26696536508B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/translation/Azure.AI.Translation.Document/Azure.AI.Translation.Document.sln
+++ b/sdk/translation/Azure.AI.Translation.Document/Azure.AI.Translation.Document.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.AI.Translation.Document.Tests", "tests\Azure.AI.Translation.Document.Tests.csproj", "{764BFCBB-D8FD-401A-8075-B8F5F10B4991}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{D55A8124-3081-4F60-A2D7-744819FA0295}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/Azure.Media.VideoAnalyzer.Edge.sln
+++ b/sdk/videoanalyzer/Azure.Media.VideoAnalyzer.Edge/Azure.Media.VideoAnalyzer.Edge.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Media.VideoAnalyzer.E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Media.VideoAnalyzer.Edge.Samples", "samples\Azure.Media.VideoAnalyzer.Edge.Samples.csproj", "{FE985514-0F2A-44AA-844A-F360A4475F21}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{B1DC71AF-5225-4E2E-A1C0-60C796D4B566}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/Azure.Messaging.WebPubSub.sln
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/Azure.Messaging.WebPubSub.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.WebPubSub",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.WebPubSub.Tests", "tests\Azure.Messaging.WebPubSub.Tests.csproj", "{ADB00BD6-8FEE-4176-BE15-4F530F5C8F29}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{96840387-72F6-45DC-A790-7E449523141B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Azure.Messaging.WebPubSub.csproj
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/src/Azure.Messaging.WebPubSub.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.Text.Json" />
-    <ProjectReference Include="../../../core/Azure.Core/src/Azure.Core.csproj" />
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/webpubsub/Azure.ResourceManager.WebPubSub/Azure.ResourceManager.WebPubSub.sln
+++ b/sdk/webpubsub/Azure.ResourceManager.WebPubSub/Azure.ResourceManager.WebPubSub.sln
@@ -8,8 +8,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.WebPu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{D834F7AA-20E1-4A74-8474-6E367332E3EB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{91F4FCC0-AEB7-4FEC-B3C2-7A3F9764CB51}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/sdk/websites/Azure.ResourceManager.AppService/Azure.ResourceManager.AppService.sln
+++ b/sdk/websites/Azure.ResourceManager.AppService/Azure.ResourceManager.AppService.sln
@@ -6,8 +6,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.AppSe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.AppService.Tests", "tests\Azure.ResourceManager.AppService.Tests.csproj", "{738C0769-57F8-439C-8078-54498A030BA0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{EF7D6C71-0600-4A71-BEC9-297DAF6C7966}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{DF15D10D-3646-447E-B00B-49506D142322}"
 EndProject
 Global


### PR DESCRIPTION
Moving library project references to package references now that [Azure.Core 1.22.0](https://www.nuget.org/packages/Azure.Core/1.22.0) has been released.