### PR TITLE
Relax entity name validation for the case of a pre-formatted subscription path

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -691,7 +691,7 @@ namespace Azure.Messaging.ServiceBus
                 return;
             }
 
-            // If the entity name is specified in both the connection string,
+            // If the entity name is specified in the connection string,
             // validate that it is the same as the passed in entity name.
 
             if (string.Equals(entityName, Connection.EntityPath, StringComparison.InvariantCultureIgnoreCase))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
@@ -406,6 +406,37 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
             Assert.IsFalse(client.IsClosed);
         }
 
+        [Test]
+        [TestCase("queue1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=queue1")]
+        [TestCase("queue1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];")]
+        [TestCase("topic1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];")]
+        [TestCase("topic1/Subscriptions/sub1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];")]
+        [TestCase("topic1/Subscriptions/sub1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic1")]
+        [TestCase("topic1/Subscriptions/sub1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic1/Subscriptions/sub1")]
+        public void ValidateEntityNameAllowsValidPaths(string entityName, string connectionString)
+        {
+            var client = new ServiceBusClient(connectionString);
+            client.ValidateEntityName(entityName);
+        }
+
+        [Test]
+        [TestCase("queue1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=queue2")]
+        [TestCase("topic1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic2")]
+        [TestCase("topic1/Subscriptions", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic1")]
+        [TestCase("topic1/Subscriptions/", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic1")]
+        [TestCase("/Subscriptions/sub1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=sub1")]
+        [TestCase("topic1/Subscriptions/sub1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic1/Subscriptions")]
+        [TestCase("topic1/Subscriptions/sub1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic2")]
+        [TestCase("topic1/Subscriptions/sub1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic1/Subscriptions/sub2")]
+        [TestCase("topic1/Subscriptions/sub1", "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=topic2/Subscriptions/sub1")]
+        public void ValidateEntityNameThrowsForInvalidPaths(string entityName, string connectionString)
+        {
+            var client = new ServiceBusClient(connectionString);
+            Assert.That(
+                () => client.ValidateEntityName(entityName),
+                Throws.InstanceOf<ArgumentException>());
+        }
+
         /// <summary>
         ///   Allows for the options used by the client to be exposed for testing purposes.
         /// </summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Client/ServiceBusClientTests.cs
@@ -416,7 +416,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Client
         public void ValidateEntityNameAllowsValidPaths(string entityName, string connectionString)
         {
             var client = new ServiceBusClient(connectionString);
-            client.ValidateEntityName(entityName);
+            Assert.That(
+                () => client.ValidateEntityName(entityName),
+                Throws.Nothing);
         }
 
         [Test]


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/26837