### PR TITLE
parent navigators added to clients

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/PathExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PathExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Storage
+{
+    internal static class PathExtensions
+    {
+        public static string GetParentPath(this string path, char delimiter = '/')
+        {
+            if (path == null)
+            {
+                throw new ArgumentException("Cannot get parent of null path");
+            }
+
+            path = path.TrimEnd(delimiter);
+
+            int lastIndex = path.LastIndexOf(delimiter);
+            if (lastIndex == -1)
+            {
+                return string.Empty;
+            }
+            return path.Substring(0, lastIndex);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/api/Azure.Storage.Files.DataLake.netstandard2.0.cs
@@ -215,6 +215,7 @@ namespace Azure.Storage.Files.DataLake
         public virtual Azure.AsyncPageable<Azure.Storage.Files.DataLake.Models.PathDeletedItem> GetDeletedPathsAsync(string pathPrefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Storage.Files.DataLake.DataLakeDirectoryClient GetDirectoryClient(string directoryName) { throw null; }
         public virtual Azure.Storage.Files.DataLake.DataLakeFileClient GetFileClient(string fileName) { throw null; }
+        protected internal virtual Azure.Storage.Files.DataLake.DataLakeServiceClient GetParentDataLakeServiceClientCore() { throw null; }
         public virtual Azure.Pageable<Azure.Storage.Files.DataLake.Models.PathItem> GetPaths(string path = null, bool recursive = false, bool userPrincipalName = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.Storage.Files.DataLake.Models.PathItem> GetPathsAsync(string path = null, bool recursive = false, bool userPrincipalName = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Storage.Files.DataLake.Models.FileSystemProperties> GetProperties(Azure.Storage.Files.DataLake.Models.DataLakeRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -284,6 +285,8 @@ namespace Azure.Storage.Files.DataLake
         public virtual System.Uri GenerateSasUri(Azure.Storage.Sas.DataLakeSasPermissions permissions, System.DateTimeOffset expiresOn) { throw null; }
         public virtual Azure.Response<Azure.Storage.Files.DataLake.Models.PathAccessControl> GetAccessControl(bool? userPrincipalName = default(bool?), Azure.Storage.Files.DataLake.Models.DataLakeRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.DataLake.Models.PathAccessControl>> GetAccessControlAsync(bool? userPrincipalName = default(bool?), Azure.Storage.Files.DataLake.Models.DataLakeRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual Azure.Storage.Files.DataLake.DataLakeDirectoryClient GetParentDataLakeDirectoryClientCore() { throw null; }
+        protected internal virtual Azure.Storage.Files.DataLake.DataLakeFileSystemClient GetParentDataLakeFileSystemClientCore() { throw null; }
         public virtual Azure.Response<Azure.Storage.Files.DataLake.Models.PathProperties> GetProperties(Azure.Storage.Files.DataLake.Models.DataLakeRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.DataLake.Models.PathProperties>> GetPropertiesAsync(Azure.Storage.Files.DataLake.Models.DataLakeRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Storage.Files.DataLake.Models.AccessControlChangeResult> RemoveAccessControlRecursive(System.Collections.Generic.IList<Azure.Storage.Files.DataLake.Models.RemovePathAccessControlItem> accessControlList, string continuationToken = null, Azure.Storage.Files.DataLake.Models.AccessControlChangeOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -980,6 +983,15 @@ namespace Azure.Storage.Files.DataLake.Models
         public string SignedTenantId { get { throw null; } }
         public string SignedVersion { get { throw null; } }
         public string Value { get { throw null; } }
+    }
+}
+namespace Azure.Storage.Files.DataLake.Specialized
+{
+    public static partial class SpecializedDataLakeExtensions
+    {
+        public static Azure.Storage.Files.DataLake.DataLakeDirectoryClient GetParentDataLakeDirectoryClient(this Azure.Storage.Files.DataLake.DataLakePathClient client) { throw null; }
+        public static Azure.Storage.Files.DataLake.DataLakeFileSystemClient GetParentDataLakeFileSystemClient(this Azure.Storage.Files.DataLake.DataLakePathClient client) { throw null; }
+        public static Azure.Storage.Files.DataLake.DataLakeServiceClient GetParentDataLakeServiceClient(this Azure.Storage.Files.DataLake.DataLakeFileSystemClient client) { throw null; }
     }
 }
 namespace Azure.Storage.Sas

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/Azure.Storage.Files.DataLake.csproj
@@ -58,6 +58,7 @@
     <Compile Include="$(AzureStorageSharedSources)NonCryptographicHashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonDisposingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PartitionedUploader.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)PathExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PooledMemoryStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ProgressIncrementingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)SasExtensions.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -17,6 +17,8 @@ using Azure.Storage.Shared;
 using Azure.Storage.Sas;
 using System.ComponentModel;
 
+#pragma warning disable SA1402  // File may only contain a single type
+
 namespace Azure.Storage.Files.DataLake
 {
     /// <summary>
@@ -2938,5 +2940,59 @@ namespace Azure.Storage.Files.DataLake
                 ClientConfiguration);
         }
         #endregion Restore Path
+
+        #region GetParentDataLakeServiceClientCore
+
+        private DataLakeServiceClient _parentServiceClient;
+
+        /// <summary>
+        /// Create a new <see cref="DataLakeServiceClient"/> that pointing to this <see cref="DataLakeFileSystemClient"/>'s parent container.
+        /// The new <see cref="DataLakeServiceClient"/>
+        /// uses the same request policy pipeline as the
+        /// <see cref="DataLakeFileSystemClient"/>.
+        /// </summary>
+        /// <returns>A new <see cref="BlobContainerClient"/> instance.</returns>
+        protected internal virtual DataLakeServiceClient GetParentDataLakeServiceClientCore()
+        {
+            if (_parentServiceClient == null)
+            {
+                DataLakeUriBuilder datalakeUriBuilder = new DataLakeUriBuilder(Uri)
+                {
+                    // erase parameters unrelated to container
+                    DirectoryOrFilePath = null,
+                    Snapshot = null,
+                };
+
+                _parentServiceClient = new DataLakeServiceClient(
+                    datalakeUriBuilder.ToUri(),
+                    ClientConfiguration);
+            }
+
+            return _parentServiceClient;
+        }
+        #endregion
+    }
+
+    namespace Specialized
+    {
+        /// <summary>
+        /// Add easy to discover methods to <see cref="DataLakePathClient"/> for
+        /// creating <see cref="DataLakeFileSystemClient"/> instances.
+        /// </summary>
+        public static partial class SpecializedDataLakeExtensions
+        {
+            /// <summary>
+            /// Create a new <see cref="DataLakeFileSystemClient"/> that pointing to this <see cref="DataLakePathClient"/>'s parent container.
+            /// The new <see cref="DataLakeFileSystemClient"/>
+            /// uses the same request policy pipeline as the
+            /// <see cref="DataLakePathClient"/>.
+            /// </summary>
+            /// <param name="client">The <see cref="DataLakePathClient"/>.</param>
+            /// <returns>A new <see cref="DataLakeFileSystemClient"/> instance.</returns>
+            public static DataLakeServiceClient GetParentDataLakeServiceClient(this DataLakeFileSystemClient client)
+            {
+                return client.GetParentDataLakeServiceClientCore();
+            }
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -17,6 +17,8 @@ using Azure.Storage.Sas;
 using Azure.Storage.Shared;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
+#pragma warning disable SA1402  // File may only contain a single type
+
 namespace Azure.Storage.Files.DataLake
 {
     /// <summary>
@@ -611,7 +613,7 @@ namespace Azure.Storage.Files.DataLake
 
         private (PathRestClient DfsPathClient, PathRestClient BlobPathClient) BuildPathRestClients(Uri dfsUri, Uri blobUri)
         {
-            PathRestClient dfsPathRestClient =  new PathRestClient(
+            PathRestClient dfsPathRestClient = new PathRestClient(
                 clientDiagnostics: _clientConfiguration.ClientDiagnostics,
                 pipeline: _clientConfiguration.Pipeline,
                 url: dfsUri.AbsoluteUri,
@@ -3385,5 +3387,103 @@ namespace Azure.Storage.Files.DataLake
             return sasUri.ToUri();
         }
         #endregion
+
+        #region GetParentDataLakeFileSystemClientCore
+
+        private DataLakeFileSystemClient _parentFileSystemClient;
+        private DataLakeDirectoryClient _parentDirectoryClient;
+
+        /// <summary>
+        /// Create a new <see cref="DataLakeFileSystemClient"/> that pointing to this <see cref="DataLakePathClient"/>'s parent container.
+        /// The new <see cref="DataLakeFileSystemClient"/>
+        /// uses the same request policy pipeline as the
+        /// <see cref="DataLakePathClient"/>.
+        /// </summary>
+        /// <returns>A new <see cref="BlobContainerClient"/> instance.</returns>
+        protected internal virtual DataLakeFileSystemClient GetParentDataLakeFileSystemClientCore()
+        {
+            if (_parentFileSystemClient == null)
+            {
+                DataLakeUriBuilder datalakeUriBuilder = new DataLakeUriBuilder(Uri)
+                {
+                    // erase parameters unrelated to container
+                    DirectoryOrFilePath = null,
+                    Snapshot = null,
+                };
+
+                _parentFileSystemClient = new DataLakeFileSystemClient(
+                    datalakeUriBuilder.ToUri(),
+                    ClientConfiguration);
+            }
+
+            return _parentFileSystemClient;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="DataLakeDirectoryClient"/> that pointing to this <see cref="DataLakePathClient"/>'s parent container.
+        /// The new <see cref="DataLakeDirectoryClient"/>
+        /// uses the same request policy pipeline as the
+        /// <see cref="DataLakePathClient"/>.
+        /// </summary>
+        /// <returns>A new <see cref="DataLakeDirectoryClient"/> instance.</returns>
+        protected internal virtual DataLakeDirectoryClient GetParentDataLakeDirectoryClientCore()
+        {
+            if (_parentDirectoryClient == null)
+            {
+                DataLakeUriBuilder dataLakeUriBuilder = new DataLakeUriBuilder(Uri)
+                {
+                    Snapshot = null,
+                };
+
+                if (dataLakeUriBuilder.DirectoryOrFilePath == null || dataLakeUriBuilder.LastDirectoryOrFileName == null)
+                {
+                    throw new InvalidOperationException();
+                }
+                dataLakeUriBuilder.DirectoryOrFilePath = dataLakeUriBuilder.DirectoryOrFilePath.GetParentPath();
+
+                _parentDirectoryClient = new DataLakeDirectoryClient(
+                    dataLakeUriBuilder.ToUri(),
+                    ClientConfiguration);
+            }
+
+            return _parentDirectoryClient;
+        }
+        #endregion
+    }
+
+    namespace Specialized
+    {
+        /// <summary>
+        /// Add easy to discover methods to <see cref="DataLakePathClient"/> for
+        /// creating <see cref="DataLakeFileSystemClient"/> instances.
+        /// </summary>
+        public static partial class SpecializedDataLakeExtensions
+        {
+            /// <summary>
+            /// Create a new <see cref="DataLakeFileSystemClient"/> that pointing to this <see cref="DataLakePathClient"/>'s parent container.
+            /// The new <see cref="DataLakeFileSystemClient"/>
+            /// uses the same request policy pipeline as the
+            /// <see cref="DataLakePathClient"/>.
+            /// </summary>
+            /// <param name="client">The <see cref="DataLakePathClient"/>.</param>
+            /// <returns>A new <see cref="DataLakeFileSystemClient"/> instance.</returns>
+            public static DataLakeFileSystemClient GetParentDataLakeFileSystemClient(this DataLakePathClient client)
+            {
+                return client.GetParentDataLakeFileSystemClientCore();
+            }
+
+            /// <summary>
+            /// Create a new <see cref="DataLakeDirectoryClient"/> that pointing to this <see cref="DataLakePathClient"/>'s parent directory.
+            /// The new <see cref="DataLakeDirectoryClient"/>
+            /// uses the same request policy pipeline as the
+            /// <see cref="DataLakePathClient"/>.
+            /// </summary>
+            /// <param name="client">The <see cref="DataLakePathClient"/>.</param>
+            /// <returns>A new <see cref="DataLakeDirectoryClient"/> instance.</returns>
+            public static DataLakeDirectoryClient GetParentDataLakeDirectoryClient(this DataLakePathClient client)
+            {
+                return client.GetParentDataLakeDirectoryClientCore();
+            }
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -316,6 +316,37 @@ namespace Azure.Storage.Files.DataLake
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="DataLakeFileSystemClient"/>
+        /// class.
+        /// </summary>
+        /// <param name="fileSystemUri">
+        /// A <see cref="Uri"/> referencing the file system that includes the
+        /// name of the account and the name of the file system.
+        /// </param>
+        /// <param name="clientConfiguration">
+        /// <see cref="DataLakeClientConfiguration"/>.
+        /// </param>
+        internal DataLakeServiceClient(
+            Uri fileSystemUri,
+            DataLakeClientConfiguration clientConfiguration)
+        {
+            DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(fileSystemUri);
+            _uri = fileSystemUri;
+            _blobUri = uriBuilder.ToBlobUri();
+
+            _clientConfiguration = clientConfiguration;
+
+            _blobServiceClient = BlobServiceClientInternals.Create(
+                _blobUri,
+                _clientConfiguration.Pipeline,
+                // auth is included in pipeline in client configuration.
+                // blobs keeps it separate for niche use cases that are inaccessible from datalake clients
+                authentication: default,
+                _clientConfiguration.Version.AsBlobsVersion(),
+                _clientConfiguration.ClientDiagnostics);
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DataLakeServiceClient"/>
         /// class.
         /// </summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientNavigationTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientNavigationTests.cs
@@ -16,7 +16,7 @@ namespace Azure.Storage.Files.DataLake.Tests
     public class ClientNavigationTests : DataLakeTestBase
     {
         public ClientNavigationTests(bool async, DataLakeClientOptions.ServiceVersion serviceVersion)
-            : base(async, serviceVersion, RecordedTestMode.Record /* RecordedTestMode.Record /* to re-record */)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientNavigationTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ClientNavigationTests.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Identity;
+using Azure.Storage.Files.DataLake.Specialized;
+using Azure.Storage.Test;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+
+namespace Azure.Storage.Files.DataLake.Tests
+{
+    public class ClientNavigationTests : DataLakeTestBase
+    {
+        public ClientNavigationTests(bool async, DataLakeClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, RecordedTestMode.Record /* RecordedTestMode.Record /* to re-record */)
+        {
+        }
+
+        [RecordedTest]
+        public async Task PathClient_CanGetParentContainerClient()
+        {
+            // Arrange
+            await using DisposingFileSystem test = await DataLakeClientBuilder.GetNewFileSystem();
+            DataLakeFileClient fileClient = InstrumentClient(test.Container.GetRootDirectoryClient().GetFileClient(DataLakeClientBuilder.GetNewFileName()));
+
+            // Act
+            DataLakeFileSystemClient filesystemClient = fileClient.GetParentDataLakeFileSystemClient();
+            // make sure that client is functional
+            var containerProperties = await filesystemClient.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.FileSystemName, filesystemClient.Name);
+            Assert.AreEqual(fileClient.AccountName, filesystemClient.AccountName);
+            Assert.IsNotNull(containerProperties);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = DataLakeClientOptions.ServiceVersion.V2019_12_12)]
+        public async Task PathClient_CanGetParentContainerClient_WithAccountSAS()
+        {
+            // Arrange
+            await using DisposingFileSystem test = await DataLakeClientBuilder.GetNewFileSystem();
+            var fileName = DataLakeClientBuilder.GetNewFileName();
+            DataLakeFileClient fileClient = InstrumentClient(
+                GetServiceClient_AccountSas()
+                .GetFileSystemClient(test.FileSystem.Name)
+                .GetRootDirectoryClient()
+                .GetFileClient(fileName));
+
+            // Act
+            var fileSystemClient = fileClient.GetParentDataLakeFileSystemClient();
+            // make sure that client is functional
+            var fileSystemProperties = await fileSystemClient.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.FileSystemName, fileSystemClient.Name);
+            Assert.AreEqual(fileClient.AccountName, fileSystemClient.AccountName);
+            Assert.IsNotNull(fileSystemProperties);
+        }
+
+        [RecordedTest]
+        public async Task PathClient_CanGetParentContainerClient_WithContainerSAS()
+        {
+            // Arrange
+            await using DisposingFileSystem test = await DataLakeClientBuilder.GetNewFileSystem();
+            var fileName = DataLakeClientBuilder.GetNewFileName();
+            DataLakeFileClient fileClient = InstrumentClient(
+                GetServiceClient_DataLakeServiceSas_FileSystem(test.Container.Name)
+                .GetFileSystemClient(test.FileSystem.Name)
+                .GetRootDirectoryClient()
+                .GetFileClient(fileName));
+
+            // Act
+            var fileSystemClient = fileClient.GetParentDataLakeFileSystemClient();
+            // make sure that client is functional
+            var pathItems = await fileSystemClient.GetPathsAsync().ToListAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.FileSystemName, fileSystemClient.Name);
+            Assert.AreEqual(fileClient.AccountName, fileSystemClient.AccountName);
+            Assert.IsNotNull(pathItems);
+        }
+
+        [RecordedTest]
+        public void PathClient_CanMockParentContainerClientRetrieval()
+        {
+            // Arrange
+            Mock<DataLakeFileClient> fileClientMock = new Mock<DataLakeFileClient>();
+            Mock<DataLakeFileSystemClient> fileSystemClientMock = new Mock<DataLakeFileSystemClient>();
+            fileClientMock.Protected().Setup<DataLakeFileSystemClient>("GetParentDataLakeFileSystemClientCore").Returns(fileSystemClientMock.Object);
+
+            // Act
+            var fileSystemClient = fileClientMock.Object.GetParentDataLakeFileSystemClientCore();
+
+            // Assert
+            Assert.IsNotNull(fileSystemClient);
+            Assert.AreSame(fileSystemClientMock.Object, fileSystemClient);
+        }
+
+        [RecordedTest]
+        public async Task PathClient_CanGetParentDirectoryClient()
+        {
+            // Arrange
+            var parentDirName = DataLakeClientBuilder.GetNewDirectoryName();
+            await using DisposingFileSystem test = await DataLakeClientBuilder.GetNewFileSystem();
+            DataLakeFileClient fileClient = InstrumentClient(test.Container
+                .GetRootDirectoryClient()
+                .GetSubDirectoryClient(parentDirName)
+                .GetFileClient(DataLakeClientBuilder.GetNewFileName()));
+            await fileClient.CreateAsync();
+
+            // Act
+            DataLakeDirectoryClient parentDirClient = fileClient.GetParentDataLakeDirectoryClient();
+            // make sure that client is functional
+            var dirProperties = await parentDirClient.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.Path.GetParentPath(), parentDirClient.Path);
+            Assert.AreEqual(fileClient.AccountName, parentDirClient.AccountName);
+            Assert.IsNotNull(dirProperties);
+        }
+
+        [RecordedTest]
+        [ServiceVersion(Min = DataLakeClientOptions.ServiceVersion.V2019_12_12)]
+        public async Task PathClient_CanGetParentDirectoryClient_WithAccountSAS()
+        {
+            // Arrange
+            var parentDirName = DataLakeClientBuilder.GetNewDirectoryName();
+            await using DisposingFileSystem test = await DataLakeClientBuilder.GetNewFileSystem();
+            var fileName = DataLakeClientBuilder.GetNewFileName();
+            DataLakeFileClient fileClient = InstrumentClient(
+                GetServiceClient_AccountSas()
+                .GetFileSystemClient(test.FileSystem.Name)
+                .GetRootDirectoryClient()
+                .GetSubDirectoryClient(parentDirName)
+                .GetFileClient(fileName));
+            await fileClient.CreateAsync();
+
+            // Act
+            DataLakeDirectoryClient parentDirClient = fileClient.GetParentDataLakeDirectoryClient();
+            // make sure that client is functional
+            var dirProperties = await parentDirClient.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.Path.GetParentPath(), parentDirClient.Path);
+            Assert.AreEqual(fileClient.AccountName, parentDirClient.AccountName);
+            Assert.IsNotNull(dirProperties);
+        }
+
+        [RecordedTest]
+        public async Task PathClient_CanGetParentDirectoryClient_WithContainerSAS()
+        {
+            // Arrange
+            var parentDirName = DataLakeClientBuilder.GetNewDirectoryName();
+            await using DisposingFileSystem test = await DataLakeClientBuilder.GetNewFileSystem();
+            var fileName = DataLakeClientBuilder.GetNewFileName();
+            DataLakeFileClient fileClient = InstrumentClient(
+                GetServiceClient_DataLakeServiceSas_FileSystem(test.Container.Name)
+                .GetFileSystemClient(test.FileSystem.Name)
+                .GetRootDirectoryClient()
+                .GetSubDirectoryClient(parentDirName)
+                .GetFileClient(fileName));
+            await fileClient.CreateAsync();
+
+            // Act
+            DataLakeDirectoryClient parentDirClient = fileClient.GetParentDataLakeDirectoryClient();
+            // make sure that client is functional
+            var pathItems = await parentDirClient.GetPathsAsync().ToListAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.Path.GetParentPath(), parentDirClient.Path);
+            Assert.AreEqual(fileClient.AccountName, parentDirClient.AccountName);
+            Assert.IsNotNull(pathItems);
+        }
+
+        [RecordedTest]
+        public void PathClient_CanMockParentDirectoryClientRetrieval()
+        {
+            // Arrange
+            Mock<DataLakeFileClient> fileClientMock = new Mock<DataLakeFileClient>();
+            Mock<DataLakeFileSystemClient> fileSystemClientMock = new Mock<DataLakeFileSystemClient>();
+            fileClientMock.Protected().Setup<DataLakeFileSystemClient>("GetParentDataLakeFileSystemClientCore").Returns(fileSystemClientMock.Object);
+
+            // Act
+            var fileSystemClient = fileClientMock.Object.GetParentDataLakeFileSystemClientCore();
+
+            // Assert
+            Assert.IsNotNull(fileSystemClient);
+            Assert.AreSame(fileSystemClientMock.Object, fileSystemClient);
+        }
+
+        [RecordedTest]
+        public void PathClient_CanGenerateSas_GetParentDataLakeFileSystemClient()
+        {
+            // Arrange
+            var constants = TestConstants.Create(this);
+            var endpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var secondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (endpoint, secondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName)
+            DataLakeFileClient file = InstrumentClient(new DataLakeFileClient(
+                connectionString,
+                GetNewFileSystemName(),
+                $"{GetNewDirectoryName()}/{GetNewFileName()}"));
+            DataLakeFileSystemClient fileSystem = file.GetParentDataLakeFileSystemClient();
+            Assert.IsTrue(fileSystem.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
+            DataLakeFileClient file2 = InstrumentClient(new DataLakeFileClient(
+                connectionString,
+                GetNewFileSystemName(),
+                $"{GetNewDirectoryName()}/{GetNewFileName()}",
+                GetOptions()));
+            DataLakeFileSystemClient fileSystem2 = file2.GetParentDataLakeFileSystemClient();
+            Assert.IsTrue(fileSystem2.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(Uri blobContainerUri, BlobClientOptions options = default)
+            DataLakeFileClient file3 = InstrumentClient(new DataLakeFileClient(
+                endpoint,
+                GetOptions()));
+            DataLakeFileSystemClient container3 = file3.GetParentDataLakeFileSystemClient();
+            Assert.IsFalse(container3.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            DataLakeFileClient file4 = InstrumentClient(new DataLakeFileClient(
+                endpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions()));
+            DataLakeFileSystemClient container4 = file4.GetParentDataLakeFileSystemClient();
+            Assert.IsTrue(container4.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            DataLakeFileClient file5 = InstrumentClient(new DataLakeFileClient(
+                endpoint,
+                tokenCredentials,
+                GetOptions()));
+            DataLakeFileSystemClient container5 = file5.GetParentDataLakeFileSystemClient();
+            Assert.IsFalse(container5.CanGenerateSasUri);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGenerateSas_GetParentDataLakeFileSystemClient.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGenerateSas_GetParentDataLakeFileSystemClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:11:32.5459382-08:00",
+    "RandomSeed": "1299989340"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGenerateSas_GetParentDataLakeFileSystemClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGenerateSas_GetParentDataLakeFileSystemClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T11:47:41.3825510-08:00",
+    "RandomSeed": "1637179365"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-8de60748-8e97-e338-58c9-19adfcac43ca?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-356412d2575d0845afb765a1b6f35a2d-b8d0f7b8b6c6c340-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "70bd2f8c-18d0-ec61-ab95-7f281c0eaf1b",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "ETag": "\u00220x8D9E759C1BC8763\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "70bd2f8c-18d0-ec61-ab95-7f281c0eaf1b",
+        "x-ms-request-id": "d45c8f72-301e-004d-1442-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-8de60748-8e97-e338-58c9-19adfcac43ca?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6e643da6e52d5747ab791e12a6cf3b44-5ca990260a2c7a41-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1dc7046d-f0cb-4490-a1a1-7c7c42e67eb7",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "ETag": "\u00220x8D9E759C1BC8763\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "Vary": "Origin",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "1dc7046d-f0cb-4490-a1a1-7c7c42e67eb7",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-immutable-storage-with-versioning-enabled": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d45c8fb2-301e-004d-4442-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-8de60748-8e97-e338-58c9-19adfcac43ca?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b2c14a3d0a3deb4aaf8a276009c2c8c2-7fefee569fc6dc44-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "690c2cdc-ce2c-3370-66db-2a4e557de461",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "690c2cdc-ce2c-3370-66db-2a4e557de461",
+        "x-ms-request-id": "d45c8fc4-301e-004d-5442-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "407823303",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClientAsync.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-93e9d894-8106-a146-9bc9-52700761cb9b?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-d201ba6c08543a4ea9dca9e3662e9b16-a9c00eda2d035b47-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "4e551c9c-0c77-dd43-fd6b-07f3b40c6e4f",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:42 GMT",
+        "ETag": "\u00220x8D9E74E0B035B29\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:42 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "4e551c9c-0c77-dd43-fd6b-07f3b40c6e4f",
+        "x-ms-request-id": "a0e96e77-c01e-0014-5336-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-93e9d894-8106-a146-9bc9-52700761cb9b?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5b8288b6b83cb34ea47b3c14fd8ce564-264983e7b3586d47-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0556efa7-4ad9-eb48-9dda-e2a20c529ad5",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:42 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:42 GMT",
+        "ETag": "\u00220x8D9E74E0B035B29\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:42 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "Vary": "Origin",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "0556efa7-4ad9-eb48-9dda-e2a20c529ad5",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-immutable-storage-with-versioning-enabled": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "a0e96eb6-c01e-0014-0636-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-93e9d894-8106-a146-9bc9-52700761cb9b?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-90db6670030e7b4f94d49fc88ce048e3-e18b3fa6c86b224e-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "54497774-42d1-780e-6ee8-4d319a823c3d",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:42 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "54497774-42d1-780e-6ee8-4d319a823c3d",
+        "x-ms-request-id": "a0e96eee-c01e-0014-3036-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "200933158",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithAccountSAS.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithAccountSAS.json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-0dcc5b22-0797-f1e4-7ae1-a76c67482d4c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-296d37e95fcbd249bd8eab7be89eee23-2a89392ed7791049-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "95cfe6d7-4a45-f661-a51a-6f16afe13f80",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "ETag": "\u00220x8D9E759C1F78BC6\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "95cfe6d7-4a45-f661-a51a-6f16afe13f80",
+        "x-ms-request-id": "d45c8ff6-301e-004d-7e42-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-0dcc5b22-0797-f1e4-7ae1-a76c67482d4c?sv=2021-04-10\u0026ss=b\u0026srt=sco\u0026st=2022-02-03T20%3A11%3A34Z\u0026se=2022-02-03T22%3A11%3A34Z\u0026sp=rwdlac\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-16e9d49e2ade09468011aa6bef6e01f9-048f3592670d2848-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fe975bac-4baf-3b15-c127-148c12b5ca2c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "ETag": "\u00220x8D9E759C1F78BC6\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "Vary": "Origin",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "fe975bac-4baf-3b15-c127-148c12b5ca2c",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-immutable-storage-with-versioning-enabled": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d45c902e-301e-004d-2b42-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-0dcc5b22-0797-f1e4-7ae1-a76c67482d4c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-259d3b78cb892a4d89240c5d3c4a7c2d-18b9599bf8767142-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d0ff4453-3ce1-42ac-5159-bf51837ab776",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "d0ff4453-3ce1-42ac-5159-bf51837ab776",
+        "x-ms-request-id": "d45c903f-301e-004d-3c42-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:11:34.2248856-08:00",
+    "RandomSeed": "176107133",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithAccountSASAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithAccountSASAsync.json
@@ -1,0 +1,96 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-690baa09-288f-fa12-ca1b-d49a158ab53d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-951d63ff7b56f744a594e8bcc5217f2a-f9f85c8be44d7f47-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "38ba9775-b917-13bd-302f-928afd20d604",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:42 GMT",
+        "ETag": "\u00220x8D9E74E0B45FFD5\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "38ba9775-b917-13bd-302f-928afd20d604",
+        "x-ms-request-id": "a0e96f1d-c01e-0014-5336-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-690baa09-288f-fa12-ca1b-d49a158ab53d?sv=2021-04-10\u0026ss=b\u0026srt=sco\u0026st=2022-02-03T18%3A47%3A43Z\u0026se=2022-02-03T20%3A47%3A43Z\u0026sp=rwdlac\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-7927057d8fe7bc41a0a257c7ad0c2df7-f567b0b6fe061748-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "be368999-4383-548a-3eea-6be07e9e7835",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "ETag": "\u00220x8D9E74E0B45FFD5\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "Vary": "Origin",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "be368999-4383-548a-3eea-6be07e9e7835",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-immutable-storage-with-versioning-enabled": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "a0e96f5b-c01e-0014-0436-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-690baa09-288f-fa12-ca1b-d49a158ab53d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-61a9c79b8a620d4587116f79563e0f3b-4be91fc4e8954848-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "11862d61-8ac4-1a6a-f4d0-3ee51146b4e7",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "11862d61-8ac4-1a6a-f4d0-3ee51146b4e7",
+        "x-ms-request-id": "a0e96fa0-c01e-0014-3b36-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T11:47:43.2705883-08:00",
+    "RandomSeed": "1039413345",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithContainerSAS.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithContainerSAS.json
@@ -1,0 +1,89 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-ea9c2963-2839-c646-c150-86e014c505b4?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6b3afe0262f06543a7f0d0bd55c69e4f-243dbf4d973dbd43-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cd22b879-2b85-a85f-83a6-2ef283923a53",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:33 GMT",
+        "ETag": "\u00220x8D9E759C2180739\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "cd22b879-2b85-a85f-83a6-2ef283923a53",
+        "x-ms-request-id": "d45c905c-301e-004d-5642-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-ea9c2963-2839-c646-c150-86e014c505b4?sv=2021-04-10\u0026st=2022-02-03T20%3A11%3A34Z\u0026se=2022-02-03T22%3A11%3A34Z\u0026sr=c\u0026sp=racwdlmeop\u0026sig=Sanitized\u0026resource=filesystem\u0026recursive=false\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "traceparent": "00-f4160c08daff2841ad24a4cf286cbca7-09c6e72e8abaf34a-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c51d80a2-3fce-f27c-e84a-54d53c025315",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json;charset=utf-8",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "c51d80a2-3fce-f27c-e84a-54d53c025315",
+        "x-ms-request-id": "3b16683e-b01f-000e-7542-19f372000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[]}\n"
+      ]
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-ea9c2963-2839-c646-c150-86e014c505b4?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f5167578c657b54595467ae83e3b6793-8adcc3ad3bd3bf40-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d4ba8445-8750-5818-0f75-7257e25900b2",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "d4ba8445-8750-5818-0f75-7257e25900b2",
+        "x-ms-request-id": "d45c9123-301e-004d-0242-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:11:34.4375599-08:00",
+    "RandomSeed": "2084615564",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithContainerSASAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithContainerSASAsync.json
@@ -1,0 +1,88 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-d0bc7feb-0a14-ccb2-c7ed-c76b4cab48da?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-19881f0a27545041ad847a10423a36bb-e7133c9671262e45-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "8a609e87-7d5f-a9f2-5f86-38cc5c6c7dee",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "ETag": "\u00220x8D9E74E0B82FFF9\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "8a609e87-7d5f-a9f2-5f86-38cc5c6c7dee",
+        "x-ms-request-id": "a0e96fd1-c01e-0014-6736-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-d0bc7feb-0a14-ccb2-c7ed-c76b4cab48da?sv=2021-04-10\u0026st=2022-02-03T18%3A47%3A43Z\u0026se=2022-02-03T20%3A47%3A43Z\u0026sr=c\u0026sp=racwdlmeop\u0026sig=Sanitized\u0026resource=filesystem\u0026recursive=false\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f59a0c56-54db-09ae-f230-a522feb2991a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json;charset=utf-8",
+        "Date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "f59a0c56-54db-09ae-f230-a522feb2991a",
+        "x-ms-request-id": "29782003-501f-0006-4d36-19e97d000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[]}\n"
+      ]
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-d0bc7feb-0a14-ccb2-c7ed-c76b4cab48da?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-e4286d09a25f224a9e63e36b55c41f7e-6e045af5d75f374f-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "02e99919-05aa-760b-97db-bb1a1858a2bb",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:43 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "02e99919-05aa-760b-97db-bb1a1858a2bb",
+        "x-ms-request-id": "a0e9708c-c01e-0014-0136-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T11:47:43.6655854-08:00",
+    "RandomSeed": "613166375",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient.json
@@ -1,0 +1,127 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-bab6eb03-c50b-73e8-94b3-add3ea9924a1?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-00e0e6291abec545bfb9f868abc4df8e-7f6c4e433fc5c441-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "fb4c3684-00c8-5eb7-a3dd-275a0ab0f09e",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "ETag": "\u00220x8D9E759C26D6D6D\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "fb4c3684-00c8-5eb7-a3dd-275a0ab0f09e",
+        "x-ms-request-id": "d45c914d-301e-004d-2842-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-bab6eb03-c50b-73e8-94b3-add3ea9924a1/test-directory-bc518b23-b80e-db83-3816-94d6f4be0ed9/test-file-fbdef2f1-f6fd-d3d6-6f82-0d3a8933c840?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2fb6d57ec3150846b1b93613c69b7648-e6e332686a8be945-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b8c29de1-2476-8ed1-6079-8b46f37dd46f",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "ETag": "\u00220x8D9E759C27B9C21\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "b8c29de1-2476-8ed1-6079-8b46f37dd46f",
+        "x-ms-request-id": "3b166840-b01f-000e-7742-19f372000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-bab6eb03-c50b-73e8-94b3-add3ea9924a1/test-directory-bc518b23-b80e-db83-3816-94d6f4be0ed9",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b85a159c2a23624cb71b1e18747f423a-b87fc6708c198943-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "eb581058-0f71-70ca-0dc0-53d39d9203c3",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "ETag": "\u00220x8D9E759C27AB1E6\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "Vary": "Origin",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "eb581058-0f71-70ca-0dc0-53d39d9203c3",
+        "x-ms-creation-time": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-last-access-time": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-hdi_isfolder": "true",
+        "x-ms-request-id": "d45c9196-301e-004d-6642-19152e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-bab6eb03-c50b-73e8-94b3-add3ea9924a1?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b5abdf4367ad8d49bb7d8f7772bd85a7-4d64d45b06a6fb46-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e2ed3dae-e824-06fe-1c56-1ea1e87d2b87",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "e2ed3dae-e824-06fe-1c56-1ea1e87d2b87",
+        "x-ms-request-id": "d45c91cd-301e-004d-1542-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "206537796",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClientAsync.json
@@ -1,0 +1,127 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-3ca58f2f-a822-3cd4-ff31-a8f905d2a980?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a2b6e22c30f57846a40a7bd69768e076-6a1abc76f6640a4e-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "82c38150-5f2c-7efb-4817-c61b845ee687",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "ETag": "\u00220x8D9E74E0BE13EF7\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "82c38150-5f2c-7efb-4817-c61b845ee687",
+        "x-ms-request-id": "a0e970c4-c01e-0014-3136-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-3ca58f2f-a822-3cd4-ff31-a8f905d2a980/test-directory-c6541c26-2d4c-ec58-5a71-c37d671f9ac3/test-file-381b43c7-5fed-0d02-4f7e-2c6be6bd22f5?resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f5c3ea8816a04b42805a23f97325d05a-ac0eae18a6c8304a-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d64e3ad0-2def-f147-7eb6-33ae3390978b",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "ETag": "\u00220x8D9E74E0BF160B4\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "d64e3ad0-2def-f147-7eb6-33ae3390978b",
+        "x-ms-request-id": "29782028-501f-0006-7236-19e97d000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-3ca58f2f-a822-3cd4-ff31-a8f905d2a980/test-directory-c6541c26-2d4c-ec58-5a71-c37d671f9ac3",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ab4073763d898142a142bd1643174bb8-c59359cd60c43345-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ac9b79dc-4c6f-9d05-2bb6-0558f2a5cea2",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "ETag": "\u00220x8D9E74E0BED429C\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "Vary": "Origin",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "ac9b79dc-4c6f-9d05-2bb6-0558f2a5cea2",
+        "x-ms-creation-time": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-last-access-time": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-hdi_isfolder": "true",
+        "x-ms-request-id": "a0e97113-c01e-0014-7236-1992ad000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-3ca58f2f-a822-3cd4-ff31-a8f905d2a980?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-ef27347b61bfca44884bc26223bfed39-e02d4d73d92efb47-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b9d20805-ebf5-a81c-cbb3-e5ff5d1fae4a",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "b9d20805-ebf5-a81c-cbb3-e5ff5d1fae4a",
+        "x-ms-request-id": "a0e97133-c01e-0014-1036-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2034150522",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithAccountSAS.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithAccountSAS.json
@@ -1,0 +1,124 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-72899feb-bcb8-e18e-b48c-6c1266eb873c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2510489b2975914a866cc614a70018fd-0f20d9c222f0f347-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "2f2d0a80-0b81-ebb6-d90d-f9ebeb504200",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "ETag": "\u00220x8D9E759C2A20A1F\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "2f2d0a80-0b81-ebb6-d90d-f9ebeb504200",
+        "x-ms-request-id": "d45c91e7-301e-004d-2c42-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-72899feb-bcb8-e18e-b48c-6c1266eb873c/test-directory-adef67a7-5777-a862-ec33-9b0499855caa/test-file-4e8a5eac-d8cb-1462-b7d7-08c5f41a4e7a?sv=2021-04-10\u0026ss=b\u0026srt=sco\u0026st=2022-02-03T20%3A11%3A35Z\u0026se=2022-02-03T22%3A11%3A35Z\u0026sp=rwdlac\u0026sig=Sanitized\u0026resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "traceparent": "00-1a213e9745c6384d9413b278c7487c44-aff7c834763a2146-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "34c7c6b0-40af-a72b-a819-77a902f0f7be",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "ETag": "\u00220x8D9E759C2B038FE\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "34c7c6b0-40af-a72b-a819-77a902f0f7be",
+        "x-ms-request-id": "3b166841-b01f-000e-7842-19f372000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-72899feb-bcb8-e18e-b48c-6c1266eb873c/test-directory-adef67a7-5777-a862-ec33-9b0499855caa?sv=2021-04-10\u0026ss=b\u0026srt=sco\u0026st=2022-02-03T20%3A11%3A35Z\u0026se=2022-02-03T22%3A11%3A35Z\u0026sp=rwdlac\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-829519f8dfee754d9a514ac71af222d5-4d9a4444588c8344-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2d14ee10-1953-bcca-49e9-b2a3e0116aa4",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "ETag": "\u00220x8D9E759C2AF75CD\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "Vary": "Origin",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "2d14ee10-1953-bcca-49e9-b2a3e0116aa4",
+        "x-ms-creation-time": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-last-access-time": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-hdi_isfolder": "true",
+        "x-ms-request-id": "d45c9236-301e-004d-7342-19152e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-72899feb-bcb8-e18e-b48c-6c1266eb873c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fd55ce543040d14da349ca715227e6a1-eb567db2a342cf45-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "1498bbe3-c9dc-a56b-b432-2cd4349f7491",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "1498bbe3-c9dc-a56b-b432-2cd4349f7491",
+        "x-ms-request-id": "d45c9253-301e-004d-0c42-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:11:35.3620750-08:00",
+    "RandomSeed": "1740502719",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithAccountSASAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithAccountSASAsync.json
@@ -1,0 +1,124 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-2bb39a9e-598d-ab8e-6746-0ad470f6bbe6?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-6f3231536286ee42ab33ad5a66520819-c5cbdcb20cf4e14c-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "eb2d1b39-cc28-e53f-fc4c-5183c79267f9",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "ETag": "\u00220x8D9E74E0C13E05D\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "eb2d1b39-cc28-e53f-fc4c-5183c79267f9",
+        "x-ms-request-id": "a0e97158-c01e-0014-2e36-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-2bb39a9e-598d-ab8e-6746-0ad470f6bbe6/test-directory-b8f88a3f-d1ca-d866-ef9e-ea038ad1afb4/test-file-794e03e3-6881-2277-a570-71dc5aacac92?sv=2021-04-10\u0026ss=b\u0026srt=sco\u0026st=2022-02-03T18%3A47%3A44Z\u0026se=2022-02-03T20%3A47%3A44Z\u0026sp=rwdlac\u0026sig=Sanitized\u0026resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "traceparent": "00-a42ce7051a50684fa9d74337a2d982b6-3879f64ede04ef4a-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fbfe054a-c685-d190-a40a-45b75b638b4f",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "ETag": "\u00220x8D9E74E0C1F20EB\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "fbfe054a-c685-d190-a40a-45b75b638b4f",
+        "x-ms-request-id": "2978202a-501f-0006-7436-19e97d000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-2bb39a9e-598d-ab8e-6746-0ad470f6bbe6/test-directory-b8f88a3f-d1ca-d866-ef9e-ea038ad1afb4?sv=2021-04-10\u0026ss=b\u0026srt=sco\u0026st=2022-02-03T18%3A47%3A44Z\u0026se=2022-02-03T20%3A47%3A44Z\u0026sp=rwdlac\u0026sig=Sanitized",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-812dcd8614df1845941e6cf8e54a78aa-ab9da28a98173441-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "559149f4-b0ae-410d-66c9-b0be8a068c6d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "ETag": "\u00220x8D9E74E0C1E5DB2\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "Vary": "Origin",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "559149f4-b0ae-410d-66c9-b0be8a068c6d",
+        "x-ms-creation-time": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-last-access-time": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-hdi_isfolder": "true",
+        "x-ms-request-id": "a0e97184-c01e-0014-5636-1992ad000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-2bb39a9e-598d-ab8e-6746-0ad470f6bbe6?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-32bd514e408124478e20d64c05e86b51-4ab4e29ed3af4a48-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "12c21111-35d1-efa1-b13b-692e6272873f",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:44 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "12c21111-35d1-efa1-b13b-692e6272873f",
+        "x-ms-request-id": "a0e9719d-c01e-0014-6d36-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T11:47:44.6025847-08:00",
+    "RandomSeed": "1068389155",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithContainerSAS.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithContainerSAS.json
@@ -1,0 +1,115 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-dc92ec3d-3600-e83a-9ac3-cce976b87144?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f33525fc03a88640b685af4cdcbd9a71-e6609231f6f47f4e-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "566168ca-5c43-00fe-bae9-9b1b44ebac80",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:34 GMT",
+        "ETag": "\u00220x8D9E759C2CEDFC9\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "566168ca-5c43-00fe-bae9-9b1b44ebac80",
+        "x-ms-request-id": "d45c927b-301e-004d-3142-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-dc92ec3d-3600-e83a-9ac3-cce976b87144/test-directory-36d1f536-11de-23d4-394c-f4aea7483422/test-file-b3cbafdb-9612-47f9-4999-9f606223a58e?sv=2021-04-10\u0026st=2022-02-03T20%3A11%3A35Z\u0026se=2022-02-03T22%3A11%3A35Z\u0026sr=c\u0026sp=racwdlmeop\u0026sig=Sanitized\u0026resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "traceparent": "00-e2c5d46b4aa1eb438e91e301ad452e57-702efe603d07a14e-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "933b53f2-3240-34c0-6e19-0ca9bc9d9e97",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "ETag": "\u00220x8D9E759C2DA7726\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "933b53f2-3240-34c0-6e19-0ca9bc9d9e97",
+        "x-ms-request-id": "3b166842-b01f-000e-7942-19f372000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-dc92ec3d-3600-e83a-9ac3-cce976b87144?sv=2021-04-10\u0026st=2022-02-03T20%3A11%3A35Z\u0026se=2022-02-03T22%3A11%3A35Z\u0026sr=c\u0026sp=racwdlmeop\u0026sig=Sanitized\u0026resource=filesystem\u0026directory=test-directory-36d1f536-11de-23d4-394c-f4aea7483422\u0026recursive=false\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "traceparent": "00-d1a99007c316f140b4d9030715476849-d098d50ffc90204b-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "0e6e4ee5-11e8-a94d-39e9-9f3e0d57c957",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json;charset=utf-8",
+        "Date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "0e6e4ee5-11e8-a94d-39e9-9f3e0d57c957",
+        "x-ms-request-id": "3b166843-b01f-000e-7a42-19f372000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[{\u0022contentLength\u0022:\u00220\u0022,\u0022creationTime\u0022:\u0022Thu, 03 Feb 2022 21:11:35 GMT\u0022,\u0022etag\u0022:\u00220x8D9E759C2DA7726\u0022,\u0022lastModified\u0022:\u0022Thu, 03 Feb 2022 21:11:35 GMT\u0022,\u0022name\u0022:\u0022test-directory-36d1f536-11de-23d4-394c-f4aea7483422/test-file-b3cbafdb-9612-47f9-4999-9f606223a58e\u0022}]}\n"
+      ]
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-dc92ec3d-3600-e83a-9ac3-cce976b87144?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9b2b6dd8e893f444b575dd7f0c135a40-e89b2aaa520bbb44-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6dc34b2b-8f2f-32af-bf94-12e2feebb357",
+        "x-ms-date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:11:35 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "6dc34b2b-8f2f-32af-bf94-12e2feebb357",
+        "x-ms-request-id": "d45c92ea-301e-004d-1842-19152e000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:11:35.6350705-08:00",
+    "RandomSeed": "962883858",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithContainerSASAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithContainerSASAsync.json
@@ -1,0 +1,114 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-fe2cec0f-f3cb-c140-dd3b-f276aa190e76?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a98deffc0fa6214e81920b95a123b220-99ed5129c3152347-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "56f5d35f-cb9b-ddc7-47a7-4991a61cb608",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "ETag": "\u00220x8D9E74E0CAA172D\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "56f5d35f-cb9b-ddc7-47a7-4991a61cb608",
+        "x-ms-request-id": "a0e972d8-c01e-0014-7036-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-fe2cec0f-f3cb-c140-dd3b-f276aa190e76/test-directory-266987d1-99cd-6092-2128-795c6cd805ba/test-file-f3e0021a-26c8-aa25-b14c-54ad0e13d740?sv=2021-04-10\u0026st=2022-02-03T18%3A47%3A45Z\u0026se=2022-02-03T20%3A47%3A45Z\u0026sr=c\u0026sp=racwdlmeop\u0026sig=Sanitized\u0026resource=file",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "traceparent": "00-e2f61dc7bc33f94eb92f2832316b2117-c76cd46906816848-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e713dc68-01bc-390d-ae4b-a44f7619ce34",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "ETag": "\u00220x8D9E74E0CBAFC6B\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "e713dc68-01bc-390d-ae4b-a44f7619ce34",
+        "x-ms-request-id": "2978202b-501f-0006-7536-19e97d000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.dfs.core.windows.net/test-filesystem-fe2cec0f-f3cb-c140-dd3b-f276aa190e76?sv=2021-04-10\u0026st=2022-02-03T18%3A47%3A45Z\u0026se=2022-02-03T20%3A47%3A45Z\u0026sr=c\u0026sp=racwdlmeop\u0026sig=Sanitized\u0026resource=filesystem\u0026directory=test-directory-266987d1-99cd-6092-2128-795c6cd805ba\u0026recursive=false\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "3145c712-efff-4684-0edd-27d7138b3a99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json;charset=utf-8",
+        "Date": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "Server": "Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0",
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "3145c712-efff-4684-0edd-27d7138b3a99",
+        "x-ms-request-id": "2978202c-501f-0006-7636-19e97d000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[{\u0022contentLength\u0022:\u00220\u0022,\u0022creationTime\u0022:\u0022Thu, 03 Feb 2022 19:47:45 GMT\u0022,\u0022etag\u0022:\u00220x8D9E74E0CBAFC6B\u0022,\u0022lastModified\u0022:\u0022Thu, 03 Feb 2022 19:47:45 GMT\u0022,\u0022name\u0022:\u0022test-directory-266987d1-99cd-6092-2128-795c6cd805ba/test-file-f3e0021a-26c8-aa25-b14c-54ad0e13d740\u0022}]}\n"
+      ]
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.blob.core.windows.net/test-filesystem-fe2cec0f-f3cb-c140-dd3b-f276aa190e76?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0e2e34baa73aaa4c935f3452ffc3ee7f-a47fa28f16e95a43-00",
+        "User-Agent": "azsdk-net-Storage.Files.DataLake/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "af3d9bbd-9dd3-e134-8403-7c27b80d4e9b",
+        "x-ms-date": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 19:47:45 GMT",
+        "Server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "af3d9bbd-9dd3-e134-8403-7c27b80d4e9b",
+        "x-ms-request-id": "a0e9733e-c01e-0014-4436-1992ad000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T11:47:45.5995890-08:00",
+    "RandomSeed": "185632665",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Sanitized\n\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
@@ -54,6 +54,7 @@ namespace Azure.Storage.Files.Shares
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual System.Threading.Tasks.Task<Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Files.Shares.Models.ShareSignedIdentifier>>> GetAccessPolicyAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual Azure.Storage.Files.Shares.ShareDirectoryClient GetDirectoryClient(string directoryName) { throw null; }
+        protected internal virtual Azure.Storage.Files.Shares.ShareServiceClient GetParentShareServiceClientCore() { throw null; }
         public virtual Azure.Response<string> GetPermission(string filePermissionKey = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<string>> GetPermissionAsync(string filePermissionKey = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.Storage.Files.Shares.Models.ShareProperties> GetProperties(Azure.Storage.Files.Shares.Models.ShareFileRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -165,6 +166,8 @@ namespace Azure.Storage.Files.Shares
         public virtual Azure.AsyncPageable<Azure.Storage.Files.Shares.Models.ShareFileItem> GetFilesAndDirectoriesAsync(string prefix, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.Storage.Files.Shares.Models.ShareFileHandle> GetHandles(bool? recursive = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.Storage.Files.Shares.Models.ShareFileHandle> GetHandlesAsync(bool? recursive = default(bool?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual Azure.Storage.Files.Shares.ShareClient GetParentShareClientCore() { throw null; }
+        protected internal virtual Azure.Storage.Files.Shares.ShareDirectoryClient GetParentShareDirectoryClientCore() { throw null; }
         public virtual Azure.Response<Azure.Storage.Files.Shares.Models.ShareDirectoryProperties> GetProperties(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Shares.Models.ShareDirectoryProperties>> GetPropertiesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Storage.Files.Shares.ShareDirectoryClient GetSubdirectoryClient(string subdirectoryName) { throw null; }
@@ -232,6 +235,8 @@ namespace Azure.Storage.Files.Shares
         public virtual System.Uri GenerateSasUri(Azure.Storage.Sas.ShareSasBuilder builder) { throw null; }
         public virtual Azure.Pageable<Azure.Storage.Files.Shares.Models.ShareFileHandle> GetHandles(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.Storage.Files.Shares.Models.ShareFileHandle> GetHandlesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual Azure.Storage.Files.Shares.ShareClient GetParentShareClientCore() { throw null; }
+        protected internal virtual Azure.Storage.Files.Shares.ShareDirectoryClient GetParentShareDirectoryClientCore() { throw null; }
         public virtual Azure.Response<Azure.Storage.Files.Shares.Models.ShareFileProperties> GetProperties(Azure.Storage.Files.Shares.Models.ShareFileRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public virtual Azure.Response<Azure.Storage.Files.Shares.Models.ShareFileProperties> GetProperties(System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -1077,6 +1082,14 @@ namespace Azure.Storage.Files.Shares.Specialized
     {
         public static Azure.Storage.Files.Shares.Specialized.ShareLeaseClient GetShareLeaseClient(this Azure.Storage.Files.Shares.ShareClient client, string leaseId = null) { throw null; }
         public static Azure.Storage.Files.Shares.Specialized.ShareLeaseClient GetShareLeaseClient(this Azure.Storage.Files.Shares.ShareFileClient client, string leaseId = null) { throw null; }
+    }
+    public static partial class SpecializedShareExtensions
+    {
+        public static Azure.Storage.Files.Shares.ShareClient GetParentShareClient(this Azure.Storage.Files.Shares.ShareDirectoryClient client) { throw null; }
+        public static Azure.Storage.Files.Shares.ShareClient GetParentShareClient(this Azure.Storage.Files.Shares.ShareFileClient client) { throw null; }
+        public static Azure.Storage.Files.Shares.ShareDirectoryClient GetParentShareDirectoryClient(this Azure.Storage.Files.Shares.ShareDirectoryClient client) { throw null; }
+        public static Azure.Storage.Files.Shares.ShareDirectoryClient GetParentShareDirectoryClient(this Azure.Storage.Files.Shares.ShareFileClient client) { throw null; }
+        public static Azure.Storage.Files.Shares.ShareServiceClient GetParentShareServiceClient(this Azure.Storage.Files.Shares.ShareClient client) { throw null; }
     }
 }
 namespace Azure.Storage.Sas

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
@@ -58,6 +58,7 @@
     <Compile Include="$(AzureStorageSharedSources)NonCryptographicHashAlgorithmHasher.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)NonDisposingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PartitionedUploader.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureStorageSharedSources)PathExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)PooledMemoryStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)ProgressIncrementingStream.cs" LinkBase="Shared" />
     <Compile Include="$(AzureStorageSharedSources)SasExtensions.cs" LinkBase="Shared" />

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -16,6 +16,8 @@ using Azure.Storage.Files.Shares.Models;
 using Azure.Storage.Sas;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
+#pragma warning disable SA1402  // File may only contain a single type
+
 namespace Azure.Storage.Files.Shares
 {
     /// <summary>
@@ -3468,5 +3470,59 @@ namespace Azure.Storage.Files.Shares
             return sasUri.ToUri();
         }
         #endregion
+
+        #region GetParentClientCore
+
+        private ShareServiceClient _parentShareServiceClient;
+
+        /// <summary>
+        /// Create a new <see cref="ShareServiceClient"/> that pointing to this <see cref="ShareClient"/>'s parent container.
+        /// The new <see cref="ShareServiceClient"/>
+        /// uses the same request policy pipeline as the
+        /// <see cref="ShareClient"/>.
+        /// </summary>
+        /// <returns>A new <see cref="ShareServiceClient"/> instance.</returns>
+        protected internal virtual ShareServiceClient GetParentShareServiceClientCore()
+        {
+            if (_parentShareServiceClient == null)
+            {
+                ShareUriBuilder shareUriBuilder = new ShareUriBuilder(Uri)
+                {
+                    // erase parameters unrelated to container
+                    DirectoryOrFilePath = null,
+                    Snapshot = null,
+                };
+
+                _parentShareServiceClient = new ShareServiceClient(
+                    shareUriBuilder.ToUri(),
+                    ClientConfiguration);
+            }
+
+            return _parentShareServiceClient;
+        }
+        #endregion
+    }
+
+    namespace Specialized
+    {
+        /// <summary>
+        /// Add easy to discover methods to <see cref="ShareFileClient"/> for
+        /// creating <see cref="ShareClient"/> instances.
+        /// </summary>
+        public static partial class SpecializedShareExtensions
+        {
+            /// <summary>
+            /// Create a new <see cref="ShareServiceClient"/> that pointing to this <see cref="ShareClient"/>'s parent container.
+            /// The new <see cref="ShareServiceClient"/>
+            /// uses the same request policy pipeline as the
+            /// <see cref="ShareClient"/>.
+            /// </summary>
+            /// <param name="client">The <see cref="ShareClient"/>.</param>
+            /// <returns>A new <see cref="ShareServiceClient"/> instance.</returns>
+            public static ShareServiceClient GetParentShareServiceClient(this ShareClient client)
+            {
+                return client.GetParentShareServiceClientCore();
+            }
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -13,6 +13,8 @@ using Azure.Storage.Sas;
 using Azure.Storage.Shared;
 using Metadata = System.Collections.Generic.IDictionary<string, string>;
 
+#pragma warning disable SA1402  // File may only contain a single type
+
 namespace Azure.Storage.Files.Shares
 {
     /// <summary>
@@ -3149,5 +3151,103 @@ namespace Azure.Storage.Files.Shares
             return sasUri.ToUri();
         }
         #endregion
+
+        #region GetParentClientCore
+
+        private ShareClient _parentShareClient;
+        private ShareDirectoryClient _parentShareDirectoryClient;
+
+        /// <summary>
+        /// Create a new <see cref="ShareClient"/> that pointing to this <see cref="ShareFileClient"/>'s parent container.
+        /// The new <see cref="ShareClient"/>
+        /// uses the same request policy pipeline as the
+        /// <see cref="ShareFileClient"/>.
+        /// </summary>
+        /// <returns>A new <see cref="ShareFileClient"/> instance.</returns>
+        protected internal virtual ShareClient GetParentShareClientCore()
+        {
+            if (_parentShareClient == null)
+            {
+                ShareUriBuilder shareUriBuilder = new ShareUriBuilder(Uri)
+                {
+                    // erase parameters unrelated to container
+                    DirectoryOrFilePath = null,
+                    Snapshot = null,
+                };
+
+                _parentShareClient = new ShareClient(
+                    shareUriBuilder.ToUri(),
+                    ClientConfiguration);
+            }
+
+            return _parentShareClient;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="ShareDirectoryClient"/> that pointing to this <see cref="ShareFileClient"/>'s parent container.
+        /// The new <see cref="ShareDirectoryClient"/>
+        /// uses the same request policy pipeline as the
+        /// <see cref="ShareFileClient"/>.
+        /// </summary>
+        /// <returns>A new <see cref="ShareFileClient"/> instance.</returns>
+        protected internal virtual ShareDirectoryClient GetParentShareDirectoryClientCore()
+        {
+            if (_parentShareDirectoryClient == null)
+            {
+                ShareUriBuilder shareUriBuilder = new ShareUriBuilder(Uri)
+                {
+                    Snapshot = null,
+                };
+
+                if (shareUriBuilder.DirectoryOrFilePath == null || shareUriBuilder.LastDirectoryOrFileName == null)
+                {
+                    throw new InvalidOperationException();
+                }
+                shareUriBuilder.DirectoryOrFilePath = shareUriBuilder.DirectoryOrFilePath.GetParentPath();
+
+                _parentShareDirectoryClient = new ShareDirectoryClient(
+                    shareUriBuilder.ToUri(),
+                    ClientConfiguration);
+            }
+
+            return _parentShareDirectoryClient;
+        }
+        #endregion
+    }
+
+    namespace Specialized
+    {
+        /// <summary>
+        /// Add easy to discover methods to <see cref="ShareFileClient"/> for
+        /// creating <see cref="ShareClient"/> instances.
+        /// </summary>
+        public static partial class SpecializedShareExtensions
+        {
+            /// <summary>
+            /// Create a new <see cref="ShareClient"/> that pointing to this <see cref="ShareDirectoryClient"/>'s parent container.
+            /// The new <see cref="ShareClient"/>
+            /// uses the same request policy pipeline as the
+            /// <see cref="ShareDirectoryClient"/>.
+            /// </summary>
+            /// <param name="client">The <see cref="ShareDirectoryClient"/>.</param>
+            /// <returns>A new <see cref="ShareClient"/> instance.</returns>
+            public static ShareClient GetParentShareClient(this ShareDirectoryClient client)
+            {
+                return client.GetParentShareClientCore();
+            }
+
+            /// <summary>
+            /// Create a new <see cref="ShareDirectoryClient"/> that pointing to this <see cref="ShareDirectoryClient"/>'s parent container.
+            /// The new <see cref="ShareDirectoryClient"/>
+            /// uses the same request policy pipeline as the
+            /// <see cref="ShareDirectoryClient"/>.
+            /// </summary>
+            /// <param name="client">The <see cref="ShareDirectoryClient"/>.</param>
+            /// <returns>A new <see cref="ShareDirectoryClient"/> instance.</returns>
+            public static ShareDirectoryClient GetParentShareDirectoryClient(this ShareDirectoryClient client)
+            {
+                return client.GetParentShareDirectoryClientCore();
+            }
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -19,6 +19,8 @@ using Metadata = System.Collections.Generic.IDictionary<string, string>;
 using System.Net.Http.Headers;
 using System.Linq;
 
+#pragma warning disable SA1402  // File may only contain a single type
+
 namespace Azure.Storage.Files.Shares
 {
     /// <summary>
@@ -6282,5 +6284,103 @@ namespace Azure.Storage.Files.Shares
             return sasUri.ToUri();
         }
         #endregion
+
+        #region GetParentClientCore
+
+        private ShareClient _parentShareClient;
+        private ShareDirectoryClient _parentShareDirectoryClient;
+
+        /// <summary>
+        /// Create a new <see cref="ShareClient"/> that pointing to this <see cref="ShareFileClient"/>'s parent container.
+        /// The new <see cref="ShareClient"/>
+        /// uses the same request policy pipeline as the
+        /// <see cref="ShareFileClient"/>.
+        /// </summary>
+        /// <returns>A new <see cref="ShareFileClient"/> instance.</returns>
+        protected internal virtual ShareClient GetParentShareClientCore()
+        {
+            if (_parentShareClient == null)
+            {
+                ShareUriBuilder shareUriBuilder = new ShareUriBuilder(Uri)
+                {
+                    // erase parameters unrelated to container
+                    DirectoryOrFilePath = null,
+                    Snapshot = null,
+                };
+
+                _parentShareClient = new ShareClient(
+                    shareUriBuilder.ToUri(),
+                    ClientConfiguration);
+            }
+
+            return _parentShareClient;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="ShareDirectoryClient"/> that pointing to this <see cref="ShareFileClient"/>'s parent container.
+        /// The new <see cref="ShareDirectoryClient"/>
+        /// uses the same request policy pipeline as the
+        /// <see cref="ShareFileClient"/>.
+        /// </summary>
+        /// <returns>A new <see cref="ShareFileClient"/> instance.</returns>
+        protected internal virtual ShareDirectoryClient GetParentShareDirectoryClientCore()
+        {
+            if (_parentShareDirectoryClient == null)
+            {
+                ShareUriBuilder shareUriBuilder = new ShareUriBuilder(Uri)
+                {
+                    Snapshot = null,
+                };
+
+                if (shareUriBuilder.DirectoryOrFilePath == null || shareUriBuilder.LastDirectoryOrFileName == null)
+                {
+                    throw new InvalidOperationException();
+                }
+                shareUriBuilder.DirectoryOrFilePath = shareUriBuilder.DirectoryOrFilePath.GetParentPath();
+
+                _parentShareDirectoryClient = new ShareDirectoryClient(
+                    shareUriBuilder.ToUri(),
+                    ClientConfiguration);
+            }
+
+            return _parentShareDirectoryClient;
+        }
+        #endregion
+    }
+
+    namespace Specialized
+    {
+        /// <summary>
+        /// Add easy to discover methods to <see cref="ShareFileClient"/> for
+        /// creating <see cref="ShareClient"/> instances.
+        /// </summary>
+        public static partial class SpecializedShareExtensions
+        {
+            /// <summary>
+            /// Create a new <see cref="ShareClient"/> that pointing to this <see cref="ShareFileClient"/>'s parent container.
+            /// The new <see cref="ShareClient"/>
+            /// uses the same request policy pipeline as the
+            /// <see cref="ShareFileClient"/>.
+            /// </summary>
+            /// <param name="client">The <see cref="ShareFileClient"/>.</param>
+            /// <returns>A new <see cref="ShareClient"/> instance.</returns>
+            public static ShareClient GetParentShareClient(this ShareFileClient client)
+            {
+                return client.GetParentShareClientCore();
+            }
+
+            /// <summary>
+            /// Create a new <see cref="ShareDirectoryClient"/> that pointing to this <see cref="ShareFileClient"/>'s parent container.
+            /// The new <see cref="ShareDirectoryClient"/>
+            /// uses the same request policy pipeline as the
+            /// <see cref="ShareFileClient"/>.
+            /// </summary>
+            /// <param name="client">The <see cref="ShareFileClient"/>.</param>
+            /// <returns>A new <see cref="ShareDirectoryClient"/> instance.</returns>
+            public static ShareDirectoryClient GetParentShareDirectoryClient(this ShareFileClient client)
+            {
+                return client.GetParentShareDirectoryClientCore();
+            }
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -197,6 +197,27 @@ namespace Azure.Storage.Files.Shares
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ShareDirectoryClient"/>
+        /// class.
+        /// </summary>
+        /// <param name="directoryUri">
+        /// A <see cref="Uri"/> referencing the directory that includes the
+        /// name of the account, the name of the share, and the path of the
+        /// directory.
+        /// </param>
+        /// <param name="clientConfiguration">
+        /// <see cref="ShareClientConfiguration"/>
+        /// </param>
+        internal ShareServiceClient(
+            Uri directoryUri,
+            ShareClientConfiguration clientConfiguration)
+        {
+            _uri = directoryUri;
+            _clientConfiguration = clientConfiguration;
+            _serviceRestClient = BuildServiceRestClient();
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ShareServiceClient"/>
         /// class.
         /// </summary>

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ClientNavigationTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ClientNavigationTests.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Storage.Files.Shares.Specialized;
+using Azure.Storage.Test;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+
+namespace Azure.Storage.Files.Shares.Tests
+{
+    internal class ClientNavigationTests : FileTestBase
+    {
+        public ClientNavigationTests(bool async, ShareClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, RecordedTestMode.Record /* RecordedTestMode.Record /* to re-record */)
+        {
+        }
+
+        [RecordedTest]
+        public async Task PathClient_CanGetParentContainerClient()
+        {
+            // Arrange
+            await using DisposingShare test = await SharesClientBuilder.GetTestShareAsync();
+            ShareFileClient fileClient = InstrumentClient(test.Container.GetRootDirectoryClient().GetFileClient(SharesClientBuilder.GetNewFileName()));
+
+            // Act
+            ShareClient filesystemClient = fileClient.GetParentShareClient();
+            // make sure that client is functional
+            var containerProperties = await filesystemClient.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.ShareName, filesystemClient.Name);
+            Assert.AreEqual(fileClient.AccountName, filesystemClient.AccountName);
+            Assert.IsNotNull(containerProperties);
+        }
+
+        [RecordedTest]
+        public async Task PathClient_CanGetParentContainerClient_WithContainerSAS()
+        {
+            // Arrange
+            await using DisposingShare test = await SharesClientBuilder.GetTestShareAsync();
+            var fileName = SharesClientBuilder.GetNewFileName();
+            ShareFileClient fileClient = InstrumentClient(
+                GetServiceClient_FileServiceSasShare(test.Container.Name)
+                .GetShareClient(test.Share.Name)
+                .GetRootDirectoryClient()
+                .GetFileClient(fileName));
+
+            // Act
+            var fileSystemClient = fileClient.GetParentShareClient();
+            // make sure that client is functional
+            var pathItems = await fileSystemClient.GetRootDirectoryClient().GetFilesAndDirectoriesAsync().ToListAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.ShareName, fileSystemClient.Name);
+            Assert.AreEqual(fileClient.AccountName, fileSystemClient.AccountName);
+            Assert.IsNotNull(pathItems);
+        }
+
+        [RecordedTest]
+        public void PathClient_CanMockParentContainerClientRetrieval()
+        {
+            // Arrange
+            Mock<ShareFileClient> fileClientMock = new Mock<ShareFileClient>();
+            Mock<ShareClient> fileSystemClientMock = new Mock<ShareClient>();
+            fileClientMock.Protected().Setup<ShareClient>("GetParentShareClientCore").Returns(fileSystemClientMock.Object);
+
+            // Act
+            var fileSystemClient = fileClientMock.Object.GetParentShareClientCore();
+
+            // Assert
+            Assert.IsNotNull(fileSystemClient);
+            Assert.AreSame(fileSystemClientMock.Object, fileSystemClient);
+        }
+
+        [RecordedTest]
+        public async Task PathClient_CanGetParentDirectoryClient()
+        {
+            // Arrange
+            var parentDirName = SharesClientBuilder.GetNewDirectoryName();
+            await using DisposingShare test = await SharesClientBuilder.GetTestShareAsync();
+            ShareDirectoryClient parentDirClient = InstrumentClient(test.Container
+                .GetRootDirectoryClient()
+                .GetSubdirectoryClient(parentDirName));
+            await parentDirClient.CreateAsync();
+            ShareFileClient fileClient = InstrumentClient(parentDirClient
+                .GetFileClient(SharesClientBuilder.GetNewFileName()));
+            await fileClient.CreateAsync(Constants.KB);
+
+            // Act
+            parentDirClient = fileClient.GetParentShareDirectoryClient();
+            // make sure that client is functional
+            var dirProperties = await parentDirClient.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.Path.GetParentPath(), parentDirClient.Path);
+            Assert.AreEqual(fileClient.AccountName, parentDirClient.AccountName);
+            Assert.IsNotNull(dirProperties);
+        }
+
+        [RecordedTest]
+        public async Task PathClient_CanGetParentDirectoryClient_WithContainerSAS()
+        {
+            // Arrange
+            var parentDirName = SharesClientBuilder.GetNewDirectoryName();
+            await using DisposingShare test = await SharesClientBuilder.GetTestShareAsync();
+            var fileName = SharesClientBuilder.GetNewFileName();
+            ShareDirectoryClient parentDirClient = InstrumentClient(
+                GetServiceClient_FileServiceSasShare(test.Container.Name)
+                .GetShareClient(test.Share.Name)
+                .GetRootDirectoryClient()
+                .GetSubdirectoryClient(parentDirName));
+            await parentDirClient.CreateAsync();
+            ShareFileClient fileClient = InstrumentClient(parentDirClient
+                .GetFileClient(SharesClientBuilder.GetNewFileName()));
+            await fileClient.CreateAsync(Constants.KB);
+
+            // Act
+            parentDirClient = fileClient.GetParentShareDirectoryClient();
+            // make sure that client is functional
+            var pathItems = await parentDirClient.GetFilesAndDirectoriesAsync().ToListAsync();
+
+            // Assert
+            Assert.AreEqual(fileClient.Path.GetParentPath(), parentDirClient.Path);
+            Assert.AreEqual(fileClient.AccountName, parentDirClient.AccountName);
+            Assert.IsNotNull(pathItems);
+        }
+
+        [RecordedTest]
+        public void PathClient_CanMockParentDirectoryClientRetrieval()
+        {
+            // Arrange
+            Mock<ShareFileClient> fileClientMock = new Mock<ShareFileClient>();
+            Mock<ShareClient> fileSystemClientMock = new Mock<ShareClient>();
+            fileClientMock.Protected().Setup<ShareClient>("GetParentShareClientCore").Returns(fileSystemClientMock.Object);
+
+            // Act
+            var fileSystemClient = fileClientMock.Object.GetParentShareClientCore();
+
+            // Assert
+            Assert.IsNotNull(fileSystemClient);
+            Assert.AreSame(fileSystemClientMock.Object, fileSystemClient);
+        }
+
+        [RecordedTest]
+        public void PathClient_CanGenerateSas_GetParentShareClient()
+        {
+            // Arrange
+            var constants = TestConstants.Create(this);
+            var endpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var secondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (endpoint, secondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName)
+            ShareFileClient file = InstrumentClient(new ShareFileClient(
+                connectionString,
+                GetNewShareName(),
+                $"{GetNewDirectoryName()}/{GetNewFileName()}"));
+            ShareClient fileSystem = file.GetParentShareClient();
+            Assert.IsTrue(fileSystem.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
+            ShareFileClient file2 = InstrumentClient(new ShareFileClient(
+                connectionString,
+                GetNewShareName(),
+                $"{GetNewDirectoryName()}/{GetNewFileName()}",
+                GetOptions()));
+            ShareClient fileSystem2 = file2.GetParentShareClient();
+            Assert.IsTrue(fileSystem2.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(Uri blobContainerUri, BlobClientOptions options = default)
+            ShareFileClient file3 = InstrumentClient(new ShareFileClient(
+                endpoint,
+                GetOptions()));
+            ShareClient container3 = file3.GetParentShareClient();
+            Assert.IsFalse(container3.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            ShareFileClient file4 = InstrumentClient(new ShareFileClient(
+                endpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions()));
+            ShareClient container4 = file4.GetParentShareClient();
+            Assert.IsTrue(container4.CanGenerateSasUri);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ClientNavigationTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ClientNavigationTests.cs
@@ -15,7 +15,7 @@ namespace Azure.Storage.Files.Shares.Tests
     internal class ClientNavigationTests : FileTestBase
     {
         public ClientNavigationTests(bool async, ShareClientOptions.ServiceVersion serviceVersion)
-            : base(async, serviceVersion, RecordedTestMode.Record /* RecordedTestMode.Record /* to re-record */)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGenerateSas_GetParentShareClient.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGenerateSas_GetParentShareClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:44:45.3114286-08:00",
+    "RandomSeed": "5376845"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGenerateSas_GetParentShareClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGenerateSas_GetParentShareClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:44:48.2864077-08:00",
+    "RandomSeed": "1719522589"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient.json
@@ -1,0 +1,95 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-6b74792b-8424-932e-fe53-fe9bd7d742bd?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-9619ea1a42acc64d920eb17fe15f1773-5d5def965c791b4f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "031c69fd-82f2-6991-bc27-df302a9df2e5",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "ETag": "\u00220x8D9E75E657B4F62\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "031c69fd-82f2-6991-bc27-df302a9df2e5",
+        "x-ms-request-id": "16bbb155-c01a-0082-0e47-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-6b74792b-8424-932e-fe53-fe9bd7d742bd?restype=share",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0826f2e181c6da48b63caeaa07fb9a4f-fe9fb7346e4c0345-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "89b110db-56a7-8427-a056-2844d43bda2d",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "ETag": "\u00220x8D9E75E657B4F62\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-access-tier": "TransactionOptimized",
+        "x-ms-access-tier-change-time": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "x-ms-client-request-id": "89b110db-56a7-8427-a056-2844d43bda2d",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16bbb158-c01a-0082-0f47-199b7c000000",
+        "x-ms-share-quota": "5120",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-6b74792b-8424-932e-fe53-fe9bd7d742bd?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1a32df40bbd23445988328fafda68041-68e7ada994dcbe43-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "7e798e11-b7dc-f142-ad18-cd65168635ce",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "7e798e11-b7dc-f142-ad18-cd65168635ce",
+        "x-ms-request-id": "16bbb159-c01a-0082-1047-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "205563474",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Kg==;\n[encryption scope]\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClientAsync.json
@@ -1,0 +1,95 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-8fe4493d-68b7-9ce7-4a5f-f326bcdf3c19?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-226be98c52112a41805b664b4e1ab200-a12e30ea4e2e7e47-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "b5e0a944-e991-d475-511d-a53ac11b3adf",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "ETag": "\u00220x8D9E75E6696CF36\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "b5e0a944-e991-d475-511d-a53ac11b3adf",
+        "x-ms-request-id": "16bbb16d-c01a-0082-1e47-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-8fe4493d-68b7-9ce7-4a5f-f326bcdf3c19?restype=share",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-08054d8d1a7794489605603a1db29472-34ab264932f9e74a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "912bf085-ccdd-4338-c679-be05167d3bd6",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "ETag": "\u00220x8D9E75E6696CF36\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-access-tier": "TransactionOptimized",
+        "x-ms-access-tier-change-time": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-client-request-id": "912bf085-ccdd-4338-c679-be05167d3bd6",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "16bbb16f-c01a-0082-1f47-199b7c000000",
+        "x-ms-share-quota": "5120",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-8fe4493d-68b7-9ce7-4a5f-f326bcdf3c19?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bc09aa58fe54604d8c132f9f3868839e-5af4620f98803049-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "a97133f7-624f-5923-649e-4d86c8825336",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "a97133f7-624f-5923-649e-4d86c8825336",
+        "x-ms-request-id": "16bbb170-c01a-0082-2047-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "2107317198",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Kg==;\n[encryption scope]\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithContainerSAS.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithContainerSAS.json
@@ -1,0 +1,86 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-0fa4b87c-2a6a-9d0a-1471-f7c65e705367?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f7923783a6c92648972d5be58546620e-75963cc41fb1a34e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e8514ca4-fe5c-083d-013a-cccd9de66601",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "ETag": "\u00220x8D9E75E65B4CD8B\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "e8514ca4-fe5c-083d-013a-cccd9de66601",
+        "x-ms-request-id": "16bbb15a-c01a-0082-1147-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-0fa4b87c-2a6a-9d0a-1471-f7c65e705367?sv=2021-04-10\u0026st=2022-02-03T20%3A44%3A46Z\u0026se=2022-02-03T22%3A44%3A46Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-c17644276f8afc4582c309e326cd8d41-24170763385f044e-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "ed4334ba-04d0-a017-e524-3d3153f21401",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "ed4334ba-04d0-a017-e524-3d3153f21401",
+        "x-ms-request-id": "16bbb15c-c01a-0082-1247-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanmcccanary3.file.core.windows.net/\u0022 ShareName=\u0022test-share-0fa4b87c-2a6a-9d0a-1471-f7c65e705367\u0022 DirectoryPath=\u0022\u0022\u003E\u003CDirectoryId\u003E0\u003C/DirectoryId\u003E\u003CEntries /\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-0fa4b87c-2a6a-9d0a-1471-f7c65e705367?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-2e3375da9242004f832e16d46615d6b6-61c2003bd57dda4b-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "c08f2e4f-aebd-6e38-9281-2dfa2dd989c3",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:46 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "c08f2e4f-aebd-6e38-9281-2dfa2dd989c3",
+        "x-ms-request-id": "16bbb15d-c01a-0082-1347-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:44:46.9279161-08:00",
+    "RandomSeed": "1807480656",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Kg==;\n[encryption scope]\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithContainerSASAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentContainerClient_WithContainerSASAsync.json
@@ -1,0 +1,85 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-f8e95d09-0f8a-5eb8-5b09-5498e8d4cfe5?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-15e91d720ae4924cb355cbd5e13811d4-d4f00a9d86e61641-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "af0255ab-66a0-2de2-ccd3-34f9b1c92435",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "ETag": "\u00220x8D9E75E66C48F55\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "af0255ab-66a0-2de2-ccd3-34f9b1c92435",
+        "x-ms-request-id": "16bbb171-c01a-0082-2147-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-f8e95d09-0f8a-5eb8-5b09-5498e8d4cfe5?sv=2021-04-10\u0026st=2022-02-03T20%3A44%3A48Z\u0026se=2022-02-03T22%3A44%3A48Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "8ca6f1d1-4a66-aef8-3d8e-e31d884e4412",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "8ca6f1d1-4a66-aef8-3d8e-e31d884e4412",
+        "x-ms-request-id": "16bbb173-c01a-0082-2247-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanmcccanary3.file.core.windows.net/\u0022 ShareName=\u0022test-share-f8e95d09-0f8a-5eb8-5b09-5498e8d4cfe5\u0022 DirectoryPath=\u0022\u0022\u003E\u003CDirectoryId\u003E0\u003C/DirectoryId\u003E\u003CEntries /\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-f8e95d09-0f8a-5eb8-5b09-5498e8d4cfe5?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-1c2ae8f46827304698067621bb65c165-b7e5d66f650d5b47-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f7c28ccd-2313-936c-f03e-55433c274169",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "f7c28ccd-2313-936c-f03e-55433c274169",
+        "x-ms-request-id": "16bbb174-c01a-0082-2347-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:44:48.7009268-08:00",
+    "RandomSeed": "65139293",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Kg==;\n[encryption scope]\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient.json
@@ -1,0 +1,176 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-351f693e-67a9-a910-5b51-7c4cee6e0e4a?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-469076d02f05e0448523ba709dd5c34a-2b9df78221af644a-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "85ebf88e-16bb-efaa-09c5-f7bfb680a243",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "ETag": "\u00220x8D9E75E65EB8D03\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "85ebf88e-16bb-efaa-09c5-f7bfb680a243",
+        "x-ms-request-id": "16bbb15e-c01a-0082-1447-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-351f693e-67a9-a910-5b51-7c4cee6e0e4a/test-directory-526f1957-3210-90cc-b16c-b18461bf9c06?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-34c1051f093684408b40e0ac9ec48f49-7454e3414317a747-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "f5bdeaf1-8982-608e-e166-8381fb673d70",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "ETag": "\u00220x8D9E75E65FE8EFE\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "f5bdeaf1-8982-608e-e166-8381fb673d70",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-02-03T21:44:47.3759486Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:47.3759486Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:47.3759486Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "17860367565182308406*11459378189709739967",
+        "x-ms-request-id": "16bbb160-c01a-0082-1547-199b7c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-351f693e-67a9-a910-5b51-7c4cee6e0e4a/test-directory-526f1957-3210-90cc-b16c-b18461bf9c06/test-file-84b06340-89f3-7f28-39a0-428fd0e42f07",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-a9b893e7503fb74f8d1a87aee29d395f-4846eb4eb7e1d74f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "5c85d5ee-3851-6766-c23e-bbe146fe8ffd",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "ETag": "\u00220x8D9E75E660A7425\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "5c85d5ee-3851-6766-c23e-bbe146fe8ffd",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-02-03T21:44:47.4539045Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:47.4539045Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:47.4539045Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "4010187179898695473*11459378189709739967",
+        "x-ms-request-id": "16bbb162-c01a-0082-1647-199b7c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-351f693e-67a9-a910-5b51-7c4cee6e0e4a/test-directory-526f1957-3210-90cc-b16c-b18461bf9c06?restype=directory",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-8183bdb2f30398478f7d1619513b46d1-9bab5297aa0b2b44-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "fba16751-d25e-d0b6-3666-0983f1de8dd9",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "ETag": "\u00220x8D9E75E65FE8EFE\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "fba16751-d25e-d0b6-3666-0983f1de8dd9",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-02-03T21:44:47.3759486Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:47.3759486Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:47.3759486Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "17860367565182308406*11459378189709739967",
+        "x-ms-request-id": "16bbb163-c01a-0082-1747-199b7c000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-351f693e-67a9-a910-5b51-7c4cee6e0e4a?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7733687a95ebbe4fba5aac60f2744564-a5d2c4d4dd9e6f45-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "de90bf4b-945d-649e-c5a8-2832682aa1c4",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "de90bf4b-945d-649e-c5a8-2832682aa1c4",
+        "x-ms-request-id": "16bbb164-c01a-0082-1847-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1571686578",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Kg==;\n[encryption scope]\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClientAsync.json
@@ -1,0 +1,176 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-8d761a9f-4d35-1fd1-910e-36565b0c313b?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-55ccd09ae2596b4ba1c78e9774c10099-f6375830c0905247-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "e2902f66-79cc-9cc3-7546-de7c7441a695",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "ETag": "\u00220x8D9E75E66E3F993\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "e2902f66-79cc-9cc3-7546-de7c7441a695",
+        "x-ms-request-id": "16bbb175-c01a-0082-2447-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-8d761a9f-4d35-1fd1-910e-36565b0c313b/test-directory-6f6546ea-ab8b-0298-a129-2e47d03bd399?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-89ca6ef0ab249f4aaecb54af5f4f7188-29e5c20d8e80fb4c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2cf09219-4e7b-e46f-416a-3216e40c5aa5",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "ETag": "\u00220x8D9E75E66EFA9CE\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "2cf09219-4e7b-e46f-416a-3216e40c5aa5",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-02-03T21:44:48.9560526Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:48.9560526Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:48.9560526Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "17860367565182308406*11459378189709739967",
+        "x-ms-request-id": "16bbb177-c01a-0082-2547-199b7c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-8d761a9f-4d35-1fd1-910e-36565b0c313b/test-directory-6f6546ea-ab8b-0298-a129-2e47d03bd399/test-file-e100c460-2a54-3a6f-f3b4-5025d495a89d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fde335d29eca304e9431572e220cf70f-17eecce9c934554f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2fceff4c-6ad7-ee00-23b6-39c6fe4a10ac",
+        "x-ms-content-length": "1024",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "ETag": "\u00220x8D9E75E66FA56A2\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "2fceff4c-6ad7-ee00-23b6-39c6fe4a10ac",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-02-03T21:44:49.0260130Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:49.0260130Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:49.0260130Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "4010187179898695473*11459378189709739967",
+        "x-ms-request-id": "16bbb178-c01a-0082-2647-199b7c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-8d761a9f-4d35-1fd1-910e-36565b0c313b/test-directory-6f6546ea-ab8b-0298-a129-2e47d03bd399?restype=directory",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-300d63176a2d1d4e9f67d34f41fab624-eab575eb85dfa845-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d4d8cabc-78c7-90c5-8974-be9a4053ab38",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "ETag": "\u00220x8D9E75E66EFA9CE\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:48 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "d4d8cabc-78c7-90c5-8974-be9a4053ab38",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-02-03T21:44:48.9560526Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:48.9560526Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:48.9560526Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "17860367565182308406*11459378189709739967",
+        "x-ms-request-id": "16bbb179-c01a-0082-2747-199b7c000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-8d761a9f-4d35-1fd1-910e-36565b0c313b?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-829ae49cf31e0641a6a64d30637e84bf-1b26c7a5cbac8848-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "33096b76-3c71-49e5-cf8a-d234bbbba656",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "33096b76-3c71-49e5-cf8a-d234bbbba656",
+        "x-ms-request-id": "16bbb17a-c01a-0082-2847-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "719360751",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Kg==;\n[encryption scope]\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithContainerSAS.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithContainerSAS.json
@@ -1,0 +1,162 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-6dc43e25-c271-fbde-c8db-059473772700?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f9cc05620a66fc41aeac5c33b61e7bdd-59433fe74bc2fb4d-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "894818ea-73c0-a8c6-c5f5-9e973716f6ce",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "ETag": "\u00220x8D9E75E662CF947\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "894818ea-73c0-a8c6-c5f5-9e973716f6ce",
+        "x-ms-request-id": "16bbb165-c01a-0082-1947-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-6dc43e25-c271-fbde-c8db-059473772700/test-directory-67f1a36a-3d72-6aaa-45d0-b57e4cb011cf?sv=2021-04-10\u0026st=2022-02-03T20%3A44%3A47Z\u0026se=2022-02-03T22%3A44%3A47Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-363e9424431e364aa6ee030cb75191ef-24b0e214b8fe7541-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "6e3c773e-517b-e914-154f-503c6d8a2ccc",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "ETag": "\u00220x8D9E75E6637710E\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "6e3c773e-517b-e914-154f-503c6d8a2ccc",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-02-03T21:44:47.7487374Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:47.7487374Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:47.7487374Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "17860367565182308406*11459378189709739967",
+        "x-ms-request-id": "16bbb167-c01a-0082-1a47-199b7c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-6dc43e25-c271-fbde-c8db-059473772700/test-directory-67f1a36a-3d72-6aaa-45d0-b57e4cb011cf/test-file-020ed01d-9a6c-0aa0-74f2-7a71b52b6dca?sv=2021-04-10\u0026st=2022-02-03T20%3A44%3A47Z\u0026se=2022-02-03T22%3A44%3A47Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-c2e44806fc504f4e88ae2d1ce2f3a65e-c8c0e0440a8f2141-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bbb97e1e-0760-a3e4-d632-f989d7a234e9",
+        "x-ms-content-length": "1024",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "ETag": "\u00220x8D9E75E6641F6D7\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "bbb97e1e-0760-a3e4-d632-f989d7a234e9",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-02-03T21:44:47.8176983Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:47.8176983Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:47.8176983Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "4010187179898695473*11459378189709739967",
+        "x-ms-request-id": "16bbb168-c01a-0082-1b47-199b7c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-6dc43e25-c271-fbde-c8db-059473772700/test-directory-67f1a36a-3d72-6aaa-45d0-b57e4cb011cf?sv=2021-04-10\u0026st=2022-02-03T20%3A44%3A47Z\u0026se=2022-02-03T22%3A44%3A47Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-d056a83dbc959a489386b33416ae464f-4a7816254be06e44-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "36527fd3-b172-7269-d05a-2d8970c95f7d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "36527fd3-b172-7269-d05a-2d8970c95f7d",
+        "x-ms-request-id": "16bbb169-c01a-0082-1c47-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanmcccanary3.file.core.windows.net/\u0022 ShareName=\u0022test-share-6dc43e25-c271-fbde-c8db-059473772700\u0022 DirectoryPath=\u0022test-directory-67f1a36a-3d72-6aaa-45d0-b57e4cb011cf\u0022\u003E\u003CDirectoryId\u003E13835128424026341376\u003C/DirectoryId\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-file-020ed01d-9a6c-0aa0-74f2-7a71b52b6dca\u003C/Name\u003E\u003CFileId\u003E11529285414812647424\u003C/FileId\u003E\u003CProperties\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-6dc43e25-c271-fbde-c8db-059473772700?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7a2d24432b84c64fa3af09ecb61dcccf-242bfbb2343fdc4f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "58b68875-fd50-3077-1c50-e732fa8742b4",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:47 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "58b68875-fd50-3077-1c50-e732fa8742b4",
+        "x-ms-request-id": "16bbb16a-c01a-0082-1d47-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:44:47.7131657-08:00",
+    "RandomSeed": "112764847",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Kg==;\n[encryption scope]\n\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithContainerSASAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ClientNavigationTests/PathClient_CanGetParentDirectoryClient_WithContainerSASAsync.json
@@ -1,0 +1,161 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-fd537983-9a84-7cdf-51d7-02be9089029d?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-5dfac0bebbbfc640bd110e741e6a91a0-bb22e023bd65a349-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "d578ad17-f269-5156-976d-cd2b56785bd6",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "ETag": "\u00220x8D9E75E6716E90C\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "d578ad17-f269-5156-976d-cd2b56785bd6",
+        "x-ms-request-id": "16bbb17b-c01a-0082-2947-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-fd537983-9a84-7cdf-51d7-02be9089029d/test-directory-1eea76eb-5902-ec37-5f54-1bb151b1b425?sv=2021-04-10\u0026st=2022-02-03T20%3A44%3A49Z\u0026se=2022-02-03T22%3A44%3A49Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-d7b27308b5844141a832e97f70dba531-b37c01c6602a314c-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "514f4f62-b47e-8d41-a29d-ff24f890dd59",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "ETag": "\u00220x8D9E75E6722994D\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "514f4f62-b47e-8d41-a29d-ff24f890dd59",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2022-02-03T21:44:49.2898637Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:49.2898637Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:49.2898637Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "17860367565182308406*11459378189709739967",
+        "x-ms-request-id": "16bbb17d-c01a-0082-2a47-199b7c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-fd537983-9a84-7cdf-51d7-02be9089029d/test-directory-1eea76eb-5902-ec37-5f54-1bb151b1b425/test-file-4e362bc0-79d1-25c4-4ba4-6013f75eff5d?sv=2021-04-10\u0026st=2022-02-03T20%3A44%3A49Z\u0026se=2022-02-03T22%3A44%3A49Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "traceparent": "00-43b5b2dc23a86e4c96d5229be2e73a44-e08eb37d3cd7664f-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "afec3ac8-6941-e9b8-8a29-06d9532d9544",
+        "x-ms-content-length": "1024",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "ETag": "\u00220x8D9E75E672E0954\u0022",
+        "Last-Modified": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "afec3ac8-6941-e9b8-8a29-06d9532d9544",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2022-02-03T21:44:49.3648212Z",
+        "x-ms-file-creation-time": "2022-02-03T21:44:49.3648212Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2022-02-03T21:44:49.3648212Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "4010187179898695473*11459378189709739967",
+        "x-ms-request-id": "16bbb17e-c01a-0082-2b47-199b7c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-fd537983-9a84-7cdf-51d7-02be9089029d/test-directory-1eea76eb-5902-ec37-5f54-1bb151b1b425?sv=2021-04-10\u0026st=2022-02-03T20%3A44%3A49Z\u0026se=2022-02-03T22%3A44%3A49Z\u0026sr=s\u0026sp=rcwdl\u0026sig=Sanitized\u0026restype=directory\u0026comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "bd4b2410-4f72-231b-b779-98c55449eb99",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/xml",
+        "Date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "bd4b2410-4f72-231b-b779-98c55449eb99",
+        "x-ms-request-id": "16bbb17f-c01a-0082-2c47-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022http://seanmcccanary3.file.core.windows.net/\u0022 ShareName=\u0022test-share-fd537983-9a84-7cdf-51d7-02be9089029d\u0022 DirectoryPath=\u0022test-directory-1eea76eb-5902-ec37-5f54-1bb151b1b425\u0022\u003E\u003CDirectoryId\u003E13835128424026341376\u003C/DirectoryId\u003E\u003CEntries\u003E\u003CFile\u003E\u003CName\u003Etest-file-4e362bc0-79d1-25c4-4ba4-6013f75eff5d\u003C/Name\u003E\u003CFileId\u003E11529285414812647424\u003C/FileId\u003E\u003CProperties\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003C/Properties\u003E\u003C/File\u003E\u003C/Entries\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+    },
+    {
+      "RequestUri": "http://seanmcccanary3.file.core.windows.net/test-share-fd537983-9a84-7cdf-51d7-02be9089029d?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b7611ab6d73b554d8adb7fd58fdab902-6df05dbc5a32e046-00",
+        "User-Agent": "azsdk-net-Storage.Files.Shares/12.9.0-alpha.20220203.1 (.NET Framework 4.8.4420.0; Microsoft Windows 10.0.19044 )",
+        "x-ms-client-request-id": "2fc9ca31-d8e1-4ed1-8675-d0b420a410bf",
+        "x-ms-date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2021-04-10"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 03 Feb 2022 21:44:49 GMT",
+        "Server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "2fc9ca31-d8e1-4ed1-8675-d0b420a410bf",
+        "x-ms-request-id": "16bbb180-c01a-0082-2d47-199b7c000000",
+        "x-ms-version": "2021-04-10"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2022-02-03T13:44:49.2443558-08:00",
+    "RandomSeed": "749791414",
+    "Storage_TestConfigDefault": "ProductionTenant\nseanmcccanary3\nU2FuaXRpemVk\nhttp://seanmcccanary3.blob.core.windows.net\nhttp://seanmcccanary3.file.core.windows.net\nhttp://seanmcccanary3.queue.core.windows.net\nhttp://seanmcccanary3.table.core.windows.net\n\n\n\n\nhttp://seanmcccanary3-secondary.blob.core.windows.net\nhttp://seanmcccanary3-secondary.file.core.windows.net\nhttp://seanmcccanary3-secondary.queue.core.windows.net\nhttp://seanmcccanary3-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://seanmcccanary3.blob.core.windows.net/;QueueEndpoint=http://seanmcccanary3.queue.core.windows.net/;FileEndpoint=http://seanmcccanary3.file.core.windows.net/;BlobSecondaryEndpoint=http://seanmcccanary3-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://seanmcccanary3-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://seanmcccanary3-secondary.file.core.windows.net/;AccountName=seanmcccanary3;AccountKey=Kg==;\n[encryption scope]\n\n"
+  }
+}


### PR DESCRIPTION
Extension methods added to Files.Shares and Files.Datalake to navigate to "parent" clients. Followed existing implementation from Blobs. Ported tests from Blobs.

Resolves #26295