### PR TITLE
Add events support to DiagnosticScope

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientDiagnosticListener.cs
@@ -60,11 +60,14 @@ namespace Azure.Core.Tests
                 if (value.Key.EndsWith(startSuffix))
                 {
                     var name = value.Key.Substring(0, value.Key.Length - startSuffix.Length);
-                    PropertyInfo propertyInfo = value.Value.GetType().GetTypeInfo().GetDeclaredProperty("Links");
-                    var links = propertyInfo?.GetValue(value.Value) as IEnumerable<Activity> ?? Array.Empty<Activity>();
+                    PropertyInfo linksPropertyInfo = value.Value.GetType().GetTypeInfo().GetDeclaredProperty("Links");
+                    var links = linksPropertyInfo?.GetValue(value.Value) as IEnumerable<Activity> ?? Array.Empty<Activity>();
 
                     var scope = new ProducedDiagnosticScope()
                     {
+#if NET6_0_OR_GREATER
+                        Events = Activity.Current.Events,
+#endif
                         Name = name,
                         Activity = Activity.Current,
                         Links = links.Select(a => new ProducedLink(a.ParentId, a.TraceStateString)).ToList(),
@@ -236,7 +239,9 @@ namespace Azure.Core.Tests
             public Exception Exception { get; set; }
             public List<ProducedLink> Links { get; set; } = new List<ProducedLink>();
             public List<Activity> LinkedActivities { get; set; } = new List<Activity>();
-
+#if NET5_0_OR_GREATER
+            public IEnumerable<ActivityEvent> Events { get; set; } = new List<ActivityEvent>();
+#endif
             public override string ToString()
             {
                 return Name;

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -552,12 +552,10 @@ namespace Azure.Core.Pipeline
                     var tagsParameter = Expression.Parameter(typeof(object));
 
                     ActivityAddEventMethod = Expression.Lambda<Action<Activity, string, DateTimeOffset, object?>>(
-                            //Expression.TryCatch(
                             Expression.Call(ActivityParameter, method,
                                 Expression.Convert(
                                     Expression.New(ctor, nameParameter, timestampParameter, Expression.Convert(tagsParameter, ActivityTagsCollectionType)),
                                     ActivityEventType!)),
-                        /*Expression.Catch(typeof(Exception), Expression.Default(typeof(object)))),*/
                              ActivityParameter, nameParameter, timestampParameter, tagsParameter).Compile();
                 }
             }

--- a/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientDiagnosticsTests.cs
@@ -243,5 +243,70 @@ namespace Azure.Core.Tests
 
             Assert.AreEqual(2, testListener.Sources.Count);
         }
+
+#if !NET5_0_OR_GREATER
+        [Test]
+        public void AddEventIsNoop()
+        {
+            using var testListener = new TestDiagnosticListener("Azure.Clients");
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
+
+            scope.Start();
+            Assert.DoesNotThrow( () => scope.AddEvent("test", default(DateTimeOffset), null));
+            scope.Dispose();
+        }
+#endif
+
+#if NET5_0_OR_GREATER
+        [Test]
+        public void StartDiagnosticSourceActivityAndAddEvent()
+        {
+            using var testListener = new TestDiagnosticListener("Azure.Clients");
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
+            scope.Start();
+
+            DateTimeOffset ts = DateTimeOffset.UtcNow.AddMinutes(-1);
+            var attrbutes = new Dictionary<string, object>();
+            attrbutes.Add("Attribute1", "Value1");
+            attrbutes.Add("Attribute2", 2);
+
+            scope.AddEvent("test1", default(DateTimeOffset), null);
+            scope.AddEvent("test2", ts, attrbutes);
+
+            Activity activity = Activity.Current;
+            scope.Dispose();
+
+            Assert.AreEqual(2, activity.Events.Count());
+            ActivityEvent event1 = activity.Events.First();
+            ActivityEvent event2 = activity.Events.Last();
+
+            Assert.AreEqual("test1", event1.Name);
+            Assert.AreEqual("test2", event2.Name);
+            Assert.AreNotEqual(default, event1.Timestamp);
+            Assert.AreEqual(ts, event2.Timestamp);
+
+            Assert.IsEmpty(event1.Tags);
+            CollectionAssert.AreEquivalent(attrbutes, event2.Tags);
+        }
+
+        [Test]
+        public void StartDiagnosticSourceActivityAddEventBeforeStartIsIgnored()
+        {
+            using var testListener = new TestDiagnosticListener("Azure.Clients");
+            DiagnosticScopeFactory clientDiagnostics = new DiagnosticScopeFactory("Azure.Clients", "Microsoft.Azure.Core.Cool.Tests", true);
+
+            DiagnosticScope scope = clientDiagnostics.CreateScope("ActivityName");
+            scope.AddEvent("test", default(DateTimeOffset), null);
+            scope.Start();
+            Activity activity = Activity.Current;
+            scope.Dispose();
+
+            Assert.IsEmpty(activity.Events);
+        }
+#endif
     }
 }


### PR DESCRIPTION
Introduces `DiagnosticScope.AddEvent` method to enable Cosmos SDK tracing needs.