### PR TITLE
Update comments for Storage Delete methods to clarify behavior

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatch.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatch.cs
@@ -159,7 +159,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteBlob(string, string, DeleteSnapshotsOption, BlobRequestConditions)"/>
         /// operation marks the specified blob or snapshot for  deletion. The
-        /// blob is later deleted during garbage collection.
+        /// blob is later deleted during garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -182,7 +182,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// deleting this blob.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.  The response
+        /// A <see cref="Response"/> on successfully marking for deletion.  The response
         /// cannot be used until the batch has been submitted with
         /// <see cref="BlobBatchClient.SubmitBatchAsync"/>.
         /// </returns>
@@ -227,7 +227,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteBlob(Uri, DeleteSnapshotsOption, BlobRequestConditions)"/>
         /// operation marks the specified blob or snapshot for deletion. The
-        /// blob is later deleted during garbage collection.
+        /// blob is later deleted during garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -247,7 +247,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// deleting this blob.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.  The response
+        /// A <see cref="Response"/> on successfully marking for deletion.  The response
         /// cannot be used until the batch has been submitted with
         /// <see cref="BlobBatchClient.SubmitBatchAsync"/>.
         /// </returns>

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatch.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatch.cs
@@ -159,7 +159,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteBlob(string, string, DeleteSnapshotsOption, BlobRequestConditions)"/>
         /// operation marks the specified blob or snapshot for  deletion. The
-        /// blob is later deleted during garbage collection which could take up to 30 seconds.
+        /// blob is later deleted during garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -227,7 +227,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteBlob(Uri, DeleteSnapshotsOption, BlobRequestConditions)"/>
         /// operation marks the specified blob or snapshot for deletion. The
-        /// blob is later deleted during garbage collection which could take up to 30 seconds.
+        /// blob is later deleted during garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
@@ -655,7 +655,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The DeleteBlobs operation marks the specified blobs for deletion.
         /// The blobs are later deleted during garbage collection which could take
-        /// up to 30 seconds.  All of the deletions are sent as a single batched request.
+        /// several minutes.  All of the deletions are sent as a single batched request.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate notifications
@@ -688,7 +688,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The DeleteBlobsAsync operation marks the specified blobs for
         /// deletion.  The blobs are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         /// All of the deletions are sent as a single batched request.
         /// </summary>
         /// <param name="cancellationToken">
@@ -722,7 +722,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The DeleteBlobsAsync operation marks the specified blobs for
         /// deletion.  The blobs are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         /// All of the deletions are sent as a single batched request.
         /// </summary>
         /// <param name="blobUris">URIs of the blobs to delete.</param>

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
@@ -654,8 +654,8 @@ namespace Azure.Storage.Blobs.Specialized
         #region DeleteBlobs
         /// <summary>
         /// The DeleteBlobs operation marks the specified blobs for deletion.
-        /// The blobs are later deleted during garbage collection.  All of the
-        /// deletions are sent as a single batched request.
+        /// The blobs are later deleted during garbage collection which could take
+        /// up to 30 seconds.  All of the deletions are sent as a single batched request.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate notifications
@@ -687,7 +687,8 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The DeleteBlobsAsync operation marks the specified blobs for
-        /// deletion.  The blobs are later deleted during garbage collection.
+        /// deletion.  The blobs are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         /// All of the deletions are sent as a single batched request.
         /// </summary>
         /// <param name="cancellationToken">
@@ -720,7 +721,8 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The DeleteBlobsAsync operation marks the specified blobs for
-        /// deletion.  The blobs are later deleted during garbage collection.
+        /// deletion.  The blobs are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         /// All of the deletions are sent as a single batched request.
         /// </summary>
         /// <param name="blobUris">URIs of the blobs to delete.</param>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -3759,7 +3759,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3781,7 +3781,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -3801,7 +3801,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3823,7 +3823,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -3843,7 +3843,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified blob
         /// or snapshot for deletion, if the blob exists. The blob is later deleted
-        /// during garbage collection.
+        /// during garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3866,7 +3866,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <returns>
         /// A <see cref="Response"/> Returns true if blob exists and was
-        /// deleted, return false otherwise.
+        /// marked for deletion, return false otherwise.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -3886,7 +3886,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified blob
         /// or snapshot for deletion, if the blob exists. The blob is later deleted
-        /// during garbage collection.
+        /// during garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3909,7 +3909,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <returns>
         /// A <see cref="Response"/> Returns true if blob exists and was
-        /// deleted, return false otherwise.
+        /// marked for deletion, return false otherwise.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -3929,7 +3929,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteIfExistsInternal"/> operation marks the specified blob
         /// or snapshot for deletion, if the blob exists. The blob is later deleted
-        /// during garbage collection.
+        /// during garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3954,7 +3954,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -4010,7 +4010,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteInternal"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -4038,7 +4038,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// Optional. To indicate if the name of the operation.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -3759,7 +3759,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3801,7 +3801,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3843,7 +3843,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified blob
         /// or snapshot for deletion, if the blob exists. The blob is later deleted
-        /// during garbage collection which could take up to 30 seconds.
+        /// during garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3886,7 +3886,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified blob
         /// or snapshot for deletion, if the blob exists. The blob is later deleted
-        /// during garbage collection which could take up to 30 seconds.
+        /// during garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3929,7 +3929,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteIfExistsInternal"/> operation marks the specified blob
         /// or snapshot for deletion, if the blob exists. The blob is later deleted
-        /// during garbage collection which could take up to 30 seconds.
+        /// during garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -4010,7 +4010,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DeleteInternal"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -1205,7 +1205,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="Delete"/> operation marks the specified
         /// container for deletion. The container and any blobs contained
         /// within it are later deleted during garbage collection which
-        /// could take up to 30 seconds.
+        /// could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1239,7 +1239,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="DeleteAsync"/> operation marks the specified
         /// container for deletion. The container and any blobs contained
         /// within it are later deleted during garbage collection which
-        /// could take up to 30 seconds.
+        /// could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1273,7 +1273,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="DeleteIfExists"/> operation marks the specified
         /// container for deletion if it exists. The container and any blobs
         /// contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1308,7 +1308,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified
         /// container for deletion if it exists. The container and any blobs
         /// contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1343,7 +1343,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="DeleteIfExistsInternal"/> operation marks the specified
         /// container for deletion if it exists. The container and any blobs
         /// contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1419,7 +1419,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="DeleteAsync"/> operation marks the specified
         /// container for deletion. The container and any blobs contained
         /// within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -3044,7 +3044,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlob"/> operation marks the specified
         /// blob or snapshot for deletion. The blob is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3088,7 +3088,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlobAsync"/> operation marks the specified
         /// blob or snapshot for deletion. The blob is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3133,7 +3133,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlobIfExists"/> operation marks the specified
         /// blob or snapshot for deletion, if the blob or snapshot exists. The blob
-        /// is later deleted during garbage collection which could take up to 30 seconds.
+        /// is later deleted during garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3177,7 +3177,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlobIfExistsAsync"/> operation marks the specified
         /// blob or snapshot for deletion, if the blob or snapshot exists. The blob
-        /// is later deleted during garbage collection which could take up to 30 seconds.
+        /// is later deleted during garbage collection which could take several minutes.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -1204,7 +1204,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified
         /// container for deletion. The container and any blobs contained
-        /// within it are later deleted during garbage collection.
+        /// within it are later deleted during garbage collection which
+        /// could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1219,7 +1220,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1237,7 +1238,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified
         /// container for deletion. The container and any blobs contained
-        /// within it are later deleted during garbage collection.
+        /// within it are later deleted during garbage collection which
+        /// could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1252,7 +1254,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1270,7 +1272,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified
         /// container for deletion if it exists. The container and any blobs
-        /// contained within it are later deleted during garbage collection.
+        /// contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1286,7 +1289,7 @@ namespace Azure.Storage.Blobs
         /// </param>
         /// <returns>
         /// A <see cref="Response"/> Returns true if container exists and was
-        /// deleted, return false otherwise.
+        /// marked for deletion, return false otherwise.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1304,7 +1307,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified
         /// container for deletion if it exists. The container and any blobs
-        /// contained within it are later deleted during garbage collection.
+        /// contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1320,7 +1324,7 @@ namespace Azure.Storage.Blobs
         /// </param>
         /// <returns>
         /// A <see cref="Response"/> Returns true if container exists and was
-        /// deleted, return false otherwise.
+        /// marked for deletion, return false otherwise.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1338,7 +1342,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteIfExistsInternal"/> operation marks the specified
         /// container for deletion if it exists. The container and any blobs
-        /// contained within it are later deleted during garbage collection.
+        /// contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1357,7 +1362,7 @@ namespace Azure.Storage.Blobs
         /// </param>
         /// <returns>
         /// A <see cref="Response"/> Returns true if container exists and was
-        /// deleted, return false otherwise.
+        /// marked for deletion, return false otherwise.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1413,7 +1418,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified
         /// container for deletion. The container and any blobs contained
-        /// within it are later deleted during garbage collection.
+        /// within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1434,7 +1440,7 @@ namespace Azure.Storage.Blobs
         /// Optional. To indicate if the name of the operation.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -3038,7 +3044,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlob"/> operation marks the specified
         /// blob or snapshot for deletion. The blob is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3061,7 +3067,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -3082,7 +3088,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlobAsync"/> operation marks the specified
         /// blob or snapshot for deletion. The blob is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3105,7 +3111,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -3127,7 +3133,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlobIfExists"/> operation marks the specified
         /// blob or snapshot for deletion, if the blob or snapshot exists. The blob
-        /// is later deleted during garbage collection.
+        /// is later deleted during garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3150,7 +3156,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -3171,7 +3177,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlobIfExistsAsync"/> operation marks the specified
         /// blob or snapshot for deletion, if the blob or snapshot exists. The blob
-        /// is later deleted during garbage collection.
+        /// is later deleted during garbage collection which could take up to 30 seconds.
         ///
         /// Note that in order to delete a blob, you must delete all of its
         /// snapshots. You can delete both at the same time using
@@ -3194,7 +3200,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -1524,7 +1524,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlobContainer"/> operation marks the
         /// specified blob container for deletion. The container and any blobs
-        /// contained within it are later deleted during garbage collection.
+        /// contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1542,7 +1543,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1561,7 +1562,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="DeleteBlobContainerAsync"/> operation marks the
         /// specified container for deletion. The container and any blobs
-        /// contained within it are later deleted during garbage collection.
+        /// contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1579,7 +1581,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -1525,7 +1525,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="DeleteBlobContainer"/> operation marks the
         /// specified blob container for deletion. The container and any blobs
         /// contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1563,7 +1563,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="DeleteBlobContainerAsync"/> operation marks the
         /// specified container for deletion. The container and any blobs
         /// contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
@@ -644,7 +644,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -659,7 +659,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -694,7 +694,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -709,7 +709,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -747,7 +747,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified directory
         /// for deletion, if the directory exists. The directory is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -762,7 +762,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -797,7 +797,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified directory
         /// for deletion, if the directory exists. The directory is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -812,7 +812,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
@@ -644,7 +644,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -694,7 +694,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -747,7 +747,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified directory
         /// for deletion, if the directory exists. The directory is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -797,7 +797,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified directory
         /// for deletion, if the directory exists. The directory is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -633,7 +633,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -683,7 +683,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -736,7 +736,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified file
         /// for deletion, if the file exists. The file is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -786,7 +786,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified file
         /// for deletion, if the file exists. The file is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -633,7 +633,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -648,7 +648,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -683,7 +683,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -698,7 +698,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -736,7 +736,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified file
         /// for deletion, if the file exists. The file is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -751,7 +751,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -786,7 +786,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified file
         /// for deletion, if the file exists. The file is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -801,7 +801,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -838,7 +838,8 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified
         /// file system for deletion. The file system and any paths contained
-        /// within it are later deleted during garbage collection.
+        /// within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -853,7 +854,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -895,7 +896,8 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified
         /// file system for deletion. The file system and any paths contained
-        /// within it are later deleted during garbage collection.
+        /// within it are later deleted during garbage collection which could
+        /// take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -910,7 +912,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -955,7 +957,8 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified
         /// file system for deletion if it exists. The file system and any files
-        /// and directories contained within it are later deleted during garbage collection.
+        /// and directories contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -970,7 +973,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1012,7 +1015,8 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified
         /// file system for deletion if it exists. The file system and any files
-        /// and directories contained within it are later deleted during garbage collection.
+        /// and directories contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1027,7 +1031,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1790,7 +1794,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteDirectory"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1808,7 +1812,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1843,7 +1847,7 @@ namespace Azure.Storage.Files.DataLake
 
         /// <summary>
         /// The <see cref="DeleteDirectoryAsync"/> deletes a directory in this file system.
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1861,7 +1865,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -839,7 +839,7 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="Delete"/> operation marks the specified
         /// file system for deletion. The file system and any paths contained
         /// within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -897,7 +897,7 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="DeleteAsync"/> operation marks the specified
         /// file system for deletion. The file system and any paths contained
         /// within it are later deleted during garbage collection which could
-        /// take up to 30 seconds.
+        /// take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -958,7 +958,7 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="DeleteIfExists"/> operation marks the specified
         /// file system for deletion if it exists. The file system and any files
         /// and directories contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1016,7 +1016,7 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified
         /// file system for deletion if it exists. The file system and any files
         /// and directories contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -1794,7 +1794,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteDirectory"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1847,7 +1847,7 @@ namespace Azure.Storage.Files.DataLake
 
         /// <summary>
         /// The <see cref="DeleteDirectoryAsync"/> deletes a directory in this file system.
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -1261,7 +1261,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1302,7 +1302,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1343,7 +1343,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteInternal"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1438,7 +1438,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified path
         /// for deletion, if the path exists. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1477,7 +1477,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified path
         /// deletion, if the path exists. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1516,7 +1516,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsInternal"/> operation marks the specified path
         /// deletion, if the path exists. The path is later deleted during
-        /// garbage collection which could take up to 30 seconds.
+        /// garbage collection which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -1261,7 +1261,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1280,7 +1280,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1302,7 +1302,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1321,7 +1321,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1343,7 +1343,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteInternal"/> operation marks the specified path
         /// deletion. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1365,7 +1365,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1438,7 +1438,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExists"/> operation marks the specified path
         /// for deletion, if the path exists. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1457,7 +1457,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1477,7 +1477,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsAsync"/> operation marks the specified path
         /// deletion, if the path exists. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1496,7 +1496,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1516,7 +1516,7 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteIfExistsInternal"/> operation marks the specified path
         /// deletion, if the path exists. The path is later deleted during
-        /// garbage collection.
+        /// garbage collection which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/delete">
@@ -1538,7 +1538,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -819,7 +819,8 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteFileSystem"/> operation marks the
         /// specified file system for deletion. The file system and any paths
-        /// contained within it are later deleted during garbage collection.
+        /// contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -837,7 +838,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -873,7 +874,8 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="DeleteFileSystemAsync"/> operation marks the
         /// specified file system for deletion. The file system and any paths
-        /// contained within it are later deleted during garbage collection.
+        /// contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -891,7 +893,7 @@ namespace Azure.Storage.Files.DataLake
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> if successful.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -820,7 +820,7 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="DeleteFileSystem"/> operation marks the
         /// specified file system for deletion. The file system and any paths
         /// contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">
@@ -875,7 +875,7 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="DeleteFileSystemAsync"/> operation marks the
         /// specified file system for deletion. The file system and any paths
         /// contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-container">

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -1320,7 +1320,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1354,7 +1354,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1388,7 +1388,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1424,7 +1424,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1460,7 +1460,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -1319,7 +1319,8 @@ namespace Azure.Storage.Files.Shares
         #region Delete
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1333,7 +1334,7 @@ namespace Azure.Storage.Files.Shares
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1352,7 +1353,8 @@ namespace Azure.Storage.Files.Shares
 
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1366,7 +1368,7 @@ namespace Azure.Storage.Files.Shares
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1385,7 +1387,8 @@ namespace Azure.Storage.Files.Shares
 
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1400,7 +1403,7 @@ namespace Azure.Storage.Files.Shares
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1420,7 +1423,8 @@ namespace Azure.Storage.Files.Shares
 
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1435,7 +1439,7 @@ namespace Azure.Storage.Files.Shares
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1455,7 +1459,8 @@ namespace Azure.Storage.Files.Shares
 
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// For more information, see
         /// <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share">
@@ -1482,7 +1487,7 @@ namespace Azure.Storage.Files.Shares
         /// Optional. To indicate if the name of the operation.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -951,7 +951,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// Currently, this method will always delete snapshots.
         /// There's no way to specify a separate value for x-ms-delete-snapshots.
@@ -993,7 +993,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
@@ -1035,7 +1035,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// Currently, this method will always delete snapshots.
         /// There's no way to specify a separate value for x-ms-delete-snapshots.
@@ -1079,7 +1079,7 @@ namespace Azure.Storage.Files.Shares
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection
-        /// which could take up to 30 seconds.
+        /// which could take several minutes.
         ///
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -950,7 +950,8 @@ namespace Azure.Storage.Files.Shares
         #region DeleteShare
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// Currently, this method will always delete snapshots.
         /// There's no way to specify a separate value for x-ms-delete-snapshots.
@@ -970,7 +971,7 @@ namespace Azure.Storage.Files.Shares
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -991,7 +992,8 @@ namespace Azure.Storage.Files.Shares
 
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
@@ -1010,7 +1012,7 @@ namespace Azure.Storage.Files.Shares
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1032,7 +1034,8 @@ namespace Azure.Storage.Files.Shares
 
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// Currently, this method will always delete snapshots.
         /// There's no way to specify a separate value for x-ms-delete-snapshots.
@@ -1053,7 +1056,7 @@ namespace Azure.Storage.Files.Shares
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if
@@ -1075,7 +1078,8 @@ namespace Azure.Storage.Files.Shares
 
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
-        /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
+        /// The share or share snapshot and any files contained within it are later deleted during garbage collection
+        /// which could take up to 30 seconds.
         ///
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
@@ -1095,7 +1099,7 @@ namespace Azure.Storage.Files.Shares
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully marking for deletion.
         /// </returns>
         /// <remarks>
         /// A <see cref="RequestFailedException"/> will be thrown if


### PR DESCRIPTION
This PR updates the comments of the various delete methods in the storage SDK to clarify their behavior.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

resolves #26045 