### PR TITLE
Handle AzurePowerShellCredential not logged in scenarios on non-windows

### DIFF
--- a/sdk/identity/Azure.Identity/src/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AzurePowerShellCredential.cs
@@ -30,6 +30,7 @@ namespace Azure.Identity
         private const string Troubleshooting = "See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/powershellcredential/troubleshoot";
         private const string AzurePowerShellFailedError = "Azure PowerShell authentication failed due to an unknown error. " + Troubleshooting;
         private const string AzurePowerShellTimeoutError = "Azure PowerShell authentication timed out.";
+        internal const string RunConnectAzAccountToLogin = "Run Connect-AzAccount to login";
         internal const string AzurePowerShellNotLogInError = "Please run 'Connect-AzAccount' to set up account.";
         internal const string AzurePowerShellModuleNotInstalledError = "Az.Account module >= 2.2.0 is not installed.";
         internal const string PowerShellNotInstalledError = "PowerShell is not installed.";
@@ -139,6 +140,7 @@ namespace Azure.Identity
             {
                 output = async ? await processRunner.RunAsync().ConfigureAwait(false) : processRunner.Run();
                 CheckForErrors(output);
+                ValidateResult(output);
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
@@ -146,21 +148,7 @@ namespace Azure.Identity
             }
             catch (InvalidOperationException exception)
             {
-                bool noPowerShell = exception.Message.IndexOf("not found", StringComparison.OrdinalIgnoreCase) != -1 ||
-                                    exception.Message.IndexOf("is not recognized", StringComparison.OrdinalIgnoreCase) != -1;
-
-                if (noPowerShell)
-                {
-                    throw new CredentialUnavailableException(PowerShellNotInstalledError);
-                }
-
-                bool noLogin = exception.Message.IndexOf("Run Connect-AzAccount to login", StringComparison.OrdinalIgnoreCase) != -1;
-
-                if (noLogin)
-                {
-                    throw new CredentialUnavailableException(AzurePowerShellNotLogInError);
-                }
-
+                CheckForErrors(exception.Message);
                 throw new AuthenticationFailedException($"{AzurePowerShellFailedError} {exception.Message}");
             }
             return DeserializeOutput(output);
@@ -168,6 +156,12 @@ namespace Azure.Identity
 
         private static void CheckForErrors(string output)
         {
+            bool noPowerShell = output.IndexOf("not found", StringComparison.OrdinalIgnoreCase) != -1 ||
+                                output.IndexOf("is not recognized", StringComparison.OrdinalIgnoreCase) != -1;
+            if (noPowerShell)
+            {
+                throw new CredentialUnavailableException(PowerShellNotInstalledError);
+            }
             if (output.IndexOf(AzurePowerShellNoAzAccountModule, StringComparison.OrdinalIgnoreCase) != -1)
             {
                 throw new CredentialUnavailableException(AzurePowerShellModuleNotInstalledError);
@@ -176,6 +170,14 @@ namespace Azure.Identity
             {
                 throw new Win32Exception(ERROR_FILE_NOT_FOUND);
             }
+            if (output.IndexOf(RunConnectAzAccountToLogin, StringComparison.OrdinalIgnoreCase) != -1)
+            {
+                throw new CredentialUnavailableException(AzurePowerShellNotLogInError);
+            }
+        }
+
+        private static void ValidateResult(string output)
+        {
             if (output.IndexOf("Microsoft.Azure.Commands.Profile.Models.PSAccessToken", StringComparison.OrdinalIgnoreCase) < 0)
             {
                 throw new CredentialUnavailableException("PowerShell did not return a valid response.");

--- a/sdk/identity/Azure.Identity/src/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AzurePowerShellCredential.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -30,22 +29,19 @@ namespace Azure.Identity
         private const string Troubleshooting = "See the troubleshooting guide for more information. https://aka.ms/azsdk/net/identity/powershellcredential/troubleshoot";
         private const string AzurePowerShellFailedError = "Azure PowerShell authentication failed due to an unknown error. " + Troubleshooting;
         private const string AzurePowerShellTimeoutError = "Azure PowerShell authentication timed out.";
-        internal const string RunConnectAzAccountToLogin = "Run Connect-AzAccount to login";
-        internal const string AzurePowerShellNotLogInError = "Please run 'Connect-AzAccount' to set up account.";
-        internal const string AzurePowerShellModuleNotInstalledError = "Az.Account module >= 2.2.0 is not installed.";
-        internal const string PowerShellNotInstalledError = "PowerShell is not installed.";
-
+        private const string RunConnectAzAccountToLogin = "Run Connect-AzAccount to login";
+        private const string NoAccountsWereFoundInTheCache = "No accounts were found in the cache";
+        private const string CannotRetrieveAccessToken = "cannot retrieve access token";
         private const string AzurePowerShellNoAzAccountModule = "NoAzAccountModule";
         private static readonly string DefaultWorkingDirWindows = Environment.GetFolderPath(Environment.SpecialFolder.System);
         private const string DefaultWorkingDirNonWindows = "/bin/";
-
-        private static readonly string DefaultWorkingDir =
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultWorkingDirWindows : DefaultWorkingDirNonWindows;
-
+        private static readonly string DefaultWorkingDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DefaultWorkingDirWindows : DefaultWorkingDirNonWindows;
         private readonly string _tenantId;
-
         private const int ERROR_FILE_NOT_FOUND = 2;
         private readonly bool _logPII;
+        internal const string AzurePowerShellNotLogInError = "Please run 'Connect-AzAccount' to set up account.";
+        internal const string AzurePowerShellModuleNotInstalledError = "Az.Account module >= 2.2.0 is not installed.";
+        internal const string PowerShellNotInstalledError = "PowerShell is not installed.";
 
         /// <summary>
         /// Creates a new instance of the <see cref="AzurePowerShellCredential"/>.
@@ -172,8 +168,8 @@ namespace Azure.Identity
             }
 
             var needsLogin = output.IndexOf(RunConnectAzAccountToLogin, StringComparison.OrdinalIgnoreCase) != -1 ||
-                             output.IndexOf("No accounts were found in the cache", StringComparison.OrdinalIgnoreCase) != -1 ||
-                             output.IndexOf("cannot retrieve access token", StringComparison.OrdinalIgnoreCase) != -1;
+                             output.IndexOf(NoAccountsWereFoundInTheCache, StringComparison.OrdinalIgnoreCase) != -1 ||
+                             output.IndexOf(CannotRetrieveAccessToken, StringComparison.OrdinalIgnoreCase) != -1;
             if (needsLogin)
             {
                 throw new CredentialUnavailableException(AzurePowerShellNotLogInError);

--- a/sdk/identity/Azure.Identity/src/AzurePowerShellCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AzurePowerShellCredential.cs
@@ -170,7 +170,11 @@ namespace Azure.Identity
             {
                 throw new Win32Exception(ERROR_FILE_NOT_FOUND);
             }
-            if (output.IndexOf(RunConnectAzAccountToLogin, StringComparison.OrdinalIgnoreCase) != -1)
+
+            var needsLogin = output.IndexOf(RunConnectAzAccountToLogin, StringComparison.OrdinalIgnoreCase) != -1 ||
+                             output.IndexOf("No accounts were found in the cache", StringComparison.OrdinalIgnoreCase) != -1 ||
+                             output.IndexOf("cannot retrieve access token", StringComparison.OrdinalIgnoreCase) != -1;
+            if (needsLogin)
             {
                 throw new CredentialUnavailableException(AzurePowerShellNotLogInError);
             }

--- a/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -61,16 +62,25 @@ namespace Azure.Identity.Tests
             }
         }
 
+        private static IEnumerable<object[]> ErrorScenarios()
+        {
+            yield return new object[]{"'pwsh' is not recognized", AzurePowerShellCredential.PowerShellNotInstalledError };
+            yield return new object[]{"pwsh: command not found", AzurePowerShellCredential.PowerShellNotInstalledError };
+            yield return new object[]{"pwsh: not found", AzurePowerShellCredential.PowerShellNotInstalledError };
+            yield return new object[]{"Run Connect-AzAccount to login", AzurePowerShellCredential.AzurePowerShellNotLogInError };
+            yield return new object[]{"NoAzAccountModule", AzurePowerShellCredential.AzurePowerShellModuleNotInstalledError };
+            yield return new object[]{"Get-AzAccessToken: Run Connect-AzAccount to login.", AzurePowerShellCredential.AzurePowerShellNotLogInError };
+        }
+
         [Test]
-        public void AuthenticateWithAzurePowerShellCredential_PwshNotInstalled(
-            [Values("'pwsh' is not recognized", "pwsh: command not found", "pwsh: not found")]
-            string errorMessage)
+        [TestCaseSource(nameof(ErrorScenarios))]
+        public void AuthenticateWithAzurePowerShellCredential_ErrorScenarios(string errorMessage, string expectedError)
         {
             var testProcess = new TestProcess { Error = errorMessage };
             AzurePowerShellCredential credential = InstrumentClient(
                 new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            Assert.AreEqual(AzurePowerShellCredential.PowerShellNotInstalledError, ex.Message);
+            Assert.AreEqual(expectedError, ex.Message);
         }
 
         [Test]
@@ -136,28 +146,6 @@ namespace Azure.Identity.Tests
                 new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
             Assert.AreEqual(AzurePowerShellCredential.PowerShellNotInstalledError, ex.Message);
-        }
-
-        [Test]
-        public void AuthenticateWithAzurePowerShellCredential_RunConnectAzAccount(
-            [Values("Run Connect-AzAccount to login")]
-            string errorMessage)
-        {
-            var testProcess = new TestProcess { Error = errorMessage };
-            AzurePowerShellCredential credential = InstrumentClient(
-                new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            Assert.AreEqual(AzurePowerShellCredential.AzurePowerShellNotLogInError, ex.Message);
-        }
-
-        [Test]
-        public void AuthenticateWithAzurePowerShellCredential_AzurePowerShellModuleNotInstalled([Values("NoAzAccountModule")] string message)
-        {
-            var testProcess = new TestProcess { Output = message };
-            AzurePowerShellCredential credential = InstrumentClient(
-                new AzurePowerShellCredential(new AzurePowerShellCredentialOptions(), CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            Assert.AreEqual(AzurePowerShellCredential.AzurePowerShellModuleNotInstalledError, ex.Message);
         }
 
         [Test]

--- a/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
@@ -70,6 +70,8 @@ namespace Azure.Identity.Tests
             yield return new object[]{"Run Connect-AzAccount to login", AzurePowerShellCredential.AzurePowerShellNotLogInError };
             yield return new object[]{"NoAzAccountModule", AzurePowerShellCredential.AzurePowerShellModuleNotInstalledError };
             yield return new object[]{"Get-AzAccessToken: Run Connect-AzAccount to login.", AzurePowerShellCredential.AzurePowerShellNotLogInError };
+            yield return new object[]{"No accounts were found in the cache", AzurePowerShellCredential.AzurePowerShellNotLogInError };
+            yield return new object[]{"cannot retrieve access token", AzurePowerShellCredential.AzurePowerShellNotLogInError };
         }
 
         [Test]

--- a/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
@@ -64,14 +64,14 @@ namespace Azure.Identity.Tests
 
         private static IEnumerable<object[]> ErrorScenarios()
         {
-            yield return new object[]{"'pwsh' is not recognized", AzurePowerShellCredential.PowerShellNotInstalledError };
-            yield return new object[]{"pwsh: command not found", AzurePowerShellCredential.PowerShellNotInstalledError };
-            yield return new object[]{"pwsh: not found", AzurePowerShellCredential.PowerShellNotInstalledError };
-            yield return new object[]{"Run Connect-AzAccount to login", AzurePowerShellCredential.AzurePowerShellNotLogInError };
-            yield return new object[]{"NoAzAccountModule", AzurePowerShellCredential.AzurePowerShellModuleNotInstalledError };
-            yield return new object[]{"Get-AzAccessToken: Run Connect-AzAccount to login.", AzurePowerShellCredential.AzurePowerShellNotLogInError };
-            yield return new object[]{"No accounts were found in the cache", AzurePowerShellCredential.AzurePowerShellNotLogInError };
-            yield return new object[]{"cannot retrieve access token", AzurePowerShellCredential.AzurePowerShellNotLogInError };
+            yield return new object[] { "'pwsh' is not recognized", AzurePowerShellCredential.PowerShellNotInstalledError };
+            yield return new object[] { "pwsh: command not found", AzurePowerShellCredential.PowerShellNotInstalledError };
+            yield return new object[] { "pwsh: not found", AzurePowerShellCredential.PowerShellNotInstalledError };
+            yield return new object[] { "Run Connect-AzAccount to login", AzurePowerShellCredential.AzurePowerShellNotLogInError };
+            yield return new object[] { "NoAzAccountModule", AzurePowerShellCredential.AzurePowerShellModuleNotInstalledError };
+            yield return new object[] { "Get-AzAccessToken: Run Connect-AzAccount to login.", AzurePowerShellCredential.AzurePowerShellNotLogInError };
+            yield return new object[] { "No accounts were found in the cache", AzurePowerShellCredential.AzurePowerShellNotLogInError };
+            yield return new object[] { "cannot retrieve access token", AzurePowerShellCredential.AzurePowerShellNotLogInError };
         }
 
         [Test]
@@ -94,10 +94,7 @@ namespace Azure.Identity.Tests
             {
                 var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzurePowerShell(TimeSpan.FromSeconds(30));
                 TestContext.WriteLine(processOutput);
-                var testProcess = new TestProcess
-                {
-                    Output = processOutput,
-                };
+                var testProcess = new TestProcess { Output = processOutput, };
                 AzurePowerShellCredential credential = InstrumentClient(
                     new AzurePowerShellCredential(
                         new AzurePowerShellCredentialOptions(),


### PR DESCRIPTION
fixes #23498