### PR TITLE
[Event Hubs] Function Bindings Tests

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubConfigurationTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubConfigurationTests.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 { $"{extensionPath}:BatchCheckpointFrequency", "5" },
                 { $"{extensionPath}:PartitionOwnershipExpirationInterval", "00:00:31" },
                 { $"{extensionPath}:LoadBalancingUpdateInterval", "00:00:21" },
-                { $"{extensionPath}:LoadBalancingStrategy", "0" },
+                { $"{extensionPath}:LoadBalancingStrategy", "greedy" },
                 { $"{extensionPath}:InitialOffsetOptions:Type", "FromEnqueuedTime" },
                 { $"{extensionPath}:InitialOffsetOptions:EnqueuedTimeUTC", "2020-09-13 12:00:00Z" },
                 { $"{extensionPath}:ClientRetryOptions:MaximumRetries", "5" },
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 { $"{extensionPath}:ClientRetryOptions:MaxDelay", "00:01:00" },
                 { $"{extensionPath}:ClientRetryOptions:TryTimeout", "00:01:30" },
                 { $"{extensionPath}:ClientRetryOptions:Mode", "0" },
-                { $"{extensionPath}:TransportType", "1" },
+                { $"{extensionPath}:TransportType", "amqpWebSockets" },
                 { $"{extensionPath}:WebProxy", "http://proxyserver:8080/" },
                 { $"{extensionPath}:CustomEndpointAddress", "http://www.customendpoint.com/" },
             };

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -386,14 +386,14 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [Test]
         public async Task EventHub_InitialOffsetFromEnqueuedTime()
         {
-            var producer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, _eventHubScope.EventHubName);
+            await using var producer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, _eventHubScope.EventHubName);
             for (int i = 0; i < 3; i++)
             {
                 // send one at a time so they will have slightly different enqueued times
                 await producer.SendAsync(new EventData[] { new EventData(new BinaryData("data")) });
                 await Task.Delay(1000);
             }
-            var consumer = new EventHubConsumerClient(
+            await using var consumer = new EventHubConsumerClient(
                 EventHubConsumerClient.DefaultConsumerGroupName,
                 EventHubsTestEnvironment.Instance.EventHubsConnectionString,
                 _eventHubScope.EventHubName);
@@ -416,8 +416,8 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                         services.Configure<EventHubOptions>(options =>
                         {
                             options.InitialOffsetOptions.Type = OffsetType.FromEnqueuedTime;
-                            // for some reason, this doesn't seem to work reliably if including milliseconds in the format
-                            var dto = DateTimeOffset.Parse(_initialOffsetEnqueuedTimeUTC.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+                            // Reads from enqueue time are non-inclusive.  To ensure that we start with the desired event, set the time slightly in the past.
+                            var dto = DateTimeOffset.Parse(_initialOffsetEnqueuedTimeUTC.AddMilliseconds(-150).ToString("yyyy-MM-ddTHH:mm:ssZ"));
                             options.InitialOffsetOptions.EnqueuedTimeUtc = dto;
                         });
                     });

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
@@ -5,10 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Tests;
-using Microsoft.Azure.WebJobs.EventHubs;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
@@ -18,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
     public class WebJobsEventHubTestBase
     {
         protected const string TestHubName = "%webjobstesthub%";
-        protected const int Timeout = 30000;
+        protected static readonly int Timeout = (int)EventHubsTestEnvironment.Instance.TestExecutionTimeLimit.TotalMilliseconds;
 
         /// <summary>The active Event Hub resource scope for the test fixture.</summary>
         protected EventHubScope _eventHubScope;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
     public class WebJobsEventHubTestBase
     {
         protected const string TestHubName = "%webjobstesthub%";
-        protected static readonly int Timeout = (int)EventHubsTestEnvironment.Instance.TestExecutionTimeLimit.TotalMilliseconds;
+        protected static readonly int Timeout = (int)TimeSpan.FromSeconds(60).TotalMilliseconds;
 
         /// <summary>The active Event Hub resource scope for the test fixture.</summary>
         protected EventHubScope _eventHubScope;


### PR DESCRIPTION
# Summary

The focus of these changes is to stabilize tests `EventHub_InitialOffsetFromEnqueuedTime` and `EventHub_PartitionKey` which have been intermittently unstable during nightly runs.

# References and Related

- [[Flaky Test] Event Hubs Function Bindings: EventHub_PartitionKey (#23605)](https://github.com/Azure/azure-sdk-for-net/issues/23605)
- [[Flaky Test] Event Hubs Function Bindings: EventHub_InitialOffsetFromEnqueuedTime (#21298)](https://github.com/Azure/azure-sdk-for-net/issues/21298)