### PR TITLE
Ensure Activity.SetStartTime is always called with UTC times

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -314,7 +314,7 @@ namespace Azure.Core.Pipeline
 
             public void SetStartTime(DateTime startTime)
             {
-                _startTime = startTime;
+                _startTime = startTime.ToUniversalTime();
                 _currentActivity?.SetStartTime(startTime);
             }
 


### PR DESCRIPTION
`SetStartTime` in System.Diagnostics.DiagnosticSource.Activity should always be called with a `DateTimeKind.Utc` [or it will produce an error](https://github.com/dotnet/runtime/blob/5906521ab238e7d5bb8e38ad81e9ce95561b9771/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs#L570-L580)

fixes #26763