### PR TITLE
Install git into identity keyring test container image

### DIFF
--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.1.4-ubuntu-focal AS build
+FROM mcr.microsoft.com/powershell:7.2.1-ubuntu-focal AS build
 
 ENV \
     NO_AT_BRIDGE=1 \
@@ -8,8 +8,8 @@ ENV \
     # Do not generate certificate
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # SDK version
-    DOTNET_SDK_VERSION_5.0=5.0.401 \
-    DOTNET_SDK_VERSION_3_1=3.1.413 \
+    DOTNET_SDK_VERSION_5_0=5.0.404 \
+    DOTNET_SDK_VERSION_3_1=3.1.416 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
@@ -30,22 +30,25 @@ RUN apt-get update \
         curl \
         git
 
-# Below taken from https://hub.docker.com/_/microsoft-dotnet-sdk
-# https://github.com/dotnet/dotnet-docker/blob/ca43690e6e4ac9c21a990a012dc2eb07e78daf08/src/sdk/5.0/focal/amd64/Dockerfile
 
 # Install .NET SDK
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION_5.0/dotnet-sdk-$DOTNET_SDK_VERSION_5.0-linux-x64.tar.gz \
-    && dotnet_sha512='a444d44007709ceb68d8f72dec0531e17f85f800efc0007ace4fa66ba27f095066930e6c6defcd2f85cdedea2fec25e163f5da461c1c2b8563e5cd7cb47091e0' \
+
+# Below adapated from https://hub.docker.com/_/microsoft-dotnet-sdk
+# https://github.com/dotnet/dotnet-docker/blob/b20c03e0644b42167d66a85fe6077ec2428a47fa/src/sdk/5.0/focal/amd64/Dockerfile
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION_5_0/dotnet-sdk-$DOTNET_SDK_VERSION_5_0-linux-x64.tar.gz \
+    && dotnet_sha512='6f9b83b2b661ce3b033a04d4c50ff3a435efa288de1a48f58be1150e64c5dd9d6bd2a4bf40f697dcd7d64ffaac24f14cc4a874e738544c5d0e8113c474fd2ee0' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
-RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION_3_1/dotnet-sdk-$DOTNET_SDK_VERSION_3_1-linux-x64.tar.gz \
-    && dotnet_sha512='2a0824f11aba0b79d3f9a36af0395649bc9b4137e61b240a48dccb671df0a5b8c2086054f8e495430b7ed6c344bb3f27ac3dfda5967d863718a6dadeca951a83' \
+# Below adapted from https://hub.docker.com/_/microsoft-dotnet-sdk
+# https://github.com/dotnet/dotnet-docker/blob/b20c03e0644b42167d66a85fe6077ec2428a47fa/src/sdk/3.1/focal/amd64/Dockerfile
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION_3_1/dotnet-sdk-$DOTNET_SDK_VERSION_3_1-linux-x64.tar.gz \
+    && dotnet_sha512='dec1dcf326487031c45dec0849a046a0d034d6cbb43ab591da6d94c2faf72da8e31deeaf4d2165049181546d5296bb874a039ccc2f618cf95e68a26399da5e7f' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -20,8 +20,12 @@ ENV \
     DOTNET_ROOT=/usr/share/dotnet  \
     PATH=$PATH:usr/share/dotnet    
 
-# Install GNOME keyring
-RUN apt-get update \
+# Install apt-add-repository
+RUN apt-get update && apt-get install -y software-properties-common
+
+# Install GNOME keyring, git >= 2.35 (for 'git sparse-checkout add' command)
+RUN apt-add-repository ppa:git-core/ppa \
+    && apt-get update \
     && apt-get install -y \
         libsecret-1-dev \
         dbus-x11 \

--- a/eng/containers/UbuntuNetCoreKeyring/Dockerfile
+++ b/eng/containers/UbuntuNetCoreKeyring/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get update \
         dbus-x11 \
         gnome-keyring \
         python \
-        curl
+        curl \
+        git
 
 # Below taken from https://hub.docker.com/_/microsoft-dotnet-sdk
 # https://github.com/dotnet/dotnet-docker/blob/ca43690e6e4ac9c21a990a012dc2eb07e78daf08/src/sdk/5.0/focal/amd64/Dockerfile

--- a/eng/containers/ci.yml
+++ b/eng/containers/ci.yml
@@ -12,10 +12,15 @@ pool:
   vmImage: 'ubuntu-20.04'
 
 variables:
-  dockerfile: ./eng/containers/UbuntuNetCoreKeyring/Dockerfile
-  containerRegistry: 'azsdkengsys'
-  imageRepository: 'dotnet/ubuntu_netcore_keyring'
-  imageTag: $(build.buildid)
+  - template: /eng/pipelines/templates/variables/globals.yml
+  - name: dockerfile
+    value: ./eng/containers/UbuntuNetCoreKeyring/Dockerfile
+  - name: containerRegistry
+    value: 'azsdkengsys'
+  - name: imageRepository
+    value: 'dotnet/ubuntu_netcore_keyring'
+  - name: imageTag
+    value: $(build.buildid)
 
 steps:
 - task: Docker@2

--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -114,6 +114,8 @@ jobs:
           }
         displayName: Set Test Mode
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
+        parameters:
+          Container: ${{ parameters.UsePlatformContainer }}
       - pwsh: >
           dotnet test eng/service.proj
           --framework $(TestTargetFramework)

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,10 +1,12 @@
 parameters:
   EnableNuGetCache: true
   NuGetCacheKey: 'Build'
+  Container: false
 
 steps:
   - task: MSBuild@1
     displayName: Install DevOps Logger
+    condition: eq(${{ parameters.Container }}, false)
     inputs:
       solution: eng/InstallDevopsLogger.proj
       msbuildArguments: /p:WorkFolder="$(Agent.WorkFolder)" /p:BuildDirectory="$(Agent.BuildDirectory)"

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -3,7 +3,8 @@ trigger: none
 resources:
   containers:
     - container: 'ubuntu_netcore_keyring'
-      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore50401_keyring:powershell714focalnet50401.4'
+      # See ./eng/containers/UbuntuNetCoreKeyring/Dockerfile for tool versions
+      image: 'azsdkengsys.azurecr.io/dotnet/ubuntu_netcore_keyring:1347171'
       endpoint: 'azsdkengsys'
       options: -ti --cap-add=IPC_LOCK
 


### PR DESCRIPTION
The live test container image job for identity keyring tests appears to be failing because git is not installed on the image. This would have been recently broken with https://github.com/Azure/azure-sdk-for-net/pull/25983 as git commands are now executed directly on the container as a pipeline step.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/26354
