### PR TITLE
Update links in IoT generate.ps1 comments

### DIFF
--- a/sdk/deviceprovisioningservices/Microsoft.Azure.Management.DeviceProvisioningServices/src/generate.ps1
+++ b/sdk/deviceprovisioningservices/Microsoft.Azure.Management.DeviceProvisioningServices/src/generate.ps1
@@ -1,6 +1,6 @@
 # Important to note:
 # Configuration for the code generation including target swagger file and code generation settings can be found here:
-# https://github.com/Azure/azure-rest-api-specs/tree/master/specification/digitaltwins/resource-manager
+# https://github.com/Azure/azure-rest-api-specs/tree/master/specification/deviceprovisioningservices/resource-manager
 
 # If running this script fails, try running it in an admin console.
 
@@ -12,7 +12,7 @@ try
 }
 catch
 {
-	Write-Error "If you have problems running this script, see the instructions at https://github.com/Azure/adx-documentation-pr/blob/master/engineering/adx_netsdk_process.md#sdk-generation-from-updated-spec"
+	Write-Error "If you have problems running this script, see the instructions at https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/78/Mgmt-.NET-SDK-release-process"
 	Write-Error "If you get an error stating that Start-AutoRestCodeGeneration script is not available, you probably need to run:"
 	Write-Host "`t > msbuild ../../../../eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules"
 }

--- a/sdk/digitaltwins/Microsoft.Azure.Management.DigitalTwins/src/generate.ps1
+++ b/sdk/digitaltwins/Microsoft.Azure.Management.DigitalTwins/src/generate.ps1
@@ -9,7 +9,7 @@ try
 }
 catch
 {
-	Write-Error "If you have problems running this script, see the instructions at https://github.com/Azure/adx-documentation-pr/blob/master/engineering/adx_netsdk_process.md#sdk-generation-from-updated-spec"
+	Write-Error "If you have problems running this script, see the instructions at https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/78/Mgmt-.NET-SDK-release-process"
 	Write-Error "If you get an error stating that Start-AutoRestCodeGeneration script is not available, you probably need to run:"
 	Write-Host "`t > msbuild ../../../../eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules"
 }

--- a/sdk/iothub/Microsoft.Azure.Management.IotHub/src/generate.ps1
+++ b/sdk/iothub/Microsoft.Azure.Management.IotHub/src/generate.ps1
@@ -8,7 +8,7 @@ try
 }
 catch
 {
-	Write-Error "If you have problems running this script, see the instructions at https://github.com/Azure/adx-documentation-pr/blob/master/engineering/adx_netsdk_process.md#sdk-generation-from-updated-spec"
+	Write-Error "If you have problems running this script, see the instructions at https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/78/Mgmt-.NET-SDK-release-process"
 	Write-Error "If you get an error stating that Start-AutoRestCodeGeneration script is not available, you probably need to run:"
 	Write-Host "`t > msbuild ../../../../eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules"
 }


### PR DESCRIPTION
The script instructions URL is out of date, and the DPS swagger link was a copy pasta error from ADT.