### PR TITLE
Fix Microsoft.Extensions.Azure reference in README

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/README.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/README.md
@@ -1,6 +1,6 @@
 # Azure client library integration for ASP.NET Core
 
-Microsoft.Extensions.Azure.Core provides shared primitives to integrate Azure clients with ASP.NET Core [dependency injection][dependency_injection] and [configuration][configuration] systems.
+Microsoft.Extensions.Azure provides shared primitives to integrate Azure clients with ASP.NET Core [dependency injection][dependency_injection] and [configuration][configuration] systems.
 
 [Source code][source_root] | [Package (NuGet)][package]
 


### PR DESCRIPTION
The README mistakenly referred to the package as Microsoft.Extensions.Azure.Core (no ".Core").
