### PR TITLE
[CODEOWNERS] Git Hub and Bot Rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,13 @@
 # Instructions for CODEOWNERS file format and automatic build failure notifications:
 # https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners
 
+################
+# Automation
+################
+
+# Git Hub integration and bot rules
+/.github/                                       @AlexGhiondea @jsquire
+
 #########
 # SDK
 #########


### PR DESCRIPTION
# Summary

The focus of these changes is to add explicit owners for the `.github` folder in the repository, containing items related to Git Hub integrations and the bot rules applied to the repo.