### PR TITLE
Add parameter to forwards client calls to support APIs that cache results

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
@@ -182,10 +182,8 @@ namespace Azure.Core.TestFramework
                 // Remove subscribers before enumerating events.
                 diagnosticListener.Dispose();
                 var skipOverrideProperty = forwardAttribute is not null ? forwardAttribute.GetType().GetProperty("SkipChecks") : null;
-                bool ? skipOverride = skipOverrideProperty is null
-                    ? default(bool?)
-                    : (bool?)skipOverrideProperty.GetValue(forwardAttribute);
-                skipChecks |= skipOverride.HasValue && skipOverride.Value;
+                bool skipOverride = skipOverrideProperty is not null ? (bool)skipOverrideProperty.GetValue(forwardAttribute) : false;
+                skipChecks |= skipOverride;
                 if (!skipChecks)
                 {
                     if (strict)

--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/DiagnosticScopeValidatingInterceptor.cs
@@ -181,9 +181,10 @@ namespace Azure.Core.TestFramework
             {
                 // Remove subscribers before enumerating events.
                 diagnosticListener.Dispose();
-                bool? skipOverride = forwardAttribute is null
+                var skipOverrideProperty = forwardAttribute is not null ? forwardAttribute.GetType().GetProperty("SkipChecks") : null;
+                bool ? skipOverride = skipOverrideProperty is null
                     ? default(bool?)
-                    : (bool?)forwardAttribute.GetType().GetProperty("SkipChecks").GetValue(forwardAttribute);
+                    : (bool?)skipOverrideProperty.GetValue(forwardAttribute);
                 skipChecks |= skipOverride.HasValue && skipOverride.Value;
                 if (!skipChecks)
                 {

--- a/sdk/core/Azure.Core/src/Shared/ForwardsClientCallsAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/ForwardsClientCallsAttribute.cs
@@ -11,5 +11,12 @@ namespace Azure.Core
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     internal class ForwardsClientCallsAttribute : Attribute
     {
+        public ForwardsClientCallsAttribute() { }
+        public ForwardsClientCallsAttribute(bool skipChecks)
+        {
+            SkipChecks = skipChecks;
+        }
+
+        public bool? SkipChecks { get; }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/ForwardsClientCallsAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/ForwardsClientCallsAttribute.cs
@@ -11,7 +11,18 @@ namespace Azure.Core
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     internal class ForwardsClientCallsAttribute : Attribute
     {
-        public ForwardsClientCallsAttribute() { }
+        /// <summary>
+        /// Creates a new instance of <see cref="ForwardsClientCallsAttribute"/>.
+        /// </summary>
+        public ForwardsClientCallsAttribute()
+            : this(false)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ForwardsClientCallsAttribute"/>.
+        /// </summary>
+        /// <param name="skipChecks"> Sets whether or not diagnostic scope validation should happen. </param>
         public ForwardsClientCallsAttribute(bool skipChecks)
         {
             SkipChecks = skipChecks;
@@ -23,6 +34,6 @@ namespace Azure.Core
         /// If the public API will cache the results then the diagnostic scope will not always be created because an Azure API is not always called.
         /// In this case we need to turn off this validation for this API only.
         /// </summary>
-        public bool? SkipChecks { get; }
+        public bool SkipChecks { get; }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/ForwardsClientCallsAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/ForwardsClientCallsAttribute.cs
@@ -6,7 +6,7 @@ using System;
 namespace Azure.Core
 {
     /// <summary>
-    /// Marks methods that call methods on other client and don't need their diagnostics verified
+    /// Marks methods that call methods on other client and don't need their diagnostics verified.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     internal class ForwardsClientCallsAttribute : Attribute
@@ -17,6 +17,12 @@ namespace Azure.Core
             SkipChecks = skipChecks;
         }
 
+        /// <summary>
+        /// Gets whether or not we should validate DiagnosticScope for this API.
+        /// In the case where there is an internal API that makes the Azure API call and a public API that uses it we need ForwardsClientCalls.
+        /// If the public API will cache the results then the diagnostic scope will not always be created because an Azure API is not always called.
+        /// In this case we need to turn off this validation for this API only.
+        /// </summary>
         public bool? SkipChecks { get; }
     }
 }

--- a/sdk/core/Azure.Core/tests/ManagementRecordedTestBaseTests.cs
+++ b/sdk/core/Azure.Core/tests/ManagementRecordedTestBaseTests.cs
@@ -194,5 +194,35 @@ namespace Azure.Core.Tests.Management
             //method waits for 10 seconds so timer should easily be less than half of that if we skip
             Assert.IsTrue(timer.ElapsedMilliseconds < 5000, $"WaitForCompletion took {timer.ElapsedMilliseconds}ms");
         }
+
+        [Test]
+        public void ValidateForwardClientCallTrue()
+        {
+            ManagementTestClient client = InstrumentClient(new ManagementTestClient());
+            TestResource testResource = client.GetTestResource();
+            Assert.AreEqual("TestResourceProxy", testResource.GetType().Name);
+            Assert.DoesNotThrowAsync( async () => testResource = await testResource.GetForwardsCallTrueAsync());
+            Assert.AreEqual("TestResourceProxy", testResource.GetType().Name);
+        }
+
+        [Test]
+        public void ValidateForwardClientCallFalse()
+        {
+            ManagementTestClient client = InstrumentClient(new ManagementTestClient());
+            TestResource testResource = client.GetTestResource();
+            Assert.AreEqual("TestResourceProxy", testResource.GetType().Name);
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => testResource = await testResource.GetForwardsCallFalseAsync());
+            Assert.AreEqual(ex.Message, "Expected some diagnostic scopes to be created, found none");
+        }
+
+        [Test]
+        public void ValidateForwardClientCallDefault()
+        {
+            ManagementTestClient client = InstrumentClient(new ManagementTestClient());
+            TestResource testResource = client.GetTestResource();
+            Assert.AreEqual("TestResourceProxy", testResource.GetType().Name);
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => testResource = await testResource.GetForwardsCallDefaultAsync());
+            Assert.AreEqual(ex.Message, "Expected some diagnostic scopes to be created, found none");
+        }
     }
 }

--- a/sdk/core/Azure.Core/tests/TestClients/TestResource.cs
+++ b/sdk/core/Azure.Core/tests/TestClients/TestResource.cs
@@ -51,6 +51,45 @@ namespace Azure.Core.Tests
             }
         }
 
+        [ForwardsClientCalls(true)]
+        public virtual Response<TestResource> GetForwardsCallTrue(CancellationToken cancellationToken = default)
+        {
+            return Response.FromValue(new TestResource(), new MockResponse(200));
+        }
+
+        [ForwardsClientCalls(true)]
+        public async virtual Task<Response<TestResource>> GetForwardsCallTrueAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(1);
+            return Response.FromValue(new TestResource(), new MockResponse(200));
+        }
+
+        [ForwardsClientCalls(false)]
+        public virtual Response<TestResource> GetForwardsCallFalse(CancellationToken cancellationToken = default)
+        {
+            return Response.FromValue(new TestResource(), new MockResponse(200));
+        }
+
+        [ForwardsClientCalls(false)]
+        public async virtual Task<Response<TestResource>> GetForwardsCallFalseAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(1);
+            return Response.FromValue(new TestResource(), new MockResponse(200));
+        }
+
+        [ForwardsClientCalls]
+        public virtual Response<TestResource> GetForwardsCallDefault(CancellationToken cancellationToken = default)
+        {
+            return Response.FromValue(new TestResource(), new MockResponse(200));
+        }
+
+        [ForwardsClientCalls]
+        public async virtual Task<Response<TestResource>> GetForwardsCallDefaultAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(1);
+            return Response.FromValue(new TestResource(), new MockResponse(200));
+        }
+
         public virtual Response<TestResource> GetResponse(CancellationToken cancellationToken = default)
         {
             using var scope = _diagnostic.CreateScope("TestResource.GetResponse");


### PR DESCRIPTION
# All SDK Contribution checklist:

This allows us to turn off DiagnosticScopeValidation for a single method on a client vs today having to turn on or off the entire client.

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
