### PR TITLE
[Service Bus] Enhance Client Options Member Documentation

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -160,7 +160,7 @@ namespace Azure.Messaging.ServiceBus
         /// <remarks>The message renew can continue for sometime in the background
         /// after completion of message and result in a few false MessageLockLostExceptions temporarily.</remarks>
         /// <value>
-        /// The maximum duration for lock renewal can be set using <see cref="ServiceBusProcessorOptions.MaxAutoLockRenewalDuration"/>
+        /// The maximum duration for lock renewal is specified using <see cref="ServiceBusProcessorOptions.MaxAutoLockRenewalDuration"/>
         /// and has a default value of 5 minutes.
         /// </value>
         public virtual TimeSpan MaxAutoLockRenewalDuration { get; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -76,6 +76,10 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets the <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.
         /// </summary>
+        /// <value>
+        /// The receive mode can be set using <see cref="ServiceBusProcessorOptions.ReceiveMode"/>
+        /// and has a default mode of <see cref="ServiceBusReceiveMode.PeekLock"/>.
+        /// </value>
         public virtual ServiceBusReceiveMode ReceiveMode { get; }
 
         /// <summary>
@@ -88,6 +92,10 @@ namespace Azure.Messaging.ServiceBus
         /// during processing. This is intended to help maximize throughput by allowing the
         /// processor to receive from a local cache rather than waiting on a service request.
         /// </summary>
+        /// <value>
+        /// The prefetch count is specified using <see cref="ServiceBusProcessorOptions.PrefetchCount"/>
+        /// and has a default value of 0.
+        /// </value>
         public virtual int PrefetchCount { get; }
 
         /// <summary>
@@ -110,8 +118,10 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets the maximum number of concurrent calls to the
         /// <see cref="ProcessMessageAsync"/> message handler the processor should initiate.
         /// </summary>
-        ///
-        /// <value>The maximum number of concurrent calls to the message handler.</value>
+        /// <value>
+        /// The number of maximum concurrent calls is specified using <see cref="ServiceBusProcessorOptions.MaxConcurrentCalls"/>
+        /// and has a default value of 1.
+        /// </value>
         public virtual int MaxConcurrentCalls => _maxConcurrentCalls;
         private volatile int _maxConcurrentCalls;
         private int _currentConcurrentCalls;
@@ -137,20 +147,22 @@ namespace Azure.Messaging.ServiceBus
         /// If the message handler triggers an exception and did not settle the message,
         /// then the message will be automatically abandoned, irrespective of <see cref= "AutoCompleteMessages" />.
         /// </remarks>
-        ///
-        /// <value>true to complete the message processing automatically on
-        /// successful execution of the operation; otherwise, false.</value>
+        /// <value>
+        /// The option to auto complete messages is specified using <see cref="ServiceBusProcessorOptions.AutoCompleteMessages"/>
+        /// and has a default value of <c>true</c>.
+        /// </value>
         public virtual bool AutoCompleteMessages { get; }
 
         /// <summary>
         /// Gets the maximum duration within which the lock will be renewed automatically. This
         /// value should be greater than the longest message lock duration; for example, the LockDuration Property.
         /// </summary>
-        ///
-        /// <value>The maximum duration during which locks are automatically renewed.</value>
-        ///
         /// <remarks>The message renew can continue for sometime in the background
         /// after completion of message and result in a few false MessageLockLostExceptions temporarily.</remarks>
+        /// <value>
+        /// The maximum duration for lock renewal can be set using <see cref="ServiceBusProcessorOptions.MaxAutoLockRenewalDuration"/>
+        /// and has a default value of 5 minutes.
+        /// </value>
         public virtual TimeSpan MaxAutoLockRenewalDuration { get; }
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -77,7 +77,7 @@ namespace Azure.Messaging.ServiceBus
         /// Gets the <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.
         /// </summary>
         /// <value>
-        /// The receive mode can be set using <see cref="ServiceBusProcessorOptions.ReceiveMode"/>
+        /// The receive mode is specified using <see cref="ServiceBusProcessorOptions.ReceiveMode"/>
         /// and has a default mode of <see cref="ServiceBusReceiveMode.PeekLock"/>.
         /// </value>
         public virtual ServiceBusReceiveMode ReceiveMode { get; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -37,8 +37,13 @@ namespace Azure.Messaging.ServiceBus
         public virtual string EntityPath { get; }
 
         /// <summary>
-        /// The <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.
+        /// The <see cref="ReceiveMode"/> used to specify how messages are received.
         /// </summary>
+        /// <value>
+        /// The option to auto complete messages is specified when creating the receiver
+        /// using <see cref="ServiceBusReceiverOptions.ReceiveMode"/> and has a default mode of
+        /// <see cref="ServiceBusReceiveMode.PeekLock"/>.
+        /// </value>
         public virtual ServiceBusReceiveMode ReceiveMode { get; }
 
         /// <summary>
@@ -49,8 +54,12 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// The number of messages that will be eagerly requested from Queues or Subscriptions and queued locally without regard to
         /// whether a processing is currently active, intended to help maximize throughput by allowing the receiver to receive
-        /// from a local cache rather than waiting on a service request.
+        /// from a local cache rather than waiting on a service request
         /// </summary>
+        /// <value>
+        /// The option to auto complete messages is specified when creating the receiver
+        /// using <see cref="ServiceBusReceiverOptions.PrefetchCount"/> and has a default value of 0.
+        /// </value>
         public virtual int PrefetchCount { get; }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to document client members where values are specified by one of the option types to make it clear where they can be set and what their default values are.

# References and Related
- [Default value of ServiceBusProcessor.PrefetchCount? (#26557)](https://github.com/Azure/azure-sdk-for-net/issues/26557)
- [Default value of ServiceBusProcessor.MaxConcurrentCalls (#26558)](https://github.com/Azure/azure-sdk-for-net/issues/26558)