### PR TITLE
SR API updates

### DIFF
--- a/sdk/core/Azure.Core.Experimental/CHANGELOG.md
+++ b/sdk/core/Azure.Core.Experimental/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Release History
 
-## 0.1.0-preview.20 (Unreleased)
+## 0.1.0-preview.20 (2022-02-07)
 
 ### Features Added
 
+- `MessageWithMetadata` is now a concrete rather than abstract class.
+
 ### Breaking Changes
+
+- `MessageWithMetadata` is now in the `Azure` namespace rather than `Azure.Messaging`.
+- Changed `ContentType` property of `MessageWithMetadata` from a `string` to a `ContentType`
 
 ### Bugs Fixed
 

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -3,7 +3,7 @@ namespace Azure
     public partial class MessageWithMetadata
     {
         public MessageWithMetadata() { }
-        public Azure.Core.ContentType? ContentType { get { throw null; } set { } }
+        public virtual Azure.Core.ContentType? ContentType { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected virtual Azure.Core.ContentType? ContentTypeCore { get { throw null; } set { } }
         public virtual System.BinaryData? Data { get { throw null; } set { } }

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -1,5 +1,14 @@
 namespace Azure
 {
+    public partial class MessageWithMetadata
+    {
+        public MessageWithMetadata() { }
+        public Azure.Core.ContentType? ContentType { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected virtual Azure.Core.ContentType? ContentTypeCore { get { throw null; } set { } }
+        public virtual System.BinaryData? Data { get { throw null; } set { } }
+        public virtual bool IsReadOnly { get { throw null; } }
+    }
     public partial class RequestOptions
     {
         public RequestOptions() { }
@@ -100,15 +109,5 @@ namespace Azure.Core.Pipeline
     public static partial class HttpPipelineExtensions
     {
         public static Azure.Core.HttpMessage CreateMessage(this Azure.Core.Pipeline.HttpPipeline pipeline, Azure.RequestOptions? options) { throw null; }
-    }
-}
-namespace Azure.Messaging
-{
-    public partial class MessageWithMetadata
-    {
-        public MessageWithMetadata() { }
-        public virtual string? ContentType { get { throw null; } set { } }
-        public virtual System.BinaryData? Data { get { throw null; } set { } }
-        public virtual bool IsReadOnly { get { throw null; } }
     }
 }

--- a/sdk/core/Azure.Core.Experimental/src/MessageWithMetadata.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MessageWithMetadata.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
+using Azure.Core;
 
-namespace Azure.Messaging
+namespace Azure
 {
     /// <summary>
     /// A message containing a content type along with its data.
@@ -18,7 +20,17 @@ namespace Azure.Messaging
         /// <summary>
         /// Gets or sets the message content type.
         /// </summary>
-        public virtual string? ContentType { get; set; }
+        public ContentType? ContentType
+        {
+            get => ContentTypeCore;
+            set => ContentTypeCore = value;
+        }
+
+        /// <summary>
+        /// This property must be overriden by inheriting types to get/set the correct content type.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual ContentType? ContentTypeCore { get; set; }
 
         /// <summary>
         /// Gets whether the message is read only or not. This

--- a/sdk/core/Azure.Core.Experimental/src/MessageWithMetadata.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MessageWithMetadata.cs
@@ -20,7 +20,7 @@ namespace Azure
         /// <summary>
         /// Gets or sets the message content type.
         /// </summary>
-        public ContentType? ContentType
+        public virtual ContentType? ContentType
         {
             get => ContentTypeCore;
             set => ContentTypeCore = value;

--- a/sdk/core/Azure.Core.Experimental/src/MessageWithMetadata.cs
+++ b/sdk/core/Azure.Core.Experimental/src/MessageWithMetadata.cs
@@ -27,7 +27,9 @@ namespace Azure
         }
 
         /// <summary>
-        /// This property must be overriden by inheriting types to get/set the correct content type.
+        /// For inheriting types that have a string ContentType property, this property should be overriden to forward
+        /// the <see cref="ContentType"/> property into the inheriting type's string property, and vice versa.
+        /// For types that have a <see cref="Azure.Core.ContentType"/> ContentType property, it is not necessary to override this member.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual ContentType? ContentTypeCore { get; set; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -18,7 +18,7 @@
 
     <PackageReference Include="Azure.Core" />
     -->
-    <PackageReference Include="Azure.Core.Experimental" />
+    
     <!-- END TEMP -->
 
     <!--

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -1,6 +1,6 @@
 namespace Azure.Messaging.EventHubs
 {
-    public partial class EventData : Azure.Messaging.MessageWithMetadata
+    public partial class EventData : Azure.MessageWithMetadata
     {
         public EventData() { }
         public EventData(System.BinaryData eventBody) { }
@@ -14,7 +14,9 @@ namespace Azure.Messaging.EventHubs
         public System.ReadOnlyMemory<byte> Body { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.IO.Stream BodyAsStream { get { throw null; } }
-        public override string ContentType { get { throw null; } set { } }
+        public new string ContentType { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected override Azure.Core.ContentType? ContentTypeCore { get { throw null; } set { } }
         public string CorrelationId { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override System.BinaryData Data { get { throw null; } set { } }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -71,7 +71,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <seealso href="https://datatracker.ietf.org/doc/html/rfc2046">RFC2046 (MIME Types)</seealso>
         ///
-        public override string ContentType
+        public new string ContentType
         {
             get
             {
@@ -94,6 +94,16 @@ namespace Azure.Messaging.EventHubs
                         : null;
                 }
             }
+        }
+
+        /// <summary>
+        /// Hidden property that translates the <see cref="MessageWithMetadata.ContentType"/> property to/from a string.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override ContentType? ContentTypeCore
+        {
+            get => new ContentType(ContentType);
+            set => ContentType = value.ToString();
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -97,7 +97,9 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Hidden property that translates the <see cref="MessageWithMetadata.ContentType"/> property to/from a string.
+        ///    This member is intended to allow the string-based <see cref="ContentType" /> in this class to be
+        ///    translated to/from the <see cref="Azure.Core.ContentType" /> type used by the <see cref="MessageWithMetadata" />
+        ///    base class.
         /// </summary>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -97,8 +97,9 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        /// Hidden property that translates the <see cref="MessageWithMetadata.ContentType"/> property to/from a string.
+        ///   Hidden property that translates the <see cref="MessageWithMetadata.ContentType"/> property to/from a string.
         /// </summary>
+        ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override ContentType? ContentTypeCore
         {

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
@@ -83,7 +83,7 @@ In order to encode an `EventData` instance with Avro information, you can do the
 var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
 
 var employee = new Employee { Age = 42, Name = "Caketown" };
-EventData eventData = await encoder.EncodeMessageDataAsync<EventData>(employee);
+EventData eventData = (EventData) await encoder.EncodeMessageDataAsync(employee, messageType: typeof(EventData));
 
 // the schema Id will be included as a parameter of the content type
 Console.WriteLine(eventData.ContentType);
@@ -94,7 +94,28 @@ Console.WriteLine(eventData.EventBody);
 
 To decode an `EventData` event that you are consuming:
 ```C# Snippet:SchemaRegistryAvroDecodeEventData
-Employee deserialized = await encoder.DecodeMessageDataAsync<Employee>(eventData);
+Employee deserialized = (Employee) await encoder.DecodeMessageDataAsync(eventData, typeof(Employee));
+Console.WriteLine(deserialized.Age);
+Console.WriteLine(deserialized.Name);
+```
+
+You can also use generic methods to encode and decode the data. This may be more convenient if you are not building a library on top of the Avro encoder, as you won't have to worry about the virality of generics:
+```C# Snippet:SchemaRegistryAvroEncodeEventDataGenerics
+var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+
+var employee = new Employee { Age = 42, Name = "Caketown" };
+EventData eventData = await encoder.EncodeMessageDataAsync<EventData, Employee>(employee);
+
+// the schema Id will be included as a parameter of the content type
+Console.WriteLine(eventData.ContentType);
+
+// the serialized Avro data will be stored in the EventBody
+Console.WriteLine(eventData.EventBody);
+```
+
+Similarly, to decode:
+```C# Snippet:SchemaRegistryAvroDecodeEventDataGenerics
+Employee deserialized = (Employee) await encoder.DecodeMessageDataAsync<Employee>(eventData);
 Console.WriteLine(deserialized.Age);
 Console.WriteLine(deserialized.Name);
 ```
@@ -104,7 +125,7 @@ Console.WriteLine(deserialized.Name);
 It is also possible to encode and decode using `MessageWithMetadata`. Use this option if you are not integrating with any of the messaging libraries that work with `MessageWithMetadata`.
 ```C# Snippet:SchemaRegistryAvroEncodeDecodeMessageWithMetadata
 var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions() { AutoRegisterSchemas = true });
-MessageWithMetadata messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata>(employee, typeof(Employee));
+MessageWithMetadata messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
 
 Employee decodedEmployee = await encoder.DecodeMessageDataAsync<Employee>(messageData);
 ```

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
@@ -80,7 +80,7 @@ Details on generating a class using the Apache Avro library can be found in the 
 
 In order to encode an `EventData` instance with Avro information, you can do the following:
 ```C# Snippet:SchemaRegistryAvroEncodeEventData
-var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
 
 var employee = new Employee { Age = 42, Name = "Caketown" };
 EventData eventData = (EventData) await encoder.EncodeMessageDataAsync(employee, messageType: typeof(EventData));
@@ -101,7 +101,7 @@ Console.WriteLine(deserialized.Name);
 
 You can also use generic methods to encode and decode the data. This may be more convenient if you are not building a library on top of the Avro encoder, as you won't have to worry about the virality of generics:
 ```C# Snippet:SchemaRegistryAvroEncodeEventDataGenerics
-var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
 
 var employee = new Employee { Age = 42, Name = "Caketown" };
 EventData eventData = await encoder.EncodeMessageDataAsync<EventData, Employee>(employee);
@@ -124,7 +124,7 @@ Console.WriteLine(deserialized.Name);
 
 It is also possible to encode and decode using `MessageWithMetadata`. Use this option if you are not integrating with any of the messaging libraries that work with `MessageWithMetadata`.
 ```C# Snippet:SchemaRegistryAvroEncodeDecodeMessageWithMetadata
-var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions() { AutoRegisterSchemas = true });
+var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions() { AutoRegisterSchemas = true });
 MessageWithMetadata messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
 
 Employee decodedEmployee = await encoder.DecodeMessageDataAsync<Employee>(messageData);

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
@@ -124,7 +124,7 @@ Console.WriteLine(deserialized.Name);
 
 It is also possible to encode and decode using `MessageWithMetadata`. Use this option if you are not integrating with any of the messaging libraries that work with `MessageWithMetadata`.
 ```C# Snippet:SchemaRegistryAvroEncodeDecodeMessageWithMetadata
-var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions() { AutoRegisterSchemas = true });
+var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
 MessageWithMetadata messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
 
 Employee decodedEmployee = await encoder.DecodeMessageDataAsync<Employee>(messageData);

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/api/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.netstandard2.0.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/api/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.netstandard2.0.cs
@@ -3,10 +3,14 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
     public partial class SchemaRegistryAvroEncoder
     {
         public SchemaRegistryAvroEncoder(Azure.Data.SchemaRegistry.SchemaRegistryClient client, string groupName, Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.SchemaRegistryAvroObjectEncoderOptions options = null) { }
-        public System.Threading.Tasks.ValueTask<T> DecodeMessageDataAsync<T>(Azure.Messaging.MessageWithMetadata message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public T DecodeMessageData<T>(Azure.Messaging.MessageWithMetadata message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask<T> EncodeMessageDataAsync<T>(object data, System.Type inputType = null, System.Func<System.BinaryData, T> messageFactory = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Messaging.MessageWithMetadata { throw null; }
-        public T EncodeMessageData<T>(object data, System.Type inputType = null, System.Func<System.BinaryData, T> messageFactory = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where T : Azure.Messaging.MessageWithMetadata { throw null; }
+        public object DecodeMessageData(Azure.MessageWithMetadata message, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<object> DecodeMessageDataAsync(Azure.MessageWithMetadata message, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<TData> DecodeMessageDataAsync<TData>(Azure.MessageWithMetadata message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public TData DecodeMessageData<TData>(Azure.MessageWithMetadata message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public Azure.MessageWithMetadata EncodeMessageData(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<Azure.MessageWithMetadata> EncodeMessageDataAsync(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<TMessage> EncodeMessageDataAsync<TMessage, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.MessageWithMetadata, new() { throw null; }
+        public TMessage EncodeMessageData<TMessage, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.MessageWithMetadata, new() { throw null; }
     }
     public partial class SchemaRegistryAvroObjectEncoderOptions
     {

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/api/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.netstandard2.0.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/api/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.netstandard2.0.cs
@@ -2,7 +2,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
 {
     public partial class SchemaRegistryAvroEncoder
     {
-        public SchemaRegistryAvroEncoder(Azure.Data.SchemaRegistry.SchemaRegistryClient client, string groupName, Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.SchemaRegistryAvroObjectEncoderOptions options = null) { }
+        public SchemaRegistryAvroEncoder(Azure.Data.SchemaRegistry.SchemaRegistryClient client, string groupName, Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.SchemaRegistryAvroEncoderOptions options = null) { }
         public object DecodeMessageData(Azure.MessageWithMetadata message, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask<object> DecodeMessageDataAsync(Azure.MessageWithMetadata message, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask<TData> DecodeMessageDataAsync<TData>(Azure.MessageWithMetadata message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -12,9 +12,9 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
         public System.Threading.Tasks.ValueTask<TMessage> EncodeMessageDataAsync<TMessage, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.MessageWithMetadata, new() { throw null; }
         public TMessage EncodeMessageData<TMessage, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.MessageWithMetadata, new() { throw null; }
     }
-    public partial class SchemaRegistryAvroObjectEncoderOptions
+    public partial class SchemaRegistryAvroEncoderOptions
     {
-        public SchemaRegistryAvroObjectEncoderOptions() { }
+        public SchemaRegistryAvroEncoderOptions() { }
         public bool AutoRegisterSchemas { get { throw null; } set { } }
     }
 }

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
     {
         private readonly SchemaRegistryClient _client;
         private readonly string _groupName;
-        private readonly SchemaRegistryAvroObjectEncoderOptions _options;
+        private readonly SchemaRegistryAvroEncoderOptions _options;
         private const string AvroMimeType = "avro/binary";
         private const int CacheCapacity = 128;
         private static readonly Encoding Utf8Encoding = new UTF8Encoding(false);
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
         /// <summary>
         /// Initializes new instance of <see cref="SchemaRegistryAvroEncoder"/>.
         /// </summary>
-        public SchemaRegistryAvroEncoder(SchemaRegistryClient client, string groupName, SchemaRegistryAvroObjectEncoderOptions options = null)
+        public SchemaRegistryAvroEncoder(SchemaRegistryClient client, string groupName, SchemaRegistryAvroEncoderOptions options = null)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _groupName = groupName ?? throw new ArgumentNullException(nameof(groupName));

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
@@ -6,20 +6,15 @@ using Avro.Generic;
 using Avro.IO;
 using Avro.Specific;
 using Azure.Core;
-using Azure.Core.Serialization;
 using Azure.Data.SchemaRegistry;
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core.Pipeline;
-using Azure.Messaging;
 
 namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
 {

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
         #region Encode
 
         /// <summary>
-        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// Encodes the message data as Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
         /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
             => (TMessage) EncodeMessageDataInternalAsync(data, typeof(TData), typeof(TMessage), false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// Encodes the message data as Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
         /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
@@ -83,13 +83,14 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
             => (TMessage) await EncodeMessageDataInternalAsync(data, typeof(TData), typeof(TMessage), true, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
-        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// Encodes the message data as Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
         /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
         /// <param name="dataType">The type of the data to encode. If left blank, the type will be determined at runtime by
         /// calling <see cref="Object.GetType"/>.</param>
-        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="MessageWithMetadata"/>.
+        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="MessageWithMetadata"/>, and
+        /// have a parameterless constructor.
         /// If left blank, the data will be encoded into a <see cref="MessageWithMetadata"/> instance.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         public MessageWithMetadata EncodeMessageData(
@@ -100,13 +101,14 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
             => EncodeMessageDataInternalAsync(data, dataType, messageType, false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// Encodes the message data as Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
         /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
         /// <param name="dataType">The type of the data to encode. If left blank, the type will be determined at runtime by
         /// calling <see cref="Object.GetType"/>.</param>
-        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="MessageWithMetadata"/>.
+        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="MessageWithMetadata"/>, and
+        /// have a parameterless constructor.
         /// If left blank, the data will be encoded into a <see cref="MessageWithMetadata"/> instance.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         public async ValueTask<MessageWithMetadata> EncodeMessageDataAsync(

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
@@ -17,6 +17,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Core.Pipeline;
 using Azure.Messaging;
 
@@ -58,19 +59,114 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
             GenericRecord
         }
 
-        private static SupportedType GetSupportedTypeOrThrow(Type type)
+        #region Encode
+
+        /// <summary>
+        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
+        /// </summary>
+        /// <param name="data">The data to serialize to Avro and encode into the message.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <typeparam name="TMessage">The <see cref="MessageWithMetadata"/> type to encode the data into.</typeparam>
+        /// <typeparam name="TData">The type of the data to encode.</typeparam>
+        public TMessage EncodeMessageData<TMessage, TData>(
+            TData data,
+            CancellationToken cancellationToken = default) where TMessage : MessageWithMetadata, new()
+            => (TMessage) EncodeMessageDataInternalAsync(data, typeof(TData), typeof(TMessage), false, cancellationToken).EnsureCompleted();
+
+        /// <summary>
+        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
+        /// </summary>
+        /// <param name="data">The data to serialize to Avro and encode into the message.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <typeparam name="TMessage">The <see cref="MessageWithMetadata"/> type to encode the data into.</typeparam>
+        /// <typeparam name="TData">The type of the data to encode.</typeparam>
+        public async ValueTask<TMessage> EncodeMessageDataAsync<TMessage, TData>(
+            TData data,
+            CancellationToken cancellationToken = default) where TMessage : MessageWithMetadata, new()
+            => (TMessage) await EncodeMessageDataInternalAsync(data, typeof(TData), typeof(TMessage), true, cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
+        /// </summary>
+        /// <param name="data">The data to serialize to Avro and encode into the message.</param>
+        /// <param name="dataType">The type of the data to encode. If left blank, the type will be determined at runtime by
+        /// calling <see cref="Object.GetType"/>.</param>
+        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="MessageWithMetadata"/>.
+        /// If left blank, the data will be encoded into a <see cref="MessageWithMetadata"/> instance.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        public MessageWithMetadata EncodeMessageData(
+            object data,
+            Type dataType = default,
+            Type messageType = default,
+            CancellationToken cancellationToken = default)
+            => EncodeMessageDataInternalAsync(data, dataType, messageType, false, cancellationToken).EnsureCompleted();
+
+        /// <summary>
+        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
+        /// </summary>
+        /// <param name="data">The data to serialize to Avro and encode into the message.</param>
+        /// <param name="dataType">The type of the data to encode. If left blank, the type will be determined at runtime by
+        /// calling <see cref="Object.GetType"/>.</param>
+        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="MessageWithMetadata"/>.
+        /// If left blank, the data will be encoded into a <see cref="MessageWithMetadata"/> instance.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        public async ValueTask<MessageWithMetadata> EncodeMessageDataAsync(
+            object data,
+            Type dataType = default,
+            Type messageType = default,
+            CancellationToken cancellationToken = default)
+            => await EncodeMessageDataInternalAsync(data, dataType, messageType, true, cancellationToken).ConfigureAwait(false);
+
+        internal async ValueTask<MessageWithMetadata> EncodeMessageDataInternalAsync(
+            object data,
+            Type dataType,
+            Type messageType,
+            bool async,
+            CancellationToken cancellationToken)
         {
-            if (typeof(ISpecificRecord).IsAssignableFrom(type))
-            {
-                return SupportedType.SpecificRecord;
-            }
+            (string schemaId, BinaryData bd) = async
+                ? await EncodeInternalAsync(data, dataType, true, cancellationToken).ConfigureAwait(false)
+                : EncodeInternalAsync(data, dataType, false, cancellationToken).EnsureCompleted();
 
-            if (typeof(GenericRecord).IsAssignableFrom(type))
-            {
-                return SupportedType.GenericRecord;
-            }
+            messageType ??= typeof(MessageWithMetadata);
+            var message = (MessageWithMetadata)Activator.CreateInstance(messageType);
+            message.Data = bd;
+            message.ContentType = $"{AvroMimeType}+{schemaId}";
+            return message;
+        }
 
-            throw new ArgumentException($"Type {type.Name} is not supported for serialization operations.");
+        private async ValueTask<(string SchemaId, BinaryData Data)> EncodeInternalAsync(
+            object value,
+            Type dataType,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            Argument.AssertNotNull(value, nameof(value));
+            dataType ??= value?.GetType() ?? typeof(object);
+
+            var supportedType = GetSupportedTypeOrThrow(dataType);
+            var writer = GetWriterAndSchema(value, supportedType, out var schema);
+
+            using Stream stream = new MemoryStream();
+            var binaryEncoder = new BinaryEncoder(stream);
+
+            writer.Write(value, binaryEncoder);
+            binaryEncoder.Flush();
+            stream.Position = 0;
+            BinaryData data = BinaryData.FromStream(stream);
+
+            if (async)
+            {
+                return (await GetSchemaIdAsync(schema, true, cancellationToken).ConfigureAwait(false), data);
+            }
+            else
+            {
+                return (GetSchemaIdAsync(schema, false, cancellationToken).EnsureCompleted(), data);
+            }
         }
 
         private async Task<string> GetSchemaIdAsync(Schema schema, bool async, CancellationToken cancellationToken)
@@ -120,33 +216,163 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
             }
         }
 
-        private async ValueTask<(string SchemaId, BinaryData Data)> EncodeInternalAsync(
-            object value,
-            Type inputType,
+        private static SupportedType GetSupportedTypeOrThrow(Type type)
+        {
+            if (typeof(ISpecificRecord).IsAssignableFrom(type))
+            {
+                return SupportedType.SpecificRecord;
+            }
+
+            if (typeof(GenericRecord).IsAssignableFrom(type))
+            {
+                return SupportedType.GenericRecord;
+            }
+
+            throw new ArgumentException($"Type {type.Name} is not supported for serialization operations.");
+        }
+        #endregion
+
+        #region Decode
+        /// <summary>
+        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
+        /// </summary>
+        /// <param name="message">The message containing the data to decode.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <typeparam name="TData">The type to decode the message data into.</typeparam>
+        /// <returns>The deserialized data.</returns>
+        /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
+        public TData DecodeMessageData<TData>(
+            MessageWithMetadata message,
+            CancellationToken cancellationToken = default)
+            => (TData) DecodeMessageDataInternalAsync(message.Data, typeof(TData), message.ContentType, false, cancellationToken).EnsureCompleted();
+
+        /// <summary>
+        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
+        /// </summary>
+        /// <param name="message">The message containing the data to decode.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <typeparam name="TData">The type to decode the message data into.</typeparam>
+        /// <returns>The deserialized data.</returns>
+        /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
+        public async ValueTask<TData> DecodeMessageDataAsync<TData>(
+            MessageWithMetadata message,
+            CancellationToken cancellationToken = default)
+            => (TData) await DecodeMessageDataInternalAsync(message.Data, typeof(TData), message.ContentType, true, cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
+        /// </summary>
+        /// <param name="message">The message containing the data to decode.</param>
+        /// <param name="dataType">The type to decode the message data into.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <returns>The deserialized data.</returns>
+        /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
+        public object DecodeMessageData(
+            MessageWithMetadata message,
+            Type dataType,
+            CancellationToken cancellationToken = default)
+            => DecodeMessageDataInternalAsync(message.Data, dataType, message.ContentType, false, cancellationToken).EnsureCompleted();
+
+        /// <summary>
+        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
+        /// </summary>
+        /// <param name="message">The message containing the data to decode.</param>
+        /// <param name="dataType">The type to decode the message data into.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <returns>The deserialized data.</returns>
+        /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
+        public async ValueTask<object> DecodeMessageDataAsync(
+            MessageWithMetadata message,
+            Type dataType,
+            CancellationToken cancellationToken = default)
+            => await DecodeMessageDataInternalAsync(message.Data, dataType, message.ContentType, true, cancellationToken).ConfigureAwait(false);
+
+        private async ValueTask<object> DecodeMessageDataInternalAsync(
+            BinaryData data,
+            Type dataType,
+            ContentType? contentType,
             bool async,
             CancellationToken cancellationToken)
         {
-            Argument.AssertNotNull(value, nameof(value));
-            inputType ??= value?.GetType() ?? typeof(object);
+            Argument.AssertNotNull(data, nameof(data));
+            Argument.AssertNotNull(contentType, nameof(contentType));
 
-            var supportedType = GetSupportedTypeOrThrow(inputType);
-            var writer = GetWriterAndSchema(value, supportedType, out var schema);
-
-            using Stream stream = new MemoryStream();
-            var binaryEncoder = new BinaryEncoder(stream);
-
-            writer.Write(value, binaryEncoder);
-            binaryEncoder.Flush();
-            stream.Position = 0;
-            BinaryData data = BinaryData.FromStream(stream);
-
-            if (async)
+            string schemaId;
+            // Back Compat for first preview
+            ReadOnlyMemory<byte> memory = data.ToMemory();
+            byte[] recordFormatIdentifier = null;
+            if (memory.Length >= RecordFormatIndicatorLength)
             {
-                return (await GetSchemaIdAsync(schema, true, cancellationToken).ConfigureAwait(false), data);
+                recordFormatIdentifier = memory.Slice(0, RecordFormatIndicatorLength).ToArray();
+            }
+            if (recordFormatIdentifier != null && recordFormatIdentifier.SequenceEqual(EmptyRecordFormatIndicator))
+            {
+                byte[] schemaIdBytes = memory.Slice(RecordFormatIndicatorLength, SchemaIdLength).ToArray();
+                schemaId = Utf8Encoding.GetString(schemaIdBytes);
+                data = new BinaryData(memory.Slice(PayloadStartPosition, memory.Length - PayloadStartPosition));
             }
             else
             {
-                return (GetSchemaIdAsync(schema, false, cancellationToken).EnsureCompleted(), data);
+                string[] contentTypeArray = contentType.ToString().Split('+');
+                if (contentTypeArray.Length != 2)
+                {
+                    throw new FormatException("Content type was not in the expected format of MIME type + schema ID");
+                }
+
+                if (contentTypeArray[0] != AvroMimeType)
+                {
+                    throw new InvalidOperationException("An avro encoder may only be used on content that is of 'avro/binary' type");
+                }
+
+                schemaId = contentTypeArray[1];
+            }
+
+            if (async)
+            {
+                return await DecodeInternalAsync(data, dataType, schemaId, true, cancellationToken).ConfigureAwait(false);            }
+            else
+            {
+                return DecodeInternalAsync(data, dataType, schemaId, false, cancellationToken).EnsureCompleted();
+            }
+        }
+
+        private async ValueTask<object> DecodeInternalAsync(
+            BinaryData data,
+            Type dataType,
+            string schemaId,
+            bool async,
+            CancellationToken cancellationToken)
+        {
+            Argument.AssertNotNull(schemaId, nameof(schemaId));
+
+            SupportedType supportedType = GetSupportedTypeOrThrow(dataType);
+
+            Schema writerSchema;
+            if (async)
+            {
+                writerSchema = await GetSchemaByIdAsync(schemaId, true, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                writerSchema = GetSchemaByIdAsync(schemaId, false, cancellationToken).EnsureCompleted();
+            }
+
+            var binaryDecoder = new BinaryDecoder(data.ToStream());
+
+            if (supportedType == SupportedType.SpecificRecord)
+            {
+                object returnInstance = Activator.CreateInstance(dataType);
+                DatumReader<object> reader = GetReader(writerSchema, ((ISpecificRecord)returnInstance).Schema, SupportedType.SpecificRecord);
+                return reader.Read(reuse: returnInstance, binaryDecoder);
+            }
+            else
+            {
+                DatumReader<object> reader = GetReader(writerSchema, writerSchema, supportedType);
+                return reader.Read(reuse: null, binaryDecoder);
             }
         }
 
@@ -184,185 +410,6 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
                     throw new ArgumentException($"Invalid supported type value: {supportedType}");
             }
         }
-
-        /// <summary>
-        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
-        /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
-        /// </summary>
-        /// <param name="data">The data to serialize to Avro and encode into the message.</param>
-        /// <param name="inputType">The type to use to serialize the data.</param>
-        /// <param name="messageFactory">Optional func to create a derived instance of <see cref="MessageWithMetadata"/> given the serialized Avro.
-        /// If not specified, it is assumed that the derived type has a public constructor accepting a <see cref="BinaryData"/> instance.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <typeparam name="T">The <see cref="MessageWithMetadata"/> type to encode the data into.</typeparam>
-        public T EncodeMessageData<T>(
-            object data,
-            Type inputType = default,
-            Func<BinaryData, T> messageFactory = default,
-            CancellationToken cancellationToken = default) where T : MessageWithMetadata
-            => EncodeMessageDataInternalAsync(data, inputType, messageFactory, false, cancellationToken).EnsureCompleted();
-
-        /// <summary>
-        /// Encodes the message data into Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
-        /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
-        /// </summary>
-        /// <param name="data">The data to serialize to Avro and encode into the message.</param>
-        /// <param name="inputType">The type to use to serialize the data.</param>
-        /// <param name="messageFactory">Optional func to create a derived instance of <see cref="MessageWithMetadata"/> given the serialized Avro.
-        /// If not specified, it is assumed that the derived type has a public constructor accepting a <see cref="BinaryData"/> instance.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <typeparam name="T">The <see cref="MessageWithMetadata"/> type to encode the data into.</typeparam>
-        public async ValueTask<T> EncodeMessageDataAsync<T>(
-            object data,
-            Type inputType = default,
-            Func<BinaryData, T> messageFactory = default,
-            CancellationToken cancellationToken = default) where T : MessageWithMetadata
-            => await EncodeMessageDataInternalAsync(data, inputType, messageFactory, true, cancellationToken).ConfigureAwait(false);
-
-        internal async ValueTask<T> EncodeMessageDataInternalAsync<T>(
-            object data,
-            Type inputType,
-            Func<BinaryData, T> messageFactory,
-            bool async,
-            CancellationToken cancellationToken) where T : MessageWithMetadata
-        {
-            (string schemaId, BinaryData bd) = async
-                ? await EncodeInternalAsync(data, inputType, true, cancellationToken).ConfigureAwait(false)
-                : EncodeInternalAsync(data, inputType, false, cancellationToken).EnsureCompleted();
-
-            MessageWithMetadata message;
-            if (messageFactory == default)
-            {
-                if (typeof(T) == typeof(MessageWithMetadata))
-                {
-                    // If concrete type is used, we need to use the parameterless constructor as the concrete type does
-                    // not have any other constructors by design (to make it easier to use across the different messaging libraries).
-                    message = (MessageWithMetadata)Activator.CreateInstance(typeof(T));
-                    message.Data = bd;
-                }
-                else
-                {
-                    message = (MessageWithMetadata)Activator.CreateInstance(typeof(T), bd);
-                }
-            }
-            else
-            {
-                message = messageFactory.Invoke(bd);
-            }
-            message.ContentType = $"{AvroMimeType}+{schemaId}";
-            return (T) message;
-        }
-
-        /// <summary>
-        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
-        /// </summary>
-        /// <param name="message">The message containing the data to decode.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <typeparam name="T">The type to decode the message data into.</typeparam>
-        /// <returns>The deserialized data.</returns>
-        /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
-        public T DecodeMessageData<T>(
-            MessageWithMetadata message,
-            CancellationToken cancellationToken = default)
-            => DecodeMessageDataInternalAsync<T>(message.Data, message.ContentType, false, cancellationToken).EnsureCompleted();
-
-        /// <summary>
-        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
-        /// </summary>
-        /// <param name="message">The message containing the data to decode.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <typeparam name="T">The type to decode the message data into.</typeparam>
-        /// <returns>The deserialized data.</returns>
-        /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
-        public async ValueTask<T> DecodeMessageDataAsync<T>(
-            MessageWithMetadata message,
-            CancellationToken cancellationToken = default)
-            => await DecodeMessageDataInternalAsync<T>(message.Data, message.ContentType, true, cancellationToken).ConfigureAwait(false);
-
-        private async ValueTask<T> DecodeMessageDataInternalAsync<T>(
-            BinaryData data,
-            string contentType,
-            bool async,
-            CancellationToken cancellationToken)
-        {
-            Argument.AssertNotNull(data, nameof(data));
-            Argument.AssertNotNull(contentType, nameof(contentType));
-
-            string schemaId;
-            // Back Compat for first preview
-            ReadOnlyMemory<byte> memory = data.ToMemory();
-            byte[] recordFormatIdentifier = null;
-            if (memory.Length >= RecordFormatIndicatorLength)
-            {
-                recordFormatIdentifier = memory.Slice(0, RecordFormatIndicatorLength).ToArray();
-            }
-            if (recordFormatIdentifier != null && recordFormatIdentifier.SequenceEqual(EmptyRecordFormatIndicator))
-            {
-                byte[] schemaIdBytes = memory.Slice(RecordFormatIndicatorLength, SchemaIdLength).ToArray();
-                schemaId = Utf8Encoding.GetString(schemaIdBytes);
-                data = new BinaryData(memory.Slice(PayloadStartPosition, memory.Length - PayloadStartPosition));
-            }
-            else
-            {
-                string[] contentTypeArray = contentType.Split('+');
-                if (contentTypeArray.Length != 2)
-                {
-                    throw new FormatException("Content type was not in the expected format of MIME type + schema ID");
-                }
-
-                if (contentTypeArray[0] != AvroMimeType)
-                {
-                    throw new InvalidOperationException("An avro encoder may only be used on content that is of 'avro/binary' type");
-                }
-
-                schemaId = contentTypeArray[1];
-            }
-
-            if (async)
-            {
-                return await DecodeInternalAsync<T>(data, schemaId, true, cancellationToken).ConfigureAwait(false);            }
-            else
-            {
-                return DecodeInternalAsync<T>(data, schemaId, false, cancellationToken).EnsureCompleted();
-            }
-        }
-
-        private async ValueTask<T> DecodeInternalAsync<T>(
-            BinaryData data,
-            string schemaId,
-            bool async,
-            CancellationToken cancellationToken)
-        {
-            Argument.AssertNotNull(schemaId, nameof(schemaId));
-
-            Type returnType = typeof(T);
-            SupportedType supportedType = GetSupportedTypeOrThrow(returnType);
-
-            Schema writerSchema;
-            if (async)
-            {
-                writerSchema = await GetSchemaByIdAsync(schemaId, true, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                writerSchema = GetSchemaByIdAsync(schemaId, false, cancellationToken).EnsureCompleted();
-            }
-
-            var binaryDecoder = new BinaryDecoder(data.ToStream());
-
-            if (supportedType == SupportedType.SpecificRecord)
-            {
-                object returnInstance = Activator.CreateInstance(returnType);
-                DatumReader<object> reader = GetReader(writerSchema, ((ISpecificRecord)returnInstance).Schema, SupportedType.SpecificRecord);
-                return (T) reader.Read(reuse: returnInstance, binaryDecoder);
-            }
-            else
-            {
-                DatumReader<object> reader = GetReader(writerSchema, writerSchema, supportedType);
-                return (T) reader.Read(reuse: null, binaryDecoder);
-            }
-        }
+        #endregion
     }
 }

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoderOptions.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoderOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
     /// <summary>
     /// Options for <see cref="SchemaRegistryAvroEncoder"/>.
     /// </summary>
-    public class SchemaRegistryAvroObjectEncoderOptions
+    public class SchemaRegistryAvroEncoderOptions
     {
         /// <summary>
         /// Gets or sets the automatic registration of schemas flag.

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var employee = new Employee { Age = 42, Name = "Caketown" };
 
             #region Snippet:SchemaRegistryAvroEncodeDecodeMessageWithMetadata
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions() { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions() { AutoRegisterSchemas = true });
             MessageWithMetadata messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
 
             Employee decodedEmployee = await encoder.DecodeMessageDataAsync<Employee>(messageData);
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var employee = new Employee_V2 { Age = 42, Name = "Caketown", City = "Redmond" };
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions() { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions() { AutoRegisterSchemas = true });
             var messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee_V2>(employee);
 
             // deserialize using the old schema, which is forward compatible with the new schema
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var employee = new Employee() { Age = 42, Name = "Caketown"};
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions() { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions() { AutoRegisterSchemas = true });
             var messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
 
             // deserialize with the new schema, which is NOT backward compatible with the old schema as it adds a new field
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             record.Add("Name", "Caketown");
             record.Add("Age", 42);
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
             var messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, GenericRecord>(record);
 
             var deserializedObject = await encoder.DecodeMessageDataAsync<GenericRecord>(messageData);
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var timeZoneInfo = TimeZoneInfo.Utc;
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
             Assert.ThrowsAsync<ArgumentException>(async () => await encoder.EncodeMessageDataAsync<MessageWithMetadata, TimeZoneInfo>(timeZoneInfo));
             await Task.CompletedTask;
         }
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
             var messageData = new MessageWithMetadata
             {
                 Data = new BinaryData(Array.Empty<byte>()),
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
             var messageData = new MessageWithMetadata
             {
                 Data = new BinaryData(Array.Empty<byte>()),
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
             #region Snippet:SchemaRegistryAvroEncodeEventData
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
 
             var employee = new Employee { Age = 42, Name = "Caketown" };
             EventData eventData = (EventData) await encoder.EncodeMessageDataAsync(employee, messageType: typeof(EventData));
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
             #region Snippet:SchemaRegistryAvroEncodeEventDataGenerics
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
 
             var employee = new Employee { Age = 42, Name = "Caketown" };
             EventData eventData = await encoder.EncodeMessageDataAsync<EventData, Employee>(employee);
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroObjectEncoderOptions { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
 
             var employee = new Employee { Age = 42, Name = "Caketown" };
             EventData eventData = await encoder.EncodeMessageDataAsync<EventData, Employee>(employee);

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var employee = new Employee { Age = 42, Name = "Caketown" };
 
             #region Snippet:SchemaRegistryAvroEncodeDecodeMessageWithMetadata
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions() { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
             MessageWithMetadata messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
 
             Employee decodedEmployee = await encoder.DecodeMessageDataAsync<Employee>(messageData);
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var employee = new Employee_V2 { Age = 42, Name = "Caketown", City = "Redmond" };
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions() { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
             var messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee_V2>(employee);
 
             // deserialize using the old schema, which is forward compatible with the new schema
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var employee = new Employee() { Age = 42, Name = "Caketown"};
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions() { AutoRegisterSchemas = true });
+            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
             var messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
 
             // deserialize with the new schema, which is NOT backward compatible with the old schema as it adds a new field

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTests/CanUseEncoderWithEventDataUsingGenerics.json
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTests/CanUseEncoderWithEventDataUsingGenerics.json
@@ -1,0 +1,55 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jolovschemaregistry.servicebus.windows.net/$schemaGroups/azsdk_net_test_group/schemas/TestSchema.Employee?api-version=2021-10",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "167",
+        "Content-Type": "application/json; serialization=Avro",
+        "User-Agent": "azsdk-net-Data.SchemaRegistry/1.0.0 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "9d24878dc2d16540c979ca71076c8e77",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "aliases": [
+          "TestSchema.EmployeeV2"
+        ],
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:16:01 GMT",
+        "Location": "https://jolovschemaregistry.servicebus.windows.net/$schemagroups/azsdk_net_test_group/schemas/TestSchema.Employee/versions/1?api-version=2021-10",
+        "Schema-Group-Name": "azsdk_net_test_group",
+        "Schema-Id": "bcadeafee2e644218aab98430171713f",
+        "Schema-Id-Location": "https://jolovschemaregistry.servicebus.windows.net:443/$schemagroups/$schemas/bcadeafee2e644218aab98430171713f?api-version=2021-10",
+        "Schema-Name": "TestSchema.Employee",
+        "Schema-Version": "1",
+        "Schema-Versions-Location": "https://jolovschemaregistry.servicebus.windows.net:443/$schemagroups/azsdk_net_test_group/schemas/TestSchema.Employee/versions?api-version=2021-10",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2005761330",
+    "SCHEMAREGISTRY_ENDPOINT": "jolovschemaregistry.servicebus.windows.net",
+    "SCHEMAREGISTRY_GROUP": "azsdk_net_test_group"
+  }
+}

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTests/CanUseEncoderWithEventDataUsingGenericsAsync.json
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SessionRecords/SchemaRegistryAvroObjectSerializerLiveTests/CanUseEncoderWithEventDataUsingGenericsAsync.json
@@ -1,0 +1,55 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://jolovschemaregistry.servicebus.windows.net/$schemaGroups/azsdk_net_test_group/schemas/TestSchema.Employee?api-version=2021-10",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "167",
+        "Content-Type": "application/json; serialization=Avro",
+        "User-Agent": "azsdk-net-Data.SchemaRegistry/1.0.0 (.NET 6.0.0-rtm.21522.10; Microsoft Windows 10.0.22000)",
+        "x-ms-client-request-id": "148f8f0a7a924867b96ac187630bc6c7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "type": "record",
+        "name": "Employee",
+        "namespace": "TestSchema",
+        "aliases": [
+          "TestSchema.EmployeeV2"
+        ],
+        "fields": [
+          {
+            "name": "Name",
+            "type": "string"
+          },
+          {
+            "name": "Age",
+            "type": "int"
+          }
+        ]
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:16:02 GMT",
+        "Location": "https://jolovschemaregistry.servicebus.windows.net/$schemagroups/azsdk_net_test_group/schemas/TestSchema.Employee/versions/1?api-version=2021-10",
+        "Schema-Group-Name": "azsdk_net_test_group",
+        "Schema-Id": "bcadeafee2e644218aab98430171713f",
+        "Schema-Id-Location": "https://jolovschemaregistry.servicebus.windows.net:443/$schemagroups/$schemas/bcadeafee2e644218aab98430171713f?api-version=2021-10",
+        "Schema-Name": "TestSchema.Employee",
+        "Schema-Version": "1",
+        "Schema-Versions-Location": "https://jolovschemaregistry.servicebus.windows.net:443/$schemagroups/azsdk_net_test_group/schemas/TestSchema.Employee/versions?api-version=2021-10",
+        "Server": "Microsoft-HTTPAPI/2.0",
+        "Strict-Transport-Security": "max-age=31536000"
+      },
+      "ResponseBody": null
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1820669089",
+    "SCHEMAREGISTRY_ENDPOINT": "jolovschemaregistry.servicebus.windows.net",
+    "SCHEMAREGISTRY_GROUP": "azsdk_net_test_group"
+  }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -152,7 +152,7 @@ namespace Azure.Messaging.ServiceBus
         SessionLockLost = 11,
         MessagingEntityAlreadyExists = 12,
     }
-    public partial class ServiceBusMessage : Azure.Messaging.MessageWithMetadata
+    public partial class ServiceBusMessage
     {
         public ServiceBusMessage() { }
         public ServiceBusMessage(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage receivedMessage) { }
@@ -161,12 +161,8 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusMessage(string body) { }
         public System.Collections.Generic.IDictionary<string, object> ApplicationProperties { get { throw null; } }
         public System.BinaryData Body { get { throw null; } set { } }
-        public override string ContentType { get { throw null; } set { } }
+        public string ContentType { get { throw null; } set { } }
         public string CorrelationId { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override System.BinaryData Data { get { throw null; } set { } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override bool IsReadOnly { get { throw null; } }
         public string MessageId { get { throw null; } set { } }
         public string PartitionKey { get { throw null; } set { } }
         public string ReplyTo { get { throw null; } set { } }
@@ -259,15 +255,13 @@ namespace Azure.Messaging.ServiceBus
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }
-    public partial class ServiceBusReceivedMessage : Azure.Messaging.MessageWithMetadata
+    public partial class ServiceBusReceivedMessage
     {
         internal ServiceBusReceivedMessage() { }
         public System.Collections.Generic.IReadOnlyDictionary<string, object> ApplicationProperties { get { throw null; } }
         public System.BinaryData Body { get { throw null; } }
-        public override string ContentType { get { throw null; } [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)] set { } }
+        public string ContentType { get { throw null; } [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)] set { } }
         public string CorrelationId { get { throw null; } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override System.BinaryData Data { get { throw null; } set { } }
         public string DeadLetterErrorDescription { get { throw null; } }
         public string DeadLetterReason { get { throw null; } }
         public string DeadLetterSource { get { throw null; } }
@@ -275,8 +269,6 @@ namespace Azure.Messaging.ServiceBus
         public long EnqueuedSequenceNumber { get { throw null; } }
         public System.DateTimeOffset EnqueuedTime { get { throw null; } }
         public System.DateTimeOffset ExpiresAt { get { throw null; } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override bool IsReadOnly { get { throw null; } }
         public System.DateTimeOffset LockedUntil { get { throw null; } }
         public string LockToken { get { throw null; } }
         public string MessageId { get { throw null; } }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -19,11 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-  <!--    
-      TEMP: Move Core to a project reference until the
-            MessageWithMetadata are shipped in Azure.Core.
-  <PackageReference Include="Azure.Core" />
-  -->
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Core.Amqp" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
@@ -61,8 +57,4 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.ServiceBus
     /// The message structure is discussed in detail in the
     /// <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads">product documentation</see>.
     /// </remarks>
-    public class ServiceBusMessage : MessageWithMetadata
+    public class ServiceBusMessage
     {
         /// <summary>
         /// Creates a new message.
@@ -156,17 +156,6 @@ namespace Azure.Messaging.ServiceBus
             {
                 AmqpMessage.Body = new AmqpMessageBody(MessageBody.FromReadOnlyMemorySegment(value));
             }
-        }
-
-        /// <summary>
-        /// Hidden property that shadows the <see cref="Body"/> property. This is added
-        /// in order to inherit from <see cref="MessageWithMetadata"/>.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override BinaryData Data
-        {
-            get => Body;
-            set => Body = value;
         }
 
         /// <summary>
@@ -361,7 +350,7 @@ namespace Azure.Messaging.ServiceBus
         /// Optionally describes the payload of the message, with a descriptor following the format of
         /// RFC2045, Section 5, for example "application/json".
         /// </remarks>
-        public override string ContentType
+        public string ContentType
         {
             get
             {
@@ -372,13 +361,6 @@ namespace Azure.Messaging.ServiceBus
                 AmqpMessage.Properties.ContentType = value;
             }
         }
-
-        /// <summary>
-        /// Hidden property that indicates that the <see cref="ServiceBusMessage"/> is not read-only. This is part of
-        /// the <see cref="MessageWithMetadata"/> abstraction.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool IsReadOnly => false;
 
         /// <summary>Gets or sets the address of an entity to send replies to.</summary>
         /// <value>The reply entity address.</value>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.ServiceBus
     /// The message structure is discussed in detail in the
     /// <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads">product documentation</see>.
     /// </remarks>
-    public class ServiceBusReceivedMessage : MessageWithMetadata
+    public class ServiceBusReceivedMessage
     {
         /// <summary>
         /// Creates a new message from the specified payload.
@@ -67,17 +67,6 @@ namespace Azure.Messaging.ServiceBus
         /// Gets the body of the message.
         /// </summary>
         public BinaryData Body => AmqpMessage.GetBody();
-
-        /// <summary>
-        /// Hidden property that shadows the <see cref="Body"/> property. This is added
-        /// in order to inherit from <see cref="MessageWithMetadata"/>.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override BinaryData Data
-        {
-            get => Body;
-            set => throw new NotImplementedException("Data cannot be set on a ServiceBusReceivedMessage");
-        }
 
         /// <summary>
         /// Gets the MessageId to identify the message.
@@ -178,19 +167,12 @@ namespace Azure.Messaging.ServiceBus
         ///   Optionally describes the payload of the message, with a descriptor following the format of
         ///   RFC2045, Section 5, for example "application/json".
         /// </remarks>
-        public override string ContentType
+        public string ContentType
         {
             get => AmqpMessage.Properties.ContentType;
             [EditorBrowsable(EditorBrowsableState.Never)]
             set => throw new NotImplementedException("Content type cannot be set on a ServiceBusReceivedMessage");
         }
-
-        /// <summary>
-        /// Hidden property that indicates that the <see cref="ServiceBusReceivedMessage"/> is read-only. This is part of
-        /// the <see cref="MessageWithMetadata"/> abstraction.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool IsReadOnly => true;
 
         /// <summary>Gets the address of an entity to send replies to.</summary>
         /// <value>The reply entity address.</value>


### PR DESCRIPTION
- Removed messageFactory and added separate generic and dynamic methods
- Updated MessageWithMetadata to use ContentType type.
- There is now a compile-time requirement that types inheriting from MessageWithMetadata that are used with the encoder have a parameterless ctor when using the generic method. For non-generic, the requirement is at runtime.