### PR TITLE
[Event Hubs] February Release Prep

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Release History
 
-## 5.7.0-beta.3 (Unreleased)
+## 5.7.0-beta.3 (2022-02-09)
 
 ### Features Added
 
 - Added `FullyQualifiedNamespace`, `EventHubName`, and `ConsumerGroup` to the partition context associated with events read by the `EventHubConsumerClient`.
+
+### Other Changes
+
+- Improved documentation for `EventPosition` to be more explicit about defaults for inclusivity.
+
+- Minor updates to the class hierarchy of `EventData` to improve integration with Azure Schema Registry.
 
 ## 5.7.0-beta.2 (2022-01-13)
 


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the `Azure.Messaging.EventHubs`  package for its February milestone release.