### PR TITLE
Azure Monitor Exporter - Small refactor in HttpHelper

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/RemoteDependencyData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/RemoteDependencyData.cs
@@ -38,6 +38,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             {
                 case PartBType.Http:
                     Data = httpUrl;
+                    // TODO: AzMonList is parsed for second time to get the same details as in httpUrl.
+                    // Change this to read once and remove default port check.
                     Target = monitorTags.PartBTags.GetDependencyTarget(PartBType.Http);
                     Type = "Http";
                     ResultCode = AzMonList.GetTagValue(ref monitorTags.PartBTags, SemanticConventions.AttributeHttpStatusCode)?.ToString() ?? "0";


### PR DESCRIPTION
* `UriBuilder` has the ability to remove default port number from `Uri`