### PR TITLE
[Event Hubs] Minor Performance Tweaks

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 5.7.0-beta.4 (Unreleased)
 
+### Acknowledgments
+
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- Daniel Marbach _([GitHub](https://github.com/danielmarbach))_
+
 ### Features Added
 
 ### Breaking Changes
@@ -9,6 +15,14 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- Attempt to retrieve AMQP objects synchronously before calling `GetOrCreateAsync`.
+
+- Remove LINQ from the `AmqpMessageConverter` in favor of direct looping.  _(Based on a community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
+
+- Change the internal batch `AsEnumerable<T>` to `AsList<T>` in order to avoid casting costs and have `Count` available to right-size transform collections. _(Based on a community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
+
+- Use the two item overload when creating a linked token source to avoid allocating an unnecessary array. _([ref](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs#L736-L739))_ _(Based on a community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_
 
 ## 5.7.0-beta.3 (2022-02-09)
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -226,7 +226,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             var failedAttemptCount = 0;
             var retryDelay = default(TimeSpan?);
-
+            var link = default(RequestResponseAmqpLink);
             var stopWatch = ValueStopwatch.StartNew();
 
             try
@@ -244,7 +244,11 @@ namespace Azure.Messaging.EventHubs.Amqp
                         var token = await AcquireAccessTokenAsync(cancellationToken).ConfigureAwait(false);
                         using AmqpMessage request = MessageConverter.CreateEventHubPropertiesRequest(EventHubName, token);
 
-                        RequestResponseAmqpLink link = await ManagementLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout.CalculateRemaining(stopWatch.GetElapsedTime())), cancellationToken).ConfigureAwait(false);
+                        if (!ManagementLink.TryGetOpenedObject(out link))
+                        {
+                            link = await ManagementLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout.CalculateRemaining(stopWatch.GetElapsedTime())), cancellationToken).ConfigureAwait(false);
+                        }
+
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                         // Send the request and process the response.
@@ -340,7 +344,11 @@ namespace Azure.Messaging.EventHubs.Amqp
                         token = await AcquireAccessTokenAsync(cancellationToken).ConfigureAwait(false);
                         using AmqpMessage request = MessageConverter.CreatePartitionPropertiesRequest(EventHubName, partitionId, token);
 
-                        link = await ManagementLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout.CalculateRemaining(stopWatch.GetElapsedTime())), cancellationToken).ConfigureAwait(false);
+                        if (!ManagementLink.TryGetOpenedObject(out link))
+                        {
+                            link = await ManagementLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout.CalculateRemaining(stopWatch.GetElapsedTime())), cancellationToken).ConfigureAwait(false);
+                        }
+
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                         // Send the request and process the response.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -301,7 +301,12 @@ namespace Azure.Messaging.EventHubs.Amqp
                 EventHubsEventSource.Log.AmqpManagementLinkCreateStart(EventHubName);
 
                 var stopWatch = ValueStopwatch.StartNew();
-                var connection = await ActiveConnection.GetOrCreateAsync(linkTimeout, cancellationToken).ConfigureAwait(false);
+
+                if (!ActiveConnection.TryGetOpenedObject(out var connection))
+                {
+                    connection = await ActiveConnection.GetOrCreateAsync(linkTimeout, cancellationToken).ConfigureAwait(false);
+                }
+
                 var link = await CreateManagementLinkAsync(connection, operationTimeout, linkTimeout.CalculateRemaining(stopWatch.GetElapsedTime()), cancellationToken).ConfigureAwait(false);
 
                 await OpenAmqpObjectAsync(link, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -363,7 +368,11 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 var stopWatch = ValueStopwatch.StartNew();
                 var consumerEndpoint = new Uri(ServiceEndpoint, string.Format(CultureInfo.InvariantCulture, ConsumerPathSuffixMask, EventHubName, consumerGroup, partitionId));
-                var connection = await ActiveConnection.GetOrCreateAsync(linkTimeout, cancellationToken).ConfigureAwait(false);
+
+                if (!ActiveConnection.TryGetOpenedObject(out var connection))
+                {
+                    connection = await ActiveConnection.GetOrCreateAsync(linkTimeout, cancellationToken).ConfigureAwait(false);
+                }
 
                 if (string.IsNullOrEmpty(linkIdentifier))
                 {
@@ -432,7 +441,11 @@ namespace Azure.Messaging.EventHubs.Amqp
                 var stopWatch = ValueStopwatch.StartNew();
                 var path = (string.IsNullOrEmpty(partitionId)) ? EventHubName : string.Format(CultureInfo.InvariantCulture, PartitionProducerPathSuffixMask, EventHubName, partitionId);
                 var producerEndpoint = new Uri(ServiceEndpoint, path);
-                var connection = await ActiveConnection.GetOrCreateAsync(linkTimeout, cancellationToken).ConfigureAwait(false);
+
+                if (!ActiveConnection.TryGetOpenedObject(out var connection))
+                {
+                    connection = await ActiveConnection.GetOrCreateAsync(linkTimeout, cancellationToken).ConfigureAwait(false);
+                }
 
                 if (string.IsNullOrEmpty(linkIdentifier))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -262,9 +262,12 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                         EventHubsEventSource.Log.EventReceiveStart(EventHubName, ConsumerGroup, PartitionId, operationId);
 
-                        link = await ReceiveLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout), cancellationToken).ConfigureAwait(false);
-                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                        if (!ReceiveLink.TryGetOpenedObject(out link))
+                        {
+                            link = await ReceiveLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout), cancellationToken).ConfigureAwait(false);
+                        }
 
+                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                         var messagesReceived = await link.ReceiveMessagesAsync(maximumEventCount, ReceiveBuildBatchInterval, waitTime, cancellationToken).ConfigureAwait(false);
 
                         // If no messages were received, then just return the empty set.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
@@ -181,14 +181,14 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <returns>The set of events as an enumerable of the requested type.</returns>
         ///
-        public override List<T> AsList<T>()
+        public override IReadOnlyCollection<T> AsReadOnlyCollection<T>()
         {
             if (typeof(T) != typeof(EventData))
             {
                 throw new FormatException(string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedTransportEventType, typeof(T).Name));
             }
 
-            return BatchEvents as List<T>;
+            return BatchEvents as IReadOnlyCollection<T>;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
@@ -102,9 +101,10 @@ namespace Azure.Messaging.EventHubs.Amqp
             MaximumSizeInBytes = options.MaximumSizeInBytes.Value;
             ActiveFeatures = activeFeatures;
 
-            // Initialize the size by reserving space for the batch envelope.
+            // Initialize the size by reserving space for the batch envelope.  At this point, the
+            // set of batch events is empty, so the message returned will only represent the envelope.
 
-            using AmqpMessage envelope = messageConverter.CreateBatchFromEvents(Enumerable.Empty<EventData>(), options.PartitionKey);
+            using AmqpMessage envelope = messageConverter.CreateBatchFromEvents(BatchEvents, options.PartitionKey);
             ReservedSize = envelope.SerializedMessageSize;
             _sizeBytes = ReservedSize;
         }
@@ -174,22 +174,21 @@ namespace Azure.Messaging.EventHubs.Amqp
         }
 
         /// <summary>
-        ///   Represents the batch as an enumerable set of transport-specific
-        ///   representations of an event.
+        ///   Represents the batch as a set of the AMQP-specific representations of an event.
         /// </summary>
         ///
         /// <typeparam name="T">The transport-specific event representation being requested.</typeparam>
         ///
         /// <returns>The set of events as an enumerable of the requested type.</returns>
         ///
-        public override IEnumerable<T> AsEnumerable<T>()
+        public override List<T> AsList<T>()
         {
             if (typeof(T) != typeof(EventData))
             {
                 throw new FormatException(string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedTransportEventType, typeof(T).Name));
             }
 
-            return (IEnumerable<T>)BatchEvents;
+            return BatchEvents as List<T>;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -230,7 +230,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             // Make a defensive copy of the messages in the batch.
 
-            AmqpMessage messageFactory() => MessageConverter.CreateBatchFromEvents(eventBatch.AsEnumerable<EventData>(), eventBatch.SendOptions?.PartitionKey);
+            AmqpMessage messageFactory() => MessageConverter.CreateBatchFromEvents(eventBatch.AsList<EventData>(), eventBatch.SendOptions?.PartitionKey);
             await SendAsync(messageFactory, eventBatch.SendOptions?.PartitionKey, cancellationToken).ConfigureAwait(false);
         }
 
@@ -269,7 +269,11 @@ namespace Azure.Messaging.EventHubs.Amqp
                 {
                     try
                     {
-                        await SendLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout), cancellationToken).ConfigureAwait(false);
+                        if (!SendLink.TryGetOpenedObject(out _))
+                        {
+                            await SendLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout), cancellationToken).ConfigureAwait(false);
+                        }
+
                         break;
                     }
                     catch (Exception ex)
@@ -344,7 +348,11 @@ namespace Azure.Messaging.EventHubs.Amqp
             {
                 try
                 {
-                    await SendLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout), cancellationToken).ConfigureAwait(false);
+                    if (!SendLink.TryGetOpenedObject(out _))
+                    {
+                        await SendLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout), cancellationToken).ConfigureAwait(false);
+                    }
+
                     break;
                 }
                 catch (Exception ex)
@@ -436,7 +444,6 @@ namespace Azure.Messaging.EventHubs.Amqp
             var failedAttemptCount = 0;
             var logPartition = PartitionId ?? partitionKey;
             var operationId = Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture);
-            var stopWatch = ValueStopwatch.StartNew();
 
             TimeSpan? retryDelay;
             SendingAmqpLink link;
@@ -457,7 +464,11 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                         EventHubsEventSource.Log.EventPublishStart(EventHubName, logPartition, operationId);
 
-                        link = await SendLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout), cancellationToken).ConfigureAwait(false);
+                        if (!SendLink.TryGetOpenedObject(out link))
+                        {
+                            link = await SendLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout), cancellationToken).ConfigureAwait(false);
+                        }
+
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                         // Validate that the batch of messages is not too large to send.  This is done after the link is created to ensure
@@ -499,7 +510,6 @@ namespace Azure.Messaging.EventHubs.Amqp
                             await Task.Delay(retryDelay.Value, cancellationToken).ConfigureAwait(false);
 
                             tryTimeout = RetryPolicy.CalculateTryTimeout(failedAttemptCount);
-                            stopWatch = ValueStopwatch.StartNew();
                         }
                         else if (ex is AmqpException)
                         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -195,7 +195,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="sendOptions">The set of options to consider when sending this batch.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
-        public override async Task SendAsync(IEnumerable<EventData> events,
+        public override async Task SendAsync(IReadOnlyCollection<EventData> events,
                                              SendEventOptions sendOptions,
                                              CancellationToken cancellationToken)
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -230,7 +230,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             // Make a defensive copy of the messages in the batch.
 
-            AmqpMessage messageFactory() => MessageConverter.CreateBatchFromEvents(eventBatch.AsList<EventData>(), eventBatch.SendOptions?.PartitionKey);
+            AmqpMessage messageFactory() => MessageConverter.CreateBatchFromEvents(eventBatch.AsReadOnlyCollection<EventData>(), eventBatch.SendOptions?.PartitionKey);
             await SendAsync(messageFactory, eventBatch.SendOptions?.PartitionKey, cancellationToken).ConfigureAwait(false);
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -696,7 +696,7 @@ namespace Azure.Messaging.EventHubs.Consumer
             var options = readOptions?.Clone() ?? new ReadEventOptions();
             var startingPosition = startReadingAtEarliestEvent ? EventPosition.Earliest : EventPosition.Latest;
 
-            using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, CancellationToken.None);
 
             try
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ChannelReaderExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ChannelReaderExtensions.cs
@@ -69,7 +69,7 @@ namespace Azure.Messaging.EventHubs.Core
                                 if ((waitSource == null) || (waitSource.IsCancellationRequested))
                                 {
                                     waitSource?.Dispose();
-                                    waitSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                                    waitSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, CancellationToken.None);
                                 }
 
                                 waitSource.CancelAfter(maximumWaitTime.Value);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
@@ -61,15 +61,14 @@ namespace Azure.Messaging.EventHubs.Core
         public abstract void Clear();
 
         /// <summary>
-        ///   Represents the batch as an enumerable set of transport-specific
-        ///   representations of an event.
+        ///   Represents the batch as a set of the transport-specific representations of an event.
         /// </summary>
         ///
         /// <typeparam name="T">The transport-specific event representation being requested.</typeparam>
         ///
         /// <returns>The set of events as an enumerable of the requested type.</returns>
         ///
-        public abstract IEnumerable<T> AsEnumerable<T>();
+        public abstract List<T> AsList<T>();
 
         /// <summary>
         ///   Performs the task needed to clean up resources used by the <see cref="TransportEventBatch" />.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
@@ -68,7 +68,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <returns>The set of events as an enumerable of the requested type.</returns>
         ///
-        public abstract List<T> AsList<T>();
+        public abstract IReadOnlyCollection<T> AsReadOnlyCollection<T>();
 
         /// <summary>
         ///   Performs the task needed to clean up resources used by the <see cref="TransportEventBatch" />.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducer.cs
@@ -36,7 +36,7 @@ namespace Azure.Messaging.EventHubs.Core
         /// <param name="sendOptions">The set of options to consider when sending this batch.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
-        public abstract Task SendAsync(IEnumerable<EventData> events,
+        public abstract Task SendAsync(IReadOnlyCollection<EventData> events,
                                        SendEventOptions sendOptions,
                                        CancellationToken cancellationToken);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
@@ -291,7 +291,12 @@ namespace Azure.Messaging.EventHubs
             ///
             /// <returns>The set of events as an enumerable of the requested type.</returns>
             ///
-            public override IEnumerable<T> AsEnumerable<T>() => (IEnumerable<T>)_backingStore;
+            public override List<T> AsList<T>() => _backingStore switch
+            {
+                List<T> storeList => storeList,
+                IList<T> storeIList => new List<T>(storeIList),
+                _ => _backingStore as List<T>
+            };
 
             /// <summary>
             ///   Performs the task needed to clean up resources used by the <see cref="TransportEventBatch" />.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
@@ -293,9 +293,8 @@ namespace Azure.Messaging.EventHubs
             ///
             public override IReadOnlyCollection<T> AsReadOnlyCollection<T>() => _backingStore switch
             {
-                List<T> storeList => storeList,
-                IList<T> storeIList => new List<T>(storeIList),
-                _ => _backingStore as List<T>
+                IReadOnlyCollection<T> storeCollection => storeCollection,
+                _ => new List<T>((IEnumerable<T>)_backingStore)
             };
 
             /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsModelFactory.cs
@@ -291,7 +291,7 @@ namespace Azure.Messaging.EventHubs
             ///
             /// <returns>The set of events as an enumerable of the requested type.</returns>
             ///
-            public override List<T> AsList<T>() => _backingStore switch
+            public override IReadOnlyCollection<T> AsReadOnlyCollection<T>() => _backingStore switch
             {
                 List<T> storeList => storeList,
                 IList<T> storeIList => new List<T>(storeIList),

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -1734,7 +1734,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                 // Create and register the partition processor.  Ownership of the cancellationSource is transferred
                 // to the processor upon creation, including the responsibility for disposal.
 
-                cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, CancellationToken.None);
                 var processor = CreatePartitionProcessor(partition, cancellationSource);
 
                 ActivePartitionProcessors.AddOrUpdate(partitionId, processor, (key, value) => processor);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -212,7 +212,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns>The set of events as an enumerable of the requested type.</returns>
         ///
-        internal List<T> AsList<T>() => InnerBatch.AsList<T>();
+        internal IReadOnlyCollection<T> AsReadOnlyCollection<T>() => InnerBatch.AsReadOnlyCollection<T>();
 
         /// <summary>
         ///   Gets the list of diagnostic identifiers of events added to this batch.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -212,7 +212,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns>The set of events as an enumerable of the requested type.</returns>
         ///
-        internal IEnumerable<T> AsEnumerable<T>() => InnerBatch.AsEnumerable<T>();
+        internal List<T> AsList<T>() => InnerBatch.AsList<T>();
 
         /// <summary>
         ///   Gets the list of diagnostic identifiers of events added to this batch.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -1089,7 +1089,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 var resetStateOnError = false;
                 var releaseGuard = false;
                 var partitionState = PartitionState.GetOrAdd(options.PartitionId, new PartitionPublishingState(options.PartitionId));
-                var eventSet = eventBatch.AsList<EventData>() ;
+                var eventSet = eventBatch.AsReadOnlyCollection<EventData>() ;
 
                 try
                 {
@@ -1356,7 +1356,7 @@ namespace Azure.Messaging.EventHubs.Producer
         private static void AssertIdempotentBatchNotPublished(EventDataBatch batch)
         {
             if ((batch.StartingPublishedSequenceNumber.HasValue)
-                || (batch.AsList<EventData>().Any(eventData => eventData.PublishedSequenceNumber.HasValue)))
+                || (batch.AsReadOnlyCollection<EventData>().Any(eventData => eventData.PublishedSequenceNumber.HasValue)))
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.IdempotentAlreadyPublished));
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -1089,12 +1089,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 var resetStateOnError = false;
                 var releaseGuard = false;
                 var partitionState = PartitionState.GetOrAdd(options.PartitionId, new PartitionPublishingState(options.PartitionId));
-
-                var eventSet = eventBatch.AsEnumerable<EventData>() switch
-                {
-                    IReadOnlyList<EventData> eventList => eventList,
-                    IEnumerable<EventData> eventEnumerable => eventEnumerable.ToList()
-                };
+                var eventSet = eventBatch.AsList<EventData>() ;
 
                 try
                 {
@@ -1361,7 +1356,7 @@ namespace Azure.Messaging.EventHubs.Producer
         private static void AssertIdempotentBatchNotPublished(EventDataBatch batch)
         {
             if ((batch.StartingPublishedSequenceNumber.HasValue)
-                || (batch.AsEnumerable<EventData>().Any(eventData => eventData.PublishedSequenceNumber.HasValue)))
+                || (batch.AsList<EventData>().Any(eventData => eventData.PublishedSequenceNumber.HasValue)))
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.IdempotentAlreadyPublished));
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -615,8 +615,8 @@ namespace Azure.Messaging.EventHubs.Producer
 
             var events = eventBatch switch
             {
-                IReadOnlyList<EventData> eventList => eventList,
-                _ => eventBatch.ToList()
+                IReadOnlyCollection<EventData> eventCollection => eventCollection,
+                _ => eventBatch.ToArray()
             };
 
             if (events.Count == 0)
@@ -833,7 +833,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <param name="options">The set of options to consider when sending this batch.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
         ///
-        private async Task SendInternalAsync(IReadOnlyList<EventData> events,
+        private async Task SendInternalAsync(IReadOnlyCollection<EventData> events,
                                              SendEventOptions options,
                                              CancellationToken cancellationToken = default)
         {
@@ -947,7 +947,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <param name="options">The set of options to consider when sending this batch.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
         ///
-        private async Task SendIdempotentAsync(IReadOnlyList<EventData> eventSet,
+        private async Task SendIdempotentAsync(IReadOnlyCollection<EventData> eventSet,
                                                SendEventOptions options,
                                                CancellationToken cancellationToken = default)
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
@@ -394,7 +394,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpEventBatch.AsEnumerable{T}" />
+        ///   Verifies functionality of the <see cref="AmqpEventBatch.AsList{T}" />
         ///   method.
         /// </summary>
         ///
@@ -413,11 +413,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(0);
 
             var batch = new AmqpEventBatch(mockConverter, options, default);
-            Assert.That(() => batch.AsEnumerable<AmqpMessage>(), Throws.InstanceOf<FormatException>());
+            Assert.That(() => batch.AsList<AmqpMessage>(), Throws.InstanceOf<FormatException>());
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpEventBatch.AsEnumerable{T}" />
+        ///   Verifies functionality of the <see cref="AmqpEventBatch.AsList{T}" />
         ///   method.
         /// </summary>
         ///
@@ -455,7 +455,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 batch.TryAdd(batchEvents[index]);
             }
 
-            IEnumerable<EventData> batchEnumerable = batch.AsEnumerable<EventData>();
+            IEnumerable<EventData> batchEnumerable = batch.AsList<EventData>();
             Assert.That(batchEnumerable, Is.Not.Null, "The batch enumerable should have been populated.");
 
             var batchEnumerableList = batchEnumerable.ToList();
@@ -669,8 +669,8 @@ namespace Azure.Messaging.EventHubs.Tests
             public Func<IEnumerable<EventData>, string, AmqpMessage> CreateBatchFromEventsHandler = (_e, _p) => null;
             public Func<IEnumerable<AmqpMessage>, string, AmqpMessage> CreateBatchFromMessagesHandler = (_m, _p) => null;
             public override AmqpMessage CreateMessageFromEvent(EventData source, string partitionKey = null) => CreateMessageFromEventHandler(source, partitionKey);
-            public override AmqpMessage CreateBatchFromEvents(IEnumerable<EventData> source, string partitionKey = null) => CreateBatchFromEventsHandler(source, partitionKey);
-            public override AmqpMessage CreateBatchFromMessages(IEnumerable<AmqpMessage> source, string partitionKey = null) => CreateBatchFromMessagesHandler(source, partitionKey);
+            public override AmqpMessage CreateBatchFromEvents(List<EventData> source, string partitionKey = null) => CreateBatchFromEventsHandler(source, partitionKey);
+            public override AmqpMessage CreateBatchFromMessages(List<AmqpMessage> source, string partitionKey = null) => CreateBatchFromMessagesHandler(source, partitionKey);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
@@ -394,7 +394,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpEventBatch.AsList{T}" />
+        ///   Verifies functionality of the <see cref="AmqpEventBatch.AsReadOnlyCollection{T}" />
         ///   method.
         /// </summary>
         ///
@@ -413,11 +413,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(0);
 
             var batch = new AmqpEventBatch(mockConverter, options, default);
-            Assert.That(() => batch.AsList<AmqpMessage>(), Throws.InstanceOf<FormatException>());
+            Assert.That(() => batch.AsReadOnlyCollection<AmqpMessage>(), Throws.InstanceOf<FormatException>());
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpEventBatch.AsList{T}" />
+        ///   Verifies functionality of the <see cref="AmqpEventBatch.AsReadOnlyCollection{T}" />
         ///   method.
         /// </summary>
         ///
@@ -455,7 +455,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 batch.TryAdd(batchEvents[index]);
             }
 
-            IEnumerable<EventData> batchEnumerable = batch.AsList<EventData>();
+            IEnumerable<EventData> batchEnumerable = batch.AsReadOnlyCollection<EventData>();
             Assert.That(batchEnumerable, Is.Not.Null, "The batch enumerable should have been populated.");
 
             var batchEnumerableList = batchEnumerable.ToList();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
@@ -669,8 +669,8 @@ namespace Azure.Messaging.EventHubs.Tests
             public Func<IEnumerable<EventData>, string, AmqpMessage> CreateBatchFromEventsHandler = (_e, _p) => null;
             public Func<IEnumerable<AmqpMessage>, string, AmqpMessage> CreateBatchFromMessagesHandler = (_m, _p) => null;
             public override AmqpMessage CreateMessageFromEvent(EventData source, string partitionKey = null) => CreateMessageFromEventHandler(source, partitionKey);
-            public override AmqpMessage CreateBatchFromEvents(List<EventData> source, string partitionKey = null) => CreateBatchFromEventsHandler(source, partitionKey);
-            public override AmqpMessage CreateBatchFromMessages(List<AmqpMessage> source, string partitionKey = null) => CreateBatchFromMessagesHandler(source, partitionKey);
+            public override AmqpMessage CreateBatchFromEvents(IReadOnlyCollection<EventData> source, string partitionKey = null) => CreateBatchFromEventsHandler(source, partitionKey);
+            public override AmqpMessage CreateBatchFromMessages(IReadOnlyCollection<AmqpMessage> source, string partitionKey = null) => CreateBatchFromMessagesHandler(source, partitionKey);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -1113,7 +1113,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var producer = new AmqpProducer("aHub", null, null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.IdempotentPublishing);
             await producer.CloseAsync(CancellationToken.None);
 
-            Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendEventOptions(), CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+            Assert.That(async () => await producer.SendAsync(Array.Empty<EventData>(), new SendEventOptions(), CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 
         /// <summary>
@@ -1137,7 +1137,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             scope.Dispose();
 
-            Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendEventOptions(), CancellationToken.None),
+            Assert.That(async () => await producer.SendAsync(Array.Empty<EventData>(), new SendEventOptions(), CancellationToken.None),
                 Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -1593,7 +1593,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await producer.Object.SendAsync(batch, CancellationToken.None);
             Assert.That(messageFactory, Is.Not.Null, "The batch message factory should have been set.");
 
-            using var batchMessage = new AmqpMessageConverter().CreateBatchFromEvents(batch.AsList<EventData>(), partitonKey);
+            using var batchMessage = new AmqpMessageConverter().CreateBatchFromEvents(batch.AsReadOnlyCollection<EventData>(), partitonKey);
             using var factoryMessage = messageFactory();
 
             Assert.That(factoryMessage.SerializedMessageSize, Is.EqualTo(batchMessage.SerializedMessageSize), "The serialized size of the messages should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -1183,7 +1183,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendEnumerableCreatesTheAmqpMessageFromTheEnumerable(string partitonKey)
         {
             var messageFactory = default(Func<AmqpMessage>);
-            var events = new[] { new EventData(new byte[] { 0x15 }) };
+            var events = new List<EventData> { new EventData(new byte[] { 0x15 }) };
 
             var producer = new Mock<AmqpProducer>("aHub", null, "fake-id", Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>(), TransportProducerFeatures.None, null)
             {
@@ -1593,7 +1593,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await producer.Object.SendAsync(batch, CancellationToken.None);
             Assert.That(messageFactory, Is.Not.Null, "The batch message factory should have been set.");
 
-            using var batchMessage = new AmqpMessageConverter().CreateBatchFromEvents(batch.AsEnumerable<EventData>(), partitonKey);
+            using var batchMessage = new AmqpMessageConverter().CreateBatchFromEvents(batch.AsList<EventData>(), partitonKey);
             using var factoryMessage = messageFactory();
 
             Assert.That(factoryMessage.SerializedMessageSize, Is.EqualTo(batchMessage.SerializedMessageSize), "The serialized size of the messages should match.");
@@ -1695,7 +1695,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new EventHubsException(true, "Test");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
+            var batch = EventHubsModelFactory.EventDataBatch(100, new List<EventData>(), options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
@@ -1739,7 +1739,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new OperationCanceledException();
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
+            var batch = EventHubsModelFactory.EventDataBatch(100, new List<EventData>(), options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
@@ -1783,7 +1783,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
+            var batch = EventHubsModelFactory.EventDataBatch(100, new List<EventData>(), options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
@@ -1826,7 +1826,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var embeddedException = new OperationCanceledException("", new ArgumentNullException());
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
+            var batch = EventHubsModelFactory.EventDataBatch(100, new List<EventData>(), options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {
@@ -1869,7 +1869,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var embeddedException = new OperationCanceledException("", new AmqpException(new Error { Condition = AmqpError.ArgumentError }));
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
+            var batch = EventHubsModelFactory.EventDataBatch(100, new List<EventData>(), options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, identifier, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy, TransportProducerFeatures.None, null)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventHubsModelFactoryTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventHubsModelFactoryTests.cs
@@ -195,7 +195,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(batch.SizeInBytes, Is.EqualTo(size), "The batch size should have been set.");
             Assert.That(batch.MaximumSizeInBytes, Is.EqualTo(options.MaximumSizeInBytes), "The maximum batch size should have been set.");
             Assert.That(batch.Count, Is.EqualTo(store.Count), "The batch count should reflect the count of the backing store.");
-            Assert.That(batch.AsEnumerable<EventData>(), Is.EquivalentTo(store), "The batch enumerable should reflect the events in the backing store.");
+            Assert.That(batch.AsList<EventData>(), Is.EquivalentTo(store), "The batch enumerable should reflect the events in the backing store.");
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(() => batch.TryAdd(new EventData(new BinaryData("Too many"))), Is.False, "The batch is full; a second attempt to add a new event should not succeed.");
 
             Assert.That(store.Count, Is.EqualTo(eventLimit), "The batch should be at its limit after the failed TryAdd attempts.");
-            Assert.That(batch.AsEnumerable<EventData>(), Is.EquivalentTo(store), "The batch enumerable should reflect the events in the backing store.");
+            Assert.That(batch.AsList<EventData>(), Is.EquivalentTo(store), "The batch enumerable should reflect the events in the backing store.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventHubsModelFactoryTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventHubsModelFactoryTests.cs
@@ -195,7 +195,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(batch.SizeInBytes, Is.EqualTo(size), "The batch size should have been set.");
             Assert.That(batch.MaximumSizeInBytes, Is.EqualTo(options.MaximumSizeInBytes), "The maximum batch size should have been set.");
             Assert.That(batch.Count, Is.EqualTo(store.Count), "The batch count should reflect the count of the backing store.");
-            Assert.That(batch.AsList<EventData>(), Is.EquivalentTo(store), "The batch enumerable should reflect the events in the backing store.");
+            Assert.That(batch.AsReadOnlyCollection<EventData>(), Is.EquivalentTo(store), "The batch enumerable should reflect the events in the backing store.");
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(() => batch.TryAdd(new EventData(new BinaryData("Too many"))), Is.False, "The batch is full; a second attempt to add a new event should not succeed.");
 
             Assert.That(store.Count, Is.EqualTo(eventLimit), "The batch should be at its limit after the failed TryAdd attempts.");
-            Assert.That(batch.AsList<EventData>(), Is.EquivalentTo(store), "The batch enumerable should reflect the events in the backing store.");
+            Assert.That(batch.AsReadOnlyCollection<EventData>(), Is.EquivalentTo(store), "The batch enumerable should reflect the events in the backing store.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -53,7 +53,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportMock = new Mock<TransportProducer>();
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
@@ -114,7 +114,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportMock = new Mock<TransportProducer>();
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             transportMock
@@ -164,7 +164,7 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData[] writtenEventsData = null;
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Callback<IEnumerable<EventData>, SendEventOptions, CancellationToken>((e, _, __) => writtenEventsData = e.ToArray())
                 .Returns(Task.CompletedTask);
 
@@ -216,7 +216,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 });
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             transportMock
@@ -263,7 +263,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportMock = new Mock<TransportProducer>();
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -132,7 +132,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies property accessors for the <see cref="EventDataBatch.AsEnumerable" />
+        ///   Verifies property accessors for the <see cref="EventDataBatch.AsList" />
         ///   method.
         /// </summary>
         ///
@@ -142,7 +142,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockBatch = new MockTransportBatch();
             var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
 
-            batch.AsEnumerable<string>();
+            batch.AsList<string>();
             Assert.That(mockBatch.AsEnumerableCalledWith, Is.EqualTo(typeof(string)), "The enumerable should delegated the requested type parameter.");
         }
 
@@ -289,7 +289,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 return true;
             }
 
-            public override IEnumerable<T> AsEnumerable<T>()
+            public override List<T> AsList<T>()
             {
                 AsEnumerableCalledWith = typeof(T);
                 return default;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -132,7 +132,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies property accessors for the <see cref="EventDataBatch.AsList" />
+        ///   Verifies property accessors for the <see cref="EventDataBatch.AsReadOnlyCollection" />
         ///   method.
         /// </summary>
         ///
@@ -142,8 +142,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockBatch = new MockTransportBatch();
             var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
 
-            batch.AsList<string>();
-            Assert.That(mockBatch.AsEnumerableCalledWith, Is.EqualTo(typeof(string)), "The enumerable should delegated the requested type parameter.");
+            batch.AsReadOnlyCollection<string>();
+            Assert.That(mockBatch.AsReadOnlyCollectionCalledWith, Is.EqualTo(typeof(string)), "The enumerable should delegated the requested type parameter.");
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             public bool DisposeInvoked = false;
             public bool ClearInvoked = false;
-            public Type AsEnumerableCalledWith = null;
+            public Type AsReadOnlyCollectionCalledWith = null;
             public EventData TryAddCalledWith = null;
 
             public override long MaximumSizeInBytes { get; } = 200;
@@ -289,9 +289,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 return true;
             }
 
-            public override List<T> AsList<T>()
+            public override IReadOnlyCollection<T> AsReadOnlyCollection<T>()
             {
-                AsEnumerableCalledWith = typeof(T);
+                AsReadOnlyCollectionCalledWith = typeof(T);
                 return default;
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -1084,7 +1084,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(expectedProperties);
 
             mockTransport
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask)
                 .Verifiable("The events should have been sent using the transport producer.");
 
@@ -1134,7 +1134,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(expectedProperties);
 
             mockTransport
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask)
                 .Verifiable("The events should have been sent using the transport producer.");
 
@@ -1184,7 +1184,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(expectedProperties);
 
             mockTransport
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new OverflowException()));
 
             using var cancellationSource = new CancellationTokenSource();
@@ -1231,7 +1231,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(expectedProperties);
 
             mockTransport
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new OverflowException()));
 
             using var cancellationSource = new CancellationTokenSource();
@@ -1269,7 +1269,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(expectedProperties);
 
             mockTransport
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new OverflowException()));
 
             using var cancellationSource = new CancellationTokenSource();
@@ -1317,7 +1317,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var sendCountdown = events.Length;
 
             mockTransport
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.Delay(TimeSpan.FromMilliseconds(150 * (--sendCountdown))));
 
             using var cancellationSource = new CancellationTokenSource();
@@ -1925,7 +1925,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var sendCountdown = batches.Length;
 
             mockTransport
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.Delay(TimeSpan.FromMilliseconds(150 * (--sendCountdown))));
 
             using var cancellationSource = new CancellationTokenSource();
@@ -1982,7 +1982,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var sendCountdown = batches.Length;
 
             mockTransport
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.Delay(TimeSpan.FromMilliseconds(150 * (--sendCountdown))));
 
             using var cancellationSource = new CancellationTokenSource();
@@ -2313,7 +2313,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = new[] { new EventData(new BinaryData(Array.Empty<byte>())) };
 
             transportProducer
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                                         It.IsAny<SendEventOptions>(),
                                                                         It.IsAny<CancellationToken>()))
                 .Throws(new EventHubsException(false, "test", EventHubsException.FailureReason.ClientClosed));
@@ -2324,7 +2324,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(async () => await producerClient.SendAsync(events, options), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
 
-            transportProducer.Verify(t => t.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+            transportProducer.Verify(t => t.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                       It.IsAny<SendEventOptions>(),
                                                       It.IsAny<CancellationToken>()),
                                      Times.Exactly(EventHubProducerClient.MaximumCreateProducerAttempts),
@@ -2383,7 +2383,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var numberOfCalls = 0;
 
             transportProducer
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                                         It.IsAny<SendEventOptions>(),
                                                                         It.IsAny<CancellationToken>()))
                 .Callback(() =>
@@ -2447,14 +2447,14 @@ namespace Azure.Messaging.EventHubs.Tests
             var producerClient = new EventHubProducerClient(eventHubConnection, transportProducer.Object, mockTransportProducerPool);
 
             transportProducer
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                                         It.IsAny<SendEventOptions>(),
                                                                         It.IsAny<CancellationToken>()))
                 .Throws(new EventHubsException(false, "test", EventHubsException.FailureReason.ClientClosed));
 
             Assert.That(async () => await producerClient.SendAsync(events, options), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
 
-            transportProducer.Verify(t => t.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+            transportProducer.Verify(t => t.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                       It.IsAny<SendEventOptions>(),
                                                       It.IsAny<CancellationToken>()),
                                      Times.Once,
@@ -2507,7 +2507,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var producerClient = new EventHubProducerClient(eventHubConnection, transportProducer.Object, mockTransportProducerPool);
 
             transportProducer
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                                         It.IsAny<SendEventOptions>(),
                                                                         It.IsAny<CancellationToken>()))
                 .Throws(new EventHubsException(false, "test", EventHubsException.FailureReason.ClientClosed));
@@ -2520,7 +2520,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(async () => await producerClient.SendAsync(events, options), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
 
-            transportProducer.Verify(t => t.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+            transportProducer.Verify(t => t.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                       It.IsAny<SendEventOptions>(),
                                                       It.IsAny<CancellationToken>()),
                                      Times.Once,
@@ -2578,7 +2578,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var producerClient = new EventHubProducerClient(eventHubConnection, transportProducer.Object, mockTransportProducerPool);
 
             transportProducer
-                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+                .Setup(transportProducer => transportProducer.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                                         It.IsAny<SendEventOptions>(),
                                                                         It.IsAny<CancellationToken>()))
                 .Throws(new EventHubsException(false, "test", EventHubsException.FailureReason.ClientClosed));
@@ -2591,7 +2591,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(async () => await producerClient.SendAsync(events, options), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
 
-            transportProducer.Verify(t => t.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+            transportProducer.Verify(t => t.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                       It.IsAny<SendEventOptions>(),
                                                       It.IsAny<CancellationToken>()),
                                      Times.Once,
@@ -2652,7 +2652,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(async () => await producerClient.SendAsync(events, options, cancellationTokenSource.Token), Throws.InstanceOf<OperationCanceledException>());
 
-            transportProducer.Verify(t => t.SendAsync(It.IsAny<IEnumerable<EventData>>(),
+            transportProducer.Verify(t => t.SendAsync(It.IsAny<IReadOnlyCollection<EventData>>(),
                                                       It.IsAny<SendEventOptions>(),
                                                       It.IsAny<CancellationToken>()),
                                      Times.Never,
@@ -2794,7 +2794,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public EventDataBatch SendBatchCalledWith;
             public CreateBatchOptions CreateBatchCalledWith;
 
-            public override Task SendAsync(IEnumerable<EventData> events,
+            public override Task SendAsync(IReadOnlyCollection<EventData> events,
                                            SendEventOptions sendOptions,
                                            CancellationToken cancellationToken)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -2934,7 +2934,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override long SizeInBytes { get; }
             public override TransportProducerFeatures ActiveFeatures { get; }
             public override int Count => Events.Count;
-            public override IEnumerable<T> AsEnumerable<T>() => (IEnumerable<T>)Events;
+            public override List<T> AsList<T>() => Events as List<T>;
             public override void Clear() => Events.Clear();
             public override void Dispose() => throw new NotImplementedException();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -2934,7 +2934,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override long SizeInBytes { get; }
             public override TransportProducerFeatures ActiveFeatures { get; }
             public override int Count => Events.Count;
-            public override List<T> AsList<T>() => Events as List<T>;
+            public override IReadOnlyCollection<T> AsReadOnlyCollection<T>() => Events as IReadOnlyCollection<T>;
             public override void Clear() => Events.Clear();
             public override void Dispose() => throw new NotImplementedException();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -456,7 +456,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 PartitionId = partitionId;
             }
 
-            public override Task SendAsync(IEnumerable<EventData> events,
+            public override Task SendAsync(IReadOnlyCollection<EventData> events,
                                            SendEventOptions sendOptions,
                                            CancellationToken cancellationToken)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -501,7 +501,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override int Count { get; }
             public override TransportProducerFeatures ActiveFeatures { get; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
-            public override List<T> AsList<T>() => throw new NotImplementedException();
+            public override IReadOnlyCollection<T> AsReadOnlyCollection<T>() => throw new NotImplementedException();
             public override void Dispose() => throw new NotImplementedException();
 
             public override void Clear()

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/TransportProducerPoolTests.cs
@@ -501,7 +501,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override int Count { get; }
             public override TransportProducerFeatures ActiveFeatures { get; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
-            public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();
+            public override List<T> AsList<T>() => throw new NotImplementedException();
             public override void Dispose() => throw new NotImplementedException();
 
             public override void Clear()


### PR DESCRIPTION
# Summary

The focus of these changes is to apply some of the performance-oriented tweaks made in Service Bus to the Event Hubs clients.   Included are:

- Attempt to retrieve AMQP objects synchronously before calling `GetOrCreateAsync`

- Remove LINQ from the `AmqpMessageConverter`

- Change the internal batch `AsEnumerable<T>` to `AsList<T>` in order to avoid casting costs and have `Count` available to right-size transform collections.

- Use the two item overload when creating a linked token source to avoid allocating an unnecessary array.  _([ref](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs#L736-L739))_

# References and Resources

- [Processor improvements (#26904)](https://github.com/Azure/azure-sdk-for-net/pull/26904)
- [Remove LINQ allocations for all batched sends (#26911)](https://github.com/Azure/azure-sdk-for-net/pull/26911)