### PR TITLE
[Event Hubs Processor] February Release Prep

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.7.0-beta.3 (Unreleased)
+## 5.7.0-beta.3 (2022-02-09)
 
 ### Features Added
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -14,21 +14,13 @@
 
   <ItemGroup>
     <!--
-        TEMP: Move Core to a project reference until the MessageWithMetadata are shipped in Azure.Core.
+        TEMP: Move Core to an implicit dependency until the MessageWithMetadata are shipped in Azure.Core.
 
     <PackageReference Include="Azure.Core" />
     -->
-    
     <!-- END TEMP -->
 
-    <!--
-        TEMP: Restore to package reference after the next release.
-
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.2" />
-    -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
-    <!-- END TEMP -->
-
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.7.0-beta.3" /><!-- Remove override when the v5.7.0 line is released for GA -->
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the `Azure.Messaging.EventHubs.Processor` package for its February milestone release.