### PR TITLE
Azure Monitor Exporter - Update resource for logs

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorConverter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorConverter.cs
@@ -56,14 +56,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return telemetryItems;
         }
 
-        internal static List<TelemetryItem> Convert(Batch<LogRecord> batchLogRecord, string instrumentationKey)
+        internal static List<TelemetryItem> Convert(Batch<LogRecord> batchLogRecord, Resource resource, string instrumentationKey)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
             TelemetryItem telemetryItem;
 
             foreach (var logRecord in batchLogRecord)
             {
-                telemetryItem = TelemetryPartA.GetTelemetryItem(logRecord, instrumentationKey);
+                telemetryItem = TelemetryPartA.GetTelemetryItem(logRecord, resource, instrumentationKey);
                 telemetryItem.Data = new MonitorBase
                 {
                     BaseType = Telemetry_Base_Type_Mapping[TelemetryType.Message],

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorLogExporter.cs
@@ -37,7 +37,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                var telemetryItems = AzureMonitorConverter.Convert(batch, this.instrumentationKey);
+                var resource = this.ParentProvider.GetResource();
+                var telemetryItems = AzureMonitorConverter.Convert(batch, resource, this.instrumentationKey);
 
                 // TODO: Handle return value, it can be converted as metrics.
                 // TODO: Validate CancellationToken and async pattern here.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -98,7 +98,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return AzMonList.GetTagValue(ref partBTags, SemanticConventions.AttributeNetPeerIp)?.ToString();
         }
 
-        internal static TelemetryItem GetTelemetryItem(LogRecord logRecord, string instrumentationKey)
+        internal static TelemetryItem GetTelemetryItem(LogRecord logRecord, Resource resource, string instrumentationKey)
         {
             var name = PartA_Name_Mapping[TelemetryType.Message];
             var time = FormatUtcTimestamp(logRecord.Timestamp);
@@ -108,10 +108,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 InstrumentationKey = instrumentationKey
             };
 
-            // TODO: I WAS TOLD THIS MIGHT BE CHANGING. IGNORING FOR NOW.
-            //InitRoleInfo(activity);
-            //telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()] = RoleName;
-            //telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = RoleInstance;
+            InitRoleInfo(resource);
+            telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()] = RoleName;
+            telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = RoleInstance;
 
             if (logRecord.TraceId != default)
             {


### PR DESCRIPTION
Update resource in logs to include `ai.cloud.role` and `ai.cloud.roleInstance` to `TraceTelemetry`

```json
{"name":"Message","time":"2022-01-14T07:35:13.4315595Z","iKey":"Ikey","tags":{"ai.cloud.role":"my-namespace.my-service","ai.cloud.roleInstance":"my-instance","ai.internal.sdkVersion":"dotnet4.8.4420.0:otel1.2.0-rc1:ext1.0.0-alpha.20220114.1"},"data":{"baseType":"MessageData","baseData":{"message":"Hello from tomato 2.99.","severityLevel":"Information","ver":2}}}
```