### PR TITLE
[Service Bus] Update docs for SupportOrdering property

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateTopicOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateTopicOptions.cs
@@ -163,7 +163,8 @@ namespace Azure.Messaging.ServiceBus.Administration
 
         /// <summary>
         /// Defines whether ordering needs to be maintained. If true, messages sent to topic will be
-        /// forwarded to the subscription in order.
+        /// forwarded to the subscription in order. For partitioned topics, defaults to false, and 
+        /// setting it to true has no effect.
         /// </summary>
         /// <remarks>Defaults to false.</remarks>
         public bool SupportOrdering { get; set; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateTopicOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/CreateTopicOptions.cs
@@ -163,7 +163,7 @@ namespace Azure.Messaging.ServiceBus.Administration
 
         /// <summary>
         /// Defines whether ordering needs to be maintained. If true, messages sent to topic will be
-        /// forwarded to the subscription in order. For partitioned topics, defaults to false, and 
+        /// forwarded to the subscription in order. For partitioned topics, defaults to false, and
         /// setting it to true has no effect.
         /// </summary>
         /// <remarks>Defaults to false.</remarks>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicProperties.cs
@@ -167,7 +167,8 @@ namespace Azure.Messaging.ServiceBus.Administration
 
         /// <summary>
         /// Defines whether ordering needs to be maintained. If true, messages sent to topic will be
-        /// forwarded to the subscription in order.
+        /// forwarded to the subscription in order. For partitioned topics, defaults to false, and 
+        /// setting it to true has no effect.
         /// </summary>
         /// <remarks>Defaults to false.</remarks>
         public bool SupportOrdering { get; set; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/TopicProperties.cs
@@ -167,7 +167,7 @@ namespace Azure.Messaging.ServiceBus.Administration
 
         /// <summary>
         /// Defines whether ordering needs to be maintained. If true, messages sent to topic will be
-        /// forwarded to the subscription in order. For partitioned topics, defaults to false, and 
+        /// forwarded to the subscription in order. For partitioned topics, defaults to false, and
         /// setting it to true has no effect.
         /// </summary>
         /// <remarks>Defaults to false.</remarks>


### PR DESCRIPTION
As a follow up from https://github.com/Azure/azure-sdk-for-js/issues/11859, this PR updates the docs for the `SupportOrdering` property on `CreateTopicOptions` and `TopicProperties` in `Azure.Messaging.ServiceBus` package. No changes are done for the corresponding queue related classes as they did not expose this property before





