### PR TITLE
Use azsdk-pool in aggregrate-reports.yml

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -9,7 +9,8 @@ pr:
       - eng/pipelines/aggregate-reports.yml
 
 pool:
-  vmImage: 'windows-2019'
+  name: azsdk-pool-mms-win-2019-general
+  vmImage: MMS2019
 
 variables:
   - template: templates/variables/globals.yml


### PR DESCRIPTION
All Windows and Ubuntu jobs should use the `azure-sdk` pools if possible