### PR TITLE
Prevent BoM upload failure on failed builds

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -109,6 +109,7 @@ jobs:
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 'Upload Package SBOM'
+        condition: succeededOrFailed()
         inputs:
           BuildDropPath: $(Build.ArtifactStagingDirectory)
 


### PR DESCRIPTION
This is the same condition fix (with the same logic) that is applied in this PR Azure/azure-sdk-for-cpp#3256