### PR TITLE
[Legacy Smoke Tests] Resolve Dependency Issue

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.0" />
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.3.0-beta.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.9.1" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.6" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.10" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.36.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.16.2" />
 


### PR DESCRIPTION
# Summary

Bumping the version for `Microsoft.Azure.Amqp` to avoid triggering a message about downgrading versions.

# References and Related

- [Smoke Tests failing in release pipeline on AMQP dependency (#26975)](https://github.com/Azure/azure-sdk-for-net/issues/26975)