### PR TITLE
[Question Answering Authoring] Activated deployment tests and regenerated client

### DIFF
--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Generated/QuestionAnsweringProjectsClient.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Generated/QuestionAnsweringProjectsClient.cs
@@ -1262,7 +1262,7 @@ namespace Azure.AI.Language.QuestionAnswering.Projects
             }
         }
 
-        /// <summary> Add Active Learning feedback. </summary>
+        /// <summary> Update Active Learning feedback. </summary>
         /// <param name="projectName"> The name of the project to use. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
@@ -1319,7 +1319,7 @@ namespace Azure.AI.Language.QuestionAnswering.Projects
             }
         }
 
-        /// <summary> Add Active Learning feedback. </summary>
+        /// <summary> Update Active Learning feedback. </summary>
         /// <param name="projectName"> The name of the project to use. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
@@ -2150,6 +2150,31 @@ namespace Azure.AI.Language.QuestionAnswering.Projects
         /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> is null. </exception>
         /// <remarks>
+        /// Schema for <c>Response Body</c>:
+        /// <code>{
+        ///   resultUrl: string,
+        ///   createdDateTime: string (ISO 8601 Format),
+        ///   expirationDateTime: string (ISO 8601 Format),
+        ///   jobId: string,
+        ///   lastUpdatedDateTime: string (ISO 8601 Format),
+        ///   status: &quot;notStarted&quot; | &quot;running&quot; | &quot;succeeded&quot; | &quot;failed&quot; | &quot;cancelled&quot; | &quot;cancelling&quot; | &quot;partiallyCompleted&quot;,
+        ///   errors: [
+        ///     {
+        ///       code: &quot;InvalidRequest&quot; | &quot;InvalidArgument&quot; | &quot;Unauthorized&quot; | &quot;Forbidden&quot; | &quot;NotFound&quot; | &quot;ProjectNotFound&quot; | &quot;OperationNotFound&quot; | &quot;AzureCognitiveSearchNotFound&quot; | &quot;AzureCognitiveSearchIndexNotFound&quot; | &quot;TooManyRequests&quot; | &quot;AzureCognitiveSearchThrottling&quot; | &quot;AzureCognitiveSearchIndexLimitReached&quot; | &quot;InternalServerError&quot; | &quot;ServiceUnavailable&quot;,
+        ///       message: string,
+        ///       target: string,
+        ///       details: [Error],
+        ///       innererror: {
+        ///         code: &quot;InvalidRequest&quot; | &quot;InvalidParameterValue&quot; | &quot;KnowledgeBaseNotFound&quot; | &quot;AzureCognitiveSearchNotFound&quot; | &quot;AzureCognitiveSearchThrottling&quot; | &quot;ExtractionFailure&quot;,
+        ///         message: string,
+        ///         details: Dictionary&lt;string, string&gt;,
+        ///         target: string,
+        ///         innererror: InnerErrorModel
+        ///       }
+        ///     }
+        ///   ]
+        /// }
+        /// </code>
         /// Schema for <c>Response Error</c>:
         /// <code>{
         ///   error: {
@@ -2197,6 +2222,31 @@ namespace Azure.AI.Language.QuestionAnswering.Projects
         /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="projectName"/> is null. </exception>
         /// <remarks>
+        /// Schema for <c>Response Body</c>:
+        /// <code>{
+        ///   resultUrl: string,
+        ///   createdDateTime: string (ISO 8601 Format),
+        ///   expirationDateTime: string (ISO 8601 Format),
+        ///   jobId: string,
+        ///   lastUpdatedDateTime: string (ISO 8601 Format),
+        ///   status: &quot;notStarted&quot; | &quot;running&quot; | &quot;succeeded&quot; | &quot;failed&quot; | &quot;cancelled&quot; | &quot;cancelling&quot; | &quot;partiallyCompleted&quot;,
+        ///   errors: [
+        ///     {
+        ///       code: &quot;InvalidRequest&quot; | &quot;InvalidArgument&quot; | &quot;Unauthorized&quot; | &quot;Forbidden&quot; | &quot;NotFound&quot; | &quot;ProjectNotFound&quot; | &quot;OperationNotFound&quot; | &quot;AzureCognitiveSearchNotFound&quot; | &quot;AzureCognitiveSearchIndexNotFound&quot; | &quot;TooManyRequests&quot; | &quot;AzureCognitiveSearchThrottling&quot; | &quot;AzureCognitiveSearchIndexLimitReached&quot; | &quot;InternalServerError&quot; | &quot;ServiceUnavailable&quot;,
+        ///       message: string,
+        ///       target: string,
+        ///       details: [Error],
+        ///       innererror: {
+        ///         code: &quot;InvalidRequest&quot; | &quot;InvalidParameterValue&quot; | &quot;KnowledgeBaseNotFound&quot; | &quot;AzureCognitiveSearchNotFound&quot; | &quot;AzureCognitiveSearchThrottling&quot; | &quot;ExtractionFailure&quot;,
+        ///         message: string,
+        ///         details: Dictionary&lt;string, string&gt;,
+        ///         target: string,
+        ///         innererror: InnerErrorModel
+        ///       }
+        ///     }
+        ///   ]
+        /// }
+        /// </code>
         /// Schema for <c>Response Error</c>:
         /// <code>{
         ///   error: {
@@ -2954,7 +3004,7 @@ namespace Azure.AI.Language.QuestionAnswering.Projects
             }
             request.Uri = uri;
             request.Headers.Add("Accept", "application/json");
-            message.ResponseClassifier = ResponseClassifier202.Instance;
+            message.ResponseClassifier = ResponseClassifier200202.Instance;
             return message;
         }
 
@@ -3416,6 +3466,20 @@ namespace Azure.AI.Language.QuestionAnswering.Projects
             {
                 return message.Response.Status switch
                 {
+                    202 => false,
+                    _ => true
+                };
+            }
+        }
+        private sealed class ResponseClassifier200202 : ResponseClassifier
+        {
+            private static ResponseClassifier _instance;
+            public static ResponseClassifier Instance => _instance ??= new ResponseClassifier200202();
+            public override bool IsErrorResponse(HttpMessage message)
+            {
+                return message.Response.Status switch
+                {
+                    200 => false,
                     202 => false,
                     _ => true
                 };

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Generated/QuestionAnsweringProjectsClient.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Generated/QuestionAnsweringProjectsClient.cs
@@ -1262,7 +1262,7 @@ namespace Azure.AI.Language.QuestionAnswering.Projects
             }
         }
 
-        /// <summary> Update Active Learning feedback. </summary>
+        /// <summary> Add Active Learning feedback. </summary>
         /// <param name="projectName"> The name of the project to use. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>
@@ -1319,7 +1319,7 @@ namespace Azure.AI.Language.QuestionAnswering.Projects
             }
         }
 
-        /// <summary> Update Active Learning feedback. </summary>
+        /// <summary> Add Active Learning feedback. </summary>
         /// <param name="projectName"> The name of the project to use. </param>
         /// <param name="content"> The content to send as the body of the request. </param>
         /// <param name="context"> The request context, which can override default behaviors on the request on a per-call basis. </param>

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Generated/QuestionAnsweringRuntimeRestClient.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/Generated/QuestionAnsweringRuntimeRestClient.cs
@@ -15,20 +15,20 @@ using Azure.Core.Pipeline;
 
 namespace Azure.AI.Language.QuestionAnswering
 {
-    internal partial class QuestionAnsweringRestClient
+    internal partial class QuestionAnsweringRuntimeRestClient
     {
         private Uri endpoint;
         private string apiVersion;
         private ClientDiagnostics _clientDiagnostics;
         private HttpPipeline _pipeline;
 
-        /// <summary> Initializes a new instance of QuestionAnsweringRestClient. </summary>
+        /// <summary> Initializes a new instance of QuestionAnsweringRuntimeRestClient. </summary>
         /// <param name="clientDiagnostics"> The handler for diagnostic messaging in the client. </param>
         /// <param name="pipeline"> The HTTP pipeline for sending and receiving REST requests and responses. </param>
         /// <param name="endpoint"> Supported Cognitive Services endpoint (e.g., https://&lt;resource-name&gt;.api.cognitiveservices.azure.com). </param>
         /// <param name="apiVersion"> Api Version. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="endpoint"/> or <paramref name="apiVersion"/> is null. </exception>
-        public QuestionAnsweringRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Uri endpoint, string apiVersion = "2021-10-01")
+        public QuestionAnsweringRuntimeRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Uri endpoint, string apiVersion = "2021-10-01")
         {
             this.endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
             this.apiVersion = apiVersion ?? throw new ArgumentNullException(nameof(apiVersion));

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/QuestionAnsweringClient.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/QuestionAnsweringClient.cs
@@ -17,7 +17,7 @@ namespace Azure.AI.Language.QuestionAnswering
     {
         internal const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
 
-        private readonly QuestionAnsweringRestClient _restClient;
+        private readonly QuestionAnsweringRuntimeRestClient _restClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QuestionAnsweringClient"/> class.

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
@@ -12,8 +12,7 @@ batch:
   clear-output-folder: true
   model-namespace: false
 
-# TODO: Uncomment when we ship authoring support and remove ./QuestionAnsweringClientOptions.cs.
-- input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/2fe971edcf58b3351e6e5e67d269d4b4c7cc2c5f/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering-authoring.json
+- input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/b791f57426508cb2793a8911650a416dcb11c6a6/specification/cognitiveservices/data-plane/Language/stable/2021-10-01/questionanswering-authoring.json
 # namespace: Azure.AI.Language.QuestionAnswering.Projects
   add-credentials: true
   data-plane: true
@@ -48,128 +47,6 @@ directive:
     ];
 ```
 
-### OperationId renames QuestionAnsweringAuthoring -> QuestionAnsweringProjects
-
-<!-- TODO: If these transforms are not needed, remove them. https://github.com/Azure/azure-sdk-for-net/issues/26173 -->
-
-```yaml
-directive:
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_ListProjects";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetProjectDetails";
-  
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}"]["patch"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_CreateProject";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}"]["delete"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_DeleteProject";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/deletion-jobs/{jobId}"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetDeleteStatus";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/:export"]["post"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_Export";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/export/jobs/{jobId}"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetExportStatus";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/:import"]["post"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_Import";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/import/jobs/{jobId}"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetImportStatus";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/deployments/{deploymentName}"]["put"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_DeployProject";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/deployments/{deploymentName}/jobs/{jobId}"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetDeployStatus";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/deployments"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_ListDeployments";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/synonyms"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetSynonyms";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/synonyms"]["put"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_UpdateSynonyms";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/sources"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetSources";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/sources"]["patch"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_UpdateSources";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/sources/jobs/{jobId}"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetUpdateSourcesStatus";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/qnas"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetQnas";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/qnas"]["patch"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_UpdateQnas";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/qnas/jobs/{jobId}"]["get"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_GetUpdateQnasStatus";
-
-  - from: swagger-document
-    where: $["paths"]["/query-knowledgebases/projects/{projectName}/feedback"]["post"]
-    transform: >
-        $["operationId"] = "QuestionAnsweringProjects_AddFeedback";
-
-  - from: swagger-document
-    where: $["paths"]["/:query-knowledgebases"]["post"]
-    transform: >
-        $["operationId"] = "QuestionAnswering_GetAnswers";
-
-  - from: swagger-document
-    where: $["paths"]["/:query-text"]["post"]
-    transform: >
-        $["operationId"] = "QuestionAnswering_GetAnswersFromText";
-
-```
 ### C# customizations
 
 ``` yaml

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/src/autorest.md
@@ -46,6 +46,15 @@ directive:
         }
     ];
 ```
+### DocString edit
+
+``` yaml
+directive:
+  - from: swagger-document
+    where: $["paths"]["/query-knowledgebases/projects/{projectName}/feedback"]["post"]
+    transform: >
+        $["summary"] = "Add Active Learning feedback";
+```
 
 ### C# customizations
 

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/QuestionAnsweringProjectsClientLiveTests.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/QuestionAnsweringProjectsClientLiveTests.cs
@@ -38,7 +38,6 @@ namespace Azure.AI.Language.QuestionAnswering.Tests
         }
 
         [RecordedTest]
-        [Ignore(reason: "Disabled until bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26401")]
         public async Task DeployProject()
         {
             string testProjectName = CreateTestProjectName();
@@ -60,7 +59,8 @@ namespace Azure.AI.Language.QuestionAnswering.Tests
                             }
                         }
                 });
-            Operation<BinaryData> updateSourcesOperation = await Client.UpdateSourcesAsync(true, testProjectName, updateSourcesRequestContent);
+            Operation<BinaryData> updateSourcesOperation = await Client.UpdateSourcesAsync(false, testProjectName, updateSourcesRequestContent);
+            await updateSourcesOperation.WaitForCompletionAsync();
 
             string testDeploymentName = "production";
             Operation<BinaryData> deploymentOperation = await Client.DeployProjectAsync(false, testProjectName, testDeploymentName);

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/Sample3_CreateAndDeployProject.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/Sample3_CreateAndDeployProject.cs
@@ -16,8 +16,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
     {
         [RecordedTest]
         [SyncOnly]
-        [Ignore(reason: "Disabled until deployment lro bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26401")]
-        public void CreateAndDeploy()
+        public async Task CreateAndDeploy()
         {
             QuestionAnsweringProjectsClient client = Client;
             #region Snippet:QuestionAnsweringProjectsClient_CreateProject
@@ -75,7 +74,12 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
                         }
                 });
 
+#if SNIPPET
             Operation<BinaryData> updateSourcesOperation = client.UpdateSources(waitForCompletion: true, newProjectName, updateSourcesRequestContent);
+#else
+            Operation<BinaryData> updateSourcesOperation = await client.UpdateSourcesAsync(waitForCompletion: false, newProjectName, updateSourcesRequestContent);
+            await updateSourcesOperation.WaitForCompletionAsync();
+#endif
 
             // Knowledge Sources can be retrieved as follows
             Pageable<BinaryData> sources = client.GetSources(newProjectName);
@@ -95,7 +99,12 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
 #if !SNIPPET
             newDeploymentName = "production";
 #endif
+#if SNIPPET
             Operation<BinaryData> deploymentOperation = client.DeployProject(waitForCompletion: true, newProjectName, newDeploymentName);
+#else
+            Operation<BinaryData> deploymentOperation = await client.DeployProjectAsync(waitForCompletion: false, newProjectName, newDeploymentName);
+            await deploymentOperation.WaitForCompletionAsync();
+#endif
 
             // Deployments can be retrieved as follows
             Pageable<BinaryData> deployments = client.GetDeployments(newProjectName);
@@ -114,8 +123,6 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
 
         [RecordedTest]
         [AsyncOnly]
-        [Ignore(reason: "Disabled until deployment lro bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26401")]
-
         public async Task CreateAndDeployAsync()
         {
             QuestionAnsweringProjectsClient client = Client;
@@ -177,7 +184,12 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
                         }
                 });
 
+#if SNIPPET
             Operation<BinaryData> updateSourcesOperation = await client.UpdateSourcesAsync(waitForCompletion: true, newProjectName, updateSourcesRequestContent);
+#else
+            Operation<BinaryData> updateSourcesOperation = await client.UpdateSourcesAsync(waitForCompletion: false, newProjectName, updateSourcesRequestContent);
+            await updateSourcesOperation.WaitForCompletionAsync();
+#endif
 
             Console.WriteLine($"Update Sources operation result: \n{updateSourcesOperation.Value}");
 
@@ -199,7 +211,12 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
 #if !SNIPPET
             newDeploymentName = "production";
 #endif
+#if SNIPPET
             Operation<BinaryData> deploymentOperation = await client.DeployProjectAsync(waitForCompletion: true, newProjectName, newDeploymentName);
+#else
+            Operation<BinaryData> deploymentOperation = await client.DeployProjectAsync(waitForCompletion: false, newProjectName, newDeploymentName);
+            await deploymentOperation.WaitForCompletionAsync();
+#endif
 
             Console.WriteLine($"Update Sources operation result: \n{deploymentOperation.Value}");
 
@@ -210,7 +227,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
             {
                 Console.WriteLine(deployment);
             }
-            #endregion
+#endregion
 
             Assert.True(deploymentOperation.HasCompleted);
             Assert.That((await deployments.ToEnumerableAsync()).Any(deployment => deployment.ToString().Contains(newDeploymentName)));

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/Sample3_CreateAndDeployProject.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/Sample3_CreateAndDeployProject.cs
@@ -16,6 +16,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
     {
         [RecordedTest]
         [SyncOnly]
+        // TODO: Make this test Sync once slowdown bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26696
         public async Task CreateAndDeploy()
         {
             QuestionAnsweringProjectsClient client = Client;
@@ -77,6 +78,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
 #if SNIPPET
             Operation<BinaryData> updateSourcesOperation = client.UpdateSources(waitForCompletion: true, newProjectName, updateSourcesRequestContent);
 #else
+            // TODO: Remove this region once slowdown bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26696
             Operation<BinaryData> updateSourcesOperation = await client.UpdateSourcesAsync(waitForCompletion: false, newProjectName, updateSourcesRequestContent);
             await updateSourcesOperation.WaitForCompletionAsync();
 #endif
@@ -102,6 +104,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
 #if SNIPPET
             Operation<BinaryData> deploymentOperation = client.DeployProject(waitForCompletion: true, newProjectName, newDeploymentName);
 #else
+            // TODO: Remove this region once slowdown bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26696
             Operation<BinaryData> deploymentOperation = await client.DeployProjectAsync(waitForCompletion: false, newProjectName, newDeploymentName);
             await deploymentOperation.WaitForCompletionAsync();
 #endif
@@ -187,6 +190,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
 #if SNIPPET
             Operation<BinaryData> updateSourcesOperation = await client.UpdateSourcesAsync(waitForCompletion: true, newProjectName, updateSourcesRequestContent);
 #else
+            // TODO: Remove this region once slowdown bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26696
             Operation<BinaryData> updateSourcesOperation = await client.UpdateSourcesAsync(waitForCompletion: false, newProjectName, updateSourcesRequestContent);
             await updateSourcesOperation.WaitForCompletionAsync();
 #endif
@@ -214,6 +218,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
 #if SNIPPET
             Operation<BinaryData> deploymentOperation = await client.DeployProjectAsync(waitForCompletion: true, newProjectName, newDeploymentName);
 #else
+            // TODO: Remove this region once slowdown bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26696
             Operation<BinaryData> deploymentOperation = await client.DeployProjectAsync(waitForCompletion: false, newProjectName, newDeploymentName);
             await deploymentOperation.WaitForCompletionAsync();
 #endif

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/Sample5_UpdateKnowledgeSources.cs
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/Samples/Sample5_UpdateKnowledgeSources.cs
@@ -17,6 +17,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
     {
         [RecordedTest]
         [SyncOnly]
+        // TODO: Make this test Sync once slowdown bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26696
         public async Task KnowledgeSources()
         {
             QuestionAnsweringProjectsClient client = Client;
@@ -50,6 +51,7 @@ namespace Azure.AI.Language.QuestionAnswering.Tests.Samples
             Operation<BinaryData> updateSourcesOperation = client.UpdateSources(waitForCompletion: false, testProjectName, updateSourcesRequestContent);
             updateSourcesOperation.WaitForCompletion();
 #else
+            // TODO: Remove this region once slowdown bug is fixed. https://github.com/Azure/azure-sdk-for-net/issues/26696
             Operation<BinaryData> updateSourcesOperation = InstrumentOperation(client.UpdateSources(waitForCompletion: false, testProjectName, updateSourcesRequestContent));
             await updateSourcesOperation.WaitForCompletionAsync();
 #endif

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/SessionRecords/QuestionAnsweringProjectsClientLiveTests/DeployProject.json
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/SessionRecords/QuestionAnsweringProjectsClientLiveTests/DeployProject.json
@@ -1,0 +1,1162 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470?api-version=2021-10-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Connection": "keep-alive",
+        "Content-Length": "171",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4eafe44092059945a7fba27a245e859a-1760bd4410825f45-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ee75c19b06ed80c823b3ea2c55b79860",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "description": "This is the description for a test project",
+        "language": "en",
+        "multilingualResource": false,
+        "settings": {
+          "defaultAnswer": "No answer found for your question."
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "281a85b2-b318-49da-8d30-656af7cbc1c0",
+        "Content-Length": "334",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "802"
+      },
+      "ResponseBody": {
+        "projectName": "TestProject1473367470",
+        "description": "This is the description for a test project",
+        "language": "en",
+        "multilingualResource": false,
+        "createdDateTime": "2022-01-30T08:46:12Z",
+        "lastModifiedDateTime": "2022-01-30T08:46:12Z",
+        "settings": {
+          "defaultAnswer": "No answer found for your question."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources?api-version=2021-10-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "259",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-a40a40c59ffcb743-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "01ca373740741a6ace7838cd7541c110",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[{\u0022op\u0022:\u0022add\u0022,\u0022value\u0022:{\u0022displayName\u0022:\u0022MicrosoftFAQ\u0022,\u0022source\u0022:\u0022https://www.microsoft.com/en-in/software-download/faq\u0022,\u0022sourceUri\u0022:\u0022https://www.microsoft.com/en-in/software-download/faq\u0022,\u0022sourceKind\u0022:\u0022url\u0022,\u0022contentStructureKind\u0022:\u0022unstructured\u0022,\u0022refresh\u0022:false}}]",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "2b2bbb0d-fdc8-4d92-b139-b73ef30d89af",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 08:46:13 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "814"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-62a9a0336ac27d44-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "19c6c6e9c8264f30e562e2d6d3576028",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "331409de-ca6d-4115-8ba1-bca49bc853df",
+        "Content-Length": "236",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:13 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "status": "notStarted"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-be3e3d0ed35d594b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "009f89842ecc5a39565a2074cdfb0be1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "91dad856-b040-4f4b-a5a7-33297d476d89",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:15 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-f4269ca94b49404d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8e43d9f17ef06f39077b1b125d934776",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "17697394-f585-4e56-adf0-6c79cc097c54",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:16 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-78017cf210a5e444-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eb481018c1a2ba448c6bc3cca7bb82ea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6d3ddb45-b0af-4223-a8ee-1817b8e66b54",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:18 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-5a7d4916685b7045-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f9e50156d11305375030f9511227fcc2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "29358dcd-4d2a-4366-a382-649aac514b97",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:19 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-ceef2d77e5aa024e-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bc5ca9121fb2303f95880284bb6cc74b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a517230a-6cd0-4b88-8987-9434f16fcd83",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:20 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-1c0ee555c88c1049-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5cbb31f84eae4763d8429b71c8f3a765",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5408a689-bbe9-4a39-bac3-16f7bef6e7a1",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:21 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-95022942c3f58547-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fdba006ec55f3737c1b4638bcfb24ae4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d87769f5-27e7-4a1c-a38c-a0d821f672e5",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:23 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-db2e03da11403f4b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e158ad68a06bc3144615e36f84cd68a1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5ad4e222-d321-420a-8474-2fa3a08a1fdf",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:24 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-08763b1feeacc944-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bb159ce0cab233ecf9849bf9ead87726",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ba650e7b-74c8-4309-beeb-590b3b269ce0",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:25 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-849630ce160b6f48-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1a09b6f8c69bcef9ebf6b649e1c7b3f3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5be37bde-4ce6-41c0-91bc-3bc61891152f",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:26 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "46"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-a502eb03d38be64d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "32aac24c8f9c9d31c024e7e7041bd86e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7071dcd4-99a8-45da-bd24-24235613c358",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:28 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-8cb7a07e8ceb4e45-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cd77bd9d4dc41906a247cfbb13a25232",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e4db7d6d-784f-40aa-8bc5-13e4f82252d4",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:29 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "47"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-044c7b1b72736f45-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "28aca7d1452e6989846b5976df12cad0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "29c2dbe1-0dcf-4120-a10a-c5505cc8f061",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:30 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-a2b2f673a81fe243-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "23ab481de550ff2fbc909055bf76891d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b28ddf8c-c179-4452-9579-409b907597a7",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:32 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-f693abf8c55b514b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5c15b4d2b06e5840340d4858f38f3a90",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3ccd3433-7a75-4feb-bbb2-3568930b9cfe",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:33 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-9a1e27b925afe346-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cb9dfe7c2ef7ebe178ad6c9db533a90e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "152d4bc8-5e15-4e8a-8cfc-42c65c4ea799",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:34 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-252dd0adf8ae7a44-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2aa43ce16dfc6d610753ef439dd60b2d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2fd90898-d42b-4609-aa36-ad0f1eb5c0e2",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:36 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-1449cae64d5f444d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c0d80056bed8a426d32ae3c143a2a300",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "02812644-8c93-480a-a541-0b68b09ca4e9",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:37 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-bc2019fe1b2dd447-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b77739630fea0f939d30c3a33e9e4ea2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3c438298-e588-48c5-9129-4d150183fe0e",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:38 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-cd2ba375ab37eb49-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b5473fa1e95a2336150057d2899f2a65",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "67be384f-3cdc-45e8-a6ef-42d1236b7012",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:40 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/sources/jobs/c99e8d0a-a5f0-4116-9e65-6a6230420938?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-96f4cbd5f90f66469badf767656bfe89-7f4d7833eff5f449-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "63dfefaf545e47426cc923a8fa826535",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "401c4371-de06-4a85-b81b-ab104cf13466",
+        "Content-Length": "291",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:12\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:12\u002B00:00",
+        "jobId": "c99e8d0a-a5f0-4116-9e65-6a6230420938",
+        "lastUpdatedDateTime": "2022-01-30T08:46:40\u002B00:00",
+        "status": "succeeded",
+        "resultUrl": "/knowledgebases/TestProject1473367470"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production?api-version=2021-10-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3afafdd4a1bc4e48ab536b1ede64c71d-8f4f157f8f63af40-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "042041dbee5b7aa50354a2eab7c085fd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "60799ebd-6715-4e7d-8e74-c18672dc6fa1",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 08:46:41 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "418"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4ff35e05ebbe4d43fc004890c58d2892",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1d9abe5b-92db-47a8-9df8-eadc8dd60053",
+        "Content-Length": "236",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:42 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "status": "notStarted"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "48f7229a267fc10949645f0ab2578fab",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "679d2b50-bc0d-43b8-afb6-4b1f19718bc7",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:43 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:42\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9ba22644168eef76fdd3075aa515b575",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "eba86a89-f16c-421a-b6aa-0cbbd2f2f85b",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:45 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:42\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "95500f2b3dc9df7d543206598b389aa4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c38b1140-f466-4816-8cd5-7019905f6942",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:46 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:42\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9f4c9c708ceb8303ab074aac1faf1b33",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "787abb98-821e-4bab-998f-2584a7872b69",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:47 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:42\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a2dfeaaffa0706e2a8c3475c101c63c5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9520037e-f3e2-4b3e-aee6-de548fa85861",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:48 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:42\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "09e9623815c89e8a0bcce9c2f3d1c0a5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9463dcd1-c75f-473b-80ec-94fd73b7850d",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:50 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:42\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a1aad216f859769dba45f72845a7728f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4649d88f-9a02-441b-8d54-5bd070f2d341",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:51 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:42\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bd7484a312c59a6b5f40963a102013d6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a3b414c2-adf4-4074-98a0-09891029d2f7",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:52 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:42\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production/jobs/9a635124-aec1-4687-a8c4-dfe27e3bacd1?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3e45a102c2723f6cc4734f821e625964",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5fc48b22-f339-4d87-9efe-a00dac2e40e1",
+        "Content-Length": "235",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:41\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:41\u002B00:00",
+        "jobId": "9a635124-aec1-4687-a8c4-dfe27e3bacd1",
+        "lastUpdatedDateTime": "2022-01-30T08:46:54\u002B00:00",
+        "status": "succeeded"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments/production?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6e1e5a59035d04e06610421861626599",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6ec2cc3c-9250-4c9c-a489-650799aab9b7",
+        "Content-Length": "86",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "53"
+      },
+      "ResponseBody": {
+        "deploymentName": "production",
+        "lastDeployedDateTime": "2022-01-30T08:46:54Z"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470/deployments?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-36932a088243e343a1cdf7f7ad612e59-c78c20f5c3887341-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a42520323461e11c1834f851c3e97bfd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "884ce03a-41c6-4350-a27b-e7ff935c8a7e",
+        "Content-Length": "123",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "55"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "deploymentName": "production",
+            "lastDeployedDateTime": "2022-01-30T08:46:54Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject1473367470?api-version=2021-10-01",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bafc53e833236643bedafda956021eb1-1f9c5170e5a2a948-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b6e131e7a501ff79c141d7627f53de62",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "2fe49d15-7182-48e7-ba7a-0811e5cf6325",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 08:46:59 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/deletion-jobs/5d73bb47-0c00-44ad-8170-84279170f22f?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "3802"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/deletion-jobs/5d73bb47-0c00-44ad-8170-84279170f22f?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bafc53e833236643bedafda956021eb1-b3cc7cac441ebf4d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fe50b50db53d25033d3d55280a8e417d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "74488296-57af-4ec7-a899-7b81b359f8d7",
+        "Content-Length": "235",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:46:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "50"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:46:58\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:46:58\u002B00:00",
+        "jobId": "5d73bb47-0c00-44ad-8170-84279170f22f",
+        "lastUpdatedDateTime": "2022-01-30T08:46:58\u002B00:00",
+        "status": "succeeded"
+      }
+    }
+  ],
+  "Variables": {
+    "QUESTIONANSWERING_ENDPOINT": "https://wuppe.api.cognitive.microsoft.com",
+    "QUESTIONANSWERING_KEY": "Sanitized",
+    "RandomSeed": "1287479195"
+  }
+}

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/SessionRecords/QuestionAnsweringProjectsClientLiveTests/DeployProjectAsync.json
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/SessionRecords/QuestionAnsweringProjectsClientLiveTests/DeployProjectAsync.json
@@ -1,0 +1,865 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895?api-version=2021-10-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "171",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5e4fe0e6f2471a40b94067fb686a6b7e-c9876b70df480c49-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c8b2a6a2496cfc8bb77d0ada65bf03e8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "description": "This is the description for a test project",
+        "language": "en",
+        "multilingualResource": false,
+        "settings": {
+          "defaultAnswer": "No answer found for your question."
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "c2052766-9123-4734-a9aa-c50dbb88b647",
+        "Content-Length": "334",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "201"
+      },
+      "ResponseBody": {
+        "projectName": "TestProject2019146895",
+        "description": "This is the description for a test project",
+        "language": "en",
+        "multilingualResource": false,
+        "createdDateTime": "2022-01-30T08:47:00Z",
+        "lastModifiedDateTime": "2022-01-30T08:47:00Z",
+        "settings": {
+          "defaultAnswer": "No answer found for your question."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources?api-version=2021-10-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "259",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-ffb70205b240b240-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4af63baa60f66a750c0b9a80efe52c44",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[{\u0022op\u0022:\u0022add\u0022,\u0022value\u0022:{\u0022displayName\u0022:\u0022MicrosoftFAQ\u0022,\u0022source\u0022:\u0022https://www.microsoft.com/en-in/software-download/faq\u0022,\u0022sourceUri\u0022:\u0022https://www.microsoft.com/en-in/software-download/faq\u0022,\u0022sourceKind\u0022:\u0022url\u0022,\u0022contentStructureKind\u0022:\u0022unstructured\u0022,\u0022refresh\u0022:false}}]",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "3f5d5bdd-b26c-486e-beff-598b4c487c4e",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 08:47:00 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "432"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-669f850ef1c03d4b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "dcd85eee2631842e45d2c73322dd1048",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "93f258b7-9082-4349-93d9-91502791ec44",
+        "Content-Length": "236",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:00 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "47"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "status": "notStarted"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-e54217982531b94e-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "72f8394834f441993047bb61af0a0cd2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7072c957-1823-4419-a194-125029e90b4b",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:02 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-69a3e1c0cbb05f4d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "06ecc65026e684b60c7105249942472f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c87fbb4c-1037-4e85-9fc5-7916cbcd64b5",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:03 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-e3afed51d310e94e-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b53752fbbaecb94fc597ace96acdd53a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d9757c7e-cd02-41eb-8fe4-e9b55333211e",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:05 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-16b35d89ad42304f-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5ce2f4c509f12261837465832f75a7ee",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b35a3256-5dfd-46c8-a589-8c45d0fa748f",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:06 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-169f3a091ec4a94e-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5c658c0057d296e57632414f7acd1a3f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0e8903bf-b0bb-42f2-8782-97d67b0bc36e",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:07 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-7887a49e33cd5645-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a45eca9beb60f13df115317854cc8950",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fac35501-54a5-4781-a0c1-7c5e8b98af74",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:08 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-4fe5f7b8395dad45-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "dde9bdef79676d680f4be5bfc811a8b6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e6a4aa16-a8f7-4e9f-bca9-d7acd6b8d857",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:10 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-8a330cf60f21e54f-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "65e7255a0316148d4f746bbd256d41a9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b5b189e3-2b64-4464-ae36-304233486c44",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:11 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-143d1af94602f94d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bc60f1a83ce322d762f19514057e29df",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1cf7d6e3-733a-41b2-a682-d22e869be200",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:12 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "46"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-2b10f8845c40b548-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2f1e7b6c24e5eb3930d48ef30daa48a1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0b65f4b8-efcb-446b-a45d-f879842f1455",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:14 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-33b9e4aed4c05346-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d7163c0aebb11dd24ec403256d790fd0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "508bd498-53a4-4baf-8b44-995e24c82112",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:15 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-1b5fbc25ebddfb40-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a9508c4b124f83c4b7748c0fade415b7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "db732f51-7373-4296-9e33-4285297fd909",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:16 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-2fa0d78cd9eb3548-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c90af4a85267812da900e02021147db6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a0a31198-6c38-43e4-b5de-50f19fbc0f9e",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:18 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-946dbd7f6cf5114f-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "81a7bec49e59f75178921f3c5fc27069",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c6622d09-dac4-4bed-9733-c064ceba632c",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:19 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:01\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/sources/jobs/62be6849-ac76-457c-98e9-de386bea6394?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1a43308338f228419af9f952f2474a05-e4d16ec0691f7a4d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "797c4baf466ef9685ecf004f31a362a2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a8eba4a4-8723-43f4-bd5c-bb1bae7a3fc9",
+        "Content-Length": "291",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:00\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:00\u002B00:00",
+        "jobId": "62be6849-ac76-457c-98e9-de386bea6394",
+        "lastUpdatedDateTime": "2022-01-30T08:47:20\u002B00:00",
+        "status": "succeeded",
+        "resultUrl": "/knowledgebases/TestProject2019146895"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments/production?api-version=2021-10-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c01e534bcfd42541a34d8b41e0205c4e-b09482f1a0e8ef4c-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ef4ad5f7943c0a5da21251d532f121e7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "855ee789-4094-442b-b99b-2b0b8b4e0e40",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 08:47:20 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/TestProject2019146895/deployments/production/jobs/659fa459-2da2-4f75-a177-221bca4da990?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "126"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments/production/jobs/659fa459-2da2-4f75-a177-221bca4da990?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d571779003987e4755ae228a9e02c5d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c8ed4011-58e6-47db-8ecb-c5d975d366f7",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:20 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:20\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:20\u002B00:00",
+        "jobId": "659fa459-2da2-4f75-a177-221bca4da990",
+        "lastUpdatedDateTime": "2022-01-30T08:47:21\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments/production/jobs/659fa459-2da2-4f75-a177-221bca4da990?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "89457c3081771b2ded71d75cf593c66c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "89e19dce-e07a-40a0-aebe-3526854ec713",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:22 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:20\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:20\u002B00:00",
+        "jobId": "659fa459-2da2-4f75-a177-221bca4da990",
+        "lastUpdatedDateTime": "2022-01-30T08:47:21\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments/production/jobs/659fa459-2da2-4f75-a177-221bca4da990?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "babe19ad8d31f30a8dcc998d71d36c9f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "729bb9ce-92e7-4765-8ad8-e64876976399",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:23 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:20\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:20\u002B00:00",
+        "jobId": "659fa459-2da2-4f75-a177-221bca4da990",
+        "lastUpdatedDateTime": "2022-01-30T08:47:21\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments/production/jobs/659fa459-2da2-4f75-a177-221bca4da990?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b5a47c4d98ac0e6f4956e7262ceb89c2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0178d7ba-facf-43f9-98e9-c1ecd5d471d6",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:25 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:20\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:20\u002B00:00",
+        "jobId": "659fa459-2da2-4f75-a177-221bca4da990",
+        "lastUpdatedDateTime": "2022-01-30T08:47:21\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments/production/jobs/659fa459-2da2-4f75-a177-221bca4da990?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "85dcb5e70b43a2a27252fbabe89faa1a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a00f5a09-5439-49d0-a74f-e1caab4a5221",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:26 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:20\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:20\u002B00:00",
+        "jobId": "659fa459-2da2-4f75-a177-221bca4da990",
+        "lastUpdatedDateTime": "2022-01-30T08:47:21\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments/production/jobs/659fa459-2da2-4f75-a177-221bca4da990?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "790e380511ee15c0a9af70dba5e3c6a1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "72dca6b1-9139-409b-a3bd-b7da7a24647f",
+        "Content-Length": "235",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:20\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:20\u002B00:00",
+        "jobId": "659fa459-2da2-4f75-a177-221bca4da990",
+        "lastUpdatedDateTime": "2022-01-30T08:47:27\u002B00:00",
+        "status": "succeeded"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments/production?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bba5d642e6f7425bd90242599cc326aa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d14c59e2-6ed8-4eaf-b4e0-2a9c869ba1e2",
+        "Content-Length": "86",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "52"
+      },
+      "ResponseBody": {
+        "deploymentName": "production",
+        "lastDeployedDateTime": "2022-01-30T08:47:27Z"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895/deployments?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2927f3f27dc3194bb515a925b802b18d-ad43a41b3237a94f-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f421cdab10dcd6d3f5c6db939ac7fc8f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fa13427b-542e-45bf-bbcf-7648028223e2",
+        "Content-Length": "123",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "51"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "deploymentName": "production",
+            "lastDeployedDateTime": "2022-01-30T08:47:27Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/TestProject2019146895?api-version=2021-10-01",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b03c5148ae346d4b9c5e5136d5205350-4a41698958eca846-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "11695a8beef91e22dccc9fecce6679e6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "29461a0b-d0b2-488c-882f-d061aee30b8d",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 08:47:31 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/deletion-jobs/28e5a018-515b-47a1-960d-2f911b1639a8?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2616"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/deletion-jobs/28e5a018-515b-47a1-960d-2f911b1639a8?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b03c5148ae346d4b9c5e5136d5205350-7ac0ed46b0b54049-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d82fc689d2c132c403cfc5300bc7a712",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "745aaa19-488a-47c3-839f-b65e39d59671",
+        "Content-Length": "235",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:47:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "49"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:47:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:47:31\u002B00:00",
+        "jobId": "28e5a018-515b-47a1-960d-2f911b1639a8",
+        "lastUpdatedDateTime": "2022-01-30T08:47:31\u002B00:00",
+        "status": "succeeded"
+      }
+    }
+  ],
+  "Variables": {
+    "QUESTIONANSWERING_ENDPOINT": "https://wuppe.api.cognitive.microsoft.com",
+    "QUESTIONANSWERING_KEY": "Sanitized",
+    "RandomSeed": "1956468830"
+  }
+}

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/SessionRecords/QuestionAnsweringProjectsClientSamples/CreateAndDeploy.json
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/SessionRecords/QuestionAnsweringProjectsClientSamples/CreateAndDeploy.json
@@ -1,0 +1,1099 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ?api-version=2021-10-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Connection": "keep-alive",
+        "Content-Length": "171",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d5e999e8a821b61b643304e2b5f8c572",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "description": "This is the description for a test project",
+        "language": "en",
+        "multilingualResource": false,
+        "settings": {
+          "defaultAnswer": "No answer found for your question."
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "a05286de-6e6b-464d-9ceb-573455950b94",
+        "Content-Length": "319",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "204"
+      },
+      "ResponseBody": {
+        "projectName": "newFAQ",
+        "description": "This is the description for a test project",
+        "language": "en",
+        "multilingualResource": false,
+        "createdDateTime": "2022-01-30T08:59:38Z",
+        "lastModifiedDateTime": "2022-01-30T08:59:38Z",
+        "settings": {
+          "defaultAnswer": "No answer found for your question."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4e841478b81101744ae68cc3c834829d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ad2aacb6-c883-4f2d-8c66-aaa21b2adbb5",
+        "Content-Length": "2175",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "122"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "projectName": "IssacNewton",
+            "description": "biography of Sir Issac Newton",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-25T15:53:45Z",
+            "lastModifiedDateTime": "2022-01-25T16:57:20Z",
+            "lastDeployedDateTime": "2022-01-25T16:57:51Z",
+            "settings": {
+              "defaultAnswer": "no answer"
+            }
+          },
+          {
+            "projectName": "Microsoft",
+            "description": "test project for some Microsoft QnAs",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-25T18:33:47Z",
+            "lastModifiedDateTime": "2022-01-25T18:45:36Z",
+            "settings": {
+              "defaultAnswer": "no answer"
+            }
+          },
+          {
+            "projectName": "TestProject131875973",
+            "description": "This is the description for a test project",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-26T09:27:33Z",
+            "lastModifiedDateTime": "2022-01-26T09:27:33Z",
+            "settings": {
+              "defaultAnswer": "No answer found for your question."
+            }
+          },
+          {
+            "projectName": "fc12a55c-be22-46cc-b4b0-5b0a270f19e3",
+            "description": "rokulkaTestNe2",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2021-06-16T09:51:00Z",
+            "lastModifiedDateTime": "2021-06-16T09:51:00Z",
+            "settings": {
+              "defaultAnswer": "No good match found in KB"
+            }
+          },
+          {
+            "projectName": "newFAQ",
+            "description": "This is the description for a test project",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-30T08:59:38Z",
+            "lastModifiedDateTime": "2022-01-30T08:59:38Z",
+            "settings": {
+              "defaultAnswer": "No answer found for your question."
+            }
+          },
+          {
+            "projectName": "rokulkatest5",
+            "description": "RokulkaTest",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-24T19:04:26Z",
+            "lastModifiedDateTime": "2022-01-24T19:04:26Z",
+            "settings": {
+              "defaultAnswer": "No good match found in KB"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2f62ffe0ae7ef51ac6fe32b46bd68d11",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "48b346ae-2563-44ac-a3f0-58ffcaf078a5",
+        "Content-Length": "2175",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "120"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "projectName": "IssacNewton",
+            "description": "biography of Sir Issac Newton",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-25T15:53:45Z",
+            "lastModifiedDateTime": "2022-01-25T16:57:20Z",
+            "lastDeployedDateTime": "2022-01-25T16:57:51Z",
+            "settings": {
+              "defaultAnswer": "no answer"
+            }
+          },
+          {
+            "projectName": "Microsoft",
+            "description": "test project for some Microsoft QnAs",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-25T18:33:47Z",
+            "lastModifiedDateTime": "2022-01-25T18:45:36Z",
+            "settings": {
+              "defaultAnswer": "no answer"
+            }
+          },
+          {
+            "projectName": "TestProject131875973",
+            "description": "This is the description for a test project",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-26T09:27:33Z",
+            "lastModifiedDateTime": "2022-01-26T09:27:33Z",
+            "settings": {
+              "defaultAnswer": "No answer found for your question."
+            }
+          },
+          {
+            "projectName": "fc12a55c-be22-46cc-b4b0-5b0a270f19e3",
+            "description": "rokulkaTestNe2",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2021-06-16T09:51:00Z",
+            "lastModifiedDateTime": "2021-06-16T09:51:00Z",
+            "settings": {
+              "defaultAnswer": "No good match found in KB"
+            }
+          },
+          {
+            "projectName": "newFAQ",
+            "description": "This is the description for a test project",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-30T08:59:38Z",
+            "lastModifiedDateTime": "2022-01-30T08:59:38Z",
+            "settings": {
+              "defaultAnswer": "No answer found for your question."
+            }
+          },
+          {
+            "projectName": "rokulkatest5",
+            "description": "RokulkaTest",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-24T19:04:26Z",
+            "lastModifiedDateTime": "2022-01-24T19:04:26Z",
+            "settings": {
+              "defaultAnswer": "No good match found in KB"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources?api-version=2021-10-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "259",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1c6502e2f11030ac24e88a3b1b58ee2f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[{\u0022op\u0022:\u0022add\u0022,\u0022value\u0022:{\u0022displayName\u0022:\u0022MicrosoftFAQ\u0022,\u0022source\u0022:\u0022https://www.microsoft.com/en-in/software-download/faq\u0022,\u0022sourceUri\u0022:\u0022https://www.microsoft.com/en-in/software-download/faq\u0022,\u0022sourceKind\u0022:\u0022url\u0022,\u0022contentStructureKind\u0022:\u0022unstructured\u0022,\u0022refresh\u0022:false}}]",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "ecf83e0e-d14b-4deb-be94-0666439beec6",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 08:59:40 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "764"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b50266b19696caf4fa8e881385bf9574",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2aadd4b1-4f29-4cca-95a9-1be85a438ebe",
+        "Content-Length": "236",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:40 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "status": "notStarted"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c5e07a5965ceef8d53310a9624deda6d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "524722d2-05fc-4c3f-9f60-d8edd6a0c152",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:41 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "05030210d7d34b7b0d9b22826899aa64",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3b6e7ea9-a331-4340-b10b-64ca08257a93",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:43 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a1e1155228774b61d91262648c5da61b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5ebf88d4-c94e-41c4-b431-4ecde11400e2",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:44 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "83021ab490bc82a0fe94b833420a86b9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0ee108f7-6454-4aa0-a7e7-7dc3d51d5989",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:46 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0e43a58638fde8f5a1b72bc07417bfaf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1166c6ed-ff3f-47b4-ae85-185035ba8cef",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:47 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "4ece07f52796c2a8745fa2e3702d09ce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "90c00c8d-8e8c-47eb-b2b1-fdc8d37e0e7e",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:48 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e6dda98c971a7b1e241ae20464df0de7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a7506a99-0b22-4319-a1ef-65179d42b7fe",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:49 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3a3e08d4383c5f23fd81999d96127873",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "016f7fd1-c42e-41e3-8a59-b6e86df2deaf",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:51 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cb345daed9395d95e952297b44a45d95",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1c820734-0beb-48b8-9e78-0c560838b480",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:52 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "670ebb51ceee5392857ee998fe80e512",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "38340e80-cf91-49d0-971e-4b63eb090eb1",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:53 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "07556ea242abfbae72e151e90ea71b58",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5f02404c-1d2a-4757-a19b-9fedcd7f89d0",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:55 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "db4b04231003df84cae045baf0fc5f68",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9547cefc-f975-4486-89e0-126d4a6c6919",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:56 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d5d9176d564f0ee90c13f40d7da844de",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "11853662-9fb8-47ef-8919-7c79d6dc9b3c",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:57 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:41\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/08b4e965-90f4-41f4-b4c1-89cd573d12c3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f97590630935910eea753ccafdf30b76",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "78d96ad4-c3c1-4c81-b7f6-38ac189426db",
+        "Content-Length": "276",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:39\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:39\u002B00:00",
+        "jobId": "08b4e965-90f4-41f4-b4c1-89cd573d12c3",
+        "lastUpdatedDateTime": "2022-01-30T08:59:58\u002B00:00",
+        "status": "succeeded",
+        "resultUrl": "/knowledgebases/newFAQ"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f77ce88145cdcd091a3ccef01b776222",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c32e9b22-ee1d-4c9f-aeb7-ac22ba316d91",
+        "Content-Length": "351",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "displayName": "MicrosoftFAQ",
+            "source": "https://www.microsoft.com/en-in/software-download/faq",
+            "sourceUri": "https://www.microsoft.com/en-in/software-download/faq",
+            "sourceKind": "url",
+            "contentStructureKind": "unstructured",
+            "lastUpdatedDateTime": "2022-01-30T08:59:55.6864761Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5f57679c658763330847ebd9191f1119",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4bfe03ea-599f-4f7b-aa5f-11063502fcc1",
+        "Content-Length": "351",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 08:59:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "displayName": "MicrosoftFAQ",
+            "source": "https://www.microsoft.com/en-in/software-download/faq",
+            "sourceUri": "https://www.microsoft.com/en-in/software-download/faq",
+            "sourceKind": "url",
+            "contentStructureKind": "unstructured",
+            "lastUpdatedDateTime": "2022-01-30T08:59:55.6864761Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production?api-version=2021-10-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "948b7e074d2c1d1087a7def83b1d7672",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "59d9e0f8-1bb4-4e04-a7b0-9ef5d38dfb4a",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 09:00:00 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/d82179c8-9c57-4e90-ad94-b5c04e99b1a8?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "404"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/d82179c8-9c57-4e90-ad94-b5c04e99b1a8?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "962e1a12ab9b1ceeb418ef855a2fb4fb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fcf47d7c-2f3f-426a-bf54-c28af636bcbd",
+        "Content-Length": "236",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:00 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:59\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:59\u002B00:00",
+        "jobId": "d82179c8-9c57-4e90-ad94-b5c04e99b1a8",
+        "lastUpdatedDateTime": "2022-01-30T08:59:59\u002B00:00",
+        "status": "notStarted"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/d82179c8-9c57-4e90-ad94-b5c04e99b1a8?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9ce8b52bcdeb4ef65639d8df863b28ea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "22962f19-e38a-4dcb-b482-04cd948d4211",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:01 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:59\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:59\u002B00:00",
+        "jobId": "d82179c8-9c57-4e90-ad94-b5c04e99b1a8",
+        "lastUpdatedDateTime": "2022-01-30T09:00:00\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/d82179c8-9c57-4e90-ad94-b5c04e99b1a8?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ffc678d17bf15c7d8f6fdf135d8ac357",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d2f19312-e8f3-4a4a-9f84-9ef381d1f8fb",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:02 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:59\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:59\u002B00:00",
+        "jobId": "d82179c8-9c57-4e90-ad94-b5c04e99b1a8",
+        "lastUpdatedDateTime": "2022-01-30T09:00:00\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/d82179c8-9c57-4e90-ad94-b5c04e99b1a8?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "86cce3f3d935458723df4062d20f9579",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7d958f0c-61ae-4004-b676-1b638635b433",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:04 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:59\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:59\u002B00:00",
+        "jobId": "d82179c8-9c57-4e90-ad94-b5c04e99b1a8",
+        "lastUpdatedDateTime": "2022-01-30T09:00:00\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/d82179c8-9c57-4e90-ad94-b5c04e99b1a8?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e1b404f0b568b00a378c0d7bede3f1cb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6114684f-cef6-4733-b2a5-b9e1c35f2498",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:05 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:59\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:59\u002B00:00",
+        "jobId": "d82179c8-9c57-4e90-ad94-b5c04e99b1a8",
+        "lastUpdatedDateTime": "2022-01-30T09:00:00\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/d82179c8-9c57-4e90-ad94-b5c04e99b1a8?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a2ec8075a16ef7b5f181db113b1b8980",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "df6d4c9c-468b-47fc-acc8-f73ce2d5173d",
+        "Content-Length": "235",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T08:59:59\u002B00:00",
+        "expirationDateTime": "2022-01-30T14:59:59\u002B00:00",
+        "jobId": "d82179c8-9c57-4e90-ad94-b5c04e99b1a8",
+        "lastUpdatedDateTime": "2022-01-30T09:00:06\u002B00:00",
+        "status": "succeeded"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "592266dae2d63defd91c4ea9cc0b5740",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bbaaebca-4e35-4619-8e46-d04a2cbd656d",
+        "Content-Length": "86",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "deploymentName": "production",
+        "lastDeployedDateTime": "2022-01-30T09:00:06Z"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "51ec74eef2224e0a4fbcf0e6d9f8751c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "047256a7-4d79-4f52-906d-73eedb721e3a",
+        "Content-Length": "123",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "deploymentName": "production",
+            "lastDeployedDateTime": "2022-01-30T09:00:06Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "87a18c0298c093f591aec952530c2be5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f83bfcd0-9bee-48a8-b7b4-a08874f8cbef",
+        "Content-Length": "123",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "deploymentName": "production",
+            "lastDeployedDateTime": "2022-01-30T09:00:06Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ?api-version=2021-10-01",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c6239b2a372ee75e5bd30919f20864e1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "3dae49b1-e128-4bfa-8dec-0b5cb6602bce",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 09:00:10 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/deletion-jobs/d0e0f8e2-1bf6-4504-a05b-a43924f67558?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2755"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/deletion-jobs/d0e0f8e2-1bf6-4504-a05b-a43924f67558?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3fa631a7cf69567f7f58c07329b8fb43",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "04f10358-c362-4c86-92f2-5b10d08b019a",
+        "Content-Length": "235",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:10 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:10\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:10\u002B00:00",
+        "jobId": "d0e0f8e2-1bf6-4504-a05b-a43924f67558",
+        "lastUpdatedDateTime": "2022-01-30T09:00:10\u002B00:00",
+        "status": "succeeded"
+      }
+    }
+  ],
+  "Variables": {
+    "QUESTIONANSWERING_ENDPOINT": "https://wuppe.api.cognitive.microsoft.com",
+    "QUESTIONANSWERING_KEY": "Sanitized",
+    "RandomSeed": "1921283387"
+  }
+}

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/SessionRecords/QuestionAnsweringProjectsClientSamples/CreateAndDeployAsyncAsync.json
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/tests/SessionRecords/QuestionAnsweringProjectsClientSamples/CreateAndDeployAsyncAsync.json
@@ -1,0 +1,1431 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ?api-version=2021-10-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "171",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-931f8c320394cd43b5822a0368feb4c4-58bf4fd427970e46-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b9840c73c66bed1e7c377bed06b0bd91",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "description": "This is the description for a test project",
+        "language": "en",
+        "multilingualResource": false,
+        "settings": {
+          "defaultAnswer": "No answer found for your question."
+        }
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "092d0cb3-646a-4059-a55e-40a4c1063d0d",
+        "Content-Length": "319",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "200"
+      },
+      "ResponseBody": {
+        "projectName": "newFAQ",
+        "description": "This is the description for a test project",
+        "language": "en",
+        "multilingualResource": false,
+        "createdDateTime": "2022-01-30T09:00:12Z",
+        "lastModifiedDateTime": "2022-01-30T09:00:12Z",
+        "settings": {
+          "defaultAnswer": "No answer found for your question."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-37f9784e0c603140ac37042cab3f1623-566f83a87b50124b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7757bd4b5af0166061e4d819b477beac",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "32203ccb-776d-4031-9af6-876b7e512cfe",
+        "Content-Length": "2175",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "120"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "projectName": "IssacNewton",
+            "description": "biography of Sir Issac Newton",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-25T15:53:45Z",
+            "lastModifiedDateTime": "2022-01-25T16:57:20Z",
+            "lastDeployedDateTime": "2022-01-25T16:57:51Z",
+            "settings": {
+              "defaultAnswer": "no answer"
+            }
+          },
+          {
+            "projectName": "Microsoft",
+            "description": "test project for some Microsoft QnAs",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-25T18:33:47Z",
+            "lastModifiedDateTime": "2022-01-25T18:45:36Z",
+            "settings": {
+              "defaultAnswer": "no answer"
+            }
+          },
+          {
+            "projectName": "TestProject131875973",
+            "description": "This is the description for a test project",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-26T09:27:33Z",
+            "lastModifiedDateTime": "2022-01-26T09:27:33Z",
+            "settings": {
+              "defaultAnswer": "No answer found for your question."
+            }
+          },
+          {
+            "projectName": "fc12a55c-be22-46cc-b4b0-5b0a270f19e3",
+            "description": "rokulkaTestNe2",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2021-06-16T09:51:00Z",
+            "lastModifiedDateTime": "2021-06-16T09:51:00Z",
+            "settings": {
+              "defaultAnswer": "No good match found in KB"
+            }
+          },
+          {
+            "projectName": "newFAQ",
+            "description": "This is the description for a test project",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-30T09:00:12Z",
+            "lastModifiedDateTime": "2022-01-30T09:00:12Z",
+            "settings": {
+              "defaultAnswer": "No answer found for your question."
+            }
+          },
+          {
+            "projectName": "rokulkatest5",
+            "description": "RokulkaTest",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-24T19:04:26Z",
+            "lastModifiedDateTime": "2022-01-24T19:04:26Z",
+            "settings": {
+              "defaultAnswer": "No good match found in KB"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e5d9833b300eb0418be77b3d168b452f-e586ec86c17bbd4d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e4547212d47b902b7081f0108206bfd4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b639392b-87b7-4d4a-ba36-f671acc4392e",
+        "Content-Length": "2175",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "119"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "projectName": "IssacNewton",
+            "description": "biography of Sir Issac Newton",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-25T15:53:45Z",
+            "lastModifiedDateTime": "2022-01-25T16:57:20Z",
+            "lastDeployedDateTime": "2022-01-25T16:57:51Z",
+            "settings": {
+              "defaultAnswer": "no answer"
+            }
+          },
+          {
+            "projectName": "Microsoft",
+            "description": "test project for some Microsoft QnAs",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-25T18:33:47Z",
+            "lastModifiedDateTime": "2022-01-25T18:45:36Z",
+            "settings": {
+              "defaultAnswer": "no answer"
+            }
+          },
+          {
+            "projectName": "TestProject131875973",
+            "description": "This is the description for a test project",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-26T09:27:33Z",
+            "lastModifiedDateTime": "2022-01-26T09:27:33Z",
+            "settings": {
+              "defaultAnswer": "No answer found for your question."
+            }
+          },
+          {
+            "projectName": "fc12a55c-be22-46cc-b4b0-5b0a270f19e3",
+            "description": "rokulkaTestNe2",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2021-06-16T09:51:00Z",
+            "lastModifiedDateTime": "2021-06-16T09:51:00Z",
+            "settings": {
+              "defaultAnswer": "No good match found in KB"
+            }
+          },
+          {
+            "projectName": "newFAQ",
+            "description": "This is the description for a test project",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-30T09:00:12Z",
+            "lastModifiedDateTime": "2022-01-30T09:00:12Z",
+            "settings": {
+              "defaultAnswer": "No answer found for your question."
+            }
+          },
+          {
+            "projectName": "rokulkatest5",
+            "description": "RokulkaTest",
+            "language": "en",
+            "multilingualResource": false,
+            "createdDateTime": "2022-01-24T19:04:26Z",
+            "lastModifiedDateTime": "2022-01-24T19:04:26Z",
+            "settings": {
+              "defaultAnswer": "No good match found in KB"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources?api-version=2021-10-01",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "259",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-c91c78951f8bc041-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f71819db38c21854ac6e5887ee043905",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[{\u0022op\u0022:\u0022add\u0022,\u0022value\u0022:{\u0022displayName\u0022:\u0022MicrosoftFAQ\u0022,\u0022source\u0022:\u0022https://www.microsoft.com/en-in/software-download/faq\u0022,\u0022sourceUri\u0022:\u0022https://www.microsoft.com/en-in/software-download/faq\u0022,\u0022sourceKind\u0022:\u0022url\u0022,\u0022contentStructureKind\u0022:\u0022unstructured\u0022,\u0022refresh\u0022:false}}]",
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "06e8bf2b-32b2-4318-ae69-325b20c92321",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 09:00:12 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "278"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-108b9c36aee6294e-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "94dacf79d85c761691c6076e6a4f945a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0f27501d-e4c4-465d-913d-37bd3881acfb",
+        "Content-Length": "236",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:12 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "status": "notStarted"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-853a27bb7c3fc34b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "9a3d0325c75edae91d3b380d7ba4a26b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "df35ce7a-1b2f-4437-82d0-155ee09ca5ca",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:14 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-709fff0603296648-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b296eb482a2c027803a166fb30e5ae5d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d4958232-a6e1-4efe-8dad-134e65f03b24",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:16 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-8ef6bba7dc7c3048-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eb61fed99ec6b1a6e5ff7621a009fbec",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6ad6146b-fff2-4d0c-a6da-8fcc7cf96a05",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:17 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-79b7cca418931f4d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7e269b24e1b8fa2e8b3b97bd61eeaa38",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ab2176d7-330f-4a48-9537-ac013d2d428f",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:18 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-91f089a47cbb8546-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7d33db8cb642aaa444e4cc2cb45762fa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "25435e73-eac2-46e8-ae04-544eeb50ece7",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:20 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-f05a566b58d2864b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "95d679a62fbff7a4d067608b07e950f7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "be5d7e24-c86f-4a83-8685-e48eeca9ffde",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:21 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-131ecd240d812443-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c5943e557dd56da9f67c3ad315014633",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d77040bc-d0af-46c7-84b3-b0190831b636",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:23 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-99b726a865628343-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e7169cd915175c78373caddb5618a25b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b37fb85c-df9a-4ae0-a0a8-49a676945222",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:24 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-5ddffedbc1071f42-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "75d7d5949cc22824cf689e43f5d0e2ce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "eb821ff7-8ea2-4ad0-97b8-e338026c89d7",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:25 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-5624d5c6d2b38542-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6ab22c2168d240e0c5378e98d0ce16de",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e2839b3b-814c-4d9f-a3dc-d67c36ea8c3b",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:27 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-4928ad039efacf4c-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "403fded9d02a3c7177ed18ae76356766",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4d03660d-f5a1-4e0b-bb64-02491fae917e",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:28 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-05a5498dee4f7143-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2ab9de5a37652b88f496b08b0d8c5701",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c06384a4-a77f-4101-8ad7-33ca684bfc44",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:29 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:14\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources/jobs/3071cbc0-5eb9-4ab3-8670-c62442cbbe55?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a6f025c3d5542b63616f225663df8-111f0c360e6a024d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1669c051a29051a4bb76f2e55032c98f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "78bea689-9549-4a0b-9b5a-d7eb73a726e9",
+        "Content-Length": "276",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:13\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:13\u002B00:00",
+        "jobId": "3071cbc0-5eb9-4ab3-8670-c62442cbbe55",
+        "lastUpdatedDateTime": "2022-01-30T09:00:30\u002B00:00",
+        "status": "succeeded",
+        "resultUrl": "/knowledgebases/newFAQ"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d54185588a87744f97962cd3abd91f46-d1b8999ce39a884e-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f23e27d0ec14a27856134b931fe62feb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f6ae4a69-75b8-46b0-a2fe-744770c14c97",
+        "Content-Length": "351",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "displayName": "MicrosoftFAQ",
+            "source": "https://www.microsoft.com/en-in/software-download/faq",
+            "sourceUri": "https://www.microsoft.com/en-in/software-download/faq",
+            "sourceKind": "url",
+            "contentStructureKind": "unstructured",
+            "lastUpdatedDateTime": "2022-01-30T09:00:27.8120985Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/sources?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0bcef3a1bf58d148a8d891ef4b440929-7268c65604142748-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b65c179550cbb7d639686fef44a3dbc2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "144e606d-6106-40d9-b53d-748fa93dcf1e",
+        "Content-Length": "351",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "displayName": "MicrosoftFAQ",
+            "source": "https://www.microsoft.com/en-in/software-download/faq",
+            "sourceUri": "https://www.microsoft.com/en-in/software-download/faq",
+            "sourceKind": "url",
+            "contentStructureKind": "unstructured",
+            "lastUpdatedDateTime": "2022-01-30T09:00:27.8120985Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production?api-version=2021-10-01",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "0",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-9133cdbe8c281648-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e5ba20cc654d65ec47c7bf7d561131d5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "af7503b4-0349-47a4-b5ed-4827901a47bb",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 09:00:31 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "134"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-241fb780240b3947-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "394f074712d67fc45186b9ac7c885db3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "eb596378-4e13-499a-83f3-c7fef237645c",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:31 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-e583b89a91af1c4c-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ffc68938492b309e2af66e0491596128",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "dd825aba-fd24-495d-a548-2f3f0ebd4dc0",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:33 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-27f2444c333b014d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3da89a37a153baec5c3b94c6ac3fe9bf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0c7fdf77-1123-4fc3-baeb-704c3e195dc9",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:34 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-bbcd64e2f0fce94f-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cc440c69314afea9681e0edfa3c0eef8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6b35b805-612b-40c5-9fa6-ff7865cdd9bc",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:35 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-cc8fcafbb95eb948-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e175912520df965f9d0ca2efb4d884eb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "9e788060-437f-41b7-a1d2-df9e03a05c18",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:37 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-03c52c312288024b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "849aaf0d941405ddf0aad435930c169c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c16f5419-02bb-4465-a6f4-f0f98a543ae1",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:38 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-f161511c6f1eb945-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1ba09c4d07ca49dfacae2f3e8fb94990",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "23869a8c-5478-43a6-ba53-4fcbe4b9beb1",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:39 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-370eb42350e3fc48-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f4d2239a692590e4b36ff1354b2a0290",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6a420051-2622-465b-9a68-6b3b3b002307",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:41 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-fcc9c2101e7db446-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "18a206f669370620cf50d765649e7637",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cb3d7fcb-ddf0-456a-a70d-0a2f58ffa346",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:42 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-83e952b36283a64d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6f9a4460213ae376b80f675a16aafd82",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3178bd82-b8c7-46df-85f0-9be41b67e939",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:43 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-fa23cc2b4bfb3149-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "88489fac3116315803cb25d4917e2b15",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fec7393f-db97-46bf-a197-e60616b13864",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:45 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "50"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-bef2c3e27998ea48-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "06d4b9f99290d45690bf602701c5f024",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b3aab321-3208-489f-b536-f572ae04cee7",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:46 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-74d6cbda3e97a44d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c5b95552ed562f20ec686c6efca15139",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "226bbc24-6562-4547-87d4-7ccb53a83ce0",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:47 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "41"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-e84428c9fbc39f4b-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5c6152e3f7d619f24973f857d1302f3d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e118b3c8-2cba-4916-8954-67bd91c4d6dd",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:48 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "42"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-e33149d0b194034a-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3c8100db66c50bbe99a41a2725e7d8ee",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "47a53684-c455-4f02-b7b4-2457b4e8f7a3",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:50 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-0ff0f44619709b44-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "af44266e93635b4d62a07ce2f5c95ebc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3139d5d0-ae53-4f56-aca6-2d938e83dbb9",
+        "Content-Length": "233",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:51 GMT",
+        "Retry-After": "00:00:30",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "status": "running"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production/jobs/db21ccb0-2ff2-419c-a903-a4a596c8bef2?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-5b1617bc1ae7bd4c-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fb922f39141f7d739356c332ddcbf361",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2c568e9f-9929-489e-af97-d188f9b2b308",
+        "Content-Length": "235",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:31\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:31\u002B00:00",
+        "jobId": "db21ccb0-2ff2-419c-a903-a4a596c8bef2",
+        "lastUpdatedDateTime": "2022-01-30T09:00:51\u002B00:00",
+        "status": "succeeded"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments/production?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3a1966ccc823f2488df606c75d4726e5-89fe725470a6764d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "aae9099b7fec48d9b326d925e9db15d0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "86efed97-81f3-4c43-bc68-be29b75984fd",
+        "Content-Length": "86",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "45"
+      },
+      "ResponseBody": {
+        "deploymentName": "production",
+        "lastDeployedDateTime": "2022-01-30T09:00:51Z"
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-36d34f354cc2c54aa85980e8459bf641-0f607856d087394d-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f6ed5d45dc5459ceb3c61c0dd01b7e97",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f417420f-6b06-4aaf-9727-11d6b8d41b58",
+        "Content-Length": "123",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "deploymentName": "production",
+            "lastDeployedDateTime": "2022-01-30T09:00:51Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ/deployments?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4376fc3f152fb34bb83e63c52c88be92-c99dc0d966079143-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ec471bacb4dfb9d0554a48f93b4e94b7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2efac98c-5388-4b40-9556-3368977a0432",
+        "Content-Length": "123",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "deploymentName": "production",
+            "lastDeployedDateTime": "2022-01-30T09:00:51Z"
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/newFAQ?api-version=2021-10-01",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-637ac5289c2bbf439533f1f8fa79d4e3-3e49003239826a45-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7fecf240fcddbe0c3b90f62563cc7797",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "apim-request-id": "7689e403-1492-42a9-8b85-b92f33200601",
+        "Content-Length": "0",
+        "Date": "Sun, 30 Jan 2022 09:00:57 GMT",
+        "operation-location": "https://wuppe.api.cognitive.microsoft.com:443/language/query-knowledgebases/projects/deletion-jobs/e5c8e2a8-e763-4228-8521-5c8621a8fbc3?api-version=2021-10-01",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "3913"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://wuppe.api.cognitive.microsoft.com/language/query-knowledgebases/projects/deletion-jobs/e5c8e2a8-e763-4228-8521-5c8621a8fbc3?api-version=2021-10-01",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-637ac5289c2bbf439533f1f8fa79d4e3-70896ae1c7d8b54e-00",
+        "User-Agent": "azsdk-net-AI.Language.QuestionAnswering/1.1.0-alpha.20220130.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "cd7841a7299391f08d34a10a94d41d64",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4ea322b3-9a18-457e-ade2-b67999300251",
+        "Content-Length": "235",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Sun, 30 Jan 2022 09:00:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "44"
+      },
+      "ResponseBody": {
+        "createdDateTime": "2022-01-30T09:00:57\u002B00:00",
+        "expirationDateTime": "2022-01-30T15:00:57\u002B00:00",
+        "jobId": "e5c8e2a8-e763-4228-8521-5c8621a8fbc3",
+        "lastUpdatedDateTime": "2022-01-30T09:00:57\u002B00:00",
+        "status": "succeeded"
+      }
+    }
+  ],
+  "Variables": {
+    "QUESTIONANSWERING_ENDPOINT": "https://wuppe.api.cognitive.microsoft.com",
+    "QUESTIONANSWERING_KEY": "Sanitized",
+    "RandomSeed": "1212694426"
+  }
+}


### PR DESCRIPTION
In this PR, I have done the following:

- Re-enabled tests for the deployment API (and samples)
- Recorded sessions for those tests
- Regenerated client with these swagger changes (minor changes in docstrings for our client in .NET)
- Removed unnecessary Operation-Id rename transforms for now. We can bring them back if needed.

This PR closes #26401 and #26173.