### PR TITLE
[Communication] - PhoneNumbers - Require phone number pool in livetests

### DIFF
--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationTestEnvironment.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationTestEnvironment.cs
@@ -31,7 +31,7 @@ namespace Azure.Communication.Tests
 
         public string LiveTestStaticAccessKey => Core.ConnectionString.Parse(LiveTestStaticConnectionString).GetRequired("accesskey");
 
-        public string CommunicationTestPhoneNumber => GetPhoneNumberByTestAgent() ?? GetRecordedVariable(AzurePhoneNumber, options => options.IsSecret("+14255550123"));
+        public string DefaultTestPhoneNumber => GetRecordedVariable(AzurePhoneNumber, options => options.IsSecret("+14255550123"));
 
         public string SkipSmsTest => GetOptionalVariable(SkipIntSmsTestEnvironmentVariableName) ?? "False";
 
@@ -41,14 +41,8 @@ namespace Azure.Communication.Tests
 
         public bool ShouldIgnorePhoneNumbersTests => bool.Parse(SkipPhoneNumbersTest);
 
-        public string AzureTestAgent => GetOptionalVariable(AzureTestAgentVariableName);
-
-        private string? GetPhoneNumberByTestAgent()
-        {
-            if (AzureTestAgent == null)
-                return null;
-
-            return GetRecordedOptionalVariable($"{AzurePhoneNumber}_{AzureTestAgent}", options => options.IsSecret("+14255550123"));
-        }
+        public string TestAgentPhoneNumber => GetRecordedVariable($"{AzurePhoneNumber}_{AzureTestAgent}", options => options.IsSecret("+14255550123"));
+        
+        private string AzureTestAgent => GetVariable(AzureTestAgentVariableName);
     }
 }

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationTestEnvironment.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationTestEnvironment.cs
@@ -42,7 +42,7 @@ namespace Azure.Communication.Tests
         public bool ShouldIgnorePhoneNumbersTests => bool.Parse(SkipPhoneNumbersTest);
 
         public string TestAgentPhoneNumber => GetRecordedVariable($"{AzurePhoneNumber}_{AzureTestAgent}", options => options.IsSecret("+14255550123"));
-        
+
         private string AzureTestAgent => GetVariable(AzureTestAgentVariableName);
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/phone-numbers-livetest-matrix.json
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/phone-numbers-livetest-matrix.json
@@ -36,24 +36,21 @@
                 "OSVmImage": "macOS-10.15",
                 "Pool": "Azure Pipelines",
                 "TestTargetFramework": "netcoreapp3.1",
-                "AZURE_PHONE_NUMBER_ID": "2",
-                "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "FALSE"
+                "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "TRUE"
             },
             "macOS-10.15_NET6.0": {
                 "OSVmImage": "macOS-10.15",
                 "Pool": "Azure Pipelines",
                 "TestTargetFramework": "net6.0",
-                "AZURE_TEST_AGENT": "macos_1015_net60"
+                "AZURE_TEST_AGENT": "macos_1015_net60",
+                "SKIP_UPDATE_CAPABILITIES_LIVE_TESTS": "FALSE"
             }
         },
         "AdditionalTestArguments": [
             "/p:UseProjectReferenceToAzureClients=false",
             "/p:UseProjectReferenceToAzureClients=true"
         ],
-        "BuildConfiguration": [
-            "Debug",
-            "Release"
-        ]
+        "BuildConfiguration": ["Debug", "Release"]
     },
     "include": [
         {

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/Infrastructure/PhoneNumbersClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/Infrastructure/PhoneNumbersClientLiveTestBase.cs
@@ -89,7 +89,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             if (TestEnvironment.Mode == RecordedTestMode.Playback)
                 return RecordedTestSanitizer.SanitizeValue;
 
-            if (!SkipPhoneNumberLiveTests)
+            if (!SkipUpdateCapabilitiesLiveTest)
                 return TestEnvironment.TestAgentPhoneNumber;
 
             return TestEnvironment.DefaultTestPhoneNumber;

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/Infrastructure/PhoneNumbersClientLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/Infrastructure/PhoneNumbersClientLiveTestBase.cs
@@ -86,9 +86,13 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
         protected string GetTestPhoneNumber()
         {
-            return TestEnvironment.Mode == RecordedTestMode.Playback
-                ? RecordedTestSanitizer.SanitizeValue
-                : TestEnvironment.CommunicationTestPhoneNumber;
+            if (TestEnvironment.Mode == RecordedTestMode.Playback)
+                return RecordedTestSanitizer.SanitizeValue;
+
+            if (!SkipPhoneNumberLiveTests)
+                return TestEnvironment.TestAgentPhoneNumber;
+
+            return TestEnvironment.DefaultTestPhoneNumber;
         }
 
         protected void SleepIfNotInPlaybackMode()


### PR DESCRIPTION
This makes the test phone numbers pool required when running the update capabilities livetests. Additionally, this fixes the configuration for the job matrix.

**NOTE: If either the `AZURE_TEST_AGENT` or `AZURE_PHONE_NUMBER_<AZURE_TEST_AGENT>` are not present when running live tests and `SKIP_UPDATE_CAPABILITIES_LIVE_TESTS=FALSE`, then the test run will fail. In any other scenario, the `AZURE_PHONE_NUMBER` will be used.**