### PR TITLE
Log WWW-Authenticate header by default

### DIFF
--- a/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
@@ -44,7 +44,8 @@ namespace Azure.Core
                 "Retry-After",
                 "Server",
                 "Transfer-Encoding",
-                "User-Agent"
+                "User-Agent",
+                "WWW-Authenticate" // OAuth Challenge header.
             };
             LoggedQueryParameters = new List<string>
             {


### PR DESCRIPTION
Logging the `WWW-Authenticate` header was a customer request and it was deemed by privacy to be safe to log. 