### PR TITLE
Use pinned cspell in Export-API.ps1 and aggregate-reports

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -56,8 +56,8 @@
     "deserializable",
     "deserializes",
     "diagnoser",
-    "dotnetcli",
     "dont",
+    "dotnetcli",
     "dtmf",
     "epsg",
     "expando",
@@ -73,23 +73,24 @@
     "otel",
     "overridden",
     "parallelization",
+    "personalizer",
     "pkcs",
     "pstn",
     "pwsh",
     "referer",
     "renormalize",
     "retriable",
+    "signup",
     "skus",
     "structs",
     "uints",
+    "unencrypted",
     "unformattable",
     "unhold",
     "uninstrumented",
-    "westus",
-    "xunit",
     "vnet",
-    "unencrypted",
-    "personalizer"
+    "westus",
+    "xunit"
   ],
   "overrides": [
     {
@@ -200,14 +201,15 @@
     {
       "filename": "**/sdk/sqlmanagement/**/*.cs",
       "words": [
-        "Droppeded",
         "CIAS",
-        "Vcores",
-        "Unrestorable",
-        "Stdev",
+        "Droppeded",
+        "Nchar",
         "Ntext",
         "Nvarchar",
-        "Stdev"
+        "Stdev",
+        "Stdev",
+        "Unrestorable",
+        "Vcores"
       ]
     },
     {

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -138,7 +138,10 @@
         "Pcnet",
         "Pmem",
         "Pvscsi",
-        "Sesparse"
+        "Sesparse",
+        "VCenter",
+        "VMware",
+        "vSphere"
       ]
     },
     {

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -207,7 +207,6 @@
         "Ntext",
         "Nvarchar",
         "Stdev",
-        "Stdev",
         "Unrestorable",
         "Vcores"
       ]

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -34,10 +34,9 @@ stages:
                 -NupkgFilesDestination 'nupkgFiles'
 
           - pwsh: |
-              npx cspell lint `
-                --config ./.vscode/cspell.json `
-                --no-must-find-files `
-                'sdk/*/*/api/*.cs'
+              ."eng/common/spelling/Invoke-Cspell.ps1" `
+                -CSpellConfigPath "./.vscode/cspell.json" `
+                -ScanGlobs "sdk/*/*/api/*.cs"
             displayName: Check spelling of public API surface
             # Spelling errors in public api surface are not blockers yet but will
             # become blockers when this is rolled out to all services. For now, turn

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -16,14 +16,13 @@ $servicesProj = Resolve-Path "$PSScriptRoot/../service.proj"
 
 dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /p:SDKType=$SDKType /restore $servicesProj
 
-if ($SpellCheckPublicApiSurface) { 
+if ($SpellCheckPublicApiSurface) {
     Write-Host "Spell check public API surface"
-    npx cspell lint `
-        --config "$PSScriptRoot/../../.vscode/cspell.json" `
-        --no-must-find-files `
-        --root "$PSScriptRoot/../../" `
-        "$PSScriptRoot/../../sdk/$ServiceDirectory/*/api/*.cs"
-    if ($LASTEXITCODE) { 
+    &"$PSScriptRoot/../common/spelling/Invoke-Cspell.ps1" `
+        -CSpellConfigPath "$PSScriptRoot/../../.vscode/cspell.json" `
+        -ScanGlobs "sdk/$ServiceDirectory/*/api/*.cs"
+
+    if ($LASTEXITCODE) {
         Write-Host "##vso[task.LogIssue type=error;]Spelling errors detected. To correct false positives or learn about spell checking see: https://aka.ms/azsdk/engsys/spellcheck"
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/Azure/azure-sdk-for-net/pull/26218 but without all the codeowners noise that comes from a messy rebase. 