### PR TITLE
[Fabric Bot] Fix rule typo

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3462,7 +3462,7 @@
         {
           "name": "addReply",
           "parameters": {
-            "comment": "Hi @${issueAuthor}.  Thank you, for your interest in helping to improve the Azure SDK experience and for your contribution.  We've noticed that there hasn't been recent engagement on this pull request.  If this is still an active work stream, please let us know by pushing some changes or leaving a comment.  Otherwise, we'll close this out in 7 days."
+            "comment": "Hi @${issueAuthor}.  Thank you for your interest in helping to improve the Azure SDK experience and for your contribution.  We've noticed that there hasn't been recent engagement on this pull request.  If this is still an active work stream, please let us know by pushing some changes or leaving a comment.  Otherwise, we'll close this out in 7 days."
           }
         }
       ]


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a typo in a comment left by the bot when a stale pull request is detected.