### PR TITLE
performance patch of JsonConverterHelper.cs

### DIFF
--- a/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/JsonConverterHelper.cs
+++ b/sdk/mgmtcommon/ClientRuntime/ClientRuntime/Serialization/JsonConverterHelper.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Rest.Serialization
                 throw new ArgumentNullException("property");
             }
 
-            string propertyName = name;
+            string propertyName = property.PropertyName;
             parentPath = new string[0];
 
             if (!string.IsNullOrEmpty(propertyName))


### PR DESCRIPTION
as far as we use this in azure web apps and it makes us problems I'm kindly suggesting this performance update
- removed LINQ
- regex split is compiled singeltone now

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.101
  [Host]     : .NET 5.0.13 (5.0.1321.56516), X64 RyuJIT  [AttachedDebugger]
  DefaultJob : .NET 5.0.13 (5.0.1321.56516), X64 RyuJIT


|        Method |     Mean |    Error |   StdDev |
|-------------- |---------:|---------:|---------:|
| OriginalSplit | 985.5 ns | 19.27 ns | 47.63 ns |
|     NewSplit1 | 478.3 ns |  9.56 ns | 12.44 ns |

On Dec 11, 2021, at 10:09 AM, Feng Yuan <fyuan@microsoft.com> wrote: 
Found a super expensive regular expression stack in NetworkWatcherTrafficAnalytics-Prod: 
![image](https://user-images.githubusercontent.com/12524436/150021056-c508c62c-877c-41c7-be84-805ba43e0b4d.png)
GetPropertyName is costing 4.1 million CPU samples, 14.84% of total CPU samples in the stream I downloaded.


testing code
```

using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Linq;
using System.Text.RegularExpressions;

namespace Becnhmarks.ConsoleX
{
    internal class Program
    {
        static void Main(string[] args)
        {
            BenchmarkRunner.Run<MyClass>();
        }
    }

    public class MyClass
    {
        private readonly string data = @"parent1\..parent2\..parent3\.";
        private string[] parent;
        
        private static readonly Regex splitCompiledRegex = new Regex(@"(?<!\\)\.", RegexOptions.Compiled);

        [Benchmark]
        public string OriginalSplit() => GetPropertyNameOriginal(data, out parent);

        [Benchmark]
        public string NewSplit1() => GetPropertyNameNew1(data, out parent);


        public static string GetPropertyNameOriginal(string name, out string[] parentPath)
        {

            string propertyName = name;
            parentPath = new string[0];

            if (!string.IsNullOrEmpty(propertyName))
            {
                string[] hierarchy = Regex.Split(propertyName, @"(?<!\\)\.")
                    .Select(p => p?.Replace("\\.", ".")).ToArray();
                if (hierarchy.Length > 1)
                {
                    propertyName = hierarchy.Last();
                    parentPath = hierarchy.Take(hierarchy.Length - 1).ToArray();
                }
            }

            return propertyName;
        }

        public static string GetPropertyNameNew1(string name, out string[] parentPath)
        {

            string propertyName = name;
            parentPath = new string[0];

            if (!string.IsNullOrEmpty(propertyName))
            {
                string[] hierarchy = splitCompiledRegex.Split(propertyName);
                for (int i = 0; i < hierarchy.Length; i++)
                {
                    hierarchy[i] = hierarchy[i]?.Replace("\\.", ".");
                }

                if (hierarchy.Length > 1)
                {
                    propertyName = hierarchy[hierarchy.Length - 1];
                    Array.Resize(ref hierarchy, hierarchy.Length - 1);
                    parentPath = hierarchy;
                }
            }

            return propertyName;
        }

    }
}

```

