### PR TITLE
Don't propagate ObjectDisposedException when cancellation was requested

### DIFF
--- a/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
+++ b/sdk/communication/Azure.Communication.CallingServer/src/Azure.Communication.CallingServer.csproj
@@ -30,6 +30,7 @@
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)RetriableStream.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)CancellationHelper.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)OperationHelpers.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)OperationInternal.cs" LinkBase="Shared" />

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Shared\HttpMessageSanitizer.cs" />
     <Compile Include="Shared\NullableAttributes.cs" />
     <Compile Include="Shared\TaskExtensions.cs" />
+    <Compile Include="Shared\CancellationHelper.cs" />
   </ItemGroup>
 
 </Project>

--- a/sdk/core/Azure.Core/src/Shared/CancellationHelper.cs
+++ b/sdk/core/Azure.Core/src/Shared/CancellationHelper.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 #pragma warning restore SA1636
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/sdk/core/Azure.Core/src/Shared/RetriableStream.cs
+++ b/sdk/core/Azure.Core/src/Shared/RetriableStream.cs
@@ -108,6 +108,13 @@ namespace Azure.Core.Pipeline
 
             private async Task RetryAsync(Exception exception, bool async, CancellationToken cancellationToken)
             {
+                // Depending on the timing, the stream can be closed as a result of cancellation when the transport closes the stream.
+                // If the user requested cancellation, we translate to TaskCanceledException, similar to what we do HttpWebRequestTransport.
+                if (exception is ObjectDisposedException)
+                {
+                    CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+                }
+
                 bool isNonCustomerCancelledException = exception is OperationCanceledException &&
                                                     !cancellationToken.IsCancellationRequested;
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
+++ b/sdk/storage/Azure.Storage.Blobs/src/Azure.Storage.Blobs.csproj
@@ -32,6 +32,7 @@
     <Compile Include="$(AzureCoreSharedSources)AzureSasCredentialSynchronousPolicy.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)OperationHelpers.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)RetriableStream.cs" LinkBase="SharedCore" />
+    <Compile Include="$(AzureCoreSharedSources)CancellationHelper.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="SharedCore" />

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Azure.Storage.Files.Shares.csproj
@@ -36,6 +36,7 @@
     <Compile Include="$(AzureCoreSharedSources)ForwardsClientCallsAttribute.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)NoBodyResponseOfT.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)RetriableStream.cs" LinkBase="SharedCore" />
+    <Compile Include="$(AzureCoreSharedSources)CancellationHelper.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="SharedCore" />
     <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="SharedCore" />


### PR DESCRIPTION
This PR adds to the fix done in https://github.com/Azure/azure-sdk-for-net/pull/17963 where we suppressed ObjectDisposedException in favor of TaskCanceledException when cancellation was requested by the user. The initial PR was limited to the transport, so it did not cover the case where cancellation was requested after the network stream was returned to the user.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/26932