### PR TITLE
Use OperationInternals instead of OperationOrResponseInternals

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/ManagementGroup/PseudoGenerated/LongRunningOperation/ManagementGroupCreateOrUpdateOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ManagementGroup/PseudoGenerated/LongRunningOperation/ManagementGroupCreateOrUpdateOperation.cs
@@ -22,7 +22,7 @@ namespace Azure.ResourceManager.Management.Models
     /// </summary>
     public partial class ManagementGroupCreateOrUpdateOperation : Operation<ManagementGroup>, IOperationSource<ManagementGroup>
     {
-        private readonly OperationOrResponseInternals<ManagementGroup> _operation;
+        private readonly OperationInternals<ManagementGroup> _operation;
 
         private readonly ArmResource _operationBase;
 
@@ -33,7 +33,7 @@ namespace Azure.ResourceManager.Management.Models
 
         internal ManagementGroupCreateOrUpdateOperation(ArmResource operationsBase, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals<ManagementGroup>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "ManagementGroupCreateOrUpdateOperation");
+            _operation = new OperationInternals<ManagementGroup>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "ManagementGroupCreateOrUpdateOperation");
             _operationBase = operationsBase;
         }
         /// <inheritdoc />

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ManagementGroup/PseudoGenerated/LongRunningOperation/ManagementGroupDeleteOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ManagementGroup/PseudoGenerated/LongRunningOperation/ManagementGroupDeleteOperation.cs
@@ -20,7 +20,7 @@ namespace Azure.ResourceManager.Management.Models
     /// </summary>
     public partial class ManagementGroupDeleteOperation : Operation
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternals _operation;
 
         /// <summary> Initializes a new instance of ManagementGroupDeleteOperation for mocking. </summary>
         protected ManagementGroupDeleteOperation()
@@ -29,7 +29,7 @@ namespace Azure.ResourceManager.Management.Models
 
         internal ManagementGroupDeleteOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "ManagementGroupDeleteOperation");
+            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.AzureAsyncOperation, "ManagementGroupDeleteOperation");
         }
         /// <inheritdoc />
         public override string Id => _operation.Id;

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/LongRunningOperation/PredefinedTagDeleteOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/Custom/LongRunningOperation/PredefinedTagDeleteOperation.cs
@@ -16,7 +16,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> The operation type for the delete API. </summary>
     public partial class PredefinedTagDeleteOperation : Operation
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternals _operation;
 
         /// <summary> Initializes a new instance of PredefinedTagDeleteOperation for mocking. </summary>
         protected PredefinedTagDeleteOperation()
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal PredefinedTagDeleteOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "PredefinedTagDeleteOperation");
+            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "PredefinedTagDeleteOperation");
         }
 
         /// <inheritdoc />

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceCreateOrUpdateByIdOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceCreateOrUpdateByIdOperation.cs
@@ -18,7 +18,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> Create a resource by ID. </summary>
     public partial class ResourceCreateOrUpdateByIdOperation : Operation<GenericResource>, IOperationSource<GenericResource>
     {
-        private readonly OperationOrResponseInternals<GenericResource> _operation;
+        private readonly OperationInternals<GenericResource> _operation;
         private readonly ArmResource _parentOperation;
 
         /// <summary> Initializes a new instance of ResourceCreateOrUpdateByIdOperation for mocking. </summary>
@@ -28,7 +28,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal ResourceCreateOrUpdateByIdOperation(ArmResource parentOperation, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals<GenericResource>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceCreateOrUpdateByIdOperation");
+            _operation = new OperationInternals<GenericResource>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceCreateOrUpdateByIdOperation");
             _parentOperation = parentOperation;
         }
         /// <inheritdoc />

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceDeleteByIdOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceDeleteByIdOperation.cs
@@ -16,7 +16,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> Deletes a resource by ID. </summary>
     public partial class ResourceDeleteByIdOperation : Operation
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternals _operation;
 
         /// <summary> Initializes a new instance of ResourceDeleteByIdOperation for mocking. </summary>
         protected ResourceDeleteByIdOperation()
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal ResourceDeleteByIdOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals( clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceDeleteByIdOperation");
+            _operation = new OperationInternals( clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceDeleteByIdOperation");
         }
         /// <inheritdoc />
         public override string Id => "";

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceDeleteOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceDeleteOperation.cs
@@ -16,7 +16,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> Deletes a resource. </summary>
     public partial class ResourceDeleteOperation : Operation
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternals _operation;
 
         /// <summary> Initializes a new instance of ResourceDeleteOperation for mocking. </summary>
         protected ResourceDeleteOperation()
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal ResourceDeleteOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceDeleteOperation");
+            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceDeleteOperation");
         }
         /// <inheritdoc />
         public override string Id => "";

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceGroupDeleteOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceGroupDeleteOperation.cs
@@ -16,7 +16,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> When you delete a resource group, all of its resources are also deleted. Deleting a resource group deletes all of its template deployments and currently stored operations. </summary>
     public partial class ResourceGroupDeleteOperation : Operation
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternals _operation;
 
         /// <summary> Initializes a new instance of ResourceGroupDeleteOperation for mocking. </summary>
         protected ResourceGroupDeleteOperation()
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal ResourceGroupDeleteOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceGroupDeleteOperation");
+            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceGroupDeleteOperation");
         }
         /// <inheritdoc />
         public override string Id => _operation.Id;

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceGroupExportTemplateOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceGroupExportTemplateOperation.cs
@@ -17,7 +17,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> Captures the specified resource group as a template. </summary>
     public partial class ResourceGroupExportTemplateOperation : Operation<ResourceGroupExportResult>, IOperationSource<ResourceGroupExportResult>
     {
-        private readonly OperationOrResponseInternals<ResourceGroupExportResult> _operation;
+        private readonly OperationInternals<ResourceGroupExportResult> _operation;
 
         /// <summary> Initializes a new instance of ResourceGroupExportTemplateOperation for mocking. </summary>
         protected ResourceGroupExportTemplateOperation()
@@ -26,7 +26,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal ResourceGroupExportTemplateOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals<ResourceGroupExportResult>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceGroupExportTemplateOperation");
+            _operation = new OperationInternals<ResourceGroupExportResult>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceGroupExportTemplateOperation");
         }
         /// <inheritdoc />
         public override string Id => _operation.Id;

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceMoveResourcesOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceMoveResourcesOperation.cs
@@ -16,7 +16,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> The resources to move must be in the same source resource group. The target resource group may be in a different subscription. When moving resources, both the source group and the target group are locked for the duration of the operation. Write and delete operations are blocked on the groups until the move completes. </summary>
     public partial class ResourceMoveResourcesOperation : Operation
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternals _operation;
 
         /// <summary> Initializes a new instance of ResourceMoveResourcesOperation for mocking. </summary>
         protected ResourceMoveResourcesOperation()
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal ResourceMoveResourcesOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceMoveResourcesOperation");
+            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceMoveResourcesOperation");
         }
 
         /// <inheritdoc />

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceUpdateByIdOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceUpdateByIdOperation.cs
@@ -18,7 +18,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> Updates a resource by ID. </summary>
     public partial class ResourceUpdateByIdOperation : Operation<GenericResource>, IOperationSource<GenericResource>
     {
-        private readonly OperationOrResponseInternals<GenericResource> _operation;
+        private readonly OperationInternals<GenericResource> _operation;
         private readonly ArmResource _parentOperation;
 
         /// <summary> Initializes a new instance of ResourceUpdateByIdOperation for mocking. </summary>
@@ -28,7 +28,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal ResourceUpdateByIdOperation(ArmResource parentOperation, ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals<GenericResource>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceUpdateByIdOperation");
+            _operation = new OperationInternals<GenericResource>(this, clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceUpdateByIdOperation");
             _parentOperation = parentOperation;
         }
         /// <inheritdoc />

--- a/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceValidateMoveResourcesOperation.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Resources/PseudoGenerated/LongRunningOperation/ResourceValidateMoveResourcesOperation.cs
@@ -16,7 +16,7 @@ namespace Azure.ResourceManager.Resources.Models
     /// <summary> This operation checks whether the specified resources can be moved to the target. The resources to move must be in the same source resource group. The target resource group may be in a different subscription. If validation succeeds, it returns HTTP response code 204 (no content). If validation fails, it returns HTTP response code 409 (Conflict) with an error message. Retrieve the URL in the Location header value to check the result of the long-running operation. </summary>
     public partial class ResourceValidateMoveResourcesOperation : Operation
     {
-        private readonly OperationOrResponseInternals _operation;
+        private readonly OperationInternals _operation;
 
         /// <summary> Initializes a new instance of ResourceValidateMoveResourcesOperation for mocking. </summary>
         protected ResourceValidateMoveResourcesOperation()
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.Resources.Models
 
         internal ResourceValidateMoveResourcesOperation(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Request request, Response response)
         {
-            _operation = new OperationOrResponseInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceValidateMoveResourcesOperation");
+            _operation = new OperationInternals(clientDiagnostics, pipeline, request, response, OperationFinalStateVia.Location, "ResourceValidateMoveResourcesOperation");
         }
         /// <inheritdoc />
         public override string Id => "";


### PR DESCRIPTION
Change pseudo generated code to match real generated code. OperationOrResponseInternals is used only in fake LROs