### PR TITLE
[Fabric Bot] Reflect CODEOWNERS for Digital Twins

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1871,13 +1871,10 @@
             "Digital Twins"
           ],
           "mentionees": [
-            "drwill-ms",
-            "timtay-microsoft",
-            "abhipsaMisra",
-            "vinagesh",
-            "azabbasi",
-            "barustum",
-            "jamdavi"
+            "johngallardo",
+            "efriesner",
+            "abhinav-gha",
+            "Aashish93-stack"
           ]
         },
         {


### PR DESCRIPTION
# Summary

The focus of these changes is to update the "Service Attention" contacts for Digital Twins to reflect the most recent updates to CODEOWNERS.

# References and Related

- [[DigitalTwins] Add Code Owners (#26718)](https://github.com/Azure/azure-sdk-for-net/pull/26718)