### PR TITLE
Update codeowners for phone numbers sdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,7 +187,7 @@
 
 # PRLabel: %Communication
 /sdk/communication/                                     @acsdevx-msft
-/sdk/communication/Azure.Communication.PhoneNumbers/    @RoyHerrod @danielav7 @whisper6284 @AlonsoMondal
+/sdk/communication/Azure.Communication.PhoneNumbers/    @whisper6284 @miguhern @lucasrsant
 /sdk/communication/Azure.Communication.Sms/             @RoyHerrod @arifibrahim4
 /sdk/communication/Azure.Communication.Identity/        @Azure/acs-identity-sdk
 


### PR DESCRIPTION
Update the codeowners for the Communication.PhoneNumbers package to reflect the current team supporting it.