### PR TITLE
Storage transmission evaluator

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageTransmissionEvaluator.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageTransmissionEvaluator.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter
+{
+    internal class StorageTransmissionEvaluator
+    {
+        private double[] _transmissionDurationsInSeconds;
+        private double[] _exportIntervalsInSeconds;
+        private int _transmissionDurationIndex = -1;
+        private int _exportIntervalIndex = -1;
+        private DateTime prevExportTime;
+        private double _currentBatchExportDuration;
+        private double _runningExportIntervalSum;
+        private double _runningTransmissionDurationSum;
+        private bool _enoughSampleSize;
+
+        internal StorageTransmissionEvaluator(int transmissionSampleSize, int exportIntervalSampleSize)
+        {
+            _transmissionDurationsInSeconds = new double[transmissionSampleSize];
+            _exportIntervalsInSeconds = new double[exportIntervalSampleSize];
+        }
+
+        internal void UpdateTransmissionDuration(double currentExportDuration)
+        {
+            _transmissionDurationIndex++;
+            // if we run out of elements, start from beginning
+            if (_transmissionDurationIndex == _transmissionDurationsInSeconds.Length)
+            {
+                _transmissionDurationIndex = 0;
+            }
+
+            _runningTransmissionDurationSum -= _transmissionDurationsInSeconds[_transmissionDurationIndex];
+            _transmissionDurationsInSeconds[_transmissionDurationIndex] = currentExportDuration;
+            _runningTransmissionDurationSum += currentExportDuration;
+        }
+
+        internal void UpdateExportInterval()
+        {
+            // todo: check if this can fail
+            double exportInterval = (DateTime.UtcNow - prevExportTime).TotalSeconds;
+
+            // If total time elapsed > 2 days
+            // set export interval to 0
+            // This can happen if
+            // 1) there was no export in 2 days of application run
+            // 2) Application just started and prevExportTime is default which = 1/1/0001 12:00:00 AM
+            if (exportInterval > 172800)
+            {
+                exportInterval = 0;
+            }
+
+            _exportIntervalIndex++;
+
+            // if we run out of elements, start from beginning
+            // This also means we now have enough samples to start calculating avg.
+            if (_exportIntervalIndex == _exportIntervalsInSeconds.Length)
+            {
+                _enoughSampleSize = true;
+                _exportIntervalIndex = 0;
+            }
+
+            _runningExportIntervalSum -= _exportIntervalsInSeconds[_exportIntervalIndex];
+            _exportIntervalsInSeconds[_exportIntervalIndex] = exportInterval;
+            _runningExportIntervalSum += exportInterval;
+            prevExportTime = DateTime.UtcNow;
+        }
+
+        internal long MaxFilesToTransmitFromStorage()
+        {
+            long totalFiles = 0;
+
+            // Check if we have enough sample size to decide
+            // otherwise, simply return 0.
+            if (_enoughSampleSize)
+            {
+                double avgDurationPerExport = CalculateAverage(_runningTransmissionDurationSum, _transmissionDurationsInSeconds.Length);
+                double avgExportInterval = CalculateAverage(_runningExportIntervalSum, _exportIntervalsInSeconds.Length);
+                if (avgExportInterval > _currentBatchExportDuration)
+                {
+                    // remove currentBatchExportDuration from avg ExportInterval first
+                    // e.g. avg export interval is 10 secs and time it took to export current batch is 5 secs
+                    // we have 5 secs left before we expect next batch
+                    // so, we can transmit 1 file (if avg duration per export is 5 secs)
+                    totalFiles = (long)((avgExportInterval - _currentBatchExportDuration) / avgDurationPerExport);
+                }
+            }
+
+            return totalFiles;
+        }
+
+        private static double CalculateAverage(double sum, int length)
+        {
+            return (sum / length);
+        }
+
+        internal double CurrentBatchExportDuration { get => _currentBatchExportDuration; set => _currentBatchExportDuration = value; }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageTransmissionEvaluator.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageTransmissionEvaluator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
@@ -12,7 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private double[] _exportIntervalsInSeconds;
         private int _transmissionDurationIndex = -1;
         private int _exportIntervalIndex = -1;
-        private DateTime prevExportTime;
+        private long prevExportTime;
         private double _currentBatchExportDuration;
         private double _runningExportIntervalSum;
         private double _runningTransmissionDurationSum;
@@ -41,8 +42,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         internal void UpdateExportInterval()
         {
+            long currentTime = Stopwatch.GetTimestamp();
             // todo: check if this can fail
-            double exportInterval = (DateTime.UtcNow - prevExportTime).TotalSeconds;
+            double exportInterval = TimeSpan.FromTicks(currentTime - prevExportTime).TotalSeconds;
+
+            prevExportTime = currentTime;
 
             // If total time elapsed > 2 days
             // set export interval to 0
@@ -67,7 +71,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             _runningExportIntervalSum -= _exportIntervalsInSeconds[_exportIntervalIndex];
             _exportIntervalsInSeconds[_exportIntervalIndex] = exportInterval;
             _runningExportIntervalSum += exportInterval;
-            prevExportTime = DateTime.UtcNow;
         }
 
         internal long MaxFilesToTransmitFromStorage()

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageTransmissionEvaluator.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/StorageTransmissionEvaluator.cs
@@ -7,6 +7,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 {
     internal class StorageTransmissionEvaluator
     {
+        private int _sampleSize;
         private double[] _transmissionDurationsInSeconds;
         private double[] _exportIntervalsInSeconds;
         private int _transmissionDurationIndex = -1;
@@ -17,10 +18,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         private double _runningTransmissionDurationSum;
         private bool _enoughSampleSize;
 
-        internal StorageTransmissionEvaluator(int transmissionSampleSize, int exportIntervalSampleSize)
+        internal StorageTransmissionEvaluator(int sampleSize)
         {
-            _transmissionDurationsInSeconds = new double[transmissionSampleSize];
-            _exportIntervalsInSeconds = new double[exportIntervalSampleSize];
+            _sampleSize = sampleSize;
+            _transmissionDurationsInSeconds = new double[sampleSize];
+            _exportIntervalsInSeconds = new double[sampleSize];
         }
 
         internal void UpdateTransmissionDuration(double currentExportDuration)
@@ -76,8 +78,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             // otherwise, simply return 0.
             if (_enoughSampleSize)
             {
-                double avgDurationPerExport = CalculateAverage(_runningTransmissionDurationSum, _transmissionDurationsInSeconds.Length);
-                double avgExportInterval = CalculateAverage(_runningExportIntervalSum, _exportIntervalsInSeconds.Length);
+                double avgDurationPerExport = CalculateAverage(_runningTransmissionDurationSum, _sampleSize);
+                double avgExportInterval = CalculateAverage(_runningExportIntervalSum, _sampleSize);
                 if (avgExportInterval > _currentBatchExportDuration)
                 {
                     // remove currentBatchExportDuration from avg ExportInterval first


### PR DESCRIPTION
This PR covers the algorithm to evaluate whether an exporter can transmit files from storage. The algorithm is based on following idea.

Consider exporter received total of 5 consecutive batches in time window of T and each of those exports took E1, E2, E3, E4, E5 time respectively
 
```text
|--------------------------------------T-------------------------------------------|
|--E1--|
                |--E2--|
                                 |--E3--|
                                                           |--E4--|
                                                                            |--E5--|
```
The above representation shows that

1) Exporter was busy exporting average of **E** = (E1+E2+E3+E4+E5)/5 time.

2) Exporter was idle for average of **I** = (T-E)/5 time.

The average idle time is the time interval between each export which can be used to export files from storage. So for any export we can calculate how many files can be transmitted from storage as follows:
```text 
(I - E)/E 
```
