### PR TITLE
Azure Monitor Exporter - Update LogRecord StateValues

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
@@ -153,6 +153,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                     {
                         message = item.Value.ToString();
                     }
+                    else
+                    {
+                        properties.Add("OriginalFormat", item.Value.ToString());
+                    }
                 }
                 else
                 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/LogsHelper.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using Microsoft.Extensions.Logging;
@@ -51,38 +50,42 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return telemetryItems;
         }
 
-        internal static string GetMessage(LogRecord logRecord)
+        internal static string GetMessageAndSetProperties(LogRecord logRecord, IDictionary<string, string> properties)
         {
             string message = null;
+            var isFormattedMessage = logRecord.FormattedMessage != null;
 
-            if (logRecord.FormattedMessage != null)
+            if (isFormattedMessage)
             {
                 message = logRecord.FormattedMessage;
             }
-            else if (logRecord.State != null)
+
+            // Both logRecord.State and logRecord.StateValues will not be set at the same time for LogRecord.
+            // Either logRecord.State != null or logRecord.StateValues will be called.
+            if (logRecord.State != null)
             {
-                message = logRecord.State.ToString();
+                if (logRecord.State is IReadOnlyCollection<KeyValuePair<string, object>> stateDictionary)
+                {
+                    ExtractProperties(ref message, properties, stateDictionary, isFormattedMessage);
+                }
             }
-            else if (logRecord.StateValues != null)
+
+            if (logRecord.StateValues != null)
             {
-                var orginalFormatState = logRecord.StateValues.Where(s => s.Key == "{OriginalFormat}").FirstOrDefault();
-                // If {OriginalFormat} is not found in StateValues
-                // SingleOrDefault will create a new KeyValuePair object with the Key and the Value to NULL
-                message = orginalFormatState.Value?.ToString();
+                ExtractProperties(ref message, properties, logRecord.StateValues, isFormattedMessage);
+            }
+
+            if (logRecord.EventId.Id != 0)
+            {
+                properties.Add("EventId", logRecord.EventId.Id.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (!string.IsNullOrEmpty(logRecord.EventId.Name))
+            {
+                properties.Add("EventName", logRecord.EventId.Name);
             }
 
             return message;
-        }
-
-        internal static void SetLogStateValuesToProperties(LogRecord logRecord, IDictionary<string, string> properties)
-        {
-            if (logRecord.StateValues != null)
-            {
-                for (int i = 0; i < logRecord.StateValues.Count; i++)
-                {
-                    properties.Add(logRecord.StateValues[i].Key, logRecord.StateValues[i].Value.ToString());
-                }
-            }
         }
 
         internal static string GetProblemId(Exception exception)
@@ -137,6 +140,24 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 case LogLevel.Trace:
                 default:
                     return SeverityLevel.Verbose;
+            }
+        }
+
+        private static void ExtractProperties(ref string message, IDictionary<string, string> properties, IReadOnlyCollection<KeyValuePair<string, object>> stateDictionary, bool isFormattedMessage)
+        {
+            foreach (KeyValuePair<string, object> item in stateDictionary)
+            {
+                if (item.Key == "{OriginalFormat}")
+                {
+                    if (!isFormattedMessage)
+                    {
+                        message = item.Value.ToString();
+                    }
+                }
+                else
+                {
+                    properties.Add(item.Key, item.Value.ToString());
+                }
             }
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MessageData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MessageData.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.Core;
 using OpenTelemetry.Logs;
 
@@ -12,9 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
         {
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
-
-            Message = LogsHelper.GetMessage(logRecord);
-            LogsHelper.SetLogStateValuesToProperties(logRecord, Properties);
+            Message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties);
             SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MessageData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MessageData.cs
@@ -10,11 +10,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
     {
         public MessageData(int version, LogRecord logRecord) : base(version)
         {
-            Message = LogsHelper.GetMessage(logRecord);
-            SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
-
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
+
+            Message = LogsHelper.GetMessage(logRecord);
+            LogsHelper.SetLogStateValuesToProperties(logRecord, Properties);
+            SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryExceptionData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryExceptionData.cs
@@ -15,7 +15,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
         public TelemetryExceptionData(int version, LogRecord logRecord) : base(version)
         {
+            Properties = new ChangeTrackingDictionary<string, string>();
+            Measurements = new ChangeTrackingDictionary<string, double>();
+
             var message = LogsHelper.GetMessage(logRecord);
+            LogsHelper.SetLogStateValuesToProperties(logRecord, Properties);
+
             SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
             ProblemId = LogsHelper.GetProblemId(logRecord.Exception);
 
@@ -44,8 +49,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             }
 
             Exceptions = exceptions;
-            Properties = new ChangeTrackingDictionary<string, string>();
-            Measurements = new ChangeTrackingDictionary<string, double>();
         }
 
         private void ConvertExceptionTree(Exception exception, string message, TelemetryExceptionDetails parentExceptionDetails, List<TelemetryExceptionDetails> exceptions)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryExceptionData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryExceptionData.cs
@@ -18,8 +18,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
 
-            var message = LogsHelper.GetMessage(logRecord);
-            LogsHelper.SetLogStateValuesToProperties(logRecord, Properties);
+            var message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties);
 
             SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
             ProblemId = LogsHelper.GetProblemId(logRecord.Exception);


### PR DESCRIPTION
```text

using var loggerFactory = LoggerFactory.Create(builder => builder
    .AddOpenTelemetry(loggerOptions =>
    {
        loggerOptions.SetResourceBuilder(resourceBuilder);
        loggerOptions.AddAzureMonitorLogExporter(exporterOptions =>
        {
            exporterOptions.ConnectionString = $"InstrumentationKey=Ikey;";
        });
    }));

var logger2 = loggerFactory.CreateLogger("Example");
logger2.LogInformation("Hello from {food} {price}.", "apple", 3.99);

{"name":"Message","time":"2022-02-15T03:28:55.4671461Z","iKey":"66f50587-a821-4a96-8511-fa96e8f28fd7","tags":{"ai.internal.sdkVersion":"dotnet4.8.4420.0:otel1.2.0-rc1:ext1.0.0-alpha.20220214.1","ai.cloud.role":"my-namespace.my-service","ai.cloud.roleInstance":"my-instance"},
"data":{"baseType":"MessageData","baseData":{"message":"Hello from {food} {price}.","severityLevel":"Information","properties":{"food":"apple","price":"3.99"},"ver":2}}}

```

```text

using var loggerFactory = LoggerFactory.Create(builder => builder
    .AddOpenTelemetry(loggerOptions =>
    {
        loggerOptions.SetResourceBuilder(resourceBuilder);
        loggerOptions.AddAzureMonitorLogExporter(exporterOptions =>
        {
            exporterOptions.ConnectionString = $"InstrumentationKey=Ikey;";
        });
        loggerOptions.IncludeFormattedMessage = true;
    }));

var logger2 = loggerFactory.CreateLogger("Example");
logger2.LogInformation("Hello from {food} {price}.", "apple", 3.99);

{"name":"Message","time":"2022-02-15T03:30:12.2025215Z","iKey":"66f50587-a821-4a96-8511-fa96e8f28fd7","tags":{"ai.internal.sdkVersion":"dotnet4.8.4420.0:otel1.2.0-rc1:ext1.0.0-alpha.20220214.1","ai.cloud.role":"my-namespace.my-service","ai.cloud.roleInstance":"my-instance"},
"data":{"baseType":"MessageData","baseData":{"message":"Hello from apple 3.99.","severityLevel":"Information","properties":{"food":"apple","price":"3.99"},"ver":2}}}

```

```text

using var loggerFactory = LoggerFactory.Create(builder => builder
    .AddOpenTelemetry(loggerOptions =>
    {
        loggerOptions.SetResourceBuilder(resourceBuilder);
        loggerOptions.AddAzureMonitorLogExporter(exporterOptions =>
        {
            exporterOptions.ConnectionString = $"InstrumentationKey=Ikey;";
        });
        loggerOptions.IncludeFormattedMessage = true;
        loggerOptions.ParseStateValues = true;
    }));

var logger2 = loggerFactory.CreateLogger("Example");
logger2.LogInformation("Hello from {food} {price}.", "apple", 3.99);

{"name":"Message","time":"2022-02-15T03:31:38.7507314Z","iKey":"66f50587-a821-4a96-8511-fa96e8f28fd7","tags":{"ai.internal.sdkVersion":"dotnet4.8.4420.0:otel1.2.0-rc1:ext1.0.0-alpha.20220214.1","ai.cloud.role":"my-namespace.my-service","ai.cloud.roleInstance":"my-instance"},
"data":{"baseType":"MessageData","baseData":{"message":"Hello from apple 3.99.","severityLevel":"Information","properties":{"food":"apple","price":"3.99"},"ver":2}}}

```

```text

using var loggerFactory = LoggerFactory.Create(builder => builder
    .AddOpenTelemetry(loggerOptions =>
    {
        loggerOptions.SetResourceBuilder(resourceBuilder);
        loggerOptions.AddAzureMonitorLogExporter(exporterOptions =>
        {
            exporterOptions.ConnectionString = $"InstrumentationKey=Ikey;";
        });
        loggerOptions.ParseStateValues = true;
    }));

var logger2 = loggerFactory.CreateLogger("Example");
logger2.LogInformation("Hello from {food} {price}.", "apple", 3.99);

{"name":"Message","time":"2022-02-15T03:34:20.8843815Z","iKey":"66f50587-a821-4a96-8511-fa96e8f28fd7","tags":{"ai.internal.sdkVersion":"dotnet4.8.4420.0:otel1.2.0-rc1:ext1.0.0-alpha.20220214.1","ai.cloud.role":"my-namespace.my-service","ai.cloud.roleInstance":"my-instance"},
"data":{"baseType":"MessageData","baseData":{"message":"Hello from {food} {price}.","severityLevel":"Information","properties":{"food":"apple","price":"3.99"},"ver":2}}}
```