### PR TITLE
Document how to select non-default AAD tenant

### DIFF
--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -78,6 +78,8 @@ The `DefaultAzureCredential` will attempt to authenticate via the following mech
  - Azure PowerShell - If the developer has authenticated an account via the Azure PowerShell `Connect-AzAccount` command, the `DefaultAzureCredential` will authenticate with that account.
  - Interactive - If enabled the `DefaultAzureCredential` will interactively authenticate the developer via the current system's default browser.
 
+> Override the default Azure Active Directory tenant by using the setting the `AZURE_TENANT_ID` environment variable or providing the `DefaultAzureCredential` constructor with `DefaultAzureCredentialOptions` and provide the tenant Id like `new DefaultAzureCredentialOptions( VisualStudioCodeTenantId = tenantId)`.
+
 ## Examples
 
 ### Authenticating with the `DefaultAzureCredential`

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -78,7 +78,7 @@ The `DefaultAzureCredential` will attempt to authenticate via the following mech
  - Azure PowerShell - If the developer has authenticated an account via the Azure PowerShell `Connect-AzAccount` command, the `DefaultAzureCredential` will authenticate with that account.
  - Interactive - If enabled the `DefaultAzureCredential` will interactively authenticate the developer via the current system's default browser.
 
-> Override the default Azure Active Directory tenant by using the setting the `AZURE_TENANT_ID` environment variable or providing the `DefaultAzureCredential` constructor with `DefaultAzureCredentialOptions` and provide the tenant Id like `new DefaultAzureCredentialOptions( VisualStudioCodeTenantId = tenantId)`.
+> Override the default Azure Active Directory tenant by setting the `AZURE_TENANT_ID` environment variable or by configuring one of the TenantId properties on `DefaultAzureCredentialOptions`. For example: `new DefaultAzureCredentialOptions( VisualStudioCodeTenantId = tenantId)`.
 
 ## Examples
 


### PR DESCRIPTION
If you have more than one AAD tenant, the default one is selected, which results authentication error for DefaultAzureCredential.
