### PR TITLE
Azure Monitor Exporter - Update to Otel1.2.0-rc1

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -108,7 +108,7 @@
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
 
     <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
-    <PackageReference Update="OpenTelemetry" Version="1.1.0"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
+    <PackageReference Update="OpenTelemetry" Version="1.2.0-rc1"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
   </ItemGroup>
 
   <!--

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -237,9 +237,9 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc7" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc7" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc7" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -20,3 +20,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) { throw null; }
     }
 }
+namespace Microsoft.Extensions.Logging {
+    public static class AzureMonitorExporterLoggingExtensions {
+        public static OpenTelemetryLoggerOptions AddAzureMonitorLogExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<AzureMonitorExporterOptions> configure = null);
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -20,8 +20,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public override OpenTelemetry.ExportResult Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) { throw null; }
     }
 }
-namespace Microsoft.Extensions.Logging {
-    public static class AzureMonitorExporterLoggingExtensions {
-        public static OpenTelemetryLoggerOptions AddAzureMonitorLogExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<AzureMonitorExporterOptions> configure = null);
+namespace Microsoft.Extensions.Logging
+{
+    public static partial class AzureMonitorExporterLoggingExtensions
+    {
+        public static OpenTelemetry.Logs.OpenTelemetryLoggerOptions AddAzureMonitorLogExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions loggerOptions, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null) { throw null; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterLoggingExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterLoggingExtensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Logs;
 
 namespace Microsoft.Extensions.Logging
 {
-    internal static class AzureMonitorExporterLoggingExtensions
+    public static class AzureMonitorExporterLoggingExtensions
     {
         public static OpenTelemetryLoggerOptions AddAzureMonitorLogExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<AzureMonitorExporterOptions> configure = null)
         {


### PR DESCRIPTION
Modified `AzureMonitorExporterLoggingExtensions` from `internal` to `public` to allow the apps to consume `AddOpenTelemetry` inside `LoggerFactory`

**Example**
```csharp
using var loggerFactory = LoggerFactory.Create(builder => builder
		.AddOpenTelemetry(loggerOptions =>
		{
			loggerOptions.SetResourceBuilder(resourceBuilder);
			loggerOptions.AddAzureMonitorLogExporter(exporterOptions =>
			{
				exporterOptions.ConnectionString = $"InstrumentationKey=Ikey;";
			});
		}));
```