### PR TITLE
[Experiment] Gen 1 convenience method calling Data Plane Generated protocol method

### DIFF
--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Generated/ContainerRegistryRestClient.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Generated/ContainerRegistryRestClient.cs
@@ -470,6 +470,38 @@ namespace Azure.Containers.ContainerRegistry
             }
         }
 
+        internal HttpMessage CreateGetPropertiesRequest(string name, RequestContext context)
+        {
+            var message = _pipeline.CreateMessage();
+            var request = message.Request;
+            request.Method = RequestMethod.Get;
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(url, false);
+            uri.AppendPath("/acr/v1/", false);
+            uri.AppendPath(name, true);
+            uri.AppendQuery("api-version", apiVersion, true);
+            request.Uri = uri;
+            request.Headers.Add("Accept", "application/json");
+            return message;
+        }
+
+
+        public async Task<Response> GetPropertiesAsync(string name, RequestContext context = default)
+        {
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ContainerRepository)}.{nameof(GetProperties)}");
+            scope.Start();
+            try
+            {
+                using HttpMessage message = CreateGetPropertiesRequest(name, context);
+                return await _pipeline.ProcessMessageAsync(message, _clientDiagnostics, context).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                scope.Failed(e);
+                throw;
+            }
+        }
+
         internal HttpMessage CreateDeleteRepositoryRequest(string name)
         {
             var message = _pipeline.CreateMessage();

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Generated/Models/ContainerRepositoryProperties.Serialization.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Generated/Models/ContainerRepositoryProperties.Serialization.cs
@@ -13,6 +13,12 @@ namespace Azure.Containers.ContainerRegistry
 {
     public partial class ContainerRepositoryProperties
     {
+        internal static ContainerRepositoryProperties FromResponse(Response response)
+        {
+            var doc = JsonDocument.Parse(response.Content.ToString());
+            return DeserializeContainerRepositoryProperties(doc.RootElement);
+        }
+
         internal static ContainerRepositoryProperties DeserializeContainerRepositoryProperties(JsonElement element)
         {
             string registry = default;

--- a/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Repository/ContainerRepository.cs
+++ b/sdk/containerregistry/Azure.Containers.ContainerRegistry/src/Repository/ContainerRepository.cs
@@ -76,17 +76,20 @@ namespace Azure.Containers.ContainerRegistry
         /// <exception cref="RequestFailedException">Thrown when a failure is returned by the Container Registry service.</exception>
         public virtual async Task<Response<ContainerRepositoryProperties>> GetPropertiesAsync(CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(ContainerRepository)}.{nameof(GetProperties)}");
-            scope.Start();
-            try
+            RequestContext context = new RequestContext()
             {
-                return await _restClient.GetPropertiesAsync(Name, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                scope.Failed(e);
-                throw;
-            }
+                CancellationToken = cancellationToken,
+                ErrorOptions = ErrorOptions.NoThrow
+            };
+
+            // Call LLC service method
+            Response response = await _restClient.GetPropertiesAsync(Name, context).ConfigureAwait(false);
+
+            // Deserialize model type
+            ContainerRepositoryProperties value = ContainerRepositoryProperties.FromResponse(response);
+
+            // Create Response<T> to return
+            return Response.FromValue(value, response);
         }
 
         /// <summary> Get the properties of the repository. </summary>


### PR DESCRIPTION
This experiment illustrates how a Generation 1 Convenience Client could call a Data Plane Generated protocol method, using the ACR library as an example.  It addresses:
- Configuring `RequestContext`
- Calling the protocol method
- Deserializing the model from `Response`
- Creating a `Response<T>` for the HLC Convenience layer