### PR TITLE
[Communication] - PhoneNumbers - Fix test pipeline script format

### DIFF
--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests.yml
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests.yml
@@ -20,7 +20,8 @@ extends:
         SubscriptionConfigurations:
           - $(sub-config-communication-int-test-resources-common)
           - $(sub-config-communication-int-test-resources-net)
-        MatrixReplace: SKIP_UPDATE_CAPABILITIES_LIVE_TESTS=FALSE/TRUE
+        MatrixReplace: 
+          - SKIP_UPDATE_CAPABILITIES_LIVE_TESTS=FALSE/TRUE
     Clouds: Public,Int
     EnvVars:
       # SKIP_PHONENUMBER_LIVE_TESTS skips certain phone number tests such as purchase and release


### PR DESCRIPTION
Correctly pass the `MatrixReplace` parameter as a list instead of a string value in live test pipeline script. This was introduced in https://github.com/Azure/azure-sdk-for-net/pull/26910.