### PR TITLE
[Document Translate] Stabilizing flaky test for CreatedAfter filter

### DIFF
--- a/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
@@ -144,6 +144,10 @@ namespace Azure.AI.Translation.Document.Tests
             // create test jobs
             await CreateTranslationJobsAsync(client, jobsCount: 1, docsPerJob: 1, jobTerminalStatus: DocumentTranslationStatus.Succeeded);
             var timestamp = Recording.UtcNow;
+
+            // Wait to account for any time discrepancies
+            Thread.Sleep(1000);
+
             var targetIds = await CreateTranslationJobsAsync(client, jobsCount: 1, docsPerJob: 1, jobTerminalStatus: DocumentTranslationStatus.Succeeded);
 
             // list translations with filter

--- a/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/GetAllTranslationsFilterTests.cs
@@ -143,10 +143,9 @@ namespace Azure.AI.Translation.Document.Tests
 
             // create test jobs
             await CreateTranslationJobsAsync(client, jobsCount: 1, docsPerJob: 1, jobTerminalStatus: DocumentTranslationStatus.Succeeded);
-            var timestamp = Recording.UtcNow;
 
-            // Wait to account for any time discrepancies
-            Thread.Sleep(1000);
+            // timestamp pushed 1 second back to account for any time discrepancies
+            var timestamp = Recording.UtcNow.AddSeconds(-1);
 
             var targetIds = await CreateTranslationJobsAsync(client, jobsCount: 1, docsPerJob: 1, jobTerminalStatus: DocumentTranslationStatus.Succeeded);
 

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedAfterTest.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedAfterTest.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source254142079?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1478981449?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-47bc4efdeac36446a29bce66dc834a25-023ccfaf9321994f-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-bc6daff698d26846a2e73405afd0f6c0-11e942aaafd1034e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "d7f5bfa300736d1d64c949e05430b741",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:20 GMT",
+        "x-ms-client-request-id": "958c601c5d71cb7277f61026dc01eb05",
+        "x-ms-date": "Tue, 18 Jan 2022 11:54:00 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -19,18 +19,21 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:21 GMT",
-        "ETag": "\u00220x8D96889803465D2\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:22 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d7f5bfa300736d1d64c949e05430b741",
-        "x-ms-request-id": "36b84425-701e-0091-7672-9a592d000000",
+        "Date": "Tue, 18 Jan 2022 11:54:00 GMT",
+        "ETag": "\u00220x8D9DA793812D9FC\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:54:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "958c601c5d71cb7277f61026dc01eb05",
+        "x-ms-request-id": "27b2c304-f01e-008f-6262-0cb5f5000000",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source254142079/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1478981449/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -38,11 +41,11 @@
         "Content-Length": "16",
         "Content-Type": "application/octet-stream",
         "If-None-Match": "*",
-        "traceparent": "00-e224cd3ef4f1a1469f3ba1eba815c8f3-1d336e6c60f5724b-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-801a1f7e9754ca4681405f07e2bf390f-f72b6d6d6424d74e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "f783c5f6fb36a56064b80229a78c9da5",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:22 GMT",
+        "x-ms-client-request-id": "04bf5d37b2fbd14dde0dbfdb5120d31e",
+        "x-ms-date": "Tue, 18 Jan 2022 11:54:01 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -51,30 +54,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Thu, 26 Aug 2021 12:03:21 GMT",
-        "ETag": "\u00220x8D9688980697E2C\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:22 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "f783c5f6fb36a56064b80229a78c9da5",
+        "Date": "Tue, 18 Jan 2022 11:54:01 GMT",
+        "ETag": "\u00220x8D9DA793843CC1E\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:54:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "04bf5d37b2fbd14dde0dbfdb5120d31e",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "36b844bf-701e-0091-7772-9a592d000000",
+        "x-ms-request-id": "27b2c393-f01e-008f-6062-0cb5f5000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1626648402?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target350713167?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-f505ba4f9f53cc45834d4fc05721228e-6ca23031cf01f648-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-8e2c8d5416c14644bd075f15d8a5f0f9-4087ace7a321fd4a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "4edfb63c36ec03a38bbf2311a9127365",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:22 GMT",
+        "x-ms-client-request-id": "fc08b42884dc4dc722b6c1f3c504527b",
+        "x-ms-date": "Tue, 18 Jan 2022 11:54:02 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -82,15 +88,18 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:21 GMT",
-        "ETag": "\u00220x8D96889808022B5\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:22 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "4edfb63c36ec03a38bbf2311a9127365",
-        "x-ms-request-id": "36b84556-701e-0091-7f72-9a592d000000",
+        "Date": "Tue, 18 Jan 2022 11:54:01 GMT",
+        "ETag": "\u00220x8D9DA7938677D21\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:54:02 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fc08b42884dc4dc722b6c1f3c504527b",
+        "x-ms-request-id": "27b2c3ef-f01e-008f-2d62-0cb5f5000000",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
       "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
@@ -100,9 +109,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-62c5d09d51ea5f4d84e177598fc2bd7c-0daa63a49deb2a46-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "aa7b619448b95ea84f72bafef3c6d72b",
+        "traceparent": "00-86c50b5e7b06164b950811cff92d84c5-e14438b4ff70eb49-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "99ca9d4e4ebf1269bab7649e96795723",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -122,57 +131,54 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "ffbf53be-3876-4aff-af3f-3e56e9355c5d",
+        "apim-request-id": "63f0f3c7-7105-4117-9028-bf52c49589e7",
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:22 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+        "Date": "Tue, 18 Jan 2022 11:54:03 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/24c943e3-e49c-4df8-91cb-e559eab632ea",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ffbf53be-3876-4aff-af3f-3e56e9355c5d"
+        "X-RequestId": "63f0f3c7-7105-4117-9028-bf52c49589e7"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/24c943e3-e49c-4df8-91cb-e559eab632ea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7a178da4f2d78e0ae0f3ab3c3c94bba6",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4db4d7f109e2d95bf8b6d8fb8cde1808",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c878e71f-9ada-408b-9c55-5d60066a1331",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "fc88c665-3a1e-4a85-a30b-60f6c05cfa10",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:23 GMT",
-        "ETag": "\u0022F633E0A25B8204586D07B7644283EB69EFA6525993DF1C8B0CB43FB517DB2111\u0022",
+        "Date": "Tue, 18 Jan 2022 11:54:03 GMT",
+        "ETag": "\u0022A66C635EDF5EDB3930CE56E8257C851CEDF83FE105D7FA02D9C77A236F071A9C\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c878e71f-9ada-408b-9c55-5d60066a1331"
+        "X-RequestId": "fc88c665-3a1e-4a85-a30b-60f6c05cfa10"
       },
       "ResponseBody": {
-        "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
-        "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:23.2692463Z",
+        "id": "24c943e3-e49c-4df8-91cb-e559eab632ea",
+        "createdDateTimeUtc": "2022-01-18T11:54:03.805391Z",
+        "lastActionDateTimeUtc": "2022-01-18T11:54:03.8053914Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -186,137 +192,38 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/24c943e3-e49c-4df8-91cb-e559eab632ea",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2b13c48ffa22f4980d80fe797ca510c5",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8203606d8508d98f4af641251f29b7a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7d5d6330-f875-4bf8-866b-be55bf969449",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "d7a41c24-3aa6-4932-9707-5ae2bfe5a967",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:24 GMT",
-        "ETag": "\u0022889280F10F268234C94CD3E8210D412DF494F17DA2E70B75EB20B586B737AE9A\u0022",
+        "Date": "Tue, 18 Jan 2022 11:54:34 GMT",
+        "ETag": "\u0022550F00A9B8CB07232BD8C7C1BFC95E59DA0C3CBE22A8E3CB439861F091EC4BC4\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "7d5d6330-f875-4bf8-866b-be55bf969449"
+        "X-RequestId": "d7a41c24-3aa6-4932-9707-5ae2bfe5a967"
       },
       "ResponseBody": {
-        "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
-        "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:24.1811716Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1c6cf7e7f9faa18d57edcac69c6b22bb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "b2424d1d-9f8d-487c-bd21-254e09c978f2",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:25 GMT",
-        "ETag": "\u0022BEA29097608D9D260A0BD524A9EC0863CA0F4B538B44F99DF81348EDFF54B5B7\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b2424d1d-9f8d-487c-bd21-254e09c978f2"
-      },
-      "ResponseBody": {
-        "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
-        "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:25.1122563Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "2e6f14b7acb3a909f4236c57f490123a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4e3948ba-c9cd-44d0-afc9-9ebc07a55a5a",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:30 GMT",
-        "ETag": "\u00222F4DA885608E11EF92D40FE821AD806D4E9DAB93A4E0B0D0F1682371EB16F08B\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4e3948ba-c9cd-44d0-afc9-9ebc07a55a5a"
-      },
-      "ResponseBody": {
-        "id": "1a576009-3964-4d41-ab65-dcd7fcd8ddfb",
-        "createdDateTimeUtc": "2021-08-26T12:03:23.2692239Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:30.7517838Z",
+        "id": "24c943e3-e49c-4df8-91cb-e559eab632ea",
+        "createdDateTimeUtc": "2022-01-18T11:54:03.805391Z",
+        "lastActionDateTimeUtc": "2022-01-18T11:54:19.397519Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -330,65 +237,62 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/1a576009-3964-4d41-ab65-dcd7fcd8ddfb/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/24c943e3-e49c-4df8-91cb-e559eab632ea/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4554e6e39e2795ab3771d43530d257a1",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ee029d5f0450459842f1a008756d85dc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b3ac3e9d-f177-4362-b028-13ccf4152cf1",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "43fe5c70-8f23-48ed-9651-4ab37a18bbb7",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:31 GMT",
-        "ETag": "\u0022B54B4E3A1442C5D5E716C0505DD029268E22B18B4F4D742856D2A6E012911B99\u0022",
+        "Date": "Tue, 18 Jan 2022 11:54:34 GMT",
+        "ETag": "\u002214851989F9794A499C1132589AE3BD270534001D565B215493FECFD4C27E116A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b3ac3e9d-f177-4362-b028-13ccf4152cf1"
+        "X-RequestId": "43fe5c70-8f23-48ed-9651-4ab37a18bbb7"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1626648402/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source254142079/File_0.txt",
-            "createdDateTimeUtc": "2021-08-26T12:03:24.19349Z",
-            "lastActionDateTimeUtc": "2021-08-26T12:03:30.7517671Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target350713167/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1478981449/File_0.txt",
+            "createdDateTimeUtc": "2022-01-18T11:54:07.610603Z",
+            "lastActionDateTimeUtc": "2022-01-18T11:54:19.39751Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000b467c-0000-0000-0000-000000000000",
+            "id": "001dba7e-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1088529502?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1206937502?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-72669318e9ff3446a6ae4a9ab30e76c2-f6a1d15cf9b1374f-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-955e8717ae8ceb4aa376d4b8d81c8352-d2e7723757629149-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "3667c14212e1ee3bc327d78d36acc6da",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:31 GMT",
+        "x-ms-client-request-id": "7536305b1ad5476bda02ecc735b9ceff",
+        "x-ms-date": "Tue, 18 Jan 2022 11:54:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -396,18 +300,21 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:31 GMT",
-        "ETag": "\u00220x8D968898615FDE4\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:31 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "3667c14212e1ee3bc327d78d36acc6da",
-        "x-ms-request-id": "36b85c84-701e-0091-2b72-9a592d000000",
+        "Date": "Tue, 18 Jan 2022 11:54:35 GMT",
+        "ETag": "\u00220x8D9DA794C7B7EEF\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:54:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7536305b1ad5476bda02ecc735b9ceff",
+        "x-ms-request-id": "27b2fee3-f01e-008f-0a62-0cb5f5000000",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1088529502/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1206937502/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -415,11 +322,11 @@
         "Content-Length": "16",
         "Content-Type": "application/octet-stream",
         "If-None-Match": "*",
-        "traceparent": "00-45e62926c9a3f647a5df6826467fb22b-52b6392558bba243-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-f99301e56fcf0147bd8973a29c2284cf-8eb8f8c813de1043-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "17b6e28f94dc6818d9f741d8d47821cb",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:31 GMT",
+        "x-ms-client-request-id": "dcee9c2eb82ac868be3f17e58763dc70",
+        "x-ms-date": "Tue, 18 Jan 2022 11:54:35 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -428,30 +335,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Thu, 26 Aug 2021 12:03:31 GMT",
-        "ETag": "\u00220x8D9688986439C94\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:32 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "17b6e28f94dc6818d9f741d8d47821cb",
+        "Date": "Tue, 18 Jan 2022 11:54:35 GMT",
+        "ETag": "\u00220x8D9DA794C980F08\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:54:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "dcee9c2eb82ac868be3f17e58763dc70",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "36b85ce5-701e-0091-8072-9a592d000000",
+        "x-ms-request-id": "27b2ff3c-f01e-008f-5962-0cb5f5000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target632004810?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1149557349?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-68ed1fdeb3c8c341ad571a7668926fd9-21678f88d3a2a54f-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-6998132530cc5b458441934fbb4fd807-43727c07fe438440-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "aacfb1f8010419d4576477d40701c40d",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:32 GMT",
+        "x-ms-client-request-id": "81f8c4878a339783a67602ac7d0d37d1",
+        "x-ms-date": "Tue, 18 Jan 2022 11:54:36 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -459,15 +369,18 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:31 GMT",
-        "ETag": "\u00220x8D96889865ADBBA\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:32 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "aacfb1f8010419d4576477d40701c40d",
-        "x-ms-request-id": "36b85db3-701e-0091-3972-9a592d000000",
+        "Date": "Tue, 18 Jan 2022 11:54:35 GMT",
+        "ETag": "\u00220x8D9DA794CE30B10\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:54:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "81f8c4878a339783a67602ac7d0d37d1",
+        "x-ms-request-id": "27b2ffdf-f01e-008f-7662-0cb5f5000000",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
       "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
@@ -477,9 +390,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7e83afb79e15d749866f252a7b515269-5dbeec4c06b7df47-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a0f0a15a818aa8aeff5cead062194a06",
+        "traceparent": "00-2cb85b77bffca541a1939ad28382bf4b-2e192829554f764d-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "96d1460874ffc8a36eb7950386c07626",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -499,105 +412,54 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "12be429c-b673-4aff-b52b-6ec76903781b",
+        "apim-request-id": "7a3d2551-2890-4a65-b441-968d8eccb4e1",
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:32 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
+        "Date": "Tue, 18 Jan 2022 11:54:36 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d7e4854c-5f7d-4fe5-9d0e-e7013d8100ab",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "12be429c-b673-4aff-b52b-6ec76903781b"
+        "X-RequestId": "7a3d2551-2890-4a65-b441-968d8eccb4e1"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d7e4854c-5f7d-4fe5-9d0e-e7013d8100ab",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "fb3dc30b2ff7e08ae2fd8530a194d1f6",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f5ae627b7ed611fa6b458342661b4132",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c4874b47-74d0-45e1-87a2-96e27e98f319",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "b23906b3-d6b7-4f23-96d2-0dec7fcfe2b3",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:32 GMT",
-        "ETag": "\u00223BCFD9C1483B7015EC341DBAB948F36A42A8367178DD300B43FCBBE6C50FF368\u0022",
+        "Date": "Tue, 18 Jan 2022 11:54:37 GMT",
+        "ETag": "\u00224E02F67481BEED037EB7D31C68625AE507DB6702DB6FAE6C867039793D2AB816\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c4874b47-74d0-45e1-87a2-96e27e98f319"
+        "X-RequestId": "b23906b3-d6b7-4f23-96d2-0dec7fcfe2b3"
       },
       "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:32.6291728Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 0,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d779ca7c2b31773f0326aba81703b63d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3d5f5996-5a68-4bca-a464-465e7d210623",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:33 GMT",
-        "ETag": "\u002249715EFEE16E9CF46E4A903717503C565142FC38D5B93D1ABA6653F2262FD458\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3d5f5996-5a68-4bca-a464-465e7d210623"
-      },
-      "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:33.1273959Z",
+        "id": "d7e4854c-5f7d-4fe5-9d0e-e7013d8100ab",
+        "createdDateTimeUtc": "2022-01-18T11:54:37.0024105Z",
+        "lastActionDateTimeUtc": "2022-01-18T11:54:37.6477652Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -611,377 +473,38 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d7e4854c-5f7d-4fe5-9d0e-e7013d8100ab",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "44c87019c9c42a15160fbe8dfc7d076a",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1d7e13dfd90a12652030137cf47f10e5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ee7c26fa-6d8c-4f9a-9a03-9ef03fec745e",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "27caa874-dd90-46a0-a68c-e8f4ff42a5e7",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:34 GMT",
-        "ETag": "\u002249715EFEE16E9CF46E4A903717503C565142FC38D5B93D1ABA6653F2262FD458\u0022",
+        "Date": "Tue, 18 Jan 2022 11:55:08 GMT",
+        "ETag": "\u0022F938942037E4D6D69D5FE2C0DA04F1956849E719EED654FE0CEE266A00D19C43\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "ee7c26fa-6d8c-4f9a-9a03-9ef03fec745e"
+        "X-RequestId": "27caa874-dd90-46a0-a68c-e8f4ff42a5e7"
       },
       "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:33.1273959Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9854f48a729fe0d483c6f7d184e2c9df",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "cb871e39-fd6f-4750-b51e-5315770ef58d",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:35 GMT",
-        "ETag": "\u00226C2C3BBAD5C9403EA44BB41405D4E83D34FAA1BABA1352FFC4FAEF65B6CB794B\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cb871e39-fd6f-4750-b51e-5315770ef58d"
-      },
-      "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:35.7246687Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "301647468cccb231b44fc0226cb27a85",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "03e6310f-1e96-40da-8cd2-23eaba3aa18a",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:37 GMT",
-        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "03e6310f-1e96-40da-8cd2-23eaba3aa18a"
-      },
-      "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "231d411e1eaea69d9ce7c1fdd144a634",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "9e7ed7fc-28f0-42b8-9972-5c3e84294b9f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:38 GMT",
-        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9e7ed7fc-28f0-42b8-9972-5c3e84294b9f"
-      },
-      "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "b446de45d667fd9ec2a1e350b2b273d1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "5e2b4c18-0f43-4dba-8156-0343ef432bc2",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:40 GMT",
-        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "5e2b4c18-0f43-4dba-8156-0343ef432bc2"
-      },
-      "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "43b2724ba6c52730aa6f94e4cb34e170",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "346d0f7a-55b8-4d01-baa1-6203254d8a61",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:41 GMT",
-        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "346d0f7a-55b8-4d01-baa1-6203254d8a61"
-      },
-      "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8edc8ca8c66b481ea21f600c3b4cf4e9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "195a0280-0967-4340-a9ea-6da7e8d5a4a6",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:42 GMT",
-        "ETag": "\u0022E8CC26C28A535ED14FEECFBB69E5BCF0EB0DAD5E8CF8C2AD9653532881FF7B25\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "195a0280-0967-4340-a9ea-6da7e8d5a4a6"
-      },
-      "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:36.8742156Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "5fb2ef7463929f6fad1f0af741b9328e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "21a5cfaf-2940-48c4-83e5-3f929c43193b",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:43 GMT",
-        "ETag": "\u002213B2015A36198CB1B9B29DA639D9B37C320F1364094A19C05DBA512D164924D6\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "21a5cfaf-2940-48c4-83e5-3f929c43193b"
-      },
-      "ResponseBody": {
-        "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-        "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:43.710026Z",
+        "id": "d7e4854c-5f7d-4fe5-9d0e-e7013d8100ab",
+        "createdDateTimeUtc": "2022-01-18T11:54:37.0024105Z",
+        "lastActionDateTimeUtc": "2022-01-18T11:54:52.0093254Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -995,92 +518,86 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/686d7a45-e204-40be-aa2f-9e132c80846b/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/d7e4854c-5f7d-4fe5-9d0e-e7013d8100ab/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "25a872c0e5d685665369a0a54524eb5d",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1b30dbff425f8afb4bbf2abaf0616152",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a1b589d0-bd6e-49c4-a349-678c7c804458",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "30f64d3c-9448-4ff4-81af-91a7d47cef7c",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:44 GMT",
-        "ETag": "\u0022687D20DCE6993F556593A13FDF3DB6ADFE18CEFEA4D4DE599BF0EC9088502455\u0022",
+        "Date": "Tue, 18 Jan 2022 11:55:08 GMT",
+        "ETag": "\u00228F937409EDA1C576DBC03F23E52365FE44C48ED1E74053DB4F15748DAAA855D4\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a1b589d0-bd6e-49c4-a349-678c7c804458"
+        "X-RequestId": "30f64d3c-9448-4ff4-81af-91a7d47cef7c"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target632004810/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1088529502/File_0.txt",
-            "createdDateTimeUtc": "2021-08-26T12:03:35.7373407Z",
-            "lastActionDateTimeUtc": "2021-08-26T12:03:43.7100188Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1149557349/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1206937502/File_0.txt",
+            "createdDateTimeUtc": "2022-01-18T11:54:42.5400388Z",
+            "lastActionDateTimeUtc": "2022-01-18T11:54:52.009318Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000b467d-0000-0000-0000-000000000000",
+            "id": "001dba7f-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2021-08-26T12%3A03%3A31.8241066Z",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2022-01-18T11%3A54%3A34.6661871Z",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-83a8070ec9c1824fa804607227811df0-87b5c0246e733b49-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "db70ab7b818145de1d3ce04bbc2706e9",
+        "traceparent": "00-3d652afceba8734bb96625d5efb761c8-364f992969615646-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "722363755942a21bfc9bd4a56b7e1cec",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f70d6fe8-d3d6-452e-b500-0cc340818622",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "aff82172-a155-4a8f-8022-f4bf7cbf83b8",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:44 GMT",
-        "ETag": "\u00224F13B76AA379E4D8A60C7AA9DC08581E9EF0A1F1C2AD4695FD2FF3E63792BE07\u0022",
+        "Date": "Tue, 18 Jan 2022 11:55:10 GMT",
+        "ETag": "\u0022265AB39A239B6A37608A33619FD9F9979BB422A28DAD2189C5F9A4E82C06428A\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "f70d6fe8-d3d6-452e-b500-0cc340818622"
+        "X-RequestId": "aff82172-a155-4a8f-8022-f4bf7cbf83b8"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "686d7a45-e204-40be-aa2f-9e132c80846b",
-            "createdDateTimeUtc": "2021-08-26T12:03:32.6291723Z",
-            "lastActionDateTimeUtc": "2021-08-26T12:03:43.710026Z",
+            "id": "d7e4854c-5f7d-4fe5-9d0e-e7013d8100ab",
+            "createdDateTimeUtc": "2022-01-18T11:54:37.0024105Z",
+            "lastActionDateTimeUtc": "2022-01-18T11:54:52.0093254Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -1097,10 +614,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-26T14:03:31.8241066\u002B02:00",
+    "DateTimeOffsetNow": "2022-01-18T13:54:35.6661871\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "221592565"
+    "RandomSeed": "1640543011"
   }
 }

--- a/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedAfterTestAsync.json
+++ b/sdk/translation/Azure.AI.Translation.Document/tests/SessionRecords/DocumentTranslationClientLiveTests/GetTranslationStatusesFilterByCreatedAfterTestAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1157461599?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source134403783?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-f005521bd8747547b35362a5f65b68d5-5259b920d5f8714e-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-68e12a5af902b347a933df74e9a1f741-41d25260c40d7348-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "e7af71a06d407893aafb6254ae09eac9",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:54 GMT",
+        "x-ms-client-request-id": "21f960040f8cfffac271b0551202a359",
+        "x-ms-date": "Tue, 18 Jan 2022 11:55:11 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -19,18 +19,21 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:53 GMT",
-        "ETag": "\u00220x8D9688993516D72\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:54 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "e7af71a06d407893aafb6254ae09eac9",
-        "x-ms-request-id": "36b89291-701e-0091-3f72-9a592d000000",
+        "Date": "Tue, 18 Jan 2022 11:55:11 GMT",
+        "ETag": "\u00220x8D9DA7961D6EB96\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:55:11 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "21f960040f8cfffac271b0551202a359",
+        "x-ms-request-id": "27b33ef5-f01e-008f-5e62-0cb5f5000000",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source1157461599/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source134403783/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -38,11 +41,11 @@
         "Content-Length": "16",
         "Content-Type": "application/octet-stream",
         "If-None-Match": "*",
-        "traceparent": "00-be3d910f34789443ac286d0c23fb873c-ea49ecef9e677245-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-c1f880a1f43dd446a615f435f21c45ba-94dd152fc9027448-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "b8403d1719c573e912fed8ea5c745df2",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:54 GMT",
+        "x-ms-client-request-id": "aa3cb78c77f06ad75a189c7d98fd2ad6",
+        "x-ms-date": "Tue, 18 Jan 2022 11:55:11 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -51,30 +54,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Thu, 26 Aug 2021 12:03:53 GMT",
-        "ETag": "\u00220x8D96889937DAF9A\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:54 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b8403d1719c573e912fed8ea5c745df2",
+        "Date": "Tue, 18 Jan 2022 11:55:11 GMT",
+        "ETag": "\u00220x8D9DA79623802C7\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:55:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "aa3cb78c77f06ad75a189c7d98fd2ad6",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "36b8932a-701e-0091-2272-9a592d000000",
+        "x-ms-request-id": "27b3402a-f01e-008f-7962-0cb5f5000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target617672365?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1463039357?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-afe929962c02e444b667ff8fdfa9f708-656adfa0eab0aa4c-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b057d468cacc854fbd5f505ad7a58c38-93eb409ae7c77b4a-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "56347764a0c30ee5263d5be12d6efaea",
-        "x-ms-date": "Thu, 26 Aug 2021 12:03:54 GMT",
+        "x-ms-client-request-id": "0ab85cc49872090ca391cf3b601df9d3",
+        "x-ms-date": "Tue, 18 Jan 2022 11:55:12 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -82,15 +88,18 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:53 GMT",
-        "ETag": "\u00220x8D968899393D9D5\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:03:54 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "56347764a0c30ee5263d5be12d6efaea",
-        "x-ms-request-id": "36b89446-701e-0091-5472-9a592d000000",
+        "Date": "Tue, 18 Jan 2022 11:55:12 GMT",
+        "ETag": "\u00220x8D9DA7962773296\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:55:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0ab85cc49872090ca391cf3b601df9d3",
+        "x-ms-request-id": "27b340ea-f01e-008f-2562-0cb5f5000000",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
       "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
@@ -100,9 +109,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c415c83494043c4b96911bf9b3a6171f-5c6c7a1b1673d14a-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9e0c24cf9a8087873cd54295a81c369e",
+        "traceparent": "00-21a6c9713066ae479ff63ac0515d8c17-52630a6f9d64f445-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0913756dd6c4898d8ec774737d67c547",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -122,57 +131,54 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "cff867c2-8def-484a-8d8a-89601a0f42c7",
+        "apim-request-id": "25689f7b-b97e-4fa9-a98e-bb2975989af7",
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:03:54 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
+        "Date": "Tue, 18 Jan 2022 11:55:12 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de92d208-d3b4-4bdc-afee-4bcde72ebf59",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "cff867c2-8def-484a-8d8a-89601a0f42c7"
+        "X-RequestId": "25689f7b-b97e-4fa9-a98e-bb2975989af7"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de92d208-d3b4-4bdc-afee-4bcde72ebf59",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "9249a77072b59c545baa9fdb8e92e48f",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a54ed8da4eeb1f192fa14de6072ff9fa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4cf06274-96bb-4cf3-a282-d01eb1ce8854",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "4d12e08c-a785-437a-8f2a-1bb18c2a5635",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:54 GMT",
-        "ETag": "\u0022DF8F730D81A1BD3F67F9E5AFC7C54D58AF09BC8AD600FD988237EDE61ECBFFB6\u0022",
+        "Date": "Tue, 18 Jan 2022 11:55:13 GMT",
+        "ETag": "\u00228E77CF6D1F33507642F6632CF43385222B11C9EEF0E248B10CC0A73301637220\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4cf06274-96bb-4cf3-a282-d01eb1ce8854"
+        "X-RequestId": "4d12e08c-a785-437a-8f2a-1bb18c2a5635"
       },
       "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:54.8079008Z",
+        "id": "de92d208-d3b4-4bdc-afee-4bcde72ebf59",
+        "createdDateTimeUtc": "2022-01-18T11:55:13.0133311Z",
+        "lastActionDateTimeUtc": "2022-01-18T11:55:13.0133314Z",
         "status": "NotStarted",
         "summary": {
           "total": 0,
@@ -186,425 +192,38 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de92d208-d3b4-4bdc-afee-4bcde72ebf59",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4f8d00dd5350ca2cefad1aed5e4f6509",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "872ba9a2cc16edb8cf2f7bab24998c3c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "98e93d6f-5713-4bcd-8e4e-e27b7be92732",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "aee3ce99-4d54-4177-b815-4f76abf4d2f2",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:55 GMT",
-        "ETag": "\u0022565F2C83BAB1DBF74D56E3F6D7CE35915FA9ACB85628CC0C71687A28CA37AF8F\u0022",
+        "Date": "Tue, 18 Jan 2022 11:55:44 GMT",
+        "ETag": "\u0022422C5D48DDE9964964366F1335C5979666E7843920A084EA4E59445C7F5A4847\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "98e93d6f-5713-4bcd-8e4e-e27b7be92732"
+        "X-RequestId": "aee3ce99-4d54-4177-b815-4f76abf4d2f2"
       },
       "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:55.6131342Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "8670bc0768245c34cf7042d6faabf8a9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "3a13feaa-f7a4-49ae-9ad7-b292b5ea4b11",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:57 GMT",
-        "ETag": "\u0022565F2C83BAB1DBF74D56E3F6D7CE35915FA9ACB85628CC0C71687A28CA37AF8F\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "3a13feaa-f7a4-49ae-9ad7-b292b5ea4b11"
-      },
-      "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:55.6131342Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "a8b7b3f0e68f1c4d7a7fa20857663e0b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "66ecb7cd-4f7e-4e61-9d4a-806c928cddd8",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:58 GMT",
-        "ETag": "\u0022565F2C83BAB1DBF74D56E3F6D7CE35915FA9ACB85628CC0C71687A28CA37AF8F\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "66ecb7cd-4f7e-4e61-9d4a-806c928cddd8"
-      },
-      "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:55.6131342Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "d1d495455e22756acc307fe01156d044",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "46e7f3e0-1914-43fd-9aa0-efc48b1f8481",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:03:59 GMT",
-        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "46e7f3e0-1914-43fd-9aa0-efc48b1f8481"
-      },
-      "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "abfc71b4bd97207a6f530ba5c52b0568",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "167d443f-d4ee-4ea0-a459-9fd926e769a7",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:00 GMT",
-        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "167d443f-d4ee-4ea0-a459-9fd926e769a7"
-      },
-      "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6491363226d692874842dc5e676d0b24",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "c5729ffa-06a1-4ea4-a76f-0337609b02ed",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:02 GMT",
-        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "c5729ffa-06a1-4ea4-a76f-0337609b02ed"
-      },
-      "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "e6545eae936a87731bb462ce53c4b0a0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8cb233a2-e10e-40eb-a4ff-8d0146be4ff8",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:03 GMT",
-        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8cb233a2-e10e-40eb-a4ff-8d0146be4ff8"
-      },
-      "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "daad162b6bc58d6de96a6255e01bb901",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "82a93a3b-01f4-4631-a13b-b8dec294ec5f",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:04 GMT",
-        "ETag": "\u0022B754265E80A9860D3863620BCC9E14EF22399CFCDDA782FA6F6B9D036F6EA552\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "82a93a3b-01f4-4631-a13b-b8dec294ec5f"
-      },
-      "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:03:59.8255032Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "67f6e6481ed69ffec2094922c3b83e83",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8f8f2300-2f0c-4ac6-a87c-f19d78bfa69a",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:05 GMT",
-        "ETag": "\u00221D665891DB5B9BA6D9A06F2B3DC4DA4D707F381F327BEE5DB57C50B98EDAAF2E\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8f8f2300-2f0c-4ac6-a87c-f19d78bfa69a"
-      },
-      "ResponseBody": {
-        "id": "49aa84fb-4f9e-4260-be33-d5723bb5038d",
-        "createdDateTimeUtc": "2021-08-26T12:03:54.8079004Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:05.8188604Z",
+        "id": "de92d208-d3b4-4bdc-afee-4bcde72ebf59",
+        "createdDateTimeUtc": "2022-01-18T11:55:13.0133311Z",
+        "lastActionDateTimeUtc": "2022-01-18T11:55:24.910022Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -618,65 +237,62 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/49aa84fb-4f9e-4260-be33-d5723bb5038d/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/de92d208-d3b4-4bdc-afee-4bcde72ebf59/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "50333b9130bf435ff1c7fcff301da700",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "886088cb54cf1ee85bf4da2389a6815f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9ac01725-0824-47b9-bb00-9e5f3752db6b",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "2dbc5f65-eba3-4c5d-8d04-b6f4f8024189",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:05 GMT",
-        "ETag": "\u0022ABFB935FC6AD81977E8462317AB908F21BB36BC7E1F96229BFC78DFE78941C7A\u0022",
+        "Date": "Tue, 18 Jan 2022 11:55:45 GMT",
+        "ETag": "\u0022B26F27E3550A555EEFB8DF95B85281DBB89437E871DC59988F7DA84F23BB75D0\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "9ac01725-0824-47b9-bb00-9e5f3752db6b"
+        "X-RequestId": "2dbc5f65-eba3-4c5d-8d04-b6f4f8024189"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target617672365/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source1157461599/File_0.txt",
-            "createdDateTimeUtc": "2021-08-26T12:03:59.3333368Z",
-            "lastActionDateTimeUtc": "2021-08-26T12:04:05.8188531Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1463039357/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source134403783/File_0.txt",
+            "createdDateTimeUtc": "2022-01-18T11:55:17.6067325Z",
+            "lastActionDateTimeUtc": "2022-01-18T11:55:24.9100084Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000b467e-0000-0000-0000-000000000000",
+            "id": "001dba80-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source637022715?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964295117?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-647fa9b0b87c75498f4cf9f47ef9c66c-1841b012c4086746-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-b82faa4b4f05424db2b2ecdc3471905d-afb1c2576829914b-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "cd6c8661c949170c0e17bc224ac9302b",
-        "x-ms-date": "Thu, 26 Aug 2021 12:04:06 GMT",
+        "x-ms-client-request-id": "3cd3d079303d1f0d60d5bbd26efb9614",
+        "x-ms-date": "Tue, 18 Jan 2022 11:55:45 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -684,18 +300,21 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:04:06 GMT",
-        "ETag": "\u00220x8D968899AE9DFBB\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:04:06 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "cd6c8661c949170c0e17bc224ac9302b",
-        "x-ms-request-id": "36b8c095-701e-0091-1e72-9a592d000000",
+        "Date": "Tue, 18 Jan 2022 11:55:45 GMT",
+        "ETag": "\u00220x8D9DA7976636717\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:55:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3cd3d079303d1f0d60d5bbd26efb9614",
+        "x-ms-request-id": "27b37331-f01e-008f-1062-0cb5f5000000",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source637022715/File_0.txt",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/source964295117/File_0.txt",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
@@ -703,11 +322,11 @@
         "Content-Length": "16",
         "Content-Type": "application/octet-stream",
         "If-None-Match": "*",
-        "traceparent": "00-ec48988df0061e49914ede667a67a143-d4de03e1d9df6f4a-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-eb1130e92d246e4c918e5f5d9d652698-ec8a7b5648109841-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "e7a4c4df41688717b3760f22ff6ea461",
-        "x-ms-date": "Thu, 26 Aug 2021 12:04:06 GMT",
+        "x-ms-client-request-id": "ce7f1a102b71c14e0c2c22f2956429ae",
+        "x-ms-date": "Tue, 18 Jan 2022 11:55:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -716,30 +335,33 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "B2caA4wOtDcj1CFpOwc8Ow==",
-        "Date": "Thu, 26 Aug 2021 12:04:06 GMT",
-        "ETag": "\u00220x8D968899B193195\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:04:07 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "e7a4c4df41688717b3760f22ff6ea461",
+        "Date": "Tue, 18 Jan 2022 11:55:45 GMT",
+        "ETag": "\u00220x8D9DA7976A2FF89\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:55:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ce7f1a102b71c14e0c2c22f2956429ae",
         "x-ms-content-crc64": "fxwoBBSnywc=",
-        "x-ms-request-id": "36b8c0e8-701e-0091-6a72-9a592d000000",
+        "x-ms-request-id": "27b373cd-f01e-008f-0462-0cb5f5000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1978624584?restype=container",
+      "RequestUri": "https://documentstorageleithy.blob.core.windows.net/target1962195483?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Authorization": "Sanitized",
         "Content-Length": "0",
-        "traceparent": "00-b8d655dede25f9418a36000192bd9216-db2e3dd11b27d54f-00",
-        "User-Agent": "azsdk-net-Storage.Blobs/12.8.0 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
+        "traceparent": "00-65031635804d7a41999d0b139d0f161d-69ca085eee8b254e-00",
+        "User-Agent": "azsdk-net-Storage.Blobs/12.10.0 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
         "x-ms-blob-public-access": "container",
-        "x-ms-client-request-id": "d232622748b5277138b018a220a6fdcb",
-        "x-ms-date": "Thu, 26 Aug 2021 12:04:07 GMT",
+        "x-ms-client-request-id": "b8c8aade8e005358686e7e2c4bedf943",
+        "x-ms-date": "Tue, 18 Jan 2022 11:55:46 GMT",
         "x-ms-return-client-request-id": "true",
         "x-ms-version": "2020-04-08"
       },
@@ -747,15 +369,18 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:04:06 GMT",
-        "ETag": "\u00220x8D968899B3240A4\u0022",
-        "Last-Modified": "Thu, 26 Aug 2021 12:04:07 GMT",
-        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "d232622748b5277138b018a220a6fdcb",
-        "x-ms-request-id": "36b8c1c2-701e-0091-2b72-9a592d000000",
+        "Date": "Tue, 18 Jan 2022 11:55:46 GMT",
+        "ETag": "\u00220x8D9DA7976CAF349\u0022",
+        "Last-Modified": "Tue, 18 Jan 2022 11:55:46 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b8c8aade8e005358686e7e2c4bedf943",
+        "x-ms-request-id": "27b37427-f01e-008f-4e62-0cb5f5000000",
         "x-ms-version": "2020-04-08"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
       "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches",
@@ -765,9 +390,9 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2001f221b19f6943b41489c1a7a132d0-a9c30f7d14ae1b47-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "025951d392186e1fe41ad3baea18a072",
+        "traceparent": "00-4fe592f0e06a924e96e1ca88207c375b-a16618d34f6aa145-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "028b780e5b91824e122f110e1b8afcac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -787,105 +412,54 @@
       },
       "StatusCode": 202,
       "ResponseHeaders": {
-        "apim-request-id": "b41f78f5-141d-4de3-b305-24843c5b214b",
+        "apim-request-id": "4f0f0603-4ccc-466b-b281-3db40623604c",
         "Content-Length": "0",
-        "Date": "Thu, 26 Aug 2021 12:04:07 GMT",
-        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
+        "Date": "Tue, 18 Jan 2022 11:55:47 GMT",
+        "Operation-Location": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8bec9f16-5c6d-41bb-b5b8-8b43c8a853f2",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "b41f78f5-141d-4de3-b305-24843c5b214b"
+        "X-RequestId": "4f0f0603-4ccc-466b-b281-3db40623604c"
       },
-      "ResponseBody": []
+      "ResponseBody": null
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8bec9f16-5c6d-41bb-b5b8-8b43c8a853f2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "6723d95a59fe7b2932c03090fee593cf",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "508fb70d5cce8c10267a08bccf94c13e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0a7e476b-b004-44a2-a3b5-9edfbd10c5c8",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "88254369-4c7f-40cd-ab91-5c250d650951",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:07 GMT",
-        "ETag": "\u002244FB88E8ABCA6D00027559017BF3052DCEEC71580358190C41EC56501A70F7F1\u0022",
+        "Date": "Tue, 18 Jan 2022 11:55:48 GMT",
+        "ETag": "\u00227FEFB3EFE7511F67109F412F8C2F6BC640D9E357F7C9E030661D2FCE466C8F68\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0a7e476b-b004-44a2-a3b5-9edfbd10c5c8"
+        "X-RequestId": "88254369-4c7f-40cd-ab91-5c250d650951"
       },
       "ResponseBody": {
-        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:07.6583599Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 0,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "1d2b56125f4b943042c4ed9b75b73d1f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8d12627e-5576-46f9-81a2-93619a36de76",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:08 GMT",
-        "ETag": "\u0022D42C7FCED043400E8195294EF7A3CC8308B9616887D5CC5483728A45F64E1E7E\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8d12627e-5576-46f9-81a2-93619a36de76"
-      },
-      "ResponseBody": {
-        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:08.1551698Z",
+        "id": "8bec9f16-5c6d-41bb-b5b8-8b43c8a853f2",
+        "createdDateTimeUtc": "2022-01-18T11:55:47.60052Z",
+        "lastActionDateTimeUtc": "2022-01-18T11:55:48.117458Z",
         "status": "NotStarted",
         "summary": {
           "total": 1,
@@ -899,281 +473,38 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8bec9f16-5c6d-41bb-b5b8-8b43c8a853f2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "4648a610968279cd27decf57628f6fff",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eb86ae29ac9d828a5c45a5d07c4a37de",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a295b88a-66b3-42eb-a91a-e02eefcbaba2",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "ad3c6ca3-bb5f-4e48-9cb6-4315a94dca1d",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:09 GMT",
-        "ETag": "\u0022D42C7FCED043400E8195294EF7A3CC8308B9616887D5CC5483728A45F64E1E7E\u0022",
+        "Date": "Tue, 18 Jan 2022 11:56:18 GMT",
+        "ETag": "\u00220DB86F14D7FC0D8798899EEDA61A57E9ABA6B0C7A392A6C79E9979753328C0ED\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "a295b88a-66b3-42eb-a91a-e02eefcbaba2"
+        "X-RequestId": "ad3c6ca3-bb5f-4e48-9cb6-4315a94dca1d"
       },
       "ResponseBody": {
-        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:08.1551698Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "93a7038682ecfb27a98f243a6c8e067a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "2f6fea1a-f691-4b14-8b40-cd6f23dacccb",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:10 GMT",
-        "ETag": "\u0022D42C7FCED043400E8195294EF7A3CC8308B9616887D5CC5483728A45F64E1E7E\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2f6fea1a-f691-4b14-8b40-cd6f23dacccb"
-      },
-      "ResponseBody": {
-        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:08.1551698Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "587f10834c9c7b4d88b1f56d8fd832b3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "2c94a30e-3a68-449d-95ab-d3f450224955",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:12 GMT",
-        "ETag": "\u0022D42C7FCED043400E8195294EF7A3CC8308B9616887D5CC5483728A45F64E1E7E\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "2c94a30e-3a68-449d-95ab-d3f450224955"
-      },
-      "ResponseBody": {
-        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:08.1551698Z",
-        "status": "NotStarted",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 0,
-          "notYetStarted": 1,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7214ed54a9108e327e4d9df271930d99",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "206b1c6c-d75f-43ba-8951-2dd20923e9f8",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:13 GMT",
-        "ETag": "\u00225F5491CA29EF2EB5FC7B887D638FAA011D69F22B04B57A57A9123AC95DE4C722\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "206b1c6c-d75f-43ba-8951-2dd20923e9f8"
-      },
-      "ResponseBody": {
-        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:13.8184144Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "51d454d7170f3a63b52b0b3b8cba6bd0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "8dd7b0fd-b927-4a02-b06a-e5c7d04e50a6",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:14 GMT",
-        "ETag": "\u002266EC335D8DEB3A7F91F56459122E5DF3BE4F58E12F62B715DC483BF992E3982F\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "8dd7b0fd-b927-4a02-b06a-e5c7d04e50a6"
-      },
-      "ResponseBody": {
-        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:14.3445642Z",
-        "status": "Running",
-        "summary": {
-          "total": 1,
-          "failed": 0,
-          "success": 0,
-          "inProgress": 1,
-          "notYetStarted": 0,
-          "cancelled": 0,
-          "totalCharacterCharged": 0
-        }
-      }
-    },
-    {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "7fe6715d9479da6addf1da4fae5a0af5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "apim-request-id": "4b51f2fd-61f7-44d7-8eb7-5ca434b1074b",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:15 GMT",
-        "ETag": "\u0022623A46C41A3D44EC3E9CA9984EA28E5B42DDD5D8B09FD5245A069D7C513E0814\u0022",
-        "Retry-After": "1",
-        "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
-        ],
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
-        "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4b51f2fd-61f7-44d7-8eb7-5ca434b1074b"
-      },
-      "ResponseBody": {
-        "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-        "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-        "lastActionDateTimeUtc": "2021-08-26T12:04:16.1141626Z",
+        "id": "8bec9f16-5c6d-41bb-b5b8-8b43c8a853f2",
+        "createdDateTimeUtc": "2022-01-18T11:55:47.60052Z",
+        "lastActionDateTimeUtc": "2022-01-18T11:55:57.2500009Z",
         "status": "Succeeded",
         "summary": {
           "total": 1,
@@ -1187,92 +518,86 @@
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/c191cac1-5192-40a3-ad33-3e2362486994/documents",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches/8bec9f16-5c6d-41bb-b5b8-8b43c8a853f2/documents",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "3b955ca4e0043ca48ad9bce49df701c3",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "941fd272a85db17567ffdb165292b37d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0e13a343-64db-4207-ab1a-a14f8ed1eea0",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "14ac0ab5-b6ec-4465-9200-3b0eea720aa2",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:17 GMT",
-        "ETag": "\u0022987B10CCD9023DBB31F552E2E31294A56FAF7DCBE80FF26DB548D81435E9B4E4\u0022",
+        "Date": "Tue, 18 Jan 2022 11:56:19 GMT",
+        "ETag": "\u00221988F4393EF1A22DF6E4C584E7646F958F71E40150F2B90D0B89B71C99E64240\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=8cda94a7913d3ab33ee9f4c90adb24581c27bc03c71f0482ecf77d7381f35e6d;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=b43e80ef1fbcb9f9d446cbc61b366e02dafefc2a9addab525b1fc3eda44b27b2;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "0e13a343-64db-4207-ab1a-a14f8ed1eea0"
+        "X-RequestId": "14ac0ab5-b6ec-4465-9200-3b0eea720aa2"
       },
       "ResponseBody": {
         "value": [
           {
-            "path": "https://documentstorageleithy.blob.core.windows.net/target1978624584/File_0.txt",
-            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source637022715/File_0.txt",
-            "createdDateTimeUtc": "2021-08-26T12:04:13.8272033Z",
-            "lastActionDateTimeUtc": "2021-08-26T12:04:16.1141571Z",
+            "path": "https://documentstorageleithy.blob.core.windows.net/target1962195483/File_0.txt",
+            "sourcePath": "https://documentstorageleithy.blob.core.windows.net/source964295117/File_0.txt",
+            "createdDateTimeUtc": "2022-01-18T11:55:52.7299466Z",
+            "lastActionDateTimeUtc": "2022-01-18T11:55:57.2499927Z",
             "status": "Succeeded",
             "to": "fr",
             "progress": 1,
-            "id": "000b467f-0000-0000-0000-000000000000",
+            "id": "001dba81-0000-0000-0000-000000000000",
             "characterCharged": 16
           }
         ]
       }
     },
     {
-      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2021-08-26T12%3A04%3A06.7589709Z",
+      "RequestUri": "https://document-translation-test.cognitiveservices.azure.com/translator/text/batch/v1.0/batches?createdDateTimeUtcStart=2022-01-18T11%3A55%3A44.6858723Z",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-510f9c22dda3004b8d46addf2307b774-bbde3b03a94b3548-00",
-        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20210826.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19043 )",
-        "x-ms-client-request-id": "0095cde18ead4320e9fa741d3d138c5a",
+        "traceparent": "00-425dc7ddddee5e438db80f12037a24e4-9c7ae18e0a98cf47-00",
+        "User-Agent": "azsdk-net-AI.Translation.Document/1.0.0-alpha.20220116.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6ce5d26e1004610e2c0df488b7400fdc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4de74637-db5c-4b72-9e14-c4a0c282d642",
-        "Cache-Control": [
-          "public",
-          "max-age=1"
-        ],
+        "apim-request-id": "6b17efd1-cee7-4beb-9551-b6171e342393",
+        "Cache-Control": "public, max-age=1",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 26 Aug 2021 12:04:17 GMT",
-        "ETag": "\u00220D4A4845FEECE96A6D04EEA2DF27306D67F9E35A5425C91E9F74205CF9BAC81A\u0022",
+        "Date": "Tue, 18 Jan 2022 11:56:19 GMT",
+        "ETag": "\u0022C43600B699C115FE7D606703D984A2231745FD21FD0A740ACC282622D0022FD1\u0022",
         "Retry-After": "1",
         "Set-Cookie": [
-          "ARRAffinity=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
-          "ARRAffinitySameSite=71659a59bc7ec5e68f754ab1110af7204cc0a6ca9121108e19aeec14032c3bc4;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
+          "ARRAffinity=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;Secure;Domain=mtbatch.nam.microsofttranslator.com",
+          "ARRAffinitySameSite=748a2cefe0e94b92294828d7237123826b9552ab7a870cd971e8858b6fa6e96a;Path=/;HttpOnly;SameSite=None;Secure;Domain=mtbatch.nam.microsofttranslator.com"
         ],
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "X-Powered-By": "ASP.NET",
-        "X-RequestId": "4de74637-db5c-4b72-9e14-c4a0c282d642"
+        "X-RequestId": "6b17efd1-cee7-4beb-9551-b6171e342393"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "c191cac1-5192-40a3-ad33-3e2362486994",
-            "createdDateTimeUtc": "2021-08-26T12:04:07.6583596Z",
-            "lastActionDateTimeUtc": "2021-08-26T12:04:16.1141626Z",
+            "id": "8bec9f16-5c6d-41bb-b5b8-8b43c8a853f2",
+            "createdDateTimeUtc": "2022-01-18T11:55:47.60052Z",
+            "lastActionDateTimeUtc": "2022-01-18T11:55:57.2500009Z",
             "status": "Succeeded",
             "summary": {
               "total": 1,
@@ -1289,10 +614,10 @@
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-08-26T14:04:06.7589709\u002B02:00",
+    "DateTimeOffsetNow": "2022-01-18T13:55:45.6858723\u002B02:00",
     "DOCUMENT_TRANSLATION_API_KEY": "Sanitized",
     "DOCUMENT_TRANSLATION_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=documentstorageleithy;AccountKey=Kg==;EndpointSuffix=core.windows.net",
     "DOCUMENT_TRANSLATION_ENDPOINT": "https://document-translation-test.cognitiveservices.azure.com/",
-    "RandomSeed": "1670188230"
+    "RandomSeed": "1293729559"
   }
 }


### PR DESCRIPTION
Closes #26352. 

After investigating, it seems that there are times where a new job has a "CreatedOn" timestamp that is slightly less than the timestamp recorded before starting the job itself. This is likely because of some discrepancy in time between the service and test runner.

I've added 1 second of delay between the two events to create a window of error. I let the test run 15 times after this change and there were no failures.