### PR TITLE
ServiceBus EventSource remove allocations and boxing

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -11,6 +11,7 @@
       <!-- TODO: Investigate and remove suppressions https://github.com/Azure/azure-sdk-for-net/issues/17154 -->
       $(NoWarn);CA2213
     </NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -1075,7 +1075,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 eventPayload[2].DataPointer = (IntPtr)receiveLinkStatePtr;
 
                 // bool maps to "win:Boolean", a 4-byte boolean
-                var isSessionReceiverInt = isSessionReceiver ? bool.True : bool.False;
+                var isSessionReceiverInt = isSessionReceiver ? 1 : 0;
                 eventPayload[3].Size = Unsafe.SizeOf<int>();
                 eventPayload[3].DataPointer = (IntPtr)Unsafe.AsPointer(ref isSessionReceiverInt);
 
@@ -1614,7 +1614,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 eventPayload[1].DataPointer = (IntPtr)amqpTransactionIdPtr;
 
                 // bool maps to "win:Boolean", a 4-byte boolean
-                var rollbackInt = rollback ? bool.True : bool.False;
+                var rollbackInt = rollback ? 1 : 0;
                 eventPayload[2].Size = Unsafe.SizeOf<int>();
                 eventPayload[2].DataPointer = (IntPtr)Unsafe.AsPointer(ref rollbackInt);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -1074,6 +1074,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 eventPayload[2].Size = (receiveLinkState.Length + 1) * sizeof(char);
                 eventPayload[2].DataPointer = (IntPtr)receiveLinkStatePtr;
 
+                // bool maps to "win:Boolean", a 4-byte boolean
                 var isSessionReceiverInt = isSessionReceiver ? bool.True : bool.False;
                 eventPayload[3].Size = Unsafe.SizeOf<int>();
                 eventPayload[3].DataPointer = (IntPtr)Unsafe.AsPointer(ref isSessionReceiverInt);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Azure.Core.Diagnostics;
 using Azure.Messaging.ServiceBus.Amqp;
@@ -334,7 +335,28 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         {
             if (IsEnabled())
             {
-                WriteEvent(PeekMessageStartEvent, identifier, sequenceNumber, messageCount);
+                PeekMessageStartCore(PeekMessageStartEvent, identifier, sequenceNumber, messageCount);
+            }
+        }
+
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void PeekMessageStartCore(int eventId, string identifier, long? sequenceNumber, int messageCount)
+        {
+            fixed (char* identifierPtr = identifier)
+            {
+                var eventPayload = stackalloc EventData[3];
+
+                eventPayload[0].Size = (identifier.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)identifierPtr;
+
+                eventPayload[1].Size = Unsafe.SizeOf<long?>();
+                eventPayload[1].DataPointer = (IntPtr)Unsafe.AsPointer(ref sequenceNumber);
+
+                eventPayload[2].Size = Unsafe.SizeOf<int>();
+                eventPayload[2].DataPointer = (IntPtr)Unsafe.AsPointer(ref messageCount);
+
+                WriteEventCore(eventId, 3, eventPayload);
             }
         }
 
@@ -864,11 +886,30 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         }
 
         [Event(ProcessorMessageHandlerExceptionEvent, Level = EventLevel.Error, Message = "{0}: User message handler complete: Message: SequenceNumber: {1}, Exception: {2}, LockToken: {3}")]
-        private void ProcessorMessageHandlerExceptionCore(string identifier, long sequenceNumber, string exception, string lockToken)
+        private unsafe void ProcessorMessageHandlerExceptionCore(string identifier, long sequenceNumber, string exception, string lockToken)
         {
             if (IsEnabled())
             {
-                WriteEvent(ProcessorMessageHandlerExceptionEvent, identifier, sequenceNumber, exception, lockToken);
+                fixed (char* identifierPtr = identifier)
+                fixed (char* exceptionPtr = exception)
+                fixed (char* lockTokenPtr = lockToken)
+                {
+                    var eventPayload = stackalloc EventData[4];
+
+                    eventPayload[0].Size = (identifier.Length + 1) * sizeof(char);
+                    eventPayload[0].DataPointer = (IntPtr)identifierPtr;
+
+                    eventPayload[1].Size = Unsafe.SizeOf<long>();
+                    eventPayload[1].DataPointer = (IntPtr)Unsafe.AsPointer(ref sequenceNumber);
+
+                    eventPayload[2].Size = (exception.Length + 1) * sizeof(char);
+                    eventPayload[2].DataPointer = (IntPtr)exceptionPtr;
+
+                    eventPayload[3].Size = (lockToken.Length + 1) * sizeof(char);
+                    eventPayload[3].DataPointer = (IntPtr)lockTokenPtr;
+
+                    WriteEventCore(ProcessorMessageHandlerExceptionEvent, 4, eventPayload);
+                }
             }
         }
 
@@ -1002,7 +1043,37 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         {
             if (IsEnabled())
             {
-                WriteEvent(LinkStateLostEvent, identifier, receiveLinkName, receiveLinkState, isSessionReceiver, exception);
+                LinkStateLostCore(LinkStateLostEvent, identifier, receiveLinkName, receiveLinkState, isSessionReceiver, exception);
+            }
+        }
+
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void LinkStateLostCore(int eventId, string identifier, string receiveLinkName, string receiveLinkState, bool isSessionReceiver, string exception)
+        {
+            fixed (char* identifierPtr = identifier)
+            fixed (char* receiveLinkNamePtr = receiveLinkName)
+            fixed (char* receiveLinkStatePtr = receiveLinkState)
+            fixed (char* exceptionPtr = exception)
+            {
+                var eventPayload = stackalloc EventData[5];
+
+                eventPayload[0].Size = (identifier.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)identifierPtr;
+
+                eventPayload[1].Size = (receiveLinkName.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)receiveLinkNamePtr;
+
+                eventPayload[2].Size = (receiveLinkState.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)receiveLinkStatePtr;
+
+                eventPayload[3].Size = Unsafe.SizeOf<bool>();
+                eventPayload[3].DataPointer = (IntPtr)Unsafe.AsPointer(ref isSessionReceiver);
+
+                eventPayload[4].Size = (exception.Length + 1) * sizeof(char);
+                eventPayload[4].DataPointer = (IntPtr)exceptionPtr;
+
+                WriteEventCore(eventId, 5, eventPayload);
             }
         }
 
@@ -1509,7 +1580,29 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         [Event(TransactionDischargedEvent, Level = EventLevel.Informational, Message = "AmqpTransactionDischarged for LocalTransactionId: {0} AmqpTransactionId: {1} Rollback: {2}.")]
         public void TransactionDischarged(string transactionId, string amqpTransactionId, bool rollback)
         {
-            WriteEvent(TransactionDischargedEvent, transactionId, amqpTransactionId, rollback);
+            TransactionDischargedCore(TransactionDischargedEvent, transactionId, amqpTransactionId, rollback);
+        }
+
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void TransactionDischargedCore(int eventId, string transactionId, string amqpTransactionId, bool rollback)
+        {
+            fixed (char* transactionIdPtr = transactionId)
+            fixed (char* amqpTransactionIdPtr = amqpTransactionId)
+            {
+                var eventPayload = stackalloc EventData[3];
+
+                eventPayload[0].Size = (transactionId.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)transactionIdPtr;
+
+                eventPayload[1].Size = (amqpTransactionId.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)amqpTransactionIdPtr;
+
+                eventPayload[2].Size = Unsafe.SizeOf<bool>();
+                eventPayload[2].DataPointer = (IntPtr)Unsafe.AsPointer(ref rollback);
+
+                WriteEventCore(eventId, 3, eventPayload);
+            }
         }
 
         [NonEvent]
@@ -1571,5 +1664,103 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             }
         }
         #endregion
+
+        /// <summary>
+        /// Writes an event with two string arguments and one int argument into a stack allocated
+        /// <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation and boxing
+        /// on the WriteEvent methods.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="arg1">The first argument.</param>
+        /// <param name="arg2">The second argument.</param>
+        /// <param name="arg3">The third argument.</param>
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void WriteEvent(int eventId, string arg1, int arg2, string arg3)
+        {
+            fixed (char* arg1Ptr = arg1)
+            fixed (char* arg3Ptr = arg3)
+            {
+                var eventPayload = stackalloc EventData[3];
+
+                eventPayload[0].Size = (arg1.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)arg1Ptr;
+
+                eventPayload[1].Size = Unsafe.SizeOf<int>();
+                eventPayload[1].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg2);
+
+                eventPayload[2].Size = (arg3.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)arg3Ptr;
+
+                WriteEventCore(eventId, 3, eventPayload);
+            }
+        }
+
+        /// <summary>
+        /// Writes an event with two string arguments and one long argument into a stack allocated
+        /// <see cref="EventSource.EventData"/> struct to avoid the parameter array allocation and boxing
+        /// on the WriteEvent methods.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="arg1">The first argument.</param>
+        /// <param name="arg2">The second argument.</param>
+        /// <param name="arg3">The third argument.</param>
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void WriteEvent(int eventId, string arg1, long arg2, string arg3)
+        {
+            fixed (char* arg1Ptr = arg1)
+            fixed (char* arg3Ptr = arg3)
+            {
+                var eventPayload = stackalloc EventData[3];
+
+                eventPayload[0].Size = (arg1.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)arg1Ptr;
+
+                eventPayload[1].Size = Unsafe.SizeOf<long>();
+                eventPayload[1].DataPointer = (IntPtr)Unsafe.AsPointer(ref arg2);
+
+                eventPayload[2].Size = (arg3.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)arg3Ptr;
+
+                WriteEventCore(eventId, 3, eventPayload);
+            }
+        }
+
+        /// <summary>
+        /// Writes an event with four string arguments into a stack allocated <see cref="EventSource.EventData"/> struct to avoid
+        /// the parameter array allocation on the WriteEvent methods.
+        /// </summary>
+        /// <param name="eventId">The event identifier.</param>
+        /// <param name="arg1">The first argument.</param>
+        /// <param name="arg2">The second argument.</param>
+        /// <param name="arg3">The third argument.</param>
+        /// <param name="arg4">The fourth argument.</param>
+        [NonEvent]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void WriteEvent(int eventId, string arg1, string arg2, string arg3, string arg4)
+        {
+            fixed (char* arg1Ptr = arg1)
+            fixed (char* arg2Ptr = arg2)
+            fixed (char* arg3Ptr = arg3)
+            fixed (char* arg4Ptr = arg4)
+            {
+                var eventPayload = stackalloc EventData[4];
+
+                eventPayload[0].Size = (arg1.Length + 1) * sizeof(char);
+                eventPayload[0].DataPointer = (IntPtr)arg1Ptr;
+
+                eventPayload[1].Size = (arg2.Length + 1) * sizeof(char);
+                eventPayload[1].DataPointer = (IntPtr)arg2Ptr;
+
+                eventPayload[2].Size = (arg3.Length + 1) * sizeof(char);
+                eventPayload[2].DataPointer = (IntPtr)arg3Ptr;
+
+                eventPayload[3].Size = (arg4.Length + 1) * sizeof(char);
+                eventPayload[3].DataPointer = (IntPtr)arg4Ptr;
+
+                WriteEventCore(eventId, 4, eventPayload);
+            }
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -1074,8 +1074,9 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 eventPayload[2].Size = (receiveLinkState.Length + 1) * sizeof(char);
                 eventPayload[2].DataPointer = (IntPtr)receiveLinkStatePtr;
 
-                eventPayload[3].Size = Unsafe.SizeOf<bool>();
-                eventPayload[3].DataPointer = (IntPtr)Unsafe.AsPointer(ref isSessionReceiver);
+                var isSessionReceiverInt = isSessionReceiver ? bool.True : bool.False;
+                eventPayload[3].Size = Unsafe.SizeOf<int>();
+                eventPayload[3].DataPointer = (IntPtr)Unsafe.AsPointer(ref isSessionReceiverInt);
 
                 eventPayload[4].Size = (exception.Length + 1) * sizeof(char);
                 eventPayload[4].DataPointer = (IntPtr)exceptionPtr;
@@ -1612,7 +1613,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 eventPayload[1].DataPointer = (IntPtr)amqpTransactionIdPtr;
 
                 // bool maps to "win:Boolean", a 4-byte boolean
-                var rollbackInt = Convert.ToInt32(rollback);
+                var rollbackInt = rollback ? bool.True : bool.False;
                 eventPayload[2].Size = Unsafe.SizeOf<int>();
                 eventPayload[2].DataPointer = (IntPtr)Unsafe.AsPointer(ref rollbackInt);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -1565,7 +1565,10 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         [Event(TransactionDeclaredEvent, Level = EventLevel.Informational, Message = "AmqpTransactionDeclared for LocalTransactionId: {0} AmqpTransactionId: {1}.")]
         public void TransactionDeclared(string transactionId, string amqpTransactionId)
         {
-            WriteEvent(TransactionDeclaredEvent, transactionId, amqpTransactionId);
+            if (IsEnabled())
+            {
+                WriteEvent(TransactionDeclaredEvent, transactionId, amqpTransactionId);
+            }
         }
 
         [NonEvent]
@@ -1580,7 +1583,10 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         [Event(TransactionDischargedEvent, Level = EventLevel.Informational, Message = "AmqpTransactionDischarged for LocalTransactionId: {0} AmqpTransactionId: {1} Rollback: {2}.")]
         public void TransactionDischarged(string transactionId, string amqpTransactionId, bool rollback)
         {
-            TransactionDischargedCore(TransactionDischargedEvent, transactionId, amqpTransactionId, rollback);
+            if (IsEnabled())
+            {
+                TransactionDischargedCore(TransactionDischargedEvent, transactionId, amqpTransactionId, rollback);
+            }
         }
 
         [NonEvent]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -1611,8 +1611,10 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 eventPayload[1].Size = (amqpTransactionId.Length + 1) * sizeof(char);
                 eventPayload[1].DataPointer = (IntPtr)amqpTransactionIdPtr;
 
-                eventPayload[2].Size = Unsafe.SizeOf<bool>();
-                eventPayload[2].DataPointer = (IntPtr)Unsafe.AsPointer(ref rollback);
+                // bool maps to "win:Boolean", a 4-byte boolean
+                var rollbackInt = Convert.ToInt32(rollback);
+                eventPayload[2].Size = Unsafe.SizeOf<int>();
+                eventPayload[2].DataPointer = (IntPtr)Unsafe.AsPointer(ref rollbackInt);
 
                 WriteEventCore(eventId, 3, eventPayload);
             }


### PR DESCRIPTION
Similar to https://github.com/Azure/azure-sdk-for-net/pull/26989 but for ServiceBus to make @JoshLove-msft a happy person too.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
