### PR TITLE
[Form Recognizer] Updated docs and added prebuilt-read sample

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.0-beta.3 (Unreleased)
+## 4.0.0-beta.3 (2021-02-10)
 
 ### Features Added
 - Added the `DocumentField.AsCurrency` method and the `DocumentFieldType.Currency` enum value to support analyzed currency fields.
@@ -8,16 +8,16 @@
 - Added the `Tags` property to the `BuildModelOptions` class. This property can be used to specify custom key-value attributes associated with the model to be built.
 - Added the `Tags` property to the `DocumentModelInfo` and to the `ModelOperationInfo` classes.
 - Added the `BuildMode` property to `DocTypeInfo` to indicate the technique used when building the correspoding model.
+- Added the `DocumentAnalysisModelFactory` static class to the `Azure.AI.FormRecognizer.DocumentAnalysis` namespace. It contains methods for instantiating `DocumentAnalysis` models for mocking.
 
 ### Breaking Changes
 - Added the required parameter `buildMode` to `StartBuildModel` methods. Users must now choose the technique (`Template` or `Neural`) used to build models. For more information about the available build modes and their differences, see [here](https://aka.ms/azsdk/formrecognizer/buildmode).
 - Added the `tags` parameter to the `GetCopyAuthorization` methods.
 - Added the `tags` parameter to the `StartCreateComposedModel` methods.
+- The `DocumentAnalysisClient` and `DocumentModelAdministrationClient` now target the service version `2022-01-30-preview`, so they don't support `2021-09-30-preview` anymore.
 
 ### Bugs Fixed
 - FormRecognizerAudience and DocumentAnalysisAudience have been added to allow the user to select the Azure cloud where the resource is located. Issue [17192](https://github.com/azure/azure-sdk-for-net/issues/17192).
-
-### Other Changes
 
 ## 4.0.0-beta.2 (2021-11-09)
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/MigrationGuide.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/MigrationGuide.md
@@ -282,11 +282,11 @@ for (int i = 0; i < result.Documents.Count; i++)
 
                     if (itemFields.TryGetValue("Amount", out DocumentField itemAmountField))
                     {
-                        if (itemAmountField.ValueType == DocumentFieldType.Double)
+                        if (itemAmountField.ValueType == DocumentFieldType.Currency)
                         {
-                            double itemAmount = itemAmountField.AsDouble();
+                            CurrencyValue itemAmount = itemAmountField.AsCurrency();
 
-                            Console.WriteLine($"  Amount: '{itemAmount}', with confidence {itemAmountField.Confidence}");
+                            Console.WriteLine($"  Amount: '{itemAmount.Symbol}{itemAmount.Amount}', with confidence {itemAmountField.Confidence}");
                         }
                     }
                 }
@@ -296,28 +296,28 @@ for (int i = 0; i < result.Documents.Count; i++)
 
     if (document.Fields.TryGetValue("SubTotal", out DocumentField subTotalField))
     {
-        if (subTotalField.ValueType == DocumentFieldType.Double)
+        if (subTotalField.ValueType == DocumentFieldType.Currency)
         {
-            double subTotal = subTotalField.AsDouble();
-            Console.WriteLine($"Sub Total: '{subTotal}', with confidence {subTotalField.Confidence}");
+            CurrencyValue subTotal = subTotalField.AsCurrency();
+            Console.WriteLine($"Sub Total: '{subTotal.Symbol}{subTotal.Amount}', with confidence {subTotalField.Confidence}");
         }
     }
 
     if (document.Fields.TryGetValue("TotalTax", out DocumentField totalTaxField))
     {
-        if (totalTaxField.ValueType == DocumentFieldType.Double)
+        if (totalTaxField.ValueType == DocumentFieldType.Currency)
         {
-            double totalTax = totalTaxField.AsDouble();
-            Console.WriteLine($"Total Tax: '{totalTax}', with confidence {totalTaxField.Confidence}");
+            CurrencyValue totalTax = totalTaxField.AsCurrency();
+            Console.WriteLine($"Total Tax: '{totalTax.Symbol}{totalTax.Amount}', with confidence {totalTaxField.Confidence}");
         }
     }
 
     if (document.Fields.TryGetValue("InvoiceTotal", out DocumentField invoiceTotalField))
     {
-        if (invoiceTotalField.ValueType == DocumentFieldType.Double)
+        if (invoiceTotalField.ValueType == DocumentFieldType.Currency)
         {
-            double invoiceTotal = invoiceTotalField.AsDouble();
-            Console.WriteLine($"Invoice Total: '{invoiceTotal}', with confidence {invoiceTotalField.Confidence}");
+            CurrencyValue invoiceTotal = invoiceTotalField.AsCurrency();
+            Console.WriteLine($"Invoice Total: '{invoiceTotal.Symbol}{invoiceTotal.Amount}', with confidence {invoiceTotalField.Confidence}");
         }
     }
 }
@@ -471,7 +471,7 @@ Console.WriteLine("Detected key-value pairs:");
 
 foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
 {
-    if (kvp.Value.Content == null)
+    if (kvp.Value == null)
     {
         Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/MigrationGuide.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/MigrationGuide.md
@@ -1,6 +1,6 @@
 # Guide for migrating Azure.AI.FormRecognizer to version 4.0.x from versions 3.1.x and below
 
-This guide is intended to assist in the migration to `Azure.AI.FormRecognizer (4.0.x)` from versions `3.1.x` and below. It will focus on side-by-side comparisons for similar operations between versions. Please note that version `4.0.0-beta.1` will be used for comparison with `3.1.1`.
+This guide is intended to assist in the migration to `Azure.AI.FormRecognizer (4.0.x)` from versions `3.1.x` and below. It will focus on side-by-side comparisons for similar operations between versions. Please note that version `4.0.0-beta.3` will be used for comparison with `3.1.1`.
 
 Familiarity with `Azure.AI.FormRecognizer (3.1.x and below)` package is assumed. For those new to the Azure Form Recognizer client library for .NET please refer to the [README][readme] rather than this guide.
 
@@ -19,7 +19,7 @@ Familiarity with `Azure.AI.FormRecognizer (3.1.x and below)` package is assumed.
 
 A natural question to ask when considering whether to adopt a new version of the library is what the benefits of doing so would be. As Azure Form Recognizer has matured and been embraced by a more diverse group of developers, we have been focused on learning the patterns and practices to best support developer productivity and add value to our customers.
 
-There are many benefits to using the new design of the `Azure.AI.FormRecognizer (4.0.x)` library. This new version of the library introduces two new clients `DocumentAnalysisClient` and the `DocumentModelAdministrationClient` with unified methods for analyzing documents and provides support for the new features added by the service in API version `2021-09-30-preview` and later.
+There are many benefits to using the new design of the `Azure.AI.FormRecognizer (4.0.x)` library. This new version of the library introduces two new clients `DocumentAnalysisClient` and the `DocumentModelAdministrationClient` with unified methods for analyzing documents and provides support for the new features added by the service in API version `2022-01-30-preview` and later.
 
 New features provided by the `DocumentAnalysisClient` include:
 - One consolidated method for analyzing document layout, a general prebuilt document model type, along with the same prebuilt models that were included previously (receipts, invoices, business cards, ID documents), and custom models.
@@ -37,7 +37,7 @@ The table below describes the relationship of each client and its supported API 
 
 |API version|Supported clients
 |-|-
-|2021-09-30-preview | DocumentAnalysisClient and DocumentModelAdministrationClient
+|2022-01-30-preview | DocumentAnalysisClient and DocumentModelAdministrationClient
 |2.1 | FormRecognizerClient and FormTrainingClient
 |2.0 | FormRecognizerClient and FormTrainingClient
 
@@ -58,7 +58,7 @@ and is not limited to documents that are "forms". As a result, we've made the fo
 
 We continue to support API key and AAD authentication methods when creating the clients. Below are the differences between the two versions:
 
-- In `4.0.x`, we have added `DocumentAnalysisClient` and `DocumentModelAdministrationClient` which support API version `2021-09-30-preview` and later.
+- In `4.0.x`, we have added `DocumentAnalysisClient` and `DocumentModelAdministrationClient` which support API version `2022-01-30-preview` and later.
 - `FormRecognizerClient` and `FormTrainingClient` will continue to work targetting API version `2.1` and `2.0`. 
 - In `DocumentAnalysisClient` all prebuilt model methods along with custom model, layout, and a prebuilt general document analysis model are unified into two methods called
 `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri`.
@@ -91,7 +91,7 @@ Differences between the versions:
 - Along with more consolidated analysis methods in the `DocumentAnalysisClient`, the return types have also been improved and remove the hierarchical dependencies between elements. An instance of the `AnalyzeResult` model is now returned which showcases important document elements, such as key-value pairs, entities, tables, and document fields and values, among others, at the top level of the returned model. This can be contrasted with `RecognizedForm` which included more hierarchical relationships, for instance tables were an element of a `FormPage` and not a top-level element.
 - In the new version of the library, the functionality of `StartRecognizeContent` has been added as a prebuilt model and can be called in library version `Azure.AI.FormRecognizer (4.0.x)` with `StartAnalyzeDocument` by passing in the `prebuilt-layout` model ID. Similarly, to get general document information, such as key-value pairs, entities, and text layout, the `prebuilt-document` model ID can be used with `StartAnalyzeDocument`.
 - When calling `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri` the returned type is an `AnalyzeResult` object, while the various methods used with `FormRecognizerClient` return a list of `RecognizedForm`.
-- The optional `IncludeFieldElements` parameter is not supported with the `DocumentAnalysisClient`. Text details are automatically included with API version `2021-09-30-preview` and later.
+- The optional `IncludeFieldElements` parameter is not supported with the `DocumentAnalysisClient`. Text details are automatically included with API version `2022-01-30-preview` and later.
 - The optional `ReadingOrder` parameter does not exist on `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri`. The service uses `natural` reading order to return data.
 
 Analyzing prebuilt models like business cards, identity documents, invoices, and receipts with `3.1.x`:
@@ -645,7 +645,7 @@ foreach (KeyValuePair<string, DocTypeInfo> docType in model.DocTypes)
 Differences between the versions:
 - Analyzing a custom model with `DocumentAnalysisClient` uses the general `StartAnalyzeDocument` and `StartAnalyzeDocumentFromUri` methods.
 - In order to analyze a custom model with `FormRecognizerClient` the `StartRecognizeCustomModels` and its corresponding Uri methods are used.
-- The `IncludeFieldElements` keyword argument is not supported with the `DocumentAnalysisClient`, text details are automatically included with API version `2021-09-30-preview` and later.
+- The `IncludeFieldElements` keyword argument is not supported with the `DocumentAnalysisClient`, text details are automatically included with API version `2022-01-30-preview` and later.
 
 Analyze a document using a custom model with `3.1.x`:
 ```C# Snippet:FormRecognizerSampleRecognizeCustomFormsFromUri
@@ -738,7 +738,7 @@ foreach (AnalyzedDocument document in result.Documents)
 ### Managing models
 
 Differences between the versions:
-- When using API version `2021-09-30-preview` and later models no longer include submodels, instead a model can analyze different document types.
+- When using API version `2022-01-30-preview` and later models no longer include submodels, instead a model can analyze different document types.
 - When building, composing, or copying models users can now assign their own model IDs and specify a description.
 - In version `4.0.x` of the library, only models that build successfully can be retrieved from the get and list model calls. Unsuccessful model operations can be viewed with the `GetOperation()` and `GetOperations()` methods (note that document model operation data persists for only 24 hours). In version `3.1.x` of the library, models that had not succeeded were still created, had to be deleted by the user, and were returned in the `GetCustomModels()` response.
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -4,7 +4,8 @@ Azure Cognitive Services Form Recognizer is a cloud service that uses machine le
 
 - Layout - Extract text, selection marks, and table structures, along with their bounding region coordinates, from documents.
 - Document - Analyze key-value pairs and entities in addition to general layout from documents.
-- Prebuilt - Analyze data from certain types of common documents (such as receipts, invoices, business cards, or identity documents) using prebuilt models.
+- Read - Read information about textual elements, such as page words and lines in addition to text language information.
+- Prebuilt - Analyze data from certain types of common documents (such as receipts, invoices, business cards, identity documents, or US W2 tax forms) using prebuilt models.
 - Custom - Build custom models to analyze text, field values, selection marks, and tabular data from documents. Custom models are trained with your own data, so they're tailored to your documents.
 
 [Source code][formreco_client_src] | [Package (NuGet)][formreco_nuget_package] | [API reference documentation][formreco_refdocs] | [Product documentation][formreco_docs] | [Samples][formreco_samples]
@@ -18,21 +19,21 @@ Install the Azure Form Recognizer client library for .NET with [NuGet][nuget]:
 dotnet add package Azure.AI.FormRecognizer
 ``` 
 
-> Note: This version of the client library defaults to the `2021-09-30-preview` version of the service.
+> Note: This version of the client library defaults to the `2022-01-30-preview` version of the service.
 
 This table shows the relationship between SDK versions and supported API versions of the service:
 
 |SDK version|Supported API version of service
 |-|-
-|4.0.0-beta.X | 2.0, 2.1, 2021-09-30-preview
+|4.0.0-beta.3 | 2.0, 2.1, 2022-01-30-preview
 |3.1.X        | 2.0, 2.1
 |3.0.X        | 2.0
 
-> Note: Starting with version `2021-09-30-preview`, a new set of clients were introduced to leverage the newest features of the Form Recognizer service. Please see the [Migration Guide][migration_guide] for detailed instructions on how to update application code from client library version `3.1.X` or lower to the latest version. Additionally, see the [Changelog][formreco_changelog] for more detailed information. The below table describes the relationship of each client and its supported API version(s):
+> Note: Starting with version `4.0.0-beta.1`, a new set of clients were introduced to leverage the newest features of the Form Recognizer service. Please see the [Migration Guide][migration_guide] for detailed instructions on how to update application code from client library version `3.1.X` or lower to the latest version. Additionally, see the [Changelog][formreco_changelog] for more detailed information. The below table describes the relationship of each client and its supported API version(s):
 
 |API version|Supported clients
 |-|-
-|2021-09-30-preview|DocumentAnalysisClient and DocumentModelAdministrationClient
+|2022-01-30-preview|DocumentAnalysisClient and DocumentModelAdministrationClient
 |2.1|FormRecognizerClient and FormTrainingClient
 |2.0|FormRecognizerClient and FormTrainingClient
 
@@ -141,10 +142,12 @@ var client = new DocumentAnalysisClient(new Uri(endpoint), new DefaultAzureCrede
 |-|-
 |`prebuilt-layout`| Text extraction, selection marks, tables
 |`prebuilt-document`| Text extraction, selection marks, tables, key-value pairs and entities
+|`prebuilt-read`| Text extraction, text languages and styles
 |`prebuilt-invoices`| Text extraction, selection marks, tables, and pre-trained fields and values pertaining to invoices
 |`prebuilt-businessCard`| Text extraction and pre-trained fields and values pertaining to business cards
 |`prebuilt-idDocument`| Text extraction and pre-trained fields and values pertaining to driver licenses and international passports
 |`prebuilt-receipt`| Text extraction and pre-trained fields and values pertaining to sales receipts
+|`prebuilt-tax.us.w2`| Text extraction and pre-trained fields and values pertaining to US W2 tax forms
 |`{custom-model-id}`| Text extraction, selection marks, tables, labeled fields and values from your custom documents
 
 Sample code snippets are provided to illustrate using a DocumentAnalysisClient [here](#examples).
@@ -190,6 +193,7 @@ The following section provides several code snippets illustrating common pattern
 ### Async examples
 * [Extract Layout](#extract-layout)
 * [Use the General Prebuilt Document Model](#use-the-general-prebuilt-document-model)
+* [Use the Prebuilt Read Model](#use-the-prebuilt-read-model)
 * [Use Prebuilt Models](#use-prebuilt-models)
 * [Build a Custom Model](#build-a-custom-model)
 * [Analyze Custom Documents](#analyze-custom-documents)
@@ -380,7 +384,13 @@ for (int i = 0; i < result.Tables.Count; i++)
 
 For more information and samples see [here][analyze_prebuilt_document].
 
+### Use the Prebuilt Read Model
+Analyze textual elements, such as page words and lines, styles, and text language information from documents using the prebuilt read model.
 
+```C# Snippet:FormRecognizerAnalyzePrebuiltReadFromUriAsync
+```
+
+For more information and samples see [here][analyze_prebuilt_read].
 
 ### Use Prebuilt Models
 Analyze data from certain types of common documents using pre-trained models provided by the Form Recognizer service.
@@ -496,6 +506,7 @@ You are not limited to invoices! There are a few prebuilt models to choose from,
 - Analyze driver licenses and international passports using the `prebuilt-idDocument` model. [Supported fields][idDocument_fields].
 - Analyze invoices using the `prebuilt-invoice` model. [Supported fields][invoice_fields].
 - Analyze receipts using the `prebuilt-receipt` model. [Supported fields][receipt_fields].
+- Analyze US W2 tax forms using the `prebuilt-tax.us.w2` model. [Supported fields][w2_fields].
 
 For more samples and information about which types of documents are supported, see [here][analyze_prebuilt].
 
@@ -537,7 +548,7 @@ foreach (KeyValuePair<string, DocTypeInfo> docType in model.DocTypes)
 For more information and samples see [here][build_a_custom_model].
 
 ### Analyze Custom Documents
-Analyze text, field values, selection marks, and table data from custom documents, using models you build with your own document types.
+Analyze text, field values, selection marks, and table data from custom documents, using models you built with your own document types.
 
 ```C# Snippet:FormRecognizerAnalyzeWithCustomModelFromUriAsync
 string modelId = "<modelId>";
@@ -721,6 +732,7 @@ Samples showing how to use the Cognitive Services Form Recognizer library are av
 
 - [Extract the layout of a document][extract_layout]
 - [Analyze with the prebuilt document model][analyze_prebuilt_document]
+- [Analyze with the prebuilt read model][analyze_prebuilt_read]
 - [Analyze a document with a custom model][analyze_custom]
 - [Analyze a document with a prebuilt model][analyze_prebuilt]
 - [Build a custom model][build_a_custom_model]
@@ -776,12 +788,14 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [idDocument_fields]: https://aka.ms/azsdk/formrecognizer/iddocumentfieldschema
 [invoice_fields]: https://aka.ms/azsdk/formrecognizer/invoicefieldschema
 [receipt_fields]: https://aka.ms/azsdk/formrecognizer/receiptfieldschema
+[w2_fields]: https://aka.ms/azsdk/formrecognizer/taxusw2fieldschema
 [dotnet_lro_guidelines]: https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-longrunning
 
 [logging]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/core/Azure.Core/samples/Diagnostics.md
 
 [extract_layout]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
 [analyze_prebuilt_document]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
+[analyze_prebuilt_read]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
 [analyze_custom]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithCustomModel.md
 [analyze_prebuilt]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
 [build_a_custom_model]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_BuildCustomModel.md

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -548,6 +548,7 @@ for (int i = 0; i < result.Documents.Count; i++)
             Console.WriteLine($"Invoice Total: '{invoiceTotal.Symbol}{invoiceTotal.Amount}', with confidence {invoiceTotalField.Confidence}");
         }
     }
+}
 ```
 
 You are not limited to invoices! There are a few prebuilt models to choose from, each of which has its own set of supported fields:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/README.md
@@ -11,18 +11,20 @@ description: Samples for the Azure.AI.FormRecognizer client library
 ---
 
 # Azure Form Recognizer client SDK Samples
-> Note: Starting with version `2021-09-30-preview`, a new set of clients were introduced to leverage the newest features of the Form Recognizer service. Please see the [Migration Guide][migration_guide] for detailed instructions on how to update application code from client library version `3.1.X` or lower to the latest version. Additionally, see the [Changelog][changelog] for more detailed information.
+> Note: Starting with version `4.0.0-beta.1`, a new set of clients were introduced to leverage the newest features of the Form Recognizer service. Please see the [Migration Guide][migration_guide] for detailed instructions on how to update application code from client library version `3.1.X` or lower to the latest version. Additionally, see the [Changelog][changelog] for more detailed information.
 
 Azure Cognitive Services Form Recognizer is a cloud service that uses machine learning to analyze text and structured data from your documents. It includes the following main features:
 
 - Layout - Extract text, selection marks, and table structures, along with their bounding region coordinates, from documents.
 - Document - Analyze key-value pairs and entities in addition to general layout from documents.
-- Prebuilt - Analyze data from certain types of common documents (such as receipts, invoices, business cards, or identity documents) using prebuilt models.
+- Read - Read information about textual elements, such as page words and lines in addition to text language information.
+- Prebuilt - Analyze data from certain types of common documents (such as receipts, invoices, business cards, identity documents, or US W2 tax forms) using prebuilt models.
 - Custom - Build custom models to analyze text, field values, selection marks, and tabular data from documents. Custom models are trained with your own data, so they're tailored to your documents.
 
 ## Common scenarios samples for client library version 4.0.0-beta.x
 - [Extract the layout of a document](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md)
 - [Analyze with the prebuilt document model](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md)
+- [Analyze with the prebuilt read model](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md)
 - [Analyze a document with a custom model](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithCustomModel.md)
 - [Analyze a document with a prebuilt model](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md)
 - [Build a custom model](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_BuildCustomModel.md)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
@@ -34,7 +34,7 @@ Console.WriteLine("Detected key-value pairs:");
 
 foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
 {
-    if (kvp.Value.Content == null)
+    if (kvp.Value == null)
     {
         Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
     }
@@ -138,7 +138,7 @@ Console.WriteLine("Detected key-value pairs:");
 
 foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
 {
-    if (kvp.Value.Content == null)
+    if (kvp.Value == null)
     {
         Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltDocument.md
@@ -125,7 +125,7 @@ for (int i = 0; i < result.Tables.Count; i++)
 To analyze a given file at a file stream, use the `StartAnalyzeDocument` method and pass `prebuilt-document` as the model ID. The returned value is an `AnalyzeResult` object containing data about the submitted document.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltDocumentFromFileAsync
-string filePath = "filePath";
+string filePath = "<filePath>";
 using var stream = new FileStream(filePath, FileMode.Open);
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentAsync("prebuilt-document", stream);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
@@ -79,7 +79,7 @@ foreach (DocumentStyle style in result.Styles)
 To analyze a given file at a file stream, use the `StartAnalyzeDocument` method and pass `prebuilt-read` as the model ID. The returned value is an `AnalyzeResult` object containing data about the submitted document.
 
 ```C# Snippet:FormRecognizerAnalyzePrebuiltReadFromFileAsync
-string filePath = "filePath";
+string filePath = "<filePath>";
 using var stream = new FileStream(filePath, FileMode.Open);
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentAsync("prebuilt-read", stream);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
@@ -24,38 +24,17 @@ To analyze a given file at a URI, use the `StartAnalyzeDocumentFromUri` method a
 ```C# Snippet:FormRecognizerAnalyzePrebuiltReadFromUriAsync
 string fileUri = "<fileUri>";
 
-AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-document", fileUri);
+AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-read", fileUri);
 
 await operation.WaitForCompletionAsync();
 
 AnalyzeResult result = operation.Value;
 
-Console.WriteLine("Detected key-value pairs:");
+Console.WriteLine("Detected languages:");
 
-foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
+foreach (DocumentLanguage language in result.Languages)
 {
-    if (kvp.Value.Content == null)
-    {
-        Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
-    }
-    else
-    {
-        Console.WriteLine($"  Found key-value pair: '{kvp.Key.Content}' and '{kvp.Value.Content}'");
-    }
-}
-
-Console.WriteLine("Detected entities:");
-
-foreach (DocumentEntity entity in result.Entities)
-{
-    if (entity.SubCategory == null)
-    {
-        Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}'.");
-    }
-    else
-    {
-        Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}' and sub-category '{entity.SubCategory}'.");
-    }
+    Console.WriteLine($"  Found language '{language.LanguageCode}' with confidence {language.Confidence}.");
 }
 
 foreach (DocumentPage page in result.Pages)
@@ -74,18 +53,6 @@ foreach (DocumentPage page in result.Pages)
         Console.WriteLine($"      Lower right => X: {line.BoundingBox[2].X}, Y= {line.BoundingBox[2].Y}");
         Console.WriteLine($"      Lower left => X: {line.BoundingBox[3].X}, Y= {line.BoundingBox[3].Y}");
     }
-
-    for (int i = 0; i < page.SelectionMarks.Count; i++)
-    {
-        DocumentSelectionMark selectionMark = page.SelectionMarks[i];
-
-        Console.WriteLine($"  Selection Mark {i} is {selectionMark.State}.");
-        Console.WriteLine($"    Its bounding box is:");
-        Console.WriteLine($"      Upper left => X: {selectionMark.BoundingBox[0].X}, Y= {selectionMark.BoundingBox[0].Y}");
-        Console.WriteLine($"      Upper right => X: {selectionMark.BoundingBox[1].X}, Y= {selectionMark.BoundingBox[1].Y}");
-        Console.WriteLine($"      Lower right => X: {selectionMark.BoundingBox[2].X}, Y= {selectionMark.BoundingBox[2].Y}");
-        Console.WriteLine($"      Lower left => X: {selectionMark.BoundingBox[3].X}, Y= {selectionMark.BoundingBox[3].Y}");
-    }
 }
 
 foreach (DocumentStyle style in result.Styles)
@@ -103,19 +70,6 @@ foreach (DocumentStyle style in result.Styles)
         {
             Console.WriteLine($"  Content: {result.Content.Substring(span.Offset, span.Length)}");
         }
-    }
-}
-
-Console.WriteLine("The following tables were extracted:");
-
-for (int i = 0; i < result.Tables.Count; i++)
-{
-    DocumentTable table = result.Tables[i];
-    Console.WriteLine($"  Table {i} has {table.RowCount} rows and {table.ColumnCount} columns.");
-
-    foreach (DocumentTableCell cell in table.Cells)
-    {
-        Console.WriteLine($"    Cell ({cell.RowIndex}, {cell.ColumnIndex}) has kind '{cell.Kind}' and content: '{cell.Content}'.");
     }
 }
 ```
@@ -128,38 +82,17 @@ To analyze a given file at a file stream, use the `StartAnalyzeDocument` method 
 string filePath = "filePath";
 using var stream = new FileStream(filePath, FileMode.Open);
 
-AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentAsync("prebuilt-document", stream);
+AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentAsync("prebuilt-read", stream);
 
 await operation.WaitForCompletionAsync();
 
 AnalyzeResult result = operation.Value;
 
-Console.WriteLine("Detected key-value pairs:");
+Console.WriteLine("Detected languages:");
 
-foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
+foreach (DocumentLanguage language in result.Languages)
 {
-    if (kvp.Value.Content == null)
-    {
-        Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
-    }
-    else
-    {
-        Console.WriteLine($"  Found key-value pair: '{kvp.Key.Content}' and '{kvp.Value.Content}'");
-    }
-}
-
-Console.WriteLine("Detected entities:");
-
-foreach (DocumentEntity entity in result.Entities)
-{
-    if (entity.SubCategory == null)
-    {
-        Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}'.");
-    }
-    else
-    {
-        Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}' and sub-category '{entity.SubCategory}'.");
-    }
+    Console.WriteLine($"  Found language '{language.LanguageCode}' with confidence {language.Confidence}.");
 }
 
 foreach (DocumentPage page in result.Pages)
@@ -178,18 +111,6 @@ foreach (DocumentPage page in result.Pages)
         Console.WriteLine($"      Lower right => X: {line.BoundingBox[2].X}, Y= {line.BoundingBox[2].Y}");
         Console.WriteLine($"      Lower left => X: {line.BoundingBox[3].X}, Y= {line.BoundingBox[3].Y}");
     }
-
-    for (int i = 0; i < page.SelectionMarks.Count; i++)
-    {
-        DocumentSelectionMark selectionMark = page.SelectionMarks[i];
-
-        Console.WriteLine($"  Selection Mark {i} is {selectionMark.State}.");
-        Console.WriteLine($"    Its bounding box is:");
-        Console.WriteLine($"      Upper left => X: {selectionMark.BoundingBox[0].X}, Y= {selectionMark.BoundingBox[0].Y}");
-        Console.WriteLine($"      Upper right => X: {selectionMark.BoundingBox[1].X}, Y= {selectionMark.BoundingBox[1].Y}");
-        Console.WriteLine($"      Lower right => X: {selectionMark.BoundingBox[2].X}, Y= {selectionMark.BoundingBox[2].Y}");
-        Console.WriteLine($"      Lower left => X: {selectionMark.BoundingBox[3].X}, Y= {selectionMark.BoundingBox[3].Y}");
-    }
 }
 
 foreach (DocumentStyle style in result.Styles)
@@ -207,19 +128,6 @@ foreach (DocumentStyle style in result.Styles)
         {
             Console.WriteLine($"  Content: {result.Content.Substring(span.Offset, span.Length)}");
         }
-    }
-}
-
-Console.WriteLine("The following tables were extracted:");
-
-for (int i = 0; i < result.Tables.Count; i++)
-{
-    DocumentTable table = result.Tables[i];
-    Console.WriteLine($"  Table {i} has {table.RowCount} rows and {table.ColumnCount} columns.");
-
-    foreach (DocumentTableCell cell in table.Cells)
-    {
-        Console.WriteLine($"    Cell ({cell.RowIndex}, {cell.ColumnIndex}) has kind '{cell.Kind}' and content: '{cell.Content}'.");
     }
 }
 ```

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzePrebuiltRead.md
@@ -1,0 +1,232 @@
+# Analyze with the prebuilt read model
+
+This sample demonstrates how to analyze textual elements, such as page words and lines, styles, and text language information from documents using the prebuilt read model.
+
+To get started you'll need a Cognitive Services resource or a Form Recognizer resource.  See [README][README] for prerequisites and instructions.
+
+## Creating a `DocumentAnalysisClient`
+
+To create a new `DocumentAnalysisClient` you need the endpoint and credentials from your resource. In the sample below you'll use a Form Recognizer API key credential by creating an `AzureKeyCredential` object, that if needed, will allow you to update the API key without creating a new client.
+
+You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
+
+```C# Snippet:CreateDocumentAnalysisClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
+var credential = new AzureKeyCredential(apiKey);
+var client = new DocumentAnalysisClient(new Uri(endpoint), credential);
+```
+
+## Use the prebuilt read model to analyze a document from a URI
+
+To analyze a given file at a URI, use the `StartAnalyzeDocumentFromUri` method and pass `prebuilt-read` as the model ID. The returned value is an `AnalyzeResult` object containing data about the submitted document.
+
+```C# Snippet:FormRecognizerAnalyzePrebuiltReadFromUriAsync
+string fileUri = "<fileUri>";
+
+AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-document", fileUri);
+
+await operation.WaitForCompletionAsync();
+
+AnalyzeResult result = operation.Value;
+
+Console.WriteLine("Detected key-value pairs:");
+
+foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
+{
+    if (kvp.Value.Content == null)
+    {
+        Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
+    }
+    else
+    {
+        Console.WriteLine($"  Found key-value pair: '{kvp.Key.Content}' and '{kvp.Value.Content}'");
+    }
+}
+
+Console.WriteLine("Detected entities:");
+
+foreach (DocumentEntity entity in result.Entities)
+{
+    if (entity.SubCategory == null)
+    {
+        Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}'.");
+    }
+    else
+    {
+        Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}' and sub-category '{entity.SubCategory}'.");
+    }
+}
+
+foreach (DocumentPage page in result.Pages)
+{
+    Console.WriteLine($"Document Page {page.PageNumber} has {page.Lines.Count} line(s), {page.Words.Count} word(s),");
+    Console.WriteLine($"and {page.SelectionMarks.Count} selection mark(s).");
+
+    for (int i = 0; i < page.Lines.Count; i++)
+    {
+        DocumentLine line = page.Lines[i];
+        Console.WriteLine($"  Line {i} has content: '{line.Content}'.");
+
+        Console.WriteLine($"    Its bounding box is:");
+        Console.WriteLine($"      Upper left => X: {line.BoundingBox[0].X}, Y= {line.BoundingBox[0].Y}");
+        Console.WriteLine($"      Upper right => X: {line.BoundingBox[1].X}, Y= {line.BoundingBox[1].Y}");
+        Console.WriteLine($"      Lower right => X: {line.BoundingBox[2].X}, Y= {line.BoundingBox[2].Y}");
+        Console.WriteLine($"      Lower left => X: {line.BoundingBox[3].X}, Y= {line.BoundingBox[3].Y}");
+    }
+
+    for (int i = 0; i < page.SelectionMarks.Count; i++)
+    {
+        DocumentSelectionMark selectionMark = page.SelectionMarks[i];
+
+        Console.WriteLine($"  Selection Mark {i} is {selectionMark.State}.");
+        Console.WriteLine($"    Its bounding box is:");
+        Console.WriteLine($"      Upper left => X: {selectionMark.BoundingBox[0].X}, Y= {selectionMark.BoundingBox[0].Y}");
+        Console.WriteLine($"      Upper right => X: {selectionMark.BoundingBox[1].X}, Y= {selectionMark.BoundingBox[1].Y}");
+        Console.WriteLine($"      Lower right => X: {selectionMark.BoundingBox[2].X}, Y= {selectionMark.BoundingBox[2].Y}");
+        Console.WriteLine($"      Lower left => X: {selectionMark.BoundingBox[3].X}, Y= {selectionMark.BoundingBox[3].Y}");
+    }
+}
+
+foreach (DocumentStyle style in result.Styles)
+{
+    // Check the style and style confidence to see if text is handwritten.
+    // Note that value '0.8' is used as an example.
+
+    bool isHandwritten = style.IsHandwritten.HasValue && style.IsHandwritten == true;
+
+    if (isHandwritten && style.Confidence > 0.8)
+    {
+        Console.WriteLine($"Handwritten content found:");
+
+        foreach (DocumentSpan span in style.Spans)
+        {
+            Console.WriteLine($"  Content: {result.Content.Substring(span.Offset, span.Length)}");
+        }
+    }
+}
+
+Console.WriteLine("The following tables were extracted:");
+
+for (int i = 0; i < result.Tables.Count; i++)
+{
+    DocumentTable table = result.Tables[i];
+    Console.WriteLine($"  Table {i} has {table.RowCount} rows and {table.ColumnCount} columns.");
+
+    foreach (DocumentTableCell cell in table.Cells)
+    {
+        Console.WriteLine($"    Cell ({cell.RowIndex}, {cell.ColumnIndex}) has kind '{cell.Kind}' and content: '{cell.Content}'.");
+    }
+}
+```
+
+## Use the prebuilt read model to analyze a document from a file stream
+
+To analyze a given file at a file stream, use the `StartAnalyzeDocument` method and pass `prebuilt-read` as the model ID. The returned value is an `AnalyzeResult` object containing data about the submitted document.
+
+```C# Snippet:FormRecognizerAnalyzePrebuiltReadFromFileAsync
+string filePath = "filePath";
+using var stream = new FileStream(filePath, FileMode.Open);
+
+AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentAsync("prebuilt-document", stream);
+
+await operation.WaitForCompletionAsync();
+
+AnalyzeResult result = operation.Value;
+
+Console.WriteLine("Detected key-value pairs:");
+
+foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
+{
+    if (kvp.Value.Content == null)
+    {
+        Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
+    }
+    else
+    {
+        Console.WriteLine($"  Found key-value pair: '{kvp.Key.Content}' and '{kvp.Value.Content}'");
+    }
+}
+
+Console.WriteLine("Detected entities:");
+
+foreach (DocumentEntity entity in result.Entities)
+{
+    if (entity.SubCategory == null)
+    {
+        Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}'.");
+    }
+    else
+    {
+        Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}' and sub-category '{entity.SubCategory}'.");
+    }
+}
+
+foreach (DocumentPage page in result.Pages)
+{
+    Console.WriteLine($"Document Page {page.PageNumber} has {page.Lines.Count} line(s), {page.Words.Count} word(s),");
+    Console.WriteLine($"and {page.SelectionMarks.Count} selection mark(s).");
+
+    for (int i = 0; i < page.Lines.Count; i++)
+    {
+        DocumentLine line = page.Lines[i];
+        Console.WriteLine($"  Line {i} has content: '{line.Content}'.");
+
+        Console.WriteLine($"    Its bounding box is:");
+        Console.WriteLine($"      Upper left => X: {line.BoundingBox[0].X}, Y= {line.BoundingBox[0].Y}");
+        Console.WriteLine($"      Upper right => X: {line.BoundingBox[1].X}, Y= {line.BoundingBox[1].Y}");
+        Console.WriteLine($"      Lower right => X: {line.BoundingBox[2].X}, Y= {line.BoundingBox[2].Y}");
+        Console.WriteLine($"      Lower left => X: {line.BoundingBox[3].X}, Y= {line.BoundingBox[3].Y}");
+    }
+
+    for (int i = 0; i < page.SelectionMarks.Count; i++)
+    {
+        DocumentSelectionMark selectionMark = page.SelectionMarks[i];
+
+        Console.WriteLine($"  Selection Mark {i} is {selectionMark.State}.");
+        Console.WriteLine($"    Its bounding box is:");
+        Console.WriteLine($"      Upper left => X: {selectionMark.BoundingBox[0].X}, Y= {selectionMark.BoundingBox[0].Y}");
+        Console.WriteLine($"      Upper right => X: {selectionMark.BoundingBox[1].X}, Y= {selectionMark.BoundingBox[1].Y}");
+        Console.WriteLine($"      Lower right => X: {selectionMark.BoundingBox[2].X}, Y= {selectionMark.BoundingBox[2].Y}");
+        Console.WriteLine($"      Lower left => X: {selectionMark.BoundingBox[3].X}, Y= {selectionMark.BoundingBox[3].Y}");
+    }
+}
+
+foreach (DocumentStyle style in result.Styles)
+{
+    // Check the style and style confidence to see if text is handwritten.
+    // Note that value '0.8' is used as an example.
+
+    bool isHandwritten = style.IsHandwritten.HasValue && style.IsHandwritten == true;
+
+    if (isHandwritten && style.Confidence > 0.8)
+    {
+        Console.WriteLine($"Handwritten content found:");
+
+        foreach (DocumentSpan span in style.Spans)
+        {
+            Console.WriteLine($"  Content: {result.Content.Substring(span.Offset, span.Length)}");
+        }
+    }
+}
+
+Console.WriteLine("The following tables were extracted:");
+
+for (int i = 0; i < result.Tables.Count; i++)
+{
+    DocumentTable table = result.Tables[i];
+    Console.WriteLine($"  Table {i} has {table.RowCount} rows and {table.ColumnCount} columns.");
+
+    foreach (DocumentTableCell cell in table.Cells)
+    {
+        Console.WriteLine($"    Cell ({cell.RowIndex}, {cell.ColumnIndex}) has kind '{cell.Kind}' and content: '{cell.Content}'.");
+    }
+}
+```
+
+To see the full example source files, see:
+
+* [Analyze with prebuilt read from URI](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs)
+* [Analyze with prebuilt read from file](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs)
+
+[README]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/formrecognizer/Azure.AI.FormRecognizer#getting-started

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
@@ -96,11 +96,11 @@ for (int i = 0; i < result.Documents.Count; i++)
 
                     if (itemFields.TryGetValue("Amount", out DocumentField itemAmountField))
                     {
-                        if (itemAmountField.ValueType == DocumentFieldType.Double)
+                        if (itemAmountField.ValueType == DocumentFieldType.Currency)
                         {
-                            double itemAmount = itemAmountField.AsDouble();
+                            CurrencyValue itemAmount = itemAmountField.AsCurrency();
 
-                            Console.WriteLine($"  Amount: '{itemAmount}', with confidence {itemAmountField.Confidence}");
+                            Console.WriteLine($"  Amount: '{itemAmount.Symbol}{itemAmount.Amount}', with confidence {itemAmountField.Confidence}");
                         }
                     }
                 }
@@ -110,28 +110,28 @@ for (int i = 0; i < result.Documents.Count; i++)
 
     if (document.Fields.TryGetValue("SubTotal", out DocumentField subTotalField))
     {
-        if (subTotalField.ValueType == DocumentFieldType.Double)
+        if (subTotalField.ValueType == DocumentFieldType.Currency)
         {
-            double subTotal = subTotalField.AsDouble();
-            Console.WriteLine($"Sub Total: '{subTotal}', with confidence {subTotalField.Confidence}");
+            CurrencyValue subTotal = subTotalField.AsCurrency();
+            Console.WriteLine($"Sub Total: '{subTotal.Symbol}{subTotal.Amount}', with confidence {subTotalField.Confidence}");
         }
     }
 
     if (document.Fields.TryGetValue("TotalTax", out DocumentField totalTaxField))
     {
-        if (totalTaxField.ValueType == DocumentFieldType.Double)
+        if (totalTaxField.ValueType == DocumentFieldType.Currency)
         {
-            double totalTax = totalTaxField.AsDouble();
-            Console.WriteLine($"Total Tax: '{totalTax}', with confidence {totalTaxField.Confidence}");
+            CurrencyValue totalTax = totalTaxField.AsCurrency();
+            Console.WriteLine($"Total Tax: '{totalTax.Symbol}{totalTax.Amount}', with confidence {totalTaxField.Confidence}");
         }
     }
 
     if (document.Fields.TryGetValue("InvoiceTotal", out DocumentField invoiceTotalField))
     {
-        if (invoiceTotalField.ValueType == DocumentFieldType.Double)
+        if (invoiceTotalField.ValueType == DocumentFieldType.Currency)
         {
-            double invoiceTotal = invoiceTotalField.AsDouble();
-            Console.WriteLine($"Invoice Total: '{invoiceTotal}', with confidence {invoiceTotalField.Confidence}");
+            CurrencyValue invoiceTotal = invoiceTotalField.AsCurrency();
+            Console.WriteLine($"Invoice Total: '{invoiceTotal.Symbol}{invoiceTotal.Amount}', with confidence {invoiceTotalField.Confidence}");
         }
     }
 }
@@ -206,11 +206,11 @@ for (int i = 0; i < result.Documents.Count; i++)
 
                     if (itemFields.TryGetValue("Amount", out DocumentField itemAmountField))
                     {
-                        if (itemAmountField.ValueType == DocumentFieldType.Double)
+                        if (itemAmountField.ValueType == DocumentFieldType.Currency)
                         {
-                            double itemAmount = itemAmountField.AsDouble();
+                            CurrencyValue itemAmount = itemAmountField.AsCurrency();
 
-                            Console.WriteLine($"  Amount: '{itemAmount}', with confidence {itemAmountField.Confidence}");
+                            Console.WriteLine($"  Amount: '{itemAmount.Symbol}{itemAmount.Amount}', with confidence {itemAmountField.Confidence}");
                         }
                     }
                 }
@@ -220,31 +220,30 @@ for (int i = 0; i < result.Documents.Count; i++)
 
     if (document.Fields.TryGetValue("SubTotal", out DocumentField subTotalField))
     {
-        if (subTotalField.ValueType == DocumentFieldType.Double)
+        if (subTotalField.ValueType == DocumentFieldType.Currency)
         {
-            double subTotal = subTotalField.AsDouble();
-            Console.WriteLine($"Sub Total: '{subTotal}', with confidence {subTotalField.Confidence}");
+            CurrencyValue subTotal = subTotalField.AsCurrency();
+            Console.WriteLine($"Sub Total: '{subTotal.Symbol}{subTotal.Amount}', with confidence {subTotalField.Confidence}");
         }
     }
 
     if (document.Fields.TryGetValue("TotalTax", out DocumentField totalTaxField))
     {
-        if (totalTaxField.ValueType == DocumentFieldType.Double)
+        if (totalTaxField.ValueType == DocumentFieldType.Currency)
         {
-            double totalTax = totalTaxField.AsDouble();
-            Console.WriteLine($"Total Tax: '{totalTax}', with confidence {totalTaxField.Confidence}");
+            CurrencyValue totalTax = totalTaxField.AsCurrency();
+            Console.WriteLine($"Total Tax: '{totalTax.Symbol}{totalTax.Amount}', with confidence {totalTaxField.Confidence}");
         }
     }
 
     if (document.Fields.TryGetValue("InvoiceTotal", out DocumentField invoiceTotalField))
     {
-        if (invoiceTotalField.ValueType == DocumentFieldType.Double)
+        if (invoiceTotalField.ValueType == DocumentFieldType.Currency)
         {
-            double invoiceTotal = invoiceTotalField.AsDouble();
-            Console.WriteLine($"Invoice Total: '{invoiceTotal}', with confidence {invoiceTotalField.Confidence}");
+            CurrencyValue invoiceTotal = invoiceTotalField.AsCurrency();
+            Console.WriteLine($"Invoice Total: '{invoiceTotal.Symbol}{invoiceTotal.Amount}', with confidence {invoiceTotalField.Confidence}");
         }
     }
-}
 ```
 
 To see the full example source files, see:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
@@ -244,6 +244,7 @@ for (int i = 0; i < result.Documents.Count; i++)
             Console.WriteLine($"Invoice Total: '{invoiceTotal.Symbol}{invoiceTotal.Amount}', with confidence {invoiceTotalField.Confidence}");
         }
     }
+}
 ```
 
 To see the full example source files, see:

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_AnalyzeWithPrebuiltModel.md
@@ -25,6 +25,7 @@ The model to use for the analyze operation depends on the type of document to be
 - prebuilt-idDocument: extracts text and key information from driver licenses and international passports. [Supported fields][idDocument_fields].
 - prebuilt-invoice: extracts text, selection marks, tables, key-value pairs, and key information from invoices. [Supported fields][invoice_fields].
 - prebuilt-receipt: extracts text and key information from receipts. [Supported fields][receipt_fields].
+- prebuilt-tax.us.w2: extracts text and key information from US W2 tax forms. [Supported fields][w2_fields].
 
 For more information about prebuilt models and which types of documents are supported, see the [service documentation][formreco_models].
 
@@ -255,6 +256,7 @@ To see the full example source files, see:
 [idDocument_fields]: https://aka.ms/azsdk/formrecognizer/iddocumentfieldschema
 [invoice_fields]: https://aka.ms/azsdk/formrecognizer/invoicefieldschema
 [receipt_fields]: https://aka.ms/azsdk/formrecognizer/receiptfieldschema
+[w2_fields]: https://aka.ms/azsdk/formrecognizer/taxusw2fieldschema
 
 [formreco_models]: https://aka.ms/azsdk/formrecognizer/models
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample_ExtractLayout.md
@@ -97,7 +97,7 @@ for (int i = 0; i < result.Tables.Count; i++)
 To extract the layout from a given file at a file stream, use the `StartAnalyzeDocument` method and pass `prebuilt-layout` as the model ID. The returned value is an `AnalyzeResult` object containing data about the submitted document.
 
 ```C# Snippet:FormRecognizerExtractLayoutFromFileAsync
-string filePath = "filePath";
+string filePath = "<filePath>";
 using var stream = new FileStream(filePath, FileMode.Open);
 
 AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentAsync("prebuilt-layout", stream);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample11_RecognizeIdentityDocuments.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample11_RecognizeIdentityDocuments.md
@@ -24,7 +24,7 @@ To recognize identity documents from a URI, use the `StartRecognizeIdentityDocum
 For simplicity, we are not showing all the fields that the service returns. To see the list of all the supported fields returned by service and its corresponding types, consult: [here](https://aka.ms/formrecognizer/iddocumentfields).
 
 ```C# Snippet:FormRecognizerSampleRecognizeIdentityDocumentsUri
-Uri sourceUri = "<sourceUri>";
+Uri sourceUri = <sourceUri>;
 
 RecognizeIdentityDocumentsOperation operation = await client.StartRecognizeIdentityDocumentsFromUriAsync(sourceUri);
 Response<RecognizedFormCollection> operationResponse = await operation.WaitForCompletionAsync();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample1_RecognizeFormContent.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/V3.1/Sample1_RecognizeFormContent.md
@@ -81,7 +81,7 @@ foreach (FormPage page in formPages)
 To recognize the content from a file stream, use the `StartRecognizeContent` method. The returned value is a collection of `FormPage` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerRecognizeFormContentFromFile
-string filePath = "filePath";
+string filePath = "<filePath>";
 using var stream = new FileStream(filePath, FileMode.Open);
 
 Response<FormPageCollection> response = await client.StartRecognizeContentAsync(stream).WaitForCompletionAsync();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltDocumentFromFileAsync.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             #region Snippet:FormRecognizerAnalyzePrebuiltDocumentFromFileAsync
 #if SNIPPET
-            string filePath = "filePath";
+            string filePath = "<filePath>";
 #else
             string filePath = DocumentAnalysisTestEnvironment.CreatePath("Form_1.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             #region Snippet:FormRecognizerAnalyzePrebuiltReadFromFileAsync
 #if SNIPPET
-            string filePath = "filePath";
+            string filePath = "<filePath>";
 #else
             string filePath = DocumentAnalysisTestEnvironment.CreatePath("Form_1.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromFileAsync.cs
@@ -13,14 +13,14 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
         [Test]
-        public async Task AnalyzePrebuiltDocumentFromFileAsync()
+        public async Task AnalyzePrebuiltReadFromFileAsync()
         {
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
             DocumentAnalysisClient client = new DocumentAnalysisClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:FormRecognizerAnalyzePrebuiltDocumentFromFileAsync
+            #region Snippet:FormRecognizerAnalyzePrebuiltReadFromFileAsync
 #if SNIPPET
             string filePath = "filePath";
 #else
@@ -28,38 +28,17 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 #endif
             using var stream = new FileStream(filePath, FileMode.Open);
 
-            AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentAsync("prebuilt-document", stream);
+            AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentAsync("prebuilt-read", stream);
 
             await operation.WaitForCompletionAsync();
 
             AnalyzeResult result = operation.Value;
 
-            Console.WriteLine("Detected key-value pairs:");
+            Console.WriteLine("Detected languages:");
 
-            foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
+            foreach (DocumentLanguage language in result.Languages)
             {
-                if (kvp.Value == null)
-                {
-                    Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
-                }
-                else
-                {
-                    Console.WriteLine($"  Found key-value pair: '{kvp.Key.Content}' and '{kvp.Value.Content}'");
-                }
-            }
-
-            Console.WriteLine("Detected entities:");
-
-            foreach (DocumentEntity entity in result.Entities)
-            {
-                if (entity.SubCategory == null)
-                {
-                    Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}'.");
-                }
-                else
-                {
-                    Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}' and sub-category '{entity.SubCategory}'.");
-                }
+                Console.WriteLine($"  Found language '{language.LanguageCode}' with confidence {language.Confidence}.");
             }
 
             foreach (DocumentPage page in result.Pages)
@@ -77,18 +56,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
                     Console.WriteLine($"      Upper right => X: {line.BoundingBox[1].X}, Y= {line.BoundingBox[1].Y}");
                     Console.WriteLine($"      Lower right => X: {line.BoundingBox[2].X}, Y= {line.BoundingBox[2].Y}");
                     Console.WriteLine($"      Lower left => X: {line.BoundingBox[3].X}, Y= {line.BoundingBox[3].Y}");
-                }
-
-                for (int i = 0; i < page.SelectionMarks.Count; i++)
-                {
-                    DocumentSelectionMark selectionMark = page.SelectionMarks[i];
-
-                    Console.WriteLine($"  Selection Mark {i} is {selectionMark.State}.");
-                    Console.WriteLine($"    Its bounding box is:");
-                    Console.WriteLine($"      Upper left => X: {selectionMark.BoundingBox[0].X}, Y= {selectionMark.BoundingBox[0].Y}");
-                    Console.WriteLine($"      Upper right => X: {selectionMark.BoundingBox[1].X}, Y= {selectionMark.BoundingBox[1].Y}");
-                    Console.WriteLine($"      Lower right => X: {selectionMark.BoundingBox[2].X}, Y= {selectionMark.BoundingBox[2].Y}");
-                    Console.WriteLine($"      Lower left => X: {selectionMark.BoundingBox[3].X}, Y= {selectionMark.BoundingBox[3].Y}");
                 }
             }
 
@@ -109,20 +76,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
                     }
                 }
             }
-
-            Console.WriteLine("The following tables were extracted:");
-
-            for (int i = 0; i < result.Tables.Count; i++)
-            {
-                DocumentTable table = result.Tables[i];
-                Console.WriteLine($"  Table {i} has {table.RowCount} rows and {table.ColumnCount} columns.");
-
-                foreach (DocumentTableCell cell in table.Cells)
-                {
-                    Console.WriteLine($"    Cell ({cell.RowIndex}, {cell.ColumnIndex}) has kind '{cell.Kind}' and content: '{cell.Content}'.");
-                }
-            }
-
             #endregion
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzePrebuiltReadFromUriAsync.cs
@@ -12,52 +12,31 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
     public partial class DocumentAnalysisSamples : SamplesBase<DocumentAnalysisTestEnvironment>
     {
         [Test]
-        public async Task AnalyzePrebuiltDocumentFromUriAsync()
+        public async Task AnalyzePrebuiltReadFromUriAsync()
         {
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
             DocumentAnalysisClient client = new DocumentAnalysisClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            #region Snippet:FormRecognizerAnalyzePrebuiltDocumentFromUriAsync
+            #region Snippet:FormRecognizerAnalyzePrebuiltReadFromUriAsync
 #if SNIPPET
             string fileUri = "<fileUri>";
 #else
             Uri fileUri = DocumentAnalysisTestEnvironment.CreateUri("Form_1.jpg");
 #endif
 
-            AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-document", fileUri);
+            AnalyzeDocumentOperation operation = await client.StartAnalyzeDocumentFromUriAsync("prebuilt-read", fileUri);
 
             await operation.WaitForCompletionAsync();
 
             AnalyzeResult result = operation.Value;
 
-            Console.WriteLine("Detected key-value pairs:");
+            Console.WriteLine("Detected languages:");
 
-            foreach (DocumentKeyValuePair kvp in result.KeyValuePairs)
+            foreach (DocumentLanguage language in result.Languages)
             {
-                if (kvp.Value == null)
-                {
-                    Console.WriteLine($"  Found key with no value: '{kvp.Key.Content}'");
-                }
-                else
-                {
-                    Console.WriteLine($"  Found key-value pair: '{kvp.Key.Content}' and '{kvp.Value.Content}'");
-                }
-            }
-
-            Console.WriteLine("Detected entities:");
-
-            foreach (DocumentEntity entity in result.Entities)
-            {
-                if (entity.SubCategory == null)
-                {
-                    Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}'.");
-                }
-                else
-                {
-                    Console.WriteLine($"  Found entity '{entity.Content}' with category '{entity.Category}' and sub-category '{entity.SubCategory}'.");
-                }
+                Console.WriteLine($"  Found language '{language.LanguageCode}' with confidence {language.Confidence}.");
             }
 
             foreach (DocumentPage page in result.Pages)
@@ -75,18 +54,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
                     Console.WriteLine($"      Upper right => X: {line.BoundingBox[1].X}, Y= {line.BoundingBox[1].Y}");
                     Console.WriteLine($"      Lower right => X: {line.BoundingBox[2].X}, Y= {line.BoundingBox[2].Y}");
                     Console.WriteLine($"      Lower left => X: {line.BoundingBox[3].X}, Y= {line.BoundingBox[3].Y}");
-                }
-
-                for (int i = 0; i < page.SelectionMarks.Count; i++)
-                {
-                    DocumentSelectionMark selectionMark = page.SelectionMarks[i];
-
-                    Console.WriteLine($"  Selection Mark {i} is {selectionMark.State}.");
-                    Console.WriteLine($"    Its bounding box is:");
-                    Console.WriteLine($"      Upper left => X: {selectionMark.BoundingBox[0].X}, Y= {selectionMark.BoundingBox[0].Y}");
-                    Console.WriteLine($"      Upper right => X: {selectionMark.BoundingBox[1].X}, Y= {selectionMark.BoundingBox[1].Y}");
-                    Console.WriteLine($"      Lower right => X: {selectionMark.BoundingBox[2].X}, Y= {selectionMark.BoundingBox[2].Y}");
-                    Console.WriteLine($"      Lower left => X: {selectionMark.BoundingBox[3].X}, Y= {selectionMark.BoundingBox[3].Y}");
                 }
             }
 
@@ -107,20 +74,6 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
                     }
                 }
             }
-
-            Console.WriteLine("The following tables were extracted:");
-
-            for (int i = 0; i < result.Tables.Count; i++)
-            {
-                DocumentTable table = result.Tables[i];
-                Console.WriteLine($"  Table {i} has {table.RowCount} rows and {table.ColumnCount} columns.");
-
-                foreach (DocumentTableCell cell in table.Cells)
-                {
-                    Console.WriteLine($"    Cell ({cell.RowIndex}, {cell.ColumnIndex}) has kind '{cell.Kind}' and content: '{cell.Content}'.");
-                }
-            }
-
             #endregion
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs
@@ -88,11 +88,11 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
                                 if (itemFields.TryGetValue("Amount", out DocumentField itemAmountField))
                                 {
-                                    if (itemAmountField.ValueType == DocumentFieldType.Double)
+                                    if (itemAmountField.ValueType == DocumentFieldType.Currency)
                                     {
-                                        double itemAmount = itemAmountField.AsDouble();
+                                        CurrencyValue itemAmount = itemAmountField.AsCurrency();
 
-                                        Console.WriteLine($"  Amount: '{itemAmount}', with confidence {itemAmountField.Confidence}");
+                                        Console.WriteLine($"  Amount: '{itemAmount.Symbol}{itemAmount.Amount}', with confidence {itemAmountField.Confidence}");
                                     }
                                 }
                             }
@@ -102,32 +102,32 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
                 if (document.Fields.TryGetValue("SubTotal", out DocumentField subTotalField))
                 {
-                    if (subTotalField.ValueType == DocumentFieldType.Double)
+                    if (subTotalField.ValueType == DocumentFieldType.Currency)
                     {
-                        double subTotal = subTotalField.AsDouble();
-                        Console.WriteLine($"Sub Total: '{subTotal}', with confidence {subTotalField.Confidence}");
+                        CurrencyValue subTotal = subTotalField.AsCurrency();
+                        Console.WriteLine($"Sub Total: '{subTotal.Symbol}{subTotal.Amount}', with confidence {subTotalField.Confidence}");
                     }
                 }
 
                 if (document.Fields.TryGetValue("TotalTax", out DocumentField totalTaxField))
                 {
-                    if (totalTaxField.ValueType == DocumentFieldType.Double)
+                    if (totalTaxField.ValueType == DocumentFieldType.Currency)
                     {
-                        double totalTax = totalTaxField.AsDouble();
-                        Console.WriteLine($"Total Tax: '{totalTax}', with confidence {totalTaxField.Confidence}");
+                        CurrencyValue totalTax = totalTaxField.AsCurrency();
+                        Console.WriteLine($"Total Tax: '{totalTax.Symbol}{totalTax.Amount}', with confidence {totalTaxField.Confidence}");
                     }
                 }
 
                 if (document.Fields.TryGetValue("InvoiceTotal", out DocumentField invoiceTotalField))
                 {
-                    if (invoiceTotalField.ValueType == DocumentFieldType.Double)
+                    if (invoiceTotalField.ValueType == DocumentFieldType.Currency)
                     {
-                        double invoiceTotal = invoiceTotalField.AsDouble();
-                        Console.WriteLine($"Invoice Total: '{invoiceTotal}', with confidence {invoiceTotalField.Confidence}");
+                        CurrencyValue invoiceTotal = invoiceTotalField.AsCurrency();
+                        Console.WriteLine($"Invoice Total: '{invoiceTotal.Symbol}{invoiceTotal.Amount}', with confidence {invoiceTotalField.Confidence}");
                     }
                 }
+                #endregion
             }
-            #endregion
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromFileAsync.cs
@@ -126,8 +126,8 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
                         Console.WriteLine($"Invoice Total: '{invoiceTotal.Symbol}{invoiceTotal.Amount}', with confidence {invoiceTotalField.Confidence}");
                     }
                 }
-                #endregion
             }
+            #endregion
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_AnalyzeWithPrebuiltModelFromUriAsync.cs
@@ -85,11 +85,11 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
                                 if (itemFields.TryGetValue("Amount", out DocumentField itemAmountField))
                                 {
-                                    if (itemAmountField.ValueType == DocumentFieldType.Double)
+                                    if (itemAmountField.ValueType == DocumentFieldType.Currency)
                                     {
-                                        double itemAmount = itemAmountField.AsDouble();
+                                        CurrencyValue itemAmount = itemAmountField.AsCurrency();
 
-                                        Console.WriteLine($"  Amount: '{itemAmount}', with confidence {itemAmountField.Confidence}");
+                                        Console.WriteLine($"  Amount: '{itemAmount.Symbol}{itemAmount.Amount}', with confidence {itemAmountField.Confidence}");
                                     }
                                 }
                             }
@@ -99,28 +99,28 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
                 if (document.Fields.TryGetValue("SubTotal", out DocumentField subTotalField))
                 {
-                    if (subTotalField.ValueType == DocumentFieldType.Double)
+                    if (subTotalField.ValueType == DocumentFieldType.Currency)
                     {
-                        double subTotal = subTotalField.AsDouble();
-                        Console.WriteLine($"Sub Total: '{subTotal}', with confidence {subTotalField.Confidence}");
+                        CurrencyValue subTotal = subTotalField.AsCurrency();
+                        Console.WriteLine($"Sub Total: '{subTotal.Symbol}{subTotal.Amount}', with confidence {subTotalField.Confidence}");
                     }
                 }
 
                 if (document.Fields.TryGetValue("TotalTax", out DocumentField totalTaxField))
                 {
-                    if (totalTaxField.ValueType == DocumentFieldType.Double)
+                    if (totalTaxField.ValueType == DocumentFieldType.Currency)
                     {
-                        double totalTax = totalTaxField.AsDouble();
-                        Console.WriteLine($"Total Tax: '{totalTax}', with confidence {totalTaxField.Confidence}");
+                        CurrencyValue totalTax = totalTaxField.AsCurrency();
+                        Console.WriteLine($"Total Tax: '{totalTax.Symbol}{totalTax.Amount}', with confidence {totalTaxField.Confidence}");
                     }
                 }
 
                 if (document.Fields.TryGetValue("InvoiceTotal", out DocumentField invoiceTotalField))
                 {
-                    if (invoiceTotalField.ValueType == DocumentFieldType.Double)
+                    if (invoiceTotalField.ValueType == DocumentFieldType.Currency)
                     {
-                        double invoiceTotal = invoiceTotalField.AsDouble();
-                        Console.WriteLine($"Invoice Total: '{invoiceTotal}', with confidence {invoiceTotalField.Confidence}");
+                        CurrencyValue invoiceTotal = invoiceTotalField.AsCurrency();
+                        Console.WriteLine($"Invoice Total: '{invoiceTotal.Symbol}{invoiceTotal.Amount}', with confidence {invoiceTotalField.Confidence}");
                     }
                 }
             }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample_ExtractLayoutFromFileAsync.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Samples
 
             #region Snippet:FormRecognizerExtractLayoutFromFileAsync
 #if SNIPPET
-            string filePath = "filePath";
+            string filePath = "<filePath>";
 #else
             string filePath = DocumentAnalysisTestEnvironment.CreatePath("Form_1.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample14_RecognizeIdentityDocumentsFromUri.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeIdentityDocumentsUri
 #if SNIPPET
-            Uri sourceUri = "<sourceUri>";
+            Uri sourceUri = <sourceUri>;
 #else
             Uri sourceUri = FormRecognizerTestEnvironment.CreateUri("license.jpg");
 #endif

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/V3.1/Sample1_RecognizeContentFromFile.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerRecognizeFormContentFromFile
 #if SNIPPET
-            string filePath = "filePath";
+            string filePath = "<filePath>";
 #else
             string filePath = FormRecognizerTestEnvironment.CreatePath("Invoice_1.pdf");
 #endif


### PR DESCRIPTION
This PR includes:
- Adding a "prebuilt-read" sample to illustrate the usage of the `DocumentLanguage` class.
- Fixing samples that were affected by the Double => Currency change.
- Updating README to reflect new changes, including the addition of the W2 prebuilt.
- Updating the CHANGELOG for release.

This PR does not include:
- Updating the migration guide to describe the usage of the new build model required input parameter. This is already being tracked by an issue, and it will have a separate PR. Samples and README have already been updated to take the build model into account.
- A W2 prebuilt model sample. We already have a general "prebuilt" sample in which we illustrate the usage of prebuilt models using `prebuilt-invoice`. We also list there the other types of documents that are supported, and W2 has been included in this list.
- The usage of the `tags` property when building a model. This is a minor feature when compared to others, so I believe there's no need to make samples more complex to showcase it.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/26318.