### PR TITLE
Event Hubs Function Bindings: Disable broken tests

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        [Ignore("https://github.com/Azure/azure-webjobs-sdk/issues/2830")]
         public async Task EventHub_ProducerClient()
         {
             var (jobHost, host) = BuildHost<EventHubTestClientDispatch>();
@@ -312,6 +313,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        [Ignore("https://github.com/Azure/azure-webjobs-sdk/issues/2830")]
         public async Task EventHub_PartitionKey()
         {
             var (jobHost, host) = BuildHost<EventHubPartitionKeyTestJobs>();
@@ -384,6 +386,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        [Ignore("https://github.com/Azure/azure-webjobs-sdk/issues/2830")]
         public async Task EventHub_InitialOffsetFromEnqueuedTime()
         {
             await using var producer = new EventHubProducerClient(EventHubsTestEnvironment.Instance.EventHubsConnectionString, _eventHubScope.EventHubName);


### PR DESCRIPTION
# Summary

The focus of these changes is to disable tests failing due to the limitations of data binding in the WebJobs SDK until a fix is released.

# References and Related

- [Event Hubs Function Bindings: Enable tests ignored due to data binding failures (#26889)](https://github.com/Azure/azure-sdk-for-net/issues/26889)
- [BindingDataProvider.FromType Fails to Resolve Shadowed Properties (WeJobs SDK #2830)](https://github.com/Azure/azure-webjobs-sdk/issues/2830)
- [Example Test Run _(Microsoft internal)_](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1355409&view=ms.vss-test-web.build-test-results-tab)