### PR TITLE
[Messaging Extensions] Add Client Options Sample

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -170,7 +170,7 @@
   <ItemGroup Condition="('$(IsTestProject)' == 'true') OR ('$(IsTestSupportProject)' == 'true') OR ('$(IsPerfProject)' == 'true') OR ('$(IsStressProject)' == 'true') OR ('$(IsSamplesProject)' == 'true')">
     <PackageReference Update="ApprovalTests" Version="3.0.22" />
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.2.0" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.6.2" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.0.0" />
     <PackageReference Update="Azure.ResourceManager.Compute" Version="1.0.0-beta.3" />
     <PackageReference Update="Azure.ResourceManager.Network" Version="1.0.0-beta.3" />
@@ -197,6 +197,7 @@
     <PackageReference Update="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
     <PackageReference Update="Microsoft.Azure.Devices" Version="1.19.0" />
     <PackageReference Update="Microsoft.Azure.Devices.Client" Version="1.35.0" />
+    <PackageReference Update="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Update="Microsoft.Azure.Graph.RBAC" Version="2.2.2-preview" />
     <PackageReference Update="Microsoft.Azure.KeyVault.Core" Version="3.0.3" />
     <PackageReference Update="Microsoft.Azure.Management.ContainerRegistry" Version="2.0.0" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/README.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/README.md
@@ -188,6 +188,39 @@ public static void Run(
 }
 ```
 
+### Configuring the Event Hubs clients
+
+The Event Hubs clients can be configured using the  [settings](https://docs.microsoft.com/azure/azure-functions/functions-bindings-event-hubs#functions-2x-and-higher) available in `host.json` for the majority of scenarios.  Some less common scenarios, however, require configuring options not available in the settings.  For example, when hosting your Function locally, it is sometimes necessary to specify the web sockets transport to request that the clients use port 443 rather than the default 5671 and 5672 which are blocked by some networks.
+
+To configure these additional options, you'll need to [create a startup class for the Function](https://docs.microsoft.com/azure/azure-functions/functions-dotnet-dependency-injection) and configure dependency injection to set the desired options when creating Event Hubs clients.  For more information on the available options, see [EventHubsOptions](https://docs.microsoft.com/dotnet/api/microsoft.azure.webjobs.eventhubs.eventhuboptions?view=azure-dotnet).
+
+```C# Snippet:Functions_EventHubs_ConfigureClientOptions
+[assembly: FunctionsStartup(typeof(<< MyNamespace >>.ConfigureClientOptions))]
+
+public class ConfigureClientOptions : FunctionsStartup
+{
+    public override void Configure(IFunctionsHostBuilder hostBuilder)
+    {
+        var builder = hostBuilder.Services.AddWebJobs(_ => { });
+
+        // This method allows you to configure the options used to
+        // create the Event Hubs clients.
+        //
+        // In this example, we're setting the transport type to
+        // use web sockets so that traffic is directed over port 443
+        // instead of 5671 and 5672, which are blocked by some networks.
+
+        builder.AddEventHubs(options =>
+        {
+            options.TransportType = EventHubsTransportType.AmqpWebSockets;
+        });
+
+        builder.AddBuiltInBindings();
+        builder.AddExecutionContextBinding();
+    }
+}
+````
+
 ## Troubleshooting
 
 Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for troubleshooting guidance.

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.csproj
@@ -6,14 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.Management.EventHub" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" VersionOverride="3.0.27" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Polly" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Samples/ConfigureClientOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Samples/ConfigureClientOptions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Azure.Messaging.EventHubs;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.Samples
+{
+#region Snippet:Functions_EventHubs_ConfigureClientOptions
+
+#if SNIPPET
+    [assembly: FunctionsStartup(typeof(<< MyNamespace >>.ConfigureClientOptions))]
+#endif
+
+    public class ConfigureClientOptions : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder hostBuilder)
+        {
+            var builder = hostBuilder.Services.AddWebJobs(_ => { });
+
+            // This method allows you to configure the options used to
+            // create the Event Hubs clients.
+            //
+            // In this example, we're setting the transport type to
+            // use web sockets so that traffic is directed over port 443
+            // instead of 5671 and 5672, which are blocked by some networks.
+
+            builder.AddEventHubs(options =>
+            {
+                options.TransportType = EventHubsTransportType.AmqpWebSockets;
+            });
+
+            builder.AddBuiltInBindings();
+            builder.AddExecutionContextBinding();
+        }
+    }
+#endregion
+}

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/README.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/README.md
@@ -217,6 +217,39 @@ public static async Task Run(
 }
 ```
 
+### Configuring the ServiceBusClient
+
+The `ServiceBusClient` can be configured using the  [settings](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus#additional-settings-for-version-5x) available in `host.json` for the majority of scenarios.  Some less common scenarios, however, require configuring options not available in the settings.  For example, when hosting your Function locally, it is sometimes necessary to specify the web sockets transport to request that the client use port 443 rather than the default 5671 and 5672 which are blocked by some networks.
+
+To configure these additional options, you'll need to [create a startup class for the Function](https://docs.microsoft.com/azure/azure-functions/functions-dotnet-dependency-injection) and configure dependency injection to set the desired options when creating Event Hubs clients.  For more information on the available options, see [ServiceBusOptions](https://docs.microsoft.com/dotnet/api/microsoft.azure.webjobs.servicebus.servicebusoptions?view=azure-dotnet).
+
+```C# Snippet:Functions_ServiceBus_ConfigureClientOptions
+[assembly: FunctionsStartup(typeof(<< MyNamespace >>.ConfigureClientOptions))]
+
+public class ConfigureClientOptions : FunctionsStartup
+{
+    public override void Configure(IFunctionsHostBuilder hostBuilder)
+    {
+        var builder = hostBuilder.Services.AddWebJobs(_ => { });
+
+        // This method allows you to configure the options used to
+        // create the Service Bus client.
+        //
+        // In this example, we're setting the transport type to
+        // use web sockets so that traffic is directed over port 443
+        // instead of 5671 and 5672, which are blocked by some networks.
+
+        builder.AddServiceBus(options =>
+        {
+            options.TransportType = ServiceBusTransportType.AmqpWebSockets;
+        });
+
+        builder.AddBuiltInBindings();
+        builder.AddExecutionContextBinding();
+    }
+}
+````
+
 ## Troubleshooting
 
 Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for troubleshooting guidance.

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests.csproj
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests.csproj
@@ -5,16 +5,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Polly" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,4 +32,4 @@
   <ItemGroup Condition="'$(IsTargetingNetFx)' == 'true'">
     <Reference Include="System.Transactions" />
   </ItemGroup>
-</Project>  
+</Project>

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Samples/ConfigureClientOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Samples/ConfigureClientOptions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Tests.Samples
+{
+#region Snippet:Functions_ServiceBus_ConfigureClientOptions
+
+#if SNIPPET
+    [assembly: FunctionsStartup(typeof(<< MyNamespace >>.ConfigureClientOptions))]
+#endif
+
+    public class ConfigureClientOptions : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder hostBuilder)
+        {
+            var builder = hostBuilder.Services.AddWebJobs(_ => { });
+
+            // This method allows you to configure the options used to
+            // create the Service Bus client.
+            //
+            // In this example, we're setting the transport type to
+            // use web sockets so that traffic is directed over port 443
+            // instead of 5671 and 5672, which are blocked by some networks.
+
+            builder.AddServiceBus(options =>
+            {
+                options.TransportType = ServiceBusTransportType.AmqpWebSockets;
+            });
+
+            builder.AddBuiltInBindings();
+            builder.AddExecutionContextBinding();
+        }
+    }
+#endregion
+}


### PR DESCRIPTION
# Summary

The focus of these changes is to add samples for the Event Hubs and Service Bus Functions extensions packages demonstrating how to configure the client options
not offered in the `host.json` settings.