### PR TITLE
OpenRead Avoid Unnecessary Rebuffer

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.Clients.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.Clients.cs
@@ -16,9 +16,6 @@ namespace Azure.Storage
         public static ArgumentException CannotBothBeNotNull(string param0, string param1)
             => new ArgumentException($"{param0} and {param1} cannot both be set");
 
-        public static ArgumentException InvalidArgument(string paramName)
-            => new ArgumentException($"{paramName} is invalid");
-
         public static ArgumentOutOfRangeException MustBeGreaterThanOrEqualTo(string paramName, long value)
             => new ArgumentOutOfRangeException(paramName, $"Value must be greater than or equal to {value}");
 
@@ -111,9 +108,6 @@ namespace Azure.Storage
                 new ResponseError(
                     response.GetErrorCode(null),
                     $"Response x-ms-client-request-id '{echo}' does not match the original expected request id, '{original}'."));
-
-        public static ArgumentException CannotDeferTransactionalHashVerification()
-            => new ArgumentException("Cannot defer transactional hash verification. Returned hash is unavailable to caller.");
 
         public static ArgumentException TransactionalHashingNotSupportedWithClientSideEncryption()
             => new ArgumentException("Client-side encryption and transactional hashing are not supported at the same time.");

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Errors.cs
@@ -25,6 +25,9 @@ namespace Azure.Storage
         public static ArgumentNullException ArgumentNull(string paramName)
             => new ArgumentNullException(paramName);
 
+        public static ArgumentException InvalidArgument(string paramName)
+            => new ArgumentException($"{paramName} is invalid");
+
         public static ArgumentException InvalidResourceType(char s)
             => new ArgumentException($"Invalid resource type: '{s}'");
 
@@ -51,6 +54,9 @@ namespace Azure.Storage
 
         public static ArgumentException PrecalculatedHashNotSupportedOnSplit()
             => new ArgumentException("Precalculated hash not supported when potentially partitioning an upload.");
+
+        public static ArgumentException CannotDeferTransactionalHashVerification()
+            => new ArgumentException("Cannot defer transactional hash verification. Returned hash is unavailable to caller.");
 
         internal static void VerifyStreamPosition(Stream stream, string streamName)
         {

--- a/sdk/storage/Azure.Storage.Common/src/Shared/LazyLoadingReadOnlyStream.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/LazyLoadingReadOnlyStream.cs
@@ -186,7 +186,7 @@ namespace Azure.Storage
                 }
             }
 
-            if (_bufferPosition == 0 || _bufferPosition == _bufferLength || _bufferInvalidated)
+            if (_bufferPosition == _bufferLength || _bufferInvalidated)
             {
                 int lastDownloadedBytes = await DownloadInternal(async, cancellationToken).ConfigureAwait(false);
                 if (lastDownloadedBytes == 0)
@@ -387,7 +387,7 @@ namespace Azure.Storage
 
             // newPosition is less than _position, but within _buffer.
             long beginningOfBuffer = _position - _bufferPosition;
-            if (newPosition < _position && newPosition > beginningOfBuffer)
+            if (newPosition < _position && newPosition >= beginningOfBuffer)
             {
                 _bufferPosition = (int)(newPosition - beginningOfBuffer);
                 _position = newPosition;

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -15,7 +15,11 @@
     <ProjectReference Include="..\..\Azure.Storage.Files.Shares\src\Azure.Storage.Files.Shares.csproj" />
     <Compile Include="$(AzureCoreSharedSources)AppContextSwitchHelper.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared\Core" />
+    <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared\Core" />
+    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared\Core" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="Shared\Core" />
+    <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared\Core" />
     <Compile Remove="Shared\AzuriteFixture.cs" />
     <Compile Remove="Shared\AzuriteNUnitFixture.cs" />
     <Compile Remove="Shared\StorageTestBase.SasVersion.cs" />
@@ -23,6 +27,12 @@
   <ItemGroup>
     <!-- To test shared resources that aren't included in Azure.Storage.Common itself. -->
     <Compile Include="$(AzureStorageSharedSources)AggregatingProgressIncrementer.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)ContentHasher.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)HashAlgorithmHasher.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)IDownloadedContent.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)IHasher.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)LazyLoadingReadOnlyStream.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)NonCryptographicHashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PartitionedUploader.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PooledMemoryStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ProgressIncrementingStream.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
+++ b/sdk/storage/Azure.Storage.Common/tests/Azure.Storage.Common.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure.Storage.Common client library tests</AssemblyTitle>
@@ -20,6 +21,9 @@
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared\Core" />
+    <Compile Include="$(AzureCoreSharedSources)OperationInternal.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)OperationInternalBase.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)OperationInternalOfT.cs" LinkBase="Shared" />
     <Compile Remove="Shared\AzuriteFixture.cs" />
     <Compile Remove="Shared\AzuriteNUnitFixture.cs" />
     <Compile Remove="Shared\StorageTestBase.SasVersion.cs" />

--- a/sdk/storage/Azure.Storage.Common/tests/LazyLoadingReadOnlyStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/LazyLoadingReadOnlyStreamTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Storage.Shared;
+using Azure.Storage.Test;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Storage.Tests
+{
+    public class LazyLoadingReadOnlyStreamTests
+    {
+        private class DownloadedContent : IDownloadedContent
+        {
+            private readonly Stream _content;
+            public Stream Content => _content;
+
+            public DownloadedContent(Stream stream)
+            {
+                _content = stream;
+            }
+        }
+
+        // int just fills the generic requirements, we don't care about data type and go straight for the raw response
+        private static Mock<LazyLoadingReadOnlyStream<int>.DownloadInternalAsync> GetDownloadBehavior(byte[] data)
+        {
+            var downloadMock = new Mock<LazyLoadingReadOnlyStream<int>.DownloadInternalAsync>();
+            downloadMock.Setup(_ => _(It.IsAny<HttpRange>(), It.IsAny<DownloadTransactionalHashingOptions>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns<HttpRange, DownloadTransactionalHashingOptions, bool, CancellationToken>((range, hashOptions, async, CancellationToken) =>
+                {
+                    var mockResponse = new Mock<Response<IDownloadedContent>>(MockBehavior.Loose);
+                    mockResponse.SetupGet(r => r.Value)
+                        .Returns(new DownloadedContent(new MemoryStream(data, (int)range.Offset, (int)(range.Length ?? (data.Length - range.Offset)))));
+                    mockResponse.Setup(r => r.GetRawResponse())
+                        .Returns(() => new MockResponse(201).AddHeader("Content-Range", $"bytes {range.Offset}-{range.Offset + range.Length - 1}/{data.Length}"));
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            return downloadMock;
+        }
+
+        // int just fills the generic requirements, we don't care about data type and go straight for the raw response
+        private static Mock<LazyLoadingReadOnlyStream<int>.GetPropertiesAsync> GetPropertiesBehavior(int totalResourceLength)
+        {
+            var propertiesMock = new Mock<LazyLoadingReadOnlyStream<int>.GetPropertiesAsync>();
+            propertiesMock.Setup(_ => _(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns<bool, CancellationToken>((value, cancellationToken) =>
+                {
+                    var mockResponse = new Mock<Response<int>>(MockBehavior.Loose);
+                    mockResponse.Setup(r => r.GetRawResponse())
+                        .Returns(() => new MockResponse(200).AddHeader("Content-Length", totalResourceLength.ToString()));
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            return propertiesMock;
+        }
+
+        [TestCase(0, Constants.KB, Constants.KB)]
+        [TestCase(0 * Constants.KB, Constants.KB, 3 * Constants.KB)]
+        [TestCase(1 * Constants.KB, Constants.KB, 3 * Constants.KB)]
+        [TestCase(2 * Constants.KB, Constants.KB, 3 * Constants.KB)]
+        public async Task AvoidRebuffer(int offset, int bufferSize, int dataSize)
+        {
+            if (offset < 0 || offset + bufferSize > dataSize)
+            {
+                throw new ArgumentException("Bad test definition.");
+            }
+
+            // Arrange
+            byte[] data = TestHelper.GetRandomBuffer(dataSize);
+
+            var downloadMock = GetDownloadBehavior(data);
+            var propertiesMock = GetPropertiesBehavior(data.Length);
+            var readStream = new LazyLoadingReadOnlyStream<int>(
+                downloadMock.Object,
+                propertiesMock.Object,
+                hashingOptions: default,
+                allowModifications: false,
+                initialLenght: dataSize,
+                position: offset,
+                bufferSize: bufferSize);
+
+            // Act
+            var readTest = new byte[bufferSize];
+            foreach (var _ in Enumerable.Range(0, 10))
+            {
+                await readStream.ReadAsync(readTest, 0, readTest.Length);
+                // seek back to exact start of current buffer
+                readStream.Position = offset;
+            }
+
+            // Assert
+            Assert.AreEqual(1, downloadMock.Invocations.Count);
+        }
+    }
+}
+
+// TODO delete; this is a temp unblocker and should not be committed
+namespace Azure.Core
+{
+#pragma warning disable SA1402 // File may only contain a single type
+    internal static class ResponseHeadersExtensions
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+        public static bool TryGetValue(this ResponseHeaders headers, string name, out byte[] value)
+        {
+            if (headers.TryGetValue(name, out string stringValue))
+            {
+                value = Convert.FromBase64String(stringValue);
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/LazyLoadingReadOnlyStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/LazyLoadingReadOnlyStreamTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Storage.Shared;
 using Azure.Storage.Test;
@@ -100,27 +97,6 @@ namespace Azure.Storage.Tests
 
             // Assert
             Assert.AreEqual(1, downloadMock.Invocations.Count);
-        }
-    }
-}
-
-// TODO delete; this is a temp unblocker and should not be committed
-namespace Azure.Core
-{
-#pragma warning disable SA1402 // File may only contain a single type
-    internal static class ResponseHeadersExtensions
-#pragma warning restore SA1402 // File may only contain a single type
-    {
-        public static bool TryGetValue(this ResponseHeaders headers, string name, out byte[] value)
-        {
-            if (headers.TryGetValue(name, out string stringValue))
-            {
-                value = Convert.FromBase64String(stringValue);
-                return true;
-            }
-
-            value = null;
-            return false;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/LazyLoadingReadOnlyStreamTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/LazyLoadingReadOnlyStreamTests.cs
@@ -30,11 +30,12 @@ namespace Azure.Storage.Tests
         // int just fills the generic requirements, we don't care about data type and go straight for the raw response
         private static Mock<LazyLoadingReadOnlyStream<int>.DownloadInternalAsync> GetDownloadBehavior(byte[] data)
         {
+            // just mocking a response from injectable behavior
             var downloadMock = new Mock<LazyLoadingReadOnlyStream<int>.DownloadInternalAsync>();
             downloadMock.Setup(_ => _(It.IsAny<HttpRange>(), It.IsAny<DownloadTransactionalHashingOptions>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Returns<HttpRange, DownloadTransactionalHashingOptions, bool, CancellationToken>((range, hashOptions, async, CancellationToken) =>
                 {
-                    var mockResponse = new Mock<Response<IDownloadedContent>>(MockBehavior.Loose);
+                    var mockResponse = new Mock<Response<IDownloadedContent>>(MockBehavior.Strict);
                     mockResponse.SetupGet(r => r.Value)
                         .Returns(new DownloadedContent(new MemoryStream(data, (int)range.Offset, (int)(range.Length ?? (data.Length - range.Offset)))));
                     mockResponse.Setup(r => r.GetRawResponse())
@@ -48,11 +49,12 @@ namespace Azure.Storage.Tests
         // int just fills the generic requirements, we don't care about data type and go straight for the raw response
         private static Mock<LazyLoadingReadOnlyStream<int>.GetPropertiesAsync> GetPropertiesBehavior(int totalResourceLength)
         {
+            // just mocking a response from injectable behavior
             var propertiesMock = new Mock<LazyLoadingReadOnlyStream<int>.GetPropertiesAsync>();
             propertiesMock.Setup(_ => _(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Returns<bool, CancellationToken>((value, cancellationToken) =>
                 {
-                    var mockResponse = new Mock<Response<int>>(MockBehavior.Loose);
+                    var mockResponse = new Mock<Response<int>>(MockBehavior.Strict);
                     mockResponse.Setup(r => r.GetRawResponse())
                         .Returns(() => new MockResponse(200).AddHeader("Content-Length", totalResourceLength.ToString()));
                     return Task.FromResult(mockResponse.Object);

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/OpenReadTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/OpenReadTestBase.cs
@@ -563,7 +563,7 @@ namespace Azure.Storage.Test.Shared
         [RecordedTest]
         // lower position within _buffer
         [TestCase(-50)]
-        // higher positiuon within _buffer
+        // higher position within _buffer
         [TestCase(50)]
         // lower position below _buffer
         [TestCase(-100)]


### PR DESCRIPTION
Resolves #26281

Seeking to exactly the beginning of the current buffer in a `LazyLoadingReadOnlyStream` no longer causes a rebuffer.