### PR TITLE
Azure.ResourceManager.Compute added to storage sln

### DIFF
--- a/sdk/storage/Azure.Storage.sln
+++ b/sdk/storage/Azure.Storage.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.352
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32002.185
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Storage.Common", "Azure.Storage.Common\src\Azure.Storage.Common.csproj", "{6890AA6B-C71C-48A0-BE49-E0D5AD4E914F}"
 EndProject
@@ -131,9 +131,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Perf", "Perf", "{FBC7A205-B
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Management.Storage", "Microsoft.Azure.Management.Storage\src\Microsoft.Azure.Management.Storage.csproj", "{AD469AF8-0675-4159-A5B7-F486E48B29CE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Test.HttpRecorder", "..\mgmtcommon\TestFramework\Microsoft.Azure.Test.HttpRecorder\Microsoft.Azure.Test.HttpRecorder.csproj", "{11D040BC-3A89-4BA1-A2C7-90A83A872555}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Test.HttpRecorder", "..\mgmtcommon\TestFramework\Microsoft.Azure.Test.HttpRecorder\Microsoft.Azure.Test.HttpRecorder.csproj", "{11D040BC-3A89-4BA1-A2C7-90A83A872555}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Rest.ClientRuntime.Azure.TestFramework", "..\mgmtcommon\TestFramework\ClientRuntime.Azure.TestFramework\Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj", "{AC65C1AC-82F8-482B-B88D-FA9E752D1BC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Azure.TestFramework", "..\mgmtcommon\TestFramework\ClientRuntime.Azure.TestFramework\Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj", "{AC65C1AC-82F8-482B-B88D-FA9E752D1BC7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager.Compute", "..\compute\Azure.ResourceManager.Compute\src\Azure.ResourceManager.Compute.csproj", "{AF72CEB5-9AED-42BF-8DF3-153F0AF3E7C5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ResourceManager", "..\resourcemanager\Azure.ResourceManager\src\Azure.ResourceManager.csproj", "{F8687F5E-8DE0-4A85-BE98-DA0C2B131129}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -141,10 +145,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9056EE3A-9ED4-441A-9A88-A567ED07DDDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9056EE3A-9ED4-441A-9A88-A567ED07DDDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9056EE3A-9ED4-441A-9A88-A567ED07DDDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9056EE3A-9ED4-441A-9A88-A567ED07DDDD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6890AA6B-C71C-48A0-BE49-E0D5AD4E914F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6890AA6B-C71C-48A0-BE49-E0D5AD4E914F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6890AA6B-C71C-48A0-BE49-E0D5AD4E914F}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -277,6 +277,14 @@ Global
 		{AC65C1AC-82F8-482B-B88D-FA9E752D1BC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC65C1AC-82F8-482B-B88D-FA9E752D1BC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC65C1AC-82F8-482B-B88D-FA9E752D1BC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF72CEB5-9AED-42BF-8DF3-153F0AF3E7C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF72CEB5-9AED-42BF-8DF3-153F0AF3E7C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF72CEB5-9AED-42BF-8DF3-153F0AF3E7C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF72CEB5-9AED-42BF-8DF3-153F0AF3E7C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8687F5E-8DE0-4A85-BE98-DA0C2B131129}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8687F5E-8DE0-4A85-BE98-DA0C2B131129}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8687F5E-8DE0-4A85-BE98-DA0C2B131129}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8687F5E-8DE0-4A85-BE98-DA0C2B131129}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds project references to Azure.Storage.sln to fix visual studio reference issue. Should not affect code in any way but will allow visual studio to load in these projects for compilation.