### PR TITLE
feat(resourcemanager): remove duplicated `GetGenericResources` methods

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
@@ -18,10 +18,6 @@ namespace Azure.ResourceManager
         public virtual Azure.ResourceManager.Resources.Feature GetFeature(Azure.Core.ResourceIdentifier id) { throw null; }
         public virtual Azure.ResourceManager.Resources.GenericResource GetGenericResource(Azure.Core.ResourceIdentifier id) { throw null; }
         public virtual Azure.ResourceManager.Resources.GenericResourceCollection GetGenericResources() { throw null; }
-        public virtual System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.Resources.GenericResource> GetGenericResources(params Azure.Core.ResourceIdentifier[] ids) { throw null; }
-        public virtual System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.Resources.GenericResource> GetGenericResources(System.Collections.Generic.IEnumerable<Azure.Core.ResourceIdentifier> ids) { throw null; }
-        public virtual System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.Resources.GenericResource> GetGenericResources(System.Collections.Generic.IEnumerable<string> ids) { throw null; }
-        public virtual System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.Resources.GenericResource> GetGenericResources(params string[] ids) { throw null; }
         public virtual Azure.ResourceManager.Management.ManagementGroup GetManagementGroup(Azure.Core.ResourceIdentifier id) { throw null; }
         public virtual Azure.ResourceManager.Resources.ManagementGroupPolicyDefinition GetManagementGroupPolicyDefinition(Azure.Core.ResourceIdentifier id) { throw null; }
         public virtual Azure.ResourceManager.Resources.ManagementGroupPolicySetDefinition GetManagementGroupPolicySetDefinition(Azure.Core.ResourceIdentifier id) { throw null; }

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmClient.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmClient.cs
@@ -239,61 +239,6 @@ namespace Azure.ResourceManager
             return func(BaseUri, Credential, ClientOptions, Pipeline);
         }
 
-        /// <summary>
-        /// Get the operations for a list of specific resources.
-        /// </summary>
-        /// <param name="ids"> A list of the IDs of the resources to retrieve. </param>
-        /// <returns> The list of operations that can be performed over the GenericResources. </returns>
-        public virtual IReadOnlyList<GenericResource> GetGenericResources(params ResourceIdentifier[] ids)
-        {
-            return GetGenericResourceOperationsInternal(ids);
-        }
-
-        /// <summary>
-        /// Get the operations for a list of specific resources.
-        /// </summary>
-        /// <param name="ids"> A list of the IDs of the resources to retrieve. </param>
-        /// <returns> The list of operations that can be performed over the GenericResources. </returns>
-        public virtual IReadOnlyList<GenericResource> GetGenericResources(IEnumerable<ResourceIdentifier> ids)
-        {
-            return GetGenericResourceOperationsInternal(ids);
-        }
-
-        /// <summary>
-        /// Get the operations for a list of specific resources.
-        /// </summary>
-        /// <param name="ids"> A list of the IDs of the resources to retrieve. </param>
-        /// <returns> The list of operations that can be performed over the GenericResources. </returns>
-        public virtual IReadOnlyList<GenericResource> GetGenericResources(params string[] ids)
-        {
-            return GetGenericResourceOperationsInternal(ids.Select(id => new ResourceIdentifier(id)));
-        }
-
-        /// <summary>
-        /// Get the operations for a list of specific resources.
-        /// </summary>
-        /// <param name="ids"> A list of the IDs of the resources to retrieve. </param>
-        /// <returns> The list of operations that can be performed over the GenericResources. </returns>
-        public virtual IReadOnlyList<GenericResource> GetGenericResources(IEnumerable<string> ids)
-        {
-            return GetGenericResourceOperationsInternal(ids.Select(id => new ResourceIdentifier(id)));
-        }
-
-        private IReadOnlyList<GenericResource> GetGenericResourceOperationsInternal(IEnumerable<ResourceIdentifier> ids)
-        {
-            if (ids == null)
-            {
-                throw new ArgumentNullException(nameof(ids));
-            }
-
-            var genericResourceOperations = new ChangeTrackingList<GenericResource>();
-            foreach (string id in ids)
-            {
-                genericResourceOperations.Add(new GenericResource(GetDefaultSubscription(), new ResourceIdentifier(id)));
-            }
-            return genericResourceOperations;
-        }
-
         /// <summary> Gets a collection of GenericResources. </summary>
         /// <returns> An object representing collection of GenericResources and their operations. </returns>
         public virtual GenericResourceCollection GetGenericResources() => _tenant.GetGenericResources();

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Scenario/ArmClientTests.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Scenario/ArmClientTests.cs
@@ -217,36 +217,6 @@ namespace Azure.ResourceManager.Tests
         }
 
         [RecordedTest]
-        public void GetGenericOperationsTests()
-        {
-            var ids = new List<string>()
-            {
-                $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/foo-1",
-                $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/foo-2",
-                $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/foo-3",
-                $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/foo-4"
-            };
-
-            var genericResourceOperationsList = Client.GetGenericResources(ids);
-
-            int index = 0;
-            foreach (GenericResource operations in genericResourceOperationsList)
-            {
-                Assert.AreEqual(ids[index], operations.Id.ToString());
-                index++;
-            }
-
-            genericResourceOperationsList = Client.GetGenericResources(ids[0], ids[1], ids[2], ids[3]);
-
-            index = 0;
-            foreach (GenericResource operations in genericResourceOperationsList)
-            {
-                Assert.AreEqual(ids[index], operations.Id.ToString());
-                index++;
-            }
-        }
-
-        [RecordedTest]
         public void GetGenericResourcesOperationsTests()
         {
             string id = $"/subscriptions/{TestEnvironment.SubscriptionId}/providers/Microsoft.Compute/virtualMachines/myVm";
@@ -279,58 +249,10 @@ namespace Azure.ResourceManager.Tests
         }
 
         [RecordedTest]
-        public async Task GetGenericOperationsWithListOfValidResource()
-        {
-            var ids = new List<string>()
-            {
-                $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/{_rgName}"
-            };
-
-            var genericResourceOperationsList = Client.GetGenericResources(ids);
-
-            foreach (GenericResource operations in genericResourceOperationsList)
-            {
-                var genericResource = await operations.GetAsync();
-                Assert.AreEqual(200, genericResource.GetRawResponse().Status);
-            }
-        }
-
-        [RecordedTest]
-        public void GetGenericOperationsWithListOfInvalidResource()
-        {
-            var ids = new List<string>()
-            {
-                $"/subscriptions/{TestEnvironment.SubscriptionId}/resourceGroups/non-existent"
-            };
-
-            var genericResourceOperationsList = Client.GetGenericResources(ids);
-
-            foreach (GenericResource operations in genericResourceOperationsList)
-            {
-                RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () => await operations.GetAsync());
-                Assert.AreEqual(404, exception.Status);
-            }
-        }
-
-        [RecordedTest]
-        public void GetGenericResourceOperationWithNullSetOfIds()
-        {
-            string[] x = null;
-            Assert.Throws<ArgumentNullException>(() => { Client.GetGenericResources(x); });
-        }
-
-        [RecordedTest]
         public void GetGenericResourceOperationWithNullId()
         {
             ResourceIdentifier x = null;
             Assert.Throws<ArgumentNullException>(() => { Client.GetGenericResource(x); });
-        }
-
-        [RecordedTest]
-        public void GetGenericResourceOperationEmptyTest()
-        {
-            var ids = new List<string>();
-            Assert.AreEqual(new List<string>(), Client.GetGenericResources(ids));
         }
 
         [RecordedTest]


### PR DESCRIPTION
There are 5 overloaded `GetGenericResources` methods. However, they are for different purpose:
- The first 4 versions are for converting IDs to `GenericResource`
- The last one is returning the `GenericResourceCollection` instance

To prevent confusion and provide better IDE experience, we decided to remove the first 4 versions since they are convenience layer APIs. We can add them back (with different names probably) if needed.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
