### PR TITLE
Disable cookies by default

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -28,12 +28,7 @@ namespace Azure.Core.TestFramework
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
         public static string RepositoryRoot { get; }
 
-        public static string DevCertPath { get; } = Path.Combine(
-            RepositoryRoot,
-            "eng",
-            "common",
-            "testproxy",
-            "dotnet-devcert.pfx");
+        public static string DevCertPath { get; }
 
         public const string DevCertPassword = "password";
 
@@ -131,6 +126,13 @@ namespace Azure.Core.TestFramework
             }
 
             RepositoryRoot = directoryInfo?.Parent?.FullName;
+
+            DevCertPath = Path.Combine(
+                RepositoryRoot,
+                "eng",
+                "common",
+                "testproxy",
+                "dotnet-devcert.pfx");
         }
 
         public RecordedTestMode? Mode { get; set; }

--- a/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs
@@ -28,6 +28,15 @@ namespace Azure.Core.TestFramework
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
         public static string RepositoryRoot { get; }
 
+        public static string DevCertPath { get; } = Path.Combine(
+            RepositoryRoot,
+            "eng",
+            "common",
+            "testproxy",
+            "dotnet-devcert.pfx");
+
+        public const string DevCertPassword = "password";
+
         private static readonly Dictionary<Type, Task> s_environmentStateCache = new();
 
         private readonly string _prefix;

--- a/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestProxy.cs
@@ -73,13 +73,8 @@ namespace Azure.Core.TestFramework
                     ["ASPNETCORE_URLS"] = $"http://{IpAddress}:0;https://{IpAddress}:0",
                     ["Logging__LogLevel__Default"] = "Error",
                     ["Logging__LogLevel__Microsoft.Hosting.Lifetime"] = "Information",
-                    ["ASPNETCORE_Kestrel__Certificates__Default__Path"] = Path.Combine(
-                        TestEnvironment.RepositoryRoot,
-                        "eng",
-                        "common",
-                        "testproxy",
-                        "dotnet-devcert.pfx"),
-                    ["ASPNETCORE_Kestrel__Certificates__Default__Password"] = "password"
+                    ["ASPNETCORE_Kestrel__Certificates__Default__Path"] = TestEnvironment.DevCertPath,
+                    ["ASPNETCORE_Kestrel__Certificates__Default__Password"] = TestEnvironment.DevCertPassword
                 }
             };
 

--- a/sdk/core/Azure.Core.TestFramework/src/TestServer.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestServer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -36,7 +37,14 @@ namespace Azure.Core.TestFramework
                     {
                         if (https)
                         {
-                            listenOptions.UseHttps();
+                            listenOptions.UseHttps(
+                                Path.Combine(
+                                    TestEnvironment.RepositoryRoot,
+                                    "eng",
+                                    "common",
+                                    "testproxy",
+                                    "dotnet-devcert.pfx"),
+                                "password");
                         }
                     });
                 })

--- a/sdk/core/Azure.Core.TestFramework/src/TestServer.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/TestServer.cs
@@ -37,14 +37,7 @@ namespace Azure.Core.TestFramework
                     {
                         if (https)
                         {
-                            listenOptions.UseHttps(
-                                Path.Combine(
-                                    TestEnvironment.RepositoryRoot,
-                                    "eng",
-                                    "common",
-                                    "testproxy",
-                                    "dotnet-devcert.pfx"),
-                                "password");
+                            listenOptions.UseHttps(TestEnvironment.DevCertPath, TestEnvironment.DevCertPassword);
                         }
                     });
                 })

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ### Breaking Changes
 
-- Cookies are no longer set on requests by default. They can be re-enabled for `HttpClientTransport` using the `Azure.Core.Pipeline.HttpClientTransport.EnableCookies` switch, or the `AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES` environment variable.
+- Cookies are no longer set on requests by default. Cookies can be re-enabled for `HttpClientTransport` by either setting an AppContext switch named "Azure.Core.Pipeline.HttpClientTransport.EnableCookies" to true or by setting the environment variable, "AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES" to "true". Note: AppContext switches can also be configured via configuration like below:
+  <ItemGroup>
+  <RuntimeHostConfigurationOption Include="Azure.Core.Pipeline.HttpClientTransport.EnableCookies" Value="true" />
+  </ItemGroup>
 
 ### Bugs Fixed
 

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Cookies are no longer set on requests by default. They can be re-enabled for `HttpClientTransport` using the `Azure.Core.Pipeline.HttpClientTransport.EnableCookies` switch, or the `AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES` environment variable.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Cookies are no longer set on requests by default. Cookies can be re-enabled for `HttpClientTransport` by either setting an AppContext switch named "Azure.Core.Pipeline.HttpClientTransport.EnableCookies" to true or by setting the environment variable, "AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES" to "true". Note: AppContext switches can also be configured via configuration like below:
 ```xml
   <ItemGroup>
-  <RuntimeHostConfigurationOption Include="Azure.Core.Pipeline.HttpClientTransport.EnableCookies" Value="true" />
+    <RuntimeHostConfigurationOption Include="Azure.Core.Pipeline.HttpClientTransport.EnableCookies" Value="true" />
   </ItemGroup>
 ```
 

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -7,9 +7,11 @@
 ### Breaking Changes
 
 - Cookies are no longer set on requests by default. Cookies can be re-enabled for `HttpClientTransport` by either setting an AppContext switch named "Azure.Core.Pipeline.HttpClientTransport.EnableCookies" to true or by setting the environment variable, "AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES" to "true". Note: AppContext switches can also be configured via configuration like below:
+```xml
   <ItemGroup>
   <RuntimeHostConfigurationOption Include="Azure.Core.Pipeline.HttpClientTransport.EnableCookies" Value="true" />
   </ItemGroup>
+```
 
 ### Bugs Fixed
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -159,13 +159,14 @@ namespace Azure.Core.Pipeline
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
             {
+                // UseCookies is not supported on "browser"
                 return new HttpClientHandler();
             }
 
 #if NETCOREAPP
-            return ApplyOptionsToHandler(new SocketsHttpHandler { AllowAutoRedirect = false }, options);
+            return ApplyOptionsToHandler(new SocketsHttpHandler { AllowAutoRedirect = false, UseCookies = UseCookies() }, options);
 #else
-            return ApplyOptionsToHandler(new HttpClientHandler { AllowAutoRedirect = false }, options);
+            return ApplyOptionsToHandler(new HttpClientHandler { AllowAutoRedirect = false, UseCookies = UseCookies() }, options);
 #endif
         }
 
@@ -613,5 +614,9 @@ namespace Azure.Core.Pipeline
             httpRequest.Properties[name] = value;
 #endif
         }
+
+        private static bool UseCookies() => AppContextSwitchHelper.GetConfigValue(
+            "Azure.Core.Pipeline.HttpClientTransport.EnableCookies",
+            "AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES");
     }
 }

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
+    [NonParallelizable]
     public class HttpClientTransportFunctionalTest : TransportFunctionalTests
     {
         private static RemoteCertificateValidationCallback certCallback = (_, _, _, _) => true;
@@ -37,6 +38,7 @@ namespace Azure.Core.Tests
         }
 
 #if NET461
+        // These setup and teardown actions require that entire test class be NonParallelizable.
         [OneTimeSetUp]
         public void TestSetup()
         {
@@ -90,7 +92,6 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        [NonParallelizable]
         public async Task CookiesCanBeEnabledUsingSwitch()
         {
             using var appContextSwitch = new TestAppContextSwitch("Azure.Core.Pipeline.HttpClientTransport.EnableCookies", "true");
@@ -99,7 +100,6 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        [NonParallelizable]
         public async Task CookiesCanBeEnabledUsingEnvVar()
         {
             using var envVar = new TestEnvVar("AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES", "true");

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
@@ -12,6 +13,8 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -84,6 +87,94 @@ namespace Azure.Core.Tests
             var transport = HttpClientTransport.Shared;
             transport.Dispose();
             Assert.DoesNotThrow(() => transport.Client.CancelPendingRequests());
+        }
+
+        [Test]
+        public async Task CookiesCanBeEnabledUsingSwitch()
+        {
+            using var appContextSwitch = new TestAppContextSwitch("Azure.Core.Pipeline.HttpClientTransport.EnableCookies", "true");
+            int requestCount = 0;
+            using (TestServer testServer = new TestServer(
+                context =>
+                {
+                    if (requestCount++ == 1)
+                    {
+                        Assert.IsTrue(context.Request.Headers.ContainsKey("cookie"));
+                        Assert.AreEqual(
+                            "stsservicecookie=estsfd",
+                            context.Request.Headers["cookie"].First());
+                    }
+
+                    context.Response.StatusCode = 200;
+                    context.Response.Headers.Add(
+                        "set-cookie",
+                        "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly");
+                    return Task.CompletedTask;
+                },
+                https: true))
+            {
+                var transport = GetTransport(https: true);
+                Request request = transport.CreateRequest();
+                request.Method = RequestMethod.Post;
+                request.Uri.Reset(testServer.Address);
+                request.Content = RequestContent.Create("Hello");
+                var response = await ExecuteRequest(request, transport);
+
+                // create a second request to verify cookies not set
+                request = transport.CreateRequest();
+                request.Method = RequestMethod.Post;
+                request.Uri.Reset(testServer.Address);
+                request.Content = RequestContent.Create("Hello");
+                await ExecuteRequest(request, transport);
+            }
+        }
+
+        [Test]
+        public async Task CookiesCanBeEnabledUsingEnvVar()
+        {
+            string oldValue = Environment.GetEnvironmentVariable("AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES");
+
+            Environment.SetEnvironmentVariable("AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES", "true");
+
+            try
+            {
+                int requestCount = 0;
+                using (TestServer testServer = new TestServer(
+                    async context =>
+                    {
+                        if (requestCount++ == 1)
+                        {
+                            Assert.IsTrue(context.Request.Headers.ContainsKey("cookie"));
+                            Assert.AreEqual("stsservicecookie=estsfd; path=/; secure; samesite=none; httponly",
+                                context.Request.Headers["cookie"]);
+                        }
+
+                        context.Response.StatusCode = 200;
+                        context.Response.Headers.Add(
+                            "set-cookie",
+                            "stsservicecookie=estsfd; path=/; secure; samesite=none; httponly");
+                        await context.Response.WriteAsync("");
+                    }))
+                {
+                    var transport = GetTransport(https: true);
+                    Request request = transport.CreateRequest();
+                    request.Method = RequestMethod.Post;
+                    request.Uri.Reset(testServer.Address);
+                    request.Content = RequestContent.Create("Hello");
+                    await ExecuteRequest(request, transport);
+
+                    // create a second request to verify cookies not set
+                    request = transport.CreateRequest();
+                    request.Method = RequestMethod.Post;
+                    request.Uri.Reset(testServer.Address);
+                    request.Content = RequestContent.Create("Hello");
+                    await ExecuteRequest(request, transport);
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AZURE_CORE_HTTPCLIENT_ENABLE_COOKIES", oldValue);
+            }
         }
 
         private static object GetHandler(HttpClient transportClient)

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -881,7 +881,6 @@ namespace Azure.Core.Tests
         public Task ThrowsTaskCanceledExceptionWhenCancelled() => ThrowsTaskCanceledExceptionWhenCancelled(false);
 
         [Test]
-        [RunOnlyOnPlatforms(Linux = true, Windows = true, OSX = false, Reason = "https://github.com/Azure/azure-sdk-for-net/issues/17986")]
         public Task ThrowsTaskCanceledExceptionWhenCancelledHttps() => ThrowsTaskCanceledExceptionWhenCancelled(true);
 
         private async Task ThrowsTaskCanceledExceptionWhenCancelled(bool https)
@@ -924,7 +923,6 @@ namespace Azure.Core.Tests
         public Task CanCancelContentUpload() => CanCancelContentUpload(false);
 
         [Test]
-        [RunOnlyOnPlatforms(Linux = true, Windows = true, OSX = false, Reason = "https://github.com/Azure/azure-sdk-for-net/issues/17986")]
         public Task CanCancelContentUploadHttps() => CanCancelContentUpload(true);
 
         private async Task CanCancelContentUpload(bool https)
@@ -995,7 +993,6 @@ namespace Azure.Core.Tests
         }
 
         [Test]
-        [RunOnlyOnPlatforms(Linux = true, Windows = true, OSX = false, Reason = "https://github.com/Azure/azure-sdk-for-net/issues/17986")]
         public async Task ServerCertificateCustomValidationCallbackIsHonored([Values(true, false)] bool setCertCallback, [Values(true, false)] bool isValidCert)
         {
             // This test assumes ServicePointManager.ServerCertificateValidationCallback will be unset.


### PR DESCRIPTION
Cookies were already disabled for HttpWebRequestTransport. This updates HttpClientTransport to also be disabled by default.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/26933