### PR TITLE
Add default storage location

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -8,7 +8,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.V2020_09_15_Preview) { }
         public string ConnectionString { get { throw null; } set { } }
-        public string StorageFolder { get { throw null; } set { } }
+        public string StorageDirectory { get { throw null; } set { } }
         public Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion Version { get { throw null; } set { } }
         public enum ServiceVersion
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -8,6 +8,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.V2020_09_15_Preview) { }
         public string ConnectionString { get { throw null; } set { } }
+        public string StorageFolder { get { throw null; } set { } }
         public Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion Version { get { throw null; } set { } }
         public enum ServiceVersion
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
@@ -29,9 +29,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             var options = new AzureMonitorExporterOptions();
             configure?.Invoke(options);
 
-            if (options.StorageFolder == null)
+            if (options.StorageDirectory == null)
             {
-                options.StorageFolder = StorageHelper.GetDefaultStorageLocation();
+                options.StorageDirectory = StorageHelper.GetdefaultStorageDirectory();
             }
 
             // TODO: Pick Simple vs Batching based on AzureMonitorExporterOptions

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
@@ -30,7 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             configure?.Invoke(options);
 
             // TODO: Allow disabling offline storage.
-            // TODO: Fallback to default location if location provided by customer does not work.
+            // TODO: Fallback to default location if location provided via options does not work.
             if (options.StorageDirectory == null)
             {
                 options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
@@ -30,6 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             configure?.Invoke(options);
 
             // TODO: Allow disabling offline storage.
+            // TODO: Fallback to default location if location provided by customer does not work.
             if (options.StorageDirectory == null)
             {
                 options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
@@ -29,6 +29,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             var options = new AzureMonitorExporterOptions();
             configure?.Invoke(options);
 
+            if (options.StorageFolder == null)
+            {
+                options.StorageFolder = StorageHelper.GetDefaultStorageLocation();
+            }
+
             // TODO: Pick Simple vs Batching based on AzureMonitorExporterOptions
             return builder.AddProcessor(new BatchActivityExportProcessor(new AzureMonitorTraceExporter(options)));
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
@@ -29,6 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             var options = new AzureMonitorExporterOptions();
             configure?.Invoke(options);
 
+            // TODO: Allow disabling offline storage.
             if (options.StorageDirectory == null)
             {
                 options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
@@ -31,7 +31,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             if (options.StorageDirectory == null)
             {
-                options.StorageDirectory = StorageHelper.GetdefaultStorageDirectory();
+                options.StorageDirectory = StorageHelper.GetDefaultStorageDirectory();
             }
 
             // TODO: Pick Simple vs Batching based on AzureMonitorExporterOptions

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -47,5 +47,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             /// </summary>
             V2020_09_15_Preview = 1,
         }
+
+        public string StorageFolder { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -48,6 +48,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             V2020_09_15_Preview = 1,
         }
 
-        public string StorageFolder { get; set; }
+        public string StorageDirectory { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    internal static class StorageHelper
+    {
+        private static readonly IDictionary environmentVars = Environment.GetEnvironmentVariables();
+        private static string defaultStorageLocation;
+        private const string nonWindowsVarTmp = "/var/tmp/";
+        private const string nonWindowsTmp = "/tmp/";
+
+        internal static string GetDefaultStorageLocation()
+        {
+            if (defaultStorageLocation != null)
+            {
+                return defaultStorageLocation;
+            }
+            else
+            {
+                bool result;
+                if (IsWindowsOS())
+                {
+                    string localAppData = GetTelemetrySubDirectory(environmentVars["LOCALAPPDATA"].ToString());
+                    if (localAppData != null)
+                    {
+                        result = TryCreateTelemetryFolder(localAppData);
+                        if (result)
+                        {
+                            defaultStorageLocation = localAppData;
+                            return defaultStorageLocation;
+                        }
+
+                        string temp = GetTelemetrySubDirectory(environmentVars["TEMP"].ToString());
+                        result = TryCreateTelemetryFolder(temp);
+                        if (result)
+                        {
+                            defaultStorageLocation = temp;
+                            return defaultStorageLocation;
+                        }
+                    }
+                }
+                else
+                {
+                    string tmpdir = GetTelemetrySubDirectory(environmentVars["TMPDIR"].ToString());
+                    if (tmpdir != null)
+                    {
+                        result = TryCreateTelemetryFolder(tmpdir);
+                        if (result)
+                        {
+                            defaultStorageLocation = tmpdir;
+                            return defaultStorageLocation;
+                        }
+                    }
+
+                    string usrTmp = GetTelemetrySubDirectory(nonWindowsVarTmp);
+                    result = TryCreateTelemetryFolder(usrTmp);
+                    if (result)
+                    {
+                        defaultStorageLocation = usrTmp;
+                        return defaultStorageLocation;
+                    }
+
+                    string tmp = GetTelemetrySubDirectory(nonWindowsTmp);
+                    result = TryCreateTelemetryFolder(tmp);
+                    if (result)
+                    {
+                        defaultStorageLocation = tmp;
+                        return defaultStorageLocation;
+                    }
+                }
+
+                return defaultStorageLocation;
+            }
+        }
+
+        private static string GetTelemetrySubDirectory(string temp)
+        {
+            return Path.Combine(temp, "Microsoft", "ApplicationInsights");
+        }
+
+        private static bool TryCreateTelemetryFolder(string path)
+        {
+            try
+            {
+                Directory.CreateDirectory(path);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AzureMonitorExporterEventSource.Log.Write($"ErrorCreatingDefaultStorageFolder{EventLevelSuffix.Error}", $"{ex.ToInvariantString()}");
+                return false;
+            }
+        }
+
+        internal static bool IsWindowsOS()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
@@ -84,7 +84,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// Creates directory for storing telemetry.
         /// </summary>
         /// <param name="path">Base directory.</param>
-        /// <returns></returns>
+        /// <returns>Directory path if it is created else null.</returns>
         private static string TryCreateTelemetryFolder(string path)
         {
             try

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
@@ -32,7 +32,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                         folderPath = TryCreateTelemetryFolder(localAppData);
                         if (folderPath != null)
                         {
-                            defaultStorageLocation = localAppData;
+                            defaultStorageLocation = folderPath;
                             return defaultStorageLocation;
                         }
 
@@ -42,7 +42,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                             folderPath = TryCreateTelemetryFolder(temp);
                             if (folderPath != null)
                             {
-                                defaultStorageLocation = temp;
+                                defaultStorageLocation = folderPath;
                                 return defaultStorageLocation;
                             }
                         }
@@ -56,7 +56,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                         folderPath = TryCreateTelemetryFolder(tmpdir);
                         if (folderPath != null)
                         {
-                            defaultStorageLocation = tmpdir;
+                            defaultStorageLocation = folderPath;
                             return defaultStorageLocation;
                         }
                     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
@@ -23,54 +23,55 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
             else
             {
-                bool result;
+                string folderPath;
                 if (IsWindowsOS())
                 {
-                    string localAppData = GetTelemetrySubDirectory(environmentVars["LOCALAPPDATA"].ToString());
+                    string localAppData = environmentVars["LOCALAPPDATA"].ToString();
                     if (localAppData != null)
                     {
-                        result = TryCreateTelemetryFolder(localAppData);
-                        if (result)
+                        folderPath = TryCreateTelemetryFolder(localAppData);
+                        if (folderPath != null)
                         {
                             defaultStorageLocation = localAppData;
                             return defaultStorageLocation;
                         }
 
-                        string temp = GetTelemetrySubDirectory(environmentVars["TEMP"].ToString());
-                        result = TryCreateTelemetryFolder(temp);
-                        if (result)
+                        string temp = environmentVars["TEMP"].ToString();
+                        if (temp != null)
                         {
-                            defaultStorageLocation = temp;
-                            return defaultStorageLocation;
+                            folderPath = TryCreateTelemetryFolder(temp);
+                            if (folderPath != null)
+                            {
+                                defaultStorageLocation = temp;
+                                return defaultStorageLocation;
+                            }
                         }
                     }
                 }
                 else
                 {
-                    string tmpdir = GetTelemetrySubDirectory(environmentVars["TMPDIR"].ToString());
+                    string tmpdir = environmentVars["TMPDIR"].ToString();
                     if (tmpdir != null)
                     {
-                        result = TryCreateTelemetryFolder(tmpdir);
-                        if (result)
+                        folderPath = TryCreateTelemetryFolder(tmpdir);
+                        if (folderPath != null)
                         {
                             defaultStorageLocation = tmpdir;
                             return defaultStorageLocation;
                         }
                     }
 
-                    string usrTmp = GetTelemetrySubDirectory(nonWindowsVarTmp);
-                    result = TryCreateTelemetryFolder(usrTmp);
-                    if (result)
+                    folderPath = TryCreateTelemetryFolder(nonWindowsVarTmp);
+                    if (folderPath != null)
                     {
-                        defaultStorageLocation = usrTmp;
+                        defaultStorageLocation = folderPath;
                         return defaultStorageLocation;
                     }
 
-                    string tmp = GetTelemetrySubDirectory(nonWindowsTmp);
-                    result = TryCreateTelemetryFolder(tmp);
-                    if (result)
+                    folderPath = TryCreateTelemetryFolder(nonWindowsTmp);
+                    if (folderPath != null)
                     {
-                        defaultStorageLocation = tmp;
+                        defaultStorageLocation = folderPath;
                         return defaultStorageLocation;
                     }
                 }
@@ -79,22 +80,23 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             }
         }
 
-        private static string GetTelemetrySubDirectory(string temp)
-        {
-            return Path.Combine(temp, "Microsoft", "ApplicationInsights");
-        }
-
-        private static bool TryCreateTelemetryFolder(string path)
+        /// <summary>
+        /// Creates directory for storing telemetry.
+        /// </summary>
+        /// <param name="path">Base directory.</param>
+        /// <returns></returns>
+        private static string TryCreateTelemetryFolder(string path)
         {
             try
             {
-                Directory.CreateDirectory(path);
-                return true;
+                string telemetryPath = Path.Combine(path, "Microsoft", "ApplicationInsights");
+                Directory.CreateDirectory(telemetryPath);
+                return telemetryPath;
             }
             catch (Exception ex)
             {
                 AzureMonitorExporterEventSource.Log.Write($"ErrorCreatingDefaultStorageFolder{EventLevelSuffix.Error}", $"{ex.ToInvariantString()}");
-                return false;
+                return null;
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
@@ -10,7 +10,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 {
     internal static class StorageHelper
     {
-        private static readonly IDictionary environmentVars = Environment.GetEnvironmentVariables();
         private static string defaultStorageLocation;
         private const string nonWindowsVarTmp = "/var/tmp/";
         private const string nonWindowsTmp = "/tmp/";
@@ -24,6 +23,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             else
             {
                 string folderPath;
+                IDictionary environmentVars = Environment.GetEnvironmentVariables();
+
                 if (IsWindowsOS())
                 {
                     string localAppData = environmentVars["LOCALAPPDATA"].ToString();

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
@@ -14,7 +14,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private const string nonWindowsVarTmp = "/var/tmp/";
         private const string nonWindowsTmp = "/tmp/";
 
-        internal static string GetdefaultStorageDirectory()
+        internal static string GetDefaultStorageDirectory()
         {
             if (defaultStorageDirectory != null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
@@ -12,6 +12,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         private static string defaultStorageDirectory;
         private const string nonWindowsVarTmp = "/var/tmp/";
+
+        // TODO: investigate if /tmp/ should be used.
         private const string nonWindowsTmp = "/tmp/";
 
         internal static string GetDefaultStorageDirectory()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageHelper.cs
@@ -10,19 +10,19 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 {
     internal static class StorageHelper
     {
-        private static string defaultStorageLocation;
+        private static string defaultStorageDirectory;
         private const string nonWindowsVarTmp = "/var/tmp/";
         private const string nonWindowsTmp = "/tmp/";
 
-        internal static string GetDefaultStorageLocation()
+        internal static string GetdefaultStorageDirectory()
         {
-            if (defaultStorageLocation != null)
+            if (defaultStorageDirectory != null)
             {
-                return defaultStorageLocation;
+                return defaultStorageDirectory;
             }
             else
             {
-                string folderPath;
+                string dirPath;
                 IDictionary environmentVars = Environment.GetEnvironmentVariables();
 
                 if (IsWindowsOS())
@@ -30,21 +30,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     string localAppData = environmentVars["LOCALAPPDATA"].ToString();
                     if (localAppData != null)
                     {
-                        folderPath = TryCreateTelemetryFolder(localAppData);
-                        if (folderPath != null)
+                        dirPath = CreateTelemetryDirectory(localAppData);
+                        if (dirPath != null)
                         {
-                            defaultStorageLocation = folderPath;
-                            return defaultStorageLocation;
+                            defaultStorageDirectory = dirPath;
+                            return defaultStorageDirectory;
                         }
 
                         string temp = environmentVars["TEMP"].ToString();
                         if (temp != null)
                         {
-                            folderPath = TryCreateTelemetryFolder(temp);
-                            if (folderPath != null)
+                            dirPath = CreateTelemetryDirectory(temp);
+                            if (dirPath != null)
                             {
-                                defaultStorageLocation = folderPath;
-                                return defaultStorageLocation;
+                                defaultStorageDirectory = dirPath;
+                                return defaultStorageDirectory;
                             }
                         }
                     }
@@ -54,30 +54,30 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     string tmpdir = environmentVars["TMPDIR"].ToString();
                     if (tmpdir != null)
                     {
-                        folderPath = TryCreateTelemetryFolder(tmpdir);
-                        if (folderPath != null)
+                        dirPath = CreateTelemetryDirectory(tmpdir);
+                        if (dirPath != null)
                         {
-                            defaultStorageLocation = folderPath;
-                            return defaultStorageLocation;
+                            defaultStorageDirectory = dirPath;
+                            return defaultStorageDirectory;
                         }
                     }
 
-                    folderPath = TryCreateTelemetryFolder(nonWindowsVarTmp);
-                    if (folderPath != null)
+                    dirPath = CreateTelemetryDirectory(nonWindowsVarTmp);
+                    if (dirPath != null)
                     {
-                        defaultStorageLocation = folderPath;
-                        return defaultStorageLocation;
+                        defaultStorageDirectory = dirPath;
+                        return defaultStorageDirectory;
                     }
 
-                    folderPath = TryCreateTelemetryFolder(nonWindowsTmp);
-                    if (folderPath != null)
+                    dirPath = CreateTelemetryDirectory(nonWindowsTmp);
+                    if (dirPath != null)
                     {
-                        defaultStorageLocation = folderPath;
-                        return defaultStorageLocation;
+                        defaultStorageDirectory = dirPath;
+                        return defaultStorageDirectory;
                     }
                 }
 
-                return defaultStorageLocation;
+                return defaultStorageDirectory;
             }
         }
 
@@ -86,13 +86,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// </summary>
         /// <param name="path">Base directory.</param>
         /// <returns>Directory path if it is created else null.</returns>
-        private static string TryCreateTelemetryFolder(string path)
+        private static string CreateTelemetryDirectory(string path)
         {
             try
             {
-                string telemetryPath = Path.Combine(path, "Microsoft", "ApplicationInsights");
-                Directory.CreateDirectory(telemetryPath);
-                return telemetryPath;
+                string telemetryDirPath = Path.Combine(path, "Microsoft", "ApplicationInsights");
+                Directory.CreateDirectory(telemetryDirPath);
+                return telemetryDirPath;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
* Adds `StorageFolder` as option to provide location for saving telemetry offline.
* If `StorageFolder` is not provided then following default base locations will be used:

For **Windows**:
* %LOCALAPPDATA%\Microsoft\ApplicationInsights
* %TEMP%\Microsoft\ApplicationInsights

For **NonWindows**:
* %TMPDIR%/Microsoft/ApplicationInsights
* /var/tmp/Microsoft/ApplicationInsights
* /tmp/Microsoft/ApplicationInsights

**Open Question**: 
1. Should we use same folder location for traces/logs/metrics or separate folder for each (e.g.  %LOCALAPPDATA%\Microsoft\ApplicationInsights\traces,  %LOCALAPPDATA%\Microsoft\ApplicationInsights\metrics).

* Having separate location for each type will result in offline telemetry transmitted by their respective exporters. TraceExporter will not be able to transmit telemetry stored offline by MetricExporter.

**NOTE:**: Using this default base location, a subdirectory will be created by persistent storage based on application.
E.g.
Telemetry for AppA will be stored in %LOCALAPPDATA%\Microsoft\ApplicationInsights\aedb383c9dd16b651394c322cf3c5eafccd12daf81246dd930e905661a8c4edd

and AppB will be stored in 
%LOCALAPPDATA%\Microsoft\ApplicationInsights\abdcc83c9dd16b6cbdbbd1246dd930e905661a8c4edd

TODO;
Add tests
Add security for directory in windows