### PR TITLE
[FormRecognizer] Ignoring Neural build mode test when running live

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
@@ -82,6 +82,11 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
         [RecordedTest]
         public async Task StartBuildModelWithNeuralBuildMode()
         {
+            if (Recording.Mode == RecordedTestMode.Live)
+            {
+                Assert.Ignore("https://github.com/Azure/azure-sdk-for-net/issues/27042");
+            }
+
             var client = CreateDocumentModelAdministrationClient();
             var trainingFilesUri = new Uri(TestEnvironment.BlobContainerSasUrl);
             var modelId = Recording.GenerateId();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/DocumentModelAdministrationClient/DocumentModelAdministrationClientLiveTests.cs
@@ -82,6 +82,10 @@ namespace Azure.AI.FormRecognizer.DocumentAnalysis.Tests
         [RecordedTest]
         public async Task StartBuildModelWithNeuralBuildMode()
         {
+            // Test takes too long to finish running, and seems to cause multiple failures in our
+            // live test pipeline. Until we find a way to run it without flakiness, this test will
+            // be ignored when running in Live mode.
+
             if (Recording.Mode == RecordedTestMode.Live)
             {
                 Assert.Ignore("https://github.com/Azure/azure-sdk-for-net/issues/27042");


### PR DESCRIPTION
The Form Recognizer pipeline is broken ([example here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1370664&view=results)). Not only timeouts, but issues when accessing the storage account with the training files required for building models also happen often ([example here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1361537&view=results)).

After some investigation, I figured out these issues started with the introduction of the `StartBuildModelWithNeuralBuildMode` test. It's a long-running test, so the timeouts were expected, but other failures weren't.

I'm skipping this test when running in Live mode for now (created https://github.com/azure/azure-sdk-for-net/issues/27042 for tracking). Playback still works, so I'm not completely ignoring it since there's value in keeping at least some validation.