### PR TITLE
Update text analytics to enable live testing in sovereign clouds for multiple services

### DIFF
--- a/sdk/textanalytics/test-resources.json.disabled
+++ b/sdk/textanalytics/test-resources.json.disabled
@@ -44,15 +44,26 @@
             "defaultValue": "textanalytics",
             "type": "string"
         },
-        "endpointSuffix": {
+        "cognitiveServicesEndpointSuffix": {
             "defaultValue": ".cognitiveservices.azure.com",
             "type": "string"
+            "type": "string",
+            "metadata": {
+                "description": "Endpoint suffix for sovereign clouds, requies the preceeding '.'. The default uses the public Azure Cloud (.cognitiveservices.azure.com)"
+            }
+        },
+        "textAnalyticsSku": {
+            "type": "string",
+            "defaultValue": "S",
+            "metadata": {
+                "description": "Text Analytics SKU to deploy. The default is 'S'"
+            }
         }
     },
     "variables": {
         "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
         "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
-        "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('endpointSuffix'))]"
+        "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('cognitiveServicesEndpointSuffix'))]"
     },
     "resources": [
         {
@@ -61,7 +72,7 @@
             "name": "[variables('uniqueSubDomainName')]",
             "location":"[parameters('location')]",
             "sku": {
-                "name": "S"
+                "name": "[parameters('textAnalyticsSku')]"
             },
             "kind": "TextAnalytics",
             "properties": {
@@ -86,6 +97,10 @@
         "TEXT_ANALYTICS_ENDPOINT": {
             "type": "string",
             "value": "[variables('endpointValue')]"
+        },
+        "TEXT_ANALYTICS_DEFAULT_SCOPE": {
+            "type": "string",
+            "value": "[parameters('cognitiveServicesEndpointSuffix')]"
         }
     }
 }

--- a/sdk/textanalytics/test-resources.json.disabled
+++ b/sdk/textanalytics/test-resources.json.disabled
@@ -97,10 +97,6 @@
         "TEXT_ANALYTICS_ENDPOINT": {
             "type": "string",
             "value": "[variables('endpointValue')]"
-        },
-        "TEXT_ANALYTICS_DEFAULT_SCOPE": {
-            "type": "string",
-            "value": "[parameters('cognitiveServicesEndpointSuffix')]"
         }
     }
 }

--- a/sdk/textanalytics/tests.yml
+++ b/sdk/textanalytics/tests.yml
@@ -14,7 +14,7 @@ extends:
         SubscriptionConfiguration: $(sub-config-gov-test-resources)
       China:
         SubscriptionConfiguration: $(sub-config-cn-test-resources)
-    SupportedClouds: 'Public,Canary,UsGov,China'
+    SupportedClouds: 'Public,UsGov,China'
     # temporary env vars for custom text features
     EnvVars:
         AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)

--- a/sdk/textanalytics/tests.yml
+++ b/sdk/textanalytics/tests.yml
@@ -10,6 +10,11 @@ extends:
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'
+      UsGov:
+        SubscriptionConfiguration: $(sub-config-gov-test-resources)
+      China:
+        SubscriptionConfiguration: $(sub-config-cn-test-resources)
+    SupportedClouds: 'Public,Canary,UsGov,China'
     # temporary env vars for custom text features
     EnvVars:
         AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)


### PR DESCRIPTION
These changes enable text analytics to run live tests against AzureUsGovernment and AzureChina clouds. The sovereign cloud live tests will be green with the changes.

Pipeline results:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1348904&view=results

@benbp, @scottaddie, @AlexGhiondea, @meeraharidasa, @mayurid, @jsquire for notification