### PR TITLE
SR API updates based on architect feedback

### DIFF
--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -1,8 +1,8 @@
 namespace Azure
 {
-    public partial class MessageWithMetadata
+    public partial class BinaryContent
     {
-        public MessageWithMetadata() { }
+        public BinaryContent() { }
         public virtual Azure.Core.ContentType? ContentType { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         protected virtual Azure.Core.ContentType? ContentTypeCore { get { throw null; } set { } }

--- a/sdk/core/Azure.Core.Experimental/src/BinaryContent.cs
+++ b/sdk/core/Azure.Core.Experimental/src/BinaryContent.cs
@@ -8,17 +8,17 @@ using Azure.Core;
 namespace Azure
 {
     /// <summary>
-    /// A message containing a content type along with its data.
+    /// Content containing a content type along with its data.
     /// </summary>
-    public class MessageWithMetadata
+    public class BinaryContent
     {
         /// <summary>
-        /// Gets or sets the message data.
+        /// Gets or sets the data.
         /// </summary>
         public virtual BinaryData? Data { get; set; }
 
         /// <summary>
-        /// Gets or sets the message content type.
+        /// Gets or sets the content type.
         /// </summary>
         public virtual ContentType? ContentType
         {
@@ -35,7 +35,7 @@ namespace Azure
         protected virtual ContentType? ContentTypeCore { get; set; }
 
         /// <summary>
-        /// Gets whether the message is read only or not. This
+        /// Gets whether the content is read only or not. This
         /// can be overriden by inheriting classes to specify whether or
         /// not the message can be modified.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -1,6 +1,6 @@
 namespace Azure.Messaging.EventHubs
 {
-    public partial class EventData : Azure.MessageWithMetadata
+    public partial class EventData : Azure.BinaryContent
     {
         public EventData() { }
         public EventData(System.BinaryData eventBody) { }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -19,7 +19,7 @@
 
     <PackageReference Include="Azure.Core" />
     -->
-    <PackageReference Include="Azure.Core.Experimental" />
+    <!--    <PackageReference Include="Azure.Core.Experimental" />-->
     <!-- END TEMP -->
 
     <PackageReference Include="Azure.Core.Amqp" />
@@ -65,5 +65,8 @@
       <Link>Resources.resx</Link>
       <CustomToolNamespace>Azure.Messaging.EventHubs</CustomToolNamespace>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -15,10 +15,11 @@
 
   <ItemGroup>
      <!--
-        TEMP: Move Core to a project reference until the MessageWithMetadata are shipped in Azure.Core.
+        TEMP: Move Core to a project reference until BinaryContent is shipped in Azure.Core.Experimental.
 
-    <PackageReference Include="Azure.Core" />
+        <PackageReference Include="Azure.Core" />
     -->
+    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
     <!--    <PackageReference Include="Azure.Core.Experimental" />-->
     <!-- END TEMP -->
 
@@ -65,8 +66,5 @@
       <Link>Resources.resx</Link>
       <CustomToolNamespace>Azure.Messaging.EventHubs</CustomToolNamespace>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -19,7 +19,7 @@ namespace Azure.Messaging.EventHubs
     ///   An Event Hubs event, encapsulating a set of data and its associated metadata.
     /// </summary>
     ///
-    public class EventData : MessageWithMetadata
+    public class EventData : BinaryContent
     {
         /// <summary>The AMQP representation of the event, allowing access to additional protocol data elements not used directly by the Event Hubs client library.</summary>
         private readonly AmqpAnnotatedMessage _amqpMessage;
@@ -98,7 +98,7 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///    This member is intended to allow the string-based <see cref="ContentType" /> in this class to be
-        ///    translated to/from the <see cref="Azure.Core.ContentType" /> type used by the <see cref="MessageWithMetadata" />
+        ///    translated to/from the <see cref="Azure.Core.ContentType" /> type used by the <see cref="BinaryContent" />
         ///    base class.
         /// </summary>
         ///
@@ -111,7 +111,7 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   Hidden property that shadows the <see cref="EventBody"/> property. This is added
-        ///   in order to inherit from <see cref="MessageWithMetadata"/>.
+        ///   in order to inherit from <see cref="BinaryContent"/>.
         /// </summary>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -123,7 +123,7 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   Hidden property that indicates that the <see cref="EventData"/> is not read-only. This is part of
-        ///   the <see cref="MessageWithMetadata"/> abstraction.
+        ///   the <see cref="BinaryContent"/> abstraction.
         /// </summary>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
@@ -80,10 +80,10 @@ Details on generating a class using the Apache Avro library can be found in the 
 
 In order to encode an `EventData` instance with Avro information, you can do the following:
 ```C# Snippet:SchemaRegistryAvroEncodeEventData
-var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
+var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
 
 var employee = new Employee { Age = 42, Name = "Caketown" };
-EventData eventData = (EventData) await encoder.EncodeMessageDataAsync(employee, messageType: typeof(EventData));
+EventData eventData = (EventData) await serializer.SerializeAsync(employee, messageType: typeof(EventData));
 
 // the schema Id will be included as a parameter of the content type
 Console.WriteLine(eventData.ContentType);
@@ -94,17 +94,17 @@ Console.WriteLine(eventData.EventBody);
 
 To decode an `EventData` event that you are consuming:
 ```C# Snippet:SchemaRegistryAvroDecodeEventData
-Employee deserialized = (Employee) await encoder.DecodeMessageDataAsync(eventData, typeof(Employee));
+Employee deserialized = (Employee) await serializer.DeserializeAsync(eventData, typeof(Employee));
 Console.WriteLine(deserialized.Age);
 Console.WriteLine(deserialized.Name);
 ```
 
 You can also use generic methods to encode and decode the data. This may be more convenient if you are not building a library on top of the Avro encoder, as you won't have to worry about the virality of generics:
 ```C# Snippet:SchemaRegistryAvroEncodeEventDataGenerics
-var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
+var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
 
 var employee = new Employee { Age = 42, Name = "Caketown" };
-EventData eventData = await encoder.EncodeMessageDataAsync<EventData, Employee>(employee);
+EventData eventData = await serializer.SerializeAsync<EventData, Employee>(employee);
 
 // the schema Id will be included as a parameter of the content type
 Console.WriteLine(eventData.ContentType);
@@ -115,7 +115,7 @@ Console.WriteLine(eventData.EventBody);
 
 Similarly, to decode:
 ```C# Snippet:SchemaRegistryAvroDecodeEventDataGenerics
-Employee deserialized = (Employee) await encoder.DecodeMessageDataAsync<Employee>(eventData);
+Employee deserialized = (Employee) await serializer.DeserializeAsync<Employee>(eventData);
 Console.WriteLine(deserialized.Age);
 Console.WriteLine(deserialized.Name);
 ```
@@ -123,11 +123,11 @@ Console.WriteLine(deserialized.Name);
 ### Encode and decode data using `MessageWithMetadata` directly
 
 It is also possible to encode and decode using `MessageWithMetadata`. Use this option if you are not integrating with any of the messaging libraries that work with `MessageWithMetadata`.
-```C# Snippet:SchemaRegistryAvroEncodeDecodeMessageWithMetadata
-var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
-MessageWithMetadata messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
+```C# Snippet:SchemaRegistryAvroEncodeDecodeBinaryContent
+var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
+BinaryContent content = await serializer.SerializeAsync<BinaryContent, Employee>(employee);
 
-Employee decodedEmployee = await encoder.DecodeMessageDataAsync<Employee>(messageData);
+Employee deserializedEmployee = await serializer.DeserializeAsync<Employee>(content);
 ```
 
 ## Troubleshooting

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/README.md
@@ -1,6 +1,6 @@
 # Azure Schema Registry Apache Avro client library for .NET
 
-Azure Schema Registry is a schema repository service hosted by Azure Event Hubs, providing schema storage, versioning, and management. This package provides an Avro encoder capable of encoding and decoding payloads containing Schema Registry schema identifiers and Avro-encoded data.
+Azure Schema Registry is a schema repository service hosted by Azure Event Hubs, providing schema storage, versioning, and management. This package provides an Avro serializer capable of serializing and deserializing payloads containing Schema Registry schema identifiers and Avro-serialized data.
 
 ## Getting started
 
@@ -50,17 +50,17 @@ var schemaRegistryClient = new SchemaRegistryClient(fullyQualifiedNamespace: ful
 
 ## Key concepts
 
-### Encoder
+### Serializer
 
-This library provides an encoder, [SchemaRegistryAvroEncoder]
-[schema_registry_avro_encoder], that interacts with `EventData` events. The SchemaRegistryAvroEncoder utilizes a SchemaRegistryClient to enrich the `EventData` events with the schema ID for the schema used to encode the data.
+This library provides a serializer, [SchemaRegistryAvroSerializer]
+[schema_registry_avro_serializer], that interacts with `EventData` events. The SchemaRegistryAvroSerializer utilizes a SchemaRegistryClient to enrich the `EventData` events with the schema ID for the schema used to serialize the data.
 
-This encoder requires the [Apache Avro library][apache_avro_library]. The payload types accepted by this encoder include [GenericRecord][generic_record] and [ISpecificRecord][specific_record].
+This serializer requires the [Apache Avro library][apache_avro_library]. The payload types accepted by this serializer include [GenericRecord][generic_record] and [ISpecificRecord][specific_record].
 
 
 ### Examples
 
-The following shows examples of what is available through the `SchemaRegistryAvroEncoder`. There are both sync and async methods available for these operations. These examples use a generated Apache Avro class [Employee.cs][employee] created using this schema:
+The following shows examples of what is available through the `SchemaRegistryAvroSerializer`. There are both sync and async methods available for these operations. These examples use a generated Apache Avro class [Employee.cs][employee] created using this schema:
 
 ```json
 {
@@ -76,9 +76,9 @@ The following shows examples of what is available through the `SchemaRegistryAvr
 
 Details on generating a class using the Apache Avro library can be found in the [Avro C# Documentation][avro_csharp_documentation].
 
-### Encode and decode data using the Event Hub EventData model
+### Serialize and deserialize data using the Event Hub EventData model
 
-In order to encode an `EventData` instance with Avro information, you can do the following:
+In order to serialize an `EventData` instance with Avro information, you can do the following:
 ```C# Snippet:SchemaRegistryAvroEncodeEventData
 var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
 
@@ -92,14 +92,14 @@ Console.WriteLine(eventData.ContentType);
 Console.WriteLine(eventData.EventBody);
 ```
 
-To decode an `EventData` event that you are consuming:
+To deserialize an `EventData` event that you are consuming:
 ```C# Snippet:SchemaRegistryAvroDecodeEventData
 Employee deserialized = (Employee) await serializer.DeserializeAsync(eventData, typeof(Employee));
 Console.WriteLine(deserialized.Age);
 Console.WriteLine(deserialized.Name);
 ```
 
-You can also use generic methods to encode and decode the data. This may be more convenient if you are not building a library on top of the Avro encoder, as you won't have to worry about the virality of generics:
+You can also use generic methods to serialize and deserialize the data. This may be more convenient if you are not building a library on top of the Avro serializer, as you won't have to worry about the virality of generics:
 ```C# Snippet:SchemaRegistryAvroEncodeEventDataGenerics
 var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
 
@@ -113,16 +113,16 @@ Console.WriteLine(eventData.ContentType);
 Console.WriteLine(eventData.EventBody);
 ```
 
-Similarly, to decode:
+Similarly, to deserialize:
 ```C# Snippet:SchemaRegistryAvroDecodeEventDataGenerics
-Employee deserialized = (Employee) await serializer.DeserializeAsync<Employee>(eventData);
+Employee deserialized = await serializer.DeserializeAsync<Employee>(eventData);
 Console.WriteLine(deserialized.Age);
 Console.WriteLine(deserialized.Name);
 ```
 
-### Encode and decode data using `MessageWithMetadata` directly
+### Serialize and deserialize data using `BinaryContent` directly
 
-It is also possible to encode and decode using `MessageWithMetadata`. Use this option if you are not integrating with any of the messaging libraries that work with `MessageWithMetadata`.
+It is also possible to serialize and deserialize using `BinaryContent`. Use this option if you are not integrating with any of the messaging libraries that work with `BinaryContent`.
 ```C# Snippet:SchemaRegistryAvroEncodeDecodeBinaryContent
 var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
 BinaryContent content = await serializer.SerializeAsync<BinaryContent, Employee>(employee);
@@ -162,7 +162,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [code_of_conduct_faq]: https://opensource.microsoft.com/codeofconduct/faq/
 [email_opencode]: mailto:opencode@microsoft.com
-[schema_registry_avro_encoder]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroEncoder.cs
+[schema_registry_avro_serializer]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroSerializer.cs
 [employee]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/Models/Employee.cs
 [avro_csharp_documentation]: https://avro.apache.org/docs/current/api/csharp/html/index.html
 [apache_avro_library]: https://www.nuget.org/packages/Apache.Avro/

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/api/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.netstandard2.0.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/api/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.netstandard2.0.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
         public TData Deserialize<TData>(Azure.BinaryContent content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public Azure.BinaryContent Serialize(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask<Azure.BinaryContent> SerializeAsync(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask<TBinaryContent> SerializeAsync<TBinaryContent, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TBinaryContent : Azure.BinaryContent, new() { throw null; }
-        public TBinaryContent Serialize<TBinaryContent, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TBinaryContent : Azure.BinaryContent, new() { throw null; }
+        public System.Threading.Tasks.ValueTask<TEnvelope> SerializeAsync<TEnvelope, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TEnvelope : Azure.BinaryContent, new() { throw null; }
+        public TEnvelope Serialize<TEnvelope, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TEnvelope : Azure.BinaryContent, new() { throw null; }
     }
     public partial class SchemaRegistryAvroSerializerOptions
     {

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/api/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.netstandard2.0.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/api/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.netstandard2.0.cs
@@ -1,20 +1,20 @@
 namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
 {
-    public partial class SchemaRegistryAvroEncoder
+    public partial class SchemaRegistryAvroSerializer
     {
-        public SchemaRegistryAvroEncoder(Azure.Data.SchemaRegistry.SchemaRegistryClient client, string groupName, Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.SchemaRegistryAvroEncoderOptions options = null) { }
-        public object DecodeMessageData(Azure.MessageWithMetadata message, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask<object> DecodeMessageDataAsync(Azure.MessageWithMetadata message, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask<TData> DecodeMessageDataAsync<TData>(Azure.MessageWithMetadata message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public TData DecodeMessageData<TData>(Azure.MessageWithMetadata message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public Azure.MessageWithMetadata EncodeMessageData(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask<Azure.MessageWithMetadata> EncodeMessageDataAsync(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask<TMessage> EncodeMessageDataAsync<TMessage, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.MessageWithMetadata, new() { throw null; }
-        public TMessage EncodeMessageData<TMessage, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TMessage : Azure.MessageWithMetadata, new() { throw null; }
+        public SchemaRegistryAvroSerializer(Azure.Data.SchemaRegistry.SchemaRegistryClient client, string groupName, Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.SchemaRegistryAvroSerializerOptions options = null) { }
+        public object Deserialize(Azure.BinaryContent content, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<object> DeserializeAsync(Azure.BinaryContent content, System.Type dataType, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<TData> DeserializeAsync<TData>(Azure.BinaryContent content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public TData Deserialize<TData>(Azure.BinaryContent content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public Azure.BinaryContent Serialize(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<Azure.BinaryContent> SerializeAsync(object data, System.Type dataType = null, System.Type messageType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public System.Threading.Tasks.ValueTask<TBinaryContent> SerializeAsync<TBinaryContent, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TBinaryContent : Azure.BinaryContent, new() { throw null; }
+        public TBinaryContent Serialize<TBinaryContent, TData>(TData data, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) where TBinaryContent : Azure.BinaryContent, new() { throw null; }
     }
-    public partial class SchemaRegistryAvroEncoderOptions
+    public partial class SchemaRegistryAvroSerializerOptions
     {
-        public SchemaRegistryAvroEncoderOptions() { }
+        public SchemaRegistryAvroSerializerOptions() { }
         public bool AutoRegisterSchemas { get { throw null; } set { } }
     }
 }

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.csproj
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Apache.Avro" />
     <PackageReference Include="Azure.Data.SchemaRegistry" />  
-    <PackageReference Include="Azure.Core.Experimental" />
+<!--    <PackageReference Include="Azure.Core.Experimental" />-->
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->
@@ -21,5 +21,8 @@
     <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)OperationHelpers.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroSerializer.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroSerializer.cs
@@ -62,12 +62,12 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <typeparam name="TBinaryContent">The <see cref="BinaryContent"/> type to encode the data into.</typeparam>
+        /// <typeparam name="TEnvelope">The <see cref="BinaryContent"/> type to encode the data into.</typeparam>
         /// <typeparam name="TData">The type of the data to encode.</typeparam>
-        public TBinaryContent Serialize<TBinaryContent, TData>(
+        public TEnvelope Serialize<TEnvelope, TData>(
             TData data,
-            CancellationToken cancellationToken = default) where TBinaryContent : BinaryContent, new()
-            => (TBinaryContent) SerializeInternalAsync(data, typeof(TData), typeof(TBinaryContent), false, cancellationToken).EnsureCompleted();
+            CancellationToken cancellationToken = default) where TEnvelope : BinaryContent, new()
+            => (TEnvelope) SerializeInternalAsync(data, typeof(TData), typeof(TEnvelope), false, cancellationToken).EnsureCompleted();
 
         /// <summary>
         /// Encodes the message data as Avro and stores it in <see cref="BinaryContent.Data"/>. The <see cref="BinaryContent.ContentType"/>
@@ -75,12 +75,12 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <typeparam name="TBinaryContent">The <see cref="BinaryContent"/> type to encode the data into.</typeparam>
+        /// <typeparam name="TEnvelope">The <see cref="BinaryContent"/> type to encode the data into.</typeparam>
         /// <typeparam name="TData">The type of the data to encode.</typeparam>
-        public async ValueTask<TBinaryContent> SerializeAsync<TBinaryContent, TData>(
+        public async ValueTask<TEnvelope> SerializeAsync<TEnvelope, TData>(
             TData data,
-            CancellationToken cancellationToken = default) where TBinaryContent : BinaryContent, new()
-            => (TBinaryContent) await SerializeInternalAsync(data, typeof(TData), typeof(TBinaryContent), true, cancellationToken).ConfigureAwait(false);
+            CancellationToken cancellationToken = default) where TEnvelope : BinaryContent, new()
+            => (TEnvelope) await SerializeInternalAsync(data, typeof(TData), typeof(TEnvelope), true, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Encodes the message data as Avro and stores it in <see cref="BinaryContent.Data"/>. The <see cref="BinaryContent.ContentType"/>

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroSerializer.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroSerializer.cs
@@ -19,22 +19,22 @@ using Azure.Core.Pipeline;
 namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
 {
     /// <summary>
-    /// A <see cref="SchemaRegistryAvroEncoder"/> uses the <see cref="SchemaRegistryClient"/> to
+    /// A <see cref="SchemaRegistryAvroSerializer"/> uses the <see cref="SchemaRegistryClient"/> to
     /// encode and decode Avro payloads.
     /// </summary>
-    public class SchemaRegistryAvroEncoder
+    public class SchemaRegistryAvroSerializer
     {
         private readonly SchemaRegistryClient _client;
         private readonly string _groupName;
-        private readonly SchemaRegistryAvroEncoderOptions _options;
+        private readonly SchemaRegistryAvroSerializerOptions _options;
         private const string AvroMimeType = "avro/binary";
         private const int CacheCapacity = 128;
         private static readonly Encoding Utf8Encoding = new UTF8Encoding(false);
 
         /// <summary>
-        /// Initializes new instance of <see cref="SchemaRegistryAvroEncoder"/>.
+        /// Initializes new instance of <see cref="SchemaRegistryAvroSerializer"/>.
         /// </summary>
-        public SchemaRegistryAvroEncoder(SchemaRegistryClient client, string groupName, SchemaRegistryAvroEncoderOptions options = null)
+        public SchemaRegistryAvroSerializer(SchemaRegistryClient client, string groupName, SchemaRegistryAvroSerializerOptions options = null)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _groupName = groupName ?? throw new ArgumentNullException(nameof(groupName));
@@ -54,71 +54,71 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
             GenericRecord
         }
 
-        #region Encode
+        #region Serialize
 
         /// <summary>
-        /// Encodes the message data as Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// Encodes the message data as Avro and stores it in <see cref="BinaryContent.Data"/>. The <see cref="BinaryContent.ContentType"/>
         /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <typeparam name="TMessage">The <see cref="MessageWithMetadata"/> type to encode the data into.</typeparam>
+        /// <typeparam name="TBinaryContent">The <see cref="BinaryContent"/> type to encode the data into.</typeparam>
         /// <typeparam name="TData">The type of the data to encode.</typeparam>
-        public TMessage EncodeMessageData<TMessage, TData>(
+        public TBinaryContent Serialize<TBinaryContent, TData>(
             TData data,
-            CancellationToken cancellationToken = default) where TMessage : MessageWithMetadata, new()
-            => (TMessage) EncodeMessageDataInternalAsync(data, typeof(TData), typeof(TMessage), false, cancellationToken).EnsureCompleted();
+            CancellationToken cancellationToken = default) where TBinaryContent : BinaryContent, new()
+            => (TBinaryContent) SerializeInternalAsync(data, typeof(TData), typeof(TBinaryContent), false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Encodes the message data as Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// Encodes the message data as Avro and stores it in <see cref="BinaryContent.Data"/>. The <see cref="BinaryContent.ContentType"/>
         /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        /// <typeparam name="TMessage">The <see cref="MessageWithMetadata"/> type to encode the data into.</typeparam>
+        /// <typeparam name="TBinaryContent">The <see cref="BinaryContent"/> type to encode the data into.</typeparam>
         /// <typeparam name="TData">The type of the data to encode.</typeparam>
-        public async ValueTask<TMessage> EncodeMessageDataAsync<TMessage, TData>(
+        public async ValueTask<TBinaryContent> SerializeAsync<TBinaryContent, TData>(
             TData data,
-            CancellationToken cancellationToken = default) where TMessage : MessageWithMetadata, new()
-            => (TMessage) await EncodeMessageDataInternalAsync(data, typeof(TData), typeof(TMessage), true, cancellationToken).ConfigureAwait(false);
+            CancellationToken cancellationToken = default) where TBinaryContent : BinaryContent, new()
+            => (TBinaryContent) await SerializeInternalAsync(data, typeof(TData), typeof(TBinaryContent), true, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
-        /// Encodes the message data as Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// Encodes the message data as Avro and stores it in <see cref="BinaryContent.Data"/>. The <see cref="BinaryContent.ContentType"/>
         /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
         /// <param name="dataType">The type of the data to encode. If left blank, the type will be determined at runtime by
         /// calling <see cref="Object.GetType"/>.</param>
-        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="MessageWithMetadata"/>, and
+        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="BinaryContent"/>, and
         /// have a parameterless constructor.
-        /// If left blank, the data will be encoded into a <see cref="MessageWithMetadata"/> instance.</param>
+        /// If left blank, the data will be encoded into a <see cref="BinaryContent"/> instance.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        public MessageWithMetadata EncodeMessageData(
+        public BinaryContent Serialize(
             object data,
             Type dataType = default,
             Type messageType = default,
             CancellationToken cancellationToken = default)
-            => EncodeMessageDataInternalAsync(data, dataType, messageType, false, cancellationToken).EnsureCompleted();
+            => SerializeInternalAsync(data, dataType, messageType, false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Encodes the message data as Avro and stores it in <see cref="MessageWithMetadata.Data"/>. The <see cref="MessageWithMetadata.ContentType"/>
+        /// Encodes the message data as Avro and stores it in <see cref="BinaryContent.Data"/>. The <see cref="BinaryContent.ContentType"/>
         /// will be set to "avro/binary+schemaId" where schemaId is the ID of the schema used to encode the data.
         /// </summary>
         /// <param name="data">The data to serialize to Avro and encode into the message.</param>
         /// <param name="dataType">The type of the data to encode. If left blank, the type will be determined at runtime by
         /// calling <see cref="Object.GetType"/>.</param>
-        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="MessageWithMetadata"/>, and
+        /// <param name="messageType">The type of message to encode the data into. Must extend from <see cref="BinaryContent"/>, and
         /// have a parameterless constructor.
-        /// If left blank, the data will be encoded into a <see cref="MessageWithMetadata"/> instance.</param>
+        /// If left blank, the data will be encoded into a <see cref="BinaryContent"/> instance.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        public async ValueTask<MessageWithMetadata> EncodeMessageDataAsync(
+        public async ValueTask<BinaryContent> SerializeAsync(
             object data,
             Type dataType = default,
             Type messageType = default,
             CancellationToken cancellationToken = default)
-            => await EncodeMessageDataInternalAsync(data, dataType, messageType, true, cancellationToken).ConfigureAwait(false);
+            => await SerializeInternalAsync(data, dataType, messageType, true, cancellationToken).ConfigureAwait(false);
 
-        internal async ValueTask<MessageWithMetadata> EncodeMessageDataInternalAsync(
+        internal async ValueTask<BinaryContent> SerializeInternalAsync(
             object data,
             Type dataType,
             Type messageType,
@@ -126,17 +126,17 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
             CancellationToken cancellationToken)
         {
             (string schemaId, BinaryData bd) = async
-                ? await EncodeInternalAsync(data, dataType, true, cancellationToken).ConfigureAwait(false)
-                : EncodeInternalAsync(data, dataType, false, cancellationToken).EnsureCompleted();
+                ? await SerializeInternalAsync(data, dataType, true, cancellationToken).ConfigureAwait(false)
+                : SerializeInternalAsync(data, dataType, false, cancellationToken).EnsureCompleted();
 
-            messageType ??= typeof(MessageWithMetadata);
-            var message = (MessageWithMetadata)Activator.CreateInstance(messageType);
+            messageType ??= typeof(BinaryContent);
+            var message = (BinaryContent)Activator.CreateInstance(messageType);
             message.Data = bd;
             message.ContentType = $"{AvroMimeType}+{schemaId}";
             return message;
         }
 
-        private async ValueTask<(string SchemaId, BinaryData Data)> EncodeInternalAsync(
+        private async ValueTask<(string SchemaId, BinaryData Data)> SerializeInternalAsync(
             object value,
             Type dataType,
             bool async,
@@ -231,62 +231,62 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
 
         #region Decode
         /// <summary>
-        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
+        /// Decodes the message data into the specified type using the schema information populated in <see cref="BinaryContent.ContentType"/>.
         /// </summary>
-        /// <param name="message">The message containing the data to decode.</param>
+        /// <param name="content">The message containing the data to decode.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <typeparam name="TData">The type to decode the message data into.</typeparam>
         /// <returns>The deserialized data.</returns>
         /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
         /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
-        public TData DecodeMessageData<TData>(
-            MessageWithMetadata message,
+        public TData Deserialize<TData>(
+            BinaryContent content,
             CancellationToken cancellationToken = default)
-            => (TData) DecodeMessageDataInternalAsync(message.Data, typeof(TData), message.ContentType, false, cancellationToken).EnsureCompleted();
+            => (TData) DecodeMessageDataInternalAsync(content.Data, typeof(TData), content.ContentType, false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
+        /// Decodes the message data into the specified type using the schema information populated in <see cref="BinaryContent.ContentType"/>.
         /// </summary>
-        /// <param name="message">The message containing the data to decode.</param>
+        /// <param name="content">The content to deserialize.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <typeparam name="TData">The type to decode the message data into.</typeparam>
         /// <returns>The deserialized data.</returns>
         /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
         /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
-        public async ValueTask<TData> DecodeMessageDataAsync<TData>(
-            MessageWithMetadata message,
+        public async ValueTask<TData> DeserializeAsync<TData>(
+            BinaryContent content,
             CancellationToken cancellationToken = default)
-            => (TData) await DecodeMessageDataInternalAsync(message.Data, typeof(TData), message.ContentType, true, cancellationToken).ConfigureAwait(false);
+            => (TData) await DecodeMessageDataInternalAsync(content.Data, typeof(TData), content.ContentType, true, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
-        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
+        /// Decodes the message data into the specified type using the schema information populated in <see cref="BinaryContent.ContentType"/>.
         /// </summary>
-        /// <param name="message">The message containing the data to decode.</param>
+        /// <param name="content">The message containing the data to decode.</param>
         /// <param name="dataType">The type to decode the message data into.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <returns>The deserialized data.</returns>
         /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
         /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
-        public object DecodeMessageData(
-            MessageWithMetadata message,
+        public object Deserialize(
+            BinaryContent content,
             Type dataType,
             CancellationToken cancellationToken = default)
-            => DecodeMessageDataInternalAsync(message.Data, dataType, message.ContentType, false, cancellationToken).EnsureCompleted();
+            => DecodeMessageDataInternalAsync(content.Data, dataType, content.ContentType, false, cancellationToken).EnsureCompleted();
 
         /// <summary>
-        /// Decodes the message data into the specified type using the schema information populated in <see cref="MessageWithMetadata.ContentType"/>.
+        /// Decodes the message data into the specified type using the schema information populated in <see cref="BinaryContent.ContentType"/>.
         /// </summary>
-        /// <param name="message">The message containing the data to decode.</param>
+        /// <param name="content">The message containing the data to decode.</param>
         /// <param name="dataType">The type to decode the message data into.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         /// <returns>The deserialized data.</returns>
         /// <exception cref="FormatException">Thrown if the content type is not in the expected format.</exception>
         /// <exception cref="InvalidOperationException">Thrown if an attempt is made to decode non-Avro data.</exception>
-        public async ValueTask<object> DecodeMessageDataAsync(
-            MessageWithMetadata message,
+        public async ValueTask<object> DeserializeAsync(
+            BinaryContent content,
             Type dataType,
             CancellationToken cancellationToken = default)
-            => await DecodeMessageDataInternalAsync(message.Data, dataType, message.ContentType, true, cancellationToken).ConfigureAwait(false);
+            => await DecodeMessageDataInternalAsync(content.Data, dataType, content.ContentType, true, cancellationToken).ConfigureAwait(false);
 
         private async ValueTask<object> DecodeMessageDataInternalAsync(
             BinaryData data,

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroSerializerOptions.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/src/SchemaRegistryAvroSerializerOptions.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro
 {
     /// <summary>
-    /// Options for <see cref="SchemaRegistryAvroEncoder"/>.
+    /// Options for <see cref="SchemaRegistryAvroSerializer"/>.
     /// </summary>
-    public class SchemaRegistryAvroEncoderOptions
+    public class SchemaRegistryAvroSerializerOptions
     {
         /// <summary>
         /// Gets or sets the automatic registration of schemas flag.

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
         }
 
         [RecordedTest]
-        public async Task CanUseserializerWithEventData()
+        public async Task CanUseEncoderWithEventData()
         {
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
         }
 
         [RecordedTest]
-        public async Task CanUseserializerWithEventDataUsingGenerics()
+        public async Task CanUseEncoderWithEventDataUsingGenerics()
         {
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             Assert.IsNotEmpty(contentType[1]);
 
             #region Snippet:SchemaRegistryAvroDecodeEventDataGenerics
-            Employee deserialized = (Employee) await serializer.DeserializeAsync<Employee>(eventData);
+            Employee deserialized = await serializer.DeserializeAsync<Employee>(eventData);
 #if SNIPPET
             Console.WriteLine(deserialized.Age);
             Console.WriteLine(deserialized.Name);

--- a/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
+++ b/sdk/schemaregistry/Microsoft.Azure.Data.SchemaRegistry.ApacheAvro/tests/SchemaRegistryAvroObjectSerializerLiveTests.cs
@@ -39,16 +39,16 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var employee = new Employee { Age = 42, Name = "Caketown" };
 
-            #region Snippet:SchemaRegistryAvroEncodeDecodeMessageWithMetadata
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
-            MessageWithMetadata messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
+            #region Snippet:SchemaRegistryAvroEncodeDecodeBinaryContent
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
+            BinaryContent content = await serializer.SerializeAsync<BinaryContent, Employee>(employee);
 
-            Employee decodedEmployee = await encoder.DecodeMessageDataAsync<Employee>(messageData);
+            Employee deserializedEmployee = await serializer.DeserializeAsync<Employee>(content);
             #endregion
 
-            Assert.IsNotNull(decodedEmployee);
-            Assert.AreEqual("Caketown", decodedEmployee.Name);
-            Assert.AreEqual(42, decodedEmployee.Age);
+            Assert.IsNotNull(deserializedEmployee);
+            Assert.AreEqual("Caketown", deserializedEmployee.Name);
+            Assert.AreEqual(42, deserializedEmployee.Age);
         }
 
         [RecordedTest]
@@ -58,19 +58,19 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var employee = new Employee_V2 { Age = 42, Name = "Caketown", City = "Redmond" };
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
-            var messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee_V2>(employee);
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
+            var content = await serializer.SerializeAsync<BinaryContent, Employee_V2>(employee);
 
             // deserialize using the old schema, which is forward compatible with the new schema
             // if you swap the old schema and the new schema in your mind, then this can also be thought as a backwards compatible test
-            var deserializedObject = await encoder.DecodeMessageDataAsync<Employee>(messageData);
+            var deserializedObject = await serializer.DeserializeAsync<Employee>(content);
             var readEmployee = deserializedObject as Employee;
             Assert.IsNotNull(readEmployee);
             Assert.AreEqual("Caketown", readEmployee.Name);
             Assert.AreEqual(42, readEmployee.Age);
 
             // deserialize using the new schema to make sure we are respecting it
-            var readEmployeeV2 = await encoder.DecodeMessageDataAsync<Employee_V2>(messageData);
+            var readEmployeeV2 = await serializer.DeserializeAsync<Employee_V2>(content);
             Assert.IsNotNull(readEmployee);
             Assert.AreEqual("Caketown", readEmployeeV2.Name);
             Assert.AreEqual(42, readEmployeeV2.Age);
@@ -84,12 +84,12 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var employee = new Employee() { Age = 42, Name = "Caketown"};
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
-            var messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, Employee>(employee);
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
+            var content = await serializer.SerializeAsync<BinaryContent, Employee>(employee);
 
             // deserialize with the new schema, which is NOT backward compatible with the old schema as it adds a new field
             Assert.That(
-                async () => await encoder.DecodeMessageDataAsync<Employee_V2>(messageData),
+                async () => await serializer.DeserializeAsync<Employee_V2>(content),
                 Throws.InstanceOf<AvroException>());
         }
 
@@ -102,10 +102,10 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             record.Add("Name", "Caketown");
             record.Add("Age", 42);
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
-            var messageData = await encoder.EncodeMessageDataAsync<MessageWithMetadata, GenericRecord>(record);
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
+            var content = await serializer.SerializeAsync<BinaryContent, GenericRecord>(record);
 
-            var deserializedObject = await encoder.DecodeMessageDataAsync<GenericRecord>(messageData);
+            var deserializedObject = await serializer.DeserializeAsync<GenericRecord>(content);
             var readRecord = deserializedObject as GenericRecord;
             Assert.IsNotNull(readRecord);
             Assert.AreEqual("Caketown", readRecord.GetValue(0));
@@ -119,8 +119,8 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var groupName = TestEnvironment.SchemaRegistryGroup;
             var timeZoneInfo = TimeZoneInfo.Utc;
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
-            Assert.ThrowsAsync<ArgumentException>(async () => await encoder.EncodeMessageDataAsync<MessageWithMetadata, TimeZoneInfo>(timeZoneInfo));
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
+            Assert.ThrowsAsync<ArgumentException>(async () => await serializer.SerializeAsync<BinaryContent, TimeZoneInfo>(timeZoneInfo));
             await Task.CompletedTask;
         }
 
@@ -130,13 +130,13 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
-            var messageData = new MessageWithMetadata
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
+            var content = new BinaryContent
             {
                 Data = new BinaryData(Array.Empty<byte>()),
                 ContentType = "avro/binary+234234"
             };
-            Assert.ThrowsAsync<ArgumentException>(async () => await encoder.DecodeMessageDataAsync<TimeZoneInfo>(messageData));
+            Assert.ThrowsAsync<ArgumentException>(async () => await serializer.DeserializeAsync<TimeZoneInfo>(content));
             await Task.CompletedTask;
         }
 
@@ -146,27 +146,27 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
-            var messageData = new MessageWithMetadata
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
+            var content = new BinaryContent
             {
                 Data = new BinaryData(Array.Empty<byte>()),
                 ContentType = null
             };
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await encoder.DecodeMessageDataAsync<TimeZoneInfo>(messageData));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await serializer.DeserializeAsync<TimeZoneInfo>(content));
             await Task.CompletedTask;
         }
 
         [RecordedTest]
-        public async Task CanUseEncoderWithEventData()
+        public async Task CanUseserializerWithEventData()
         {
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
             #region Snippet:SchemaRegistryAvroEncodeEventData
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
 
             var employee = new Employee { Age = 42, Name = "Caketown" };
-            EventData eventData = (EventData) await encoder.EncodeMessageDataAsync(employee, messageType: typeof(EventData));
+            EventData eventData = (EventData) await serializer.SerializeAsync(employee, messageType: typeof(EventData));
 
 #if SNIPPET
             // the schema Id will be included as a parameter of the content type
@@ -177,14 +177,14 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
 #endif
             #endregion
 
-            Assert.IsFalse(((MessageWithMetadata) eventData).IsReadOnly);
+            Assert.IsFalse(((BinaryContent) eventData).IsReadOnly);
             string[] contentType = eventData.ContentType.Split('+');
             Assert.AreEqual(2, contentType.Length);
             Assert.AreEqual("avro/binary", contentType[0]);
             Assert.IsNotEmpty(contentType[1]);
 
             #region Snippet:SchemaRegistryAvroDecodeEventData
-            Employee deserialized = (Employee) await encoder.DecodeMessageDataAsync(eventData, typeof(Employee));
+            Employee deserialized = (Employee) await serializer.DeserializeAsync(eventData, typeof(Employee));
 #if SNIPPET
             Console.WriteLine(deserialized.Age);
             Console.WriteLine(deserialized.Name);
@@ -204,16 +204,16 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
         }
 
         [RecordedTest]
-        public async Task CanUseEncoderWithEventDataUsingGenerics()
+        public async Task CanUseserializerWithEventDataUsingGenerics()
         {
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
             #region Snippet:SchemaRegistryAvroEncodeEventDataGenerics
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
 
             var employee = new Employee { Age = 42, Name = "Caketown" };
-            EventData eventData = await encoder.EncodeMessageDataAsync<EventData, Employee>(employee);
+            EventData eventData = await serializer.SerializeAsync<EventData, Employee>(employee);
 
 #if SNIPPET
             // the schema Id will be included as a parameter of the content type
@@ -224,14 +224,14 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
 #endif
             #endregion
 
-            Assert.IsFalse(((MessageWithMetadata) eventData).IsReadOnly);
+            Assert.IsFalse(((BinaryContent) eventData).IsReadOnly);
             string[] contentType = eventData.ContentType.Split('+');
             Assert.AreEqual(2, contentType.Length);
             Assert.AreEqual("avro/binary", contentType[0]);
             Assert.IsNotEmpty(contentType[1]);
 
             #region Snippet:SchemaRegistryAvroDecodeEventDataGenerics
-            Employee deserialized = (Employee) await encoder.DecodeMessageDataAsync<Employee>(eventData);
+            Employee deserialized = (Employee) await serializer.DeserializeAsync<Employee>(eventData);
 #if SNIPPET
             Console.WriteLine(deserialized.Age);
             Console.WriteLine(deserialized.Name);
@@ -256,10 +256,10 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             var client = CreateClient();
             var groupName = TestEnvironment.SchemaRegistryGroup;
 
-            var encoder = new SchemaRegistryAvroEncoder(client, groupName, new SchemaRegistryAvroEncoderOptions { AutoRegisterSchemas = true });
+            var serializer = new SchemaRegistryAvroSerializer(client, groupName, new SchemaRegistryAvroSerializerOptions { AutoRegisterSchemas = true });
 
             var employee = new Employee { Age = 42, Name = "Caketown" };
-            EventData eventData = await encoder.EncodeMessageDataAsync<EventData, Employee>(employee);
+            EventData eventData = await serializer.SerializeAsync<EventData, Employee>(employee);
             string schemaId = eventData.ContentType.Split('+')[1];
             eventData.ContentType = "avro/binary";
 
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Data.SchemaRegistry.ApacheAvro.Tests
             stream.Position = 0;
             eventData.EventBody = BinaryData.FromStream(stream);
 
-            Employee deserialized = await encoder.DecodeMessageDataAsync<Employee>(eventData);
+            Employee deserialized = await serializer.DeserializeAsync<Employee>(eventData);
 
             // decoding should not alter the message
             Assert.AreEqual("avro/binary", eventData.ContentType);


### PR DESCRIPTION
- MessageWithMetadata renamed to BinaryContent
- Encoder/Encode/Decode replaced with Serializer/Serialize/Deserialize - since we don't use "ObjectSerializer" we think this will be enough to differentiate from the abstraction.