### PR TITLE
Azure Monitor Exporter - Update TagObjectsGetValuesBenchmarks

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzMonList.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzMonList.cs
@@ -68,7 +68,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             for (int i = 0; i < length; i++)
             {
-                if (list[i].Key == tagName)
+                if (ReferenceEquals(list[i].Key, tagName))
                 {
                     return list[i].Value;
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsGetValuesBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsGetValuesBenchmarks.cs
@@ -2,21 +2,35 @@
 // Licensed under the MIT License.
 
 using BenchmarkDotNet.Attributes;
-using OpenTelemetry.Trace;
 using System.Collections.Generic;
 using System.Diagnostics;
+
+/*
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
+.NET SDK=6.0.102
+  [Host]     : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT
+  DefaultJob : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT
+
+
+|                        Method |      Mean |     Error |    StdDev |    Median | Allocated |
+|------------------------------ |----------:|----------:|----------:|----------:|----------:|
+|    GetTagValueEmptyTagObjects |  5.762 ns | 0.1512 ns | 0.4412 ns |  5.650 ns |         - |
+| GetTagValueNonemptyTagObjects | 14.824 ns | 0.3339 ns | 0.8796 ns | 14.521 ns |         - |
+|     GetTagValueEmptyAzMonList |  1.909 ns | 0.0737 ns | 0.1618 ns |  1.901 ns |         - |
+|  GetTagValueNonemptyAzMonList |  9.269 ns | 0.2202 ns | 0.4833 ns |  9.220 ns |         - |
+*/
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
 {
     [MemoryDiagnoser]
     public class TagObjectsGetValuesBenchmarks
     {
-        private AzMonList AzMonList_No_Item;
-        private AzMonList AzMonList_Items;
-        private IEnumerable<KeyValuePair<string, object>> TagObjects_No_Item;
-        private IEnumerable<KeyValuePair<string, object>> TagObjects_Items;
-        private Activity ItemActivity;
-        private Activity EmptyActivity;
+        private AzMonList _azMonList_No_Item;
+        private AzMonList _azMonList_Items;
+        private IEnumerable<KeyValuePair<string, object>> _tagObjects_No_Item;
+        private IEnumerable<KeyValuePair<string, object>> _tagObjects_Items;
+        private Activity _itemActivity;
 
         static TagObjectsGetValuesBenchmarks()
         {
@@ -35,21 +49,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            AzMonList_No_Item = AzMonList.Initialize();
-            TagObjects_No_Item = new Dictionary<string, object>();
+            _azMonList_No_Item = AzMonList.Initialize();
+            _tagObjects_No_Item = new Dictionary<string, object>();
 
-            AzMonList_Items = AzMonList.Initialize();
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>("intKey", 1));
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>("doubleKey", 1.1));
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "https"));
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>("stringKey", "test"));
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "localhost"));
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>("boolKey", true));
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHostPort, "8888"));
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>("arrayKey", new int[] { 1, 2, 3 }));
-           AzMonList.Add(ref AzMonList_Items, new KeyValuePair<string, object>("somekey", "value"));
+            _azMonList_Items = AzMonList.Initialize();
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("intKey", 1));
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("doubleKey", 1.1));
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "https"));
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("stringKey", "test"));
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "localhost"));
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("boolKey", true));
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHostPort, "8888"));
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("arrayKey", new int[] { 1, 2, 3 }));
+           AzMonList.Add(ref _azMonList_Items, new KeyValuePair<string, object>("somekey", "value"));
 
-            TagObjects_Items = new Dictionary<string, object>
+            _tagObjects_Items = new Dictionary<string, object>
             {
                 ["intKey"] = 1,
                 ["doubleKey"] = 1.1,
@@ -63,42 +77,40 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
             };
 
             using var activitySource = new ActivitySource("test");
-            this.ItemActivity = activitySource.StartActivity("WithTags");
-            this.ItemActivity.AddTag("intKey", 1);
-            this.ItemActivity.AddTag("doubleKey", 1.1);
-            this.ItemActivity.AddTag(SemanticConventions.AttributeHttpScheme, "https");
-            this.ItemActivity.AddTag("stringKey", "test");
-            this.ItemActivity.AddTag(SemanticConventions.AttributeHttpHost, "localhost");
-            this.ItemActivity.AddTag("boolKey", true);
-            this.ItemActivity.AddTag(SemanticConventions.AttributeHttpHostPort, "8888");
-            this.ItemActivity.AddTag("arrayKey", new int[] { 1, 2, 3 });
-            this.ItemActivity.AddTag("somekey", "value");
-
-            this.EmptyActivity = activitySource.StartActivity("NoTags");
+            _itemActivity = activitySource.StartActivity("WithTags");
+            _itemActivity.AddTag("intKey", 1);
+            _itemActivity.AddTag("doubleKey", 1.1);
+            _itemActivity.AddTag(SemanticConventions.AttributeHttpScheme, "https");
+            _itemActivity.AddTag("stringKey", "test");
+            _itemActivity.AddTag(SemanticConventions.AttributeHttpHost, "localhost");
+            _itemActivity.AddTag("boolKey", true);
+            _itemActivity.AddTag(SemanticConventions.AttributeHttpHostPort, "8888");
+            _itemActivity.AddTag("arrayKey", new int[] { 1, 2, 3 });
+            _itemActivity.AddTag("somekey", "value");
         }
 
         [Benchmark]
         public void GetTagValueEmptyTagObjects()
         {
-            (TagObjects_No_Item as Dictionary<string, object>).TryGetValue(SemanticConventions.AttributeHttpHost, out _);
+            (_tagObjects_No_Item as Dictionary<string, object>).TryGetValue(SemanticConventions.AttributeHttpHost, out _);
         }
 
         [Benchmark]
         public void GetTagValueNonemptyTagObjects()
         {
-            (TagObjects_Items as Dictionary<string, object>).TryGetValue(SemanticConventions.AttributeHttpHost, out _);
+            (_tagObjects_Items as Dictionary<string, object>).TryGetValue("somekey", out _);
         }
 
         [Benchmark]
         public void GetTagValueEmptyAzMonList()
         {
-            object _ = AzMonList.GetTagValue(ref AzMonList_No_Item, SemanticConventions.AttributeHttpHost);
+            AzMonList.GetTagValue(ref _azMonList_No_Item, SemanticConventions.AttributeHttpHost);
         }
 
         [Benchmark]
         public void GetTagValueNonemptyAzMonList()
         {
-            object _ = AzMonList.GetTagValue(ref AzMonList_Items, SemanticConventions.AttributeHttpHost);
+            AzMonList.GetTagValue(ref _azMonList_Items, "somekey");
         }
     }
 }


### PR DESCRIPTION
* `ReferenceEquals` in AzMonList.GetValue increased performance factor for non-empty list.
* Modified benchmark for Non-Empty list to check the last item.

**Current Implementation**
|                        Method |      Mean |     Error |    StdDev |    Median | Allocated |
|------------------------------ |----------:|----------:|----------:|----------:|----------:|
|    GetTagValueEmptyTagObjects |  5.360 ns | 0.4369 ns | 1.2606 ns |  4.978 ns |         - |
| GetTagValueNonemptyTagObjects | 19.127 ns | 0.4384 ns | 1.2857 ns | 19.129 ns |         - |
|     GetTagValueEmptyAzMonList |  2.650 ns | 0.0989 ns | 0.1975 ns |  2.676 ns |         - |
|  GetTagValueNonemptyAzMonList | 30.536 ns | 0.6547 ns | 1.0938 ns | 30.290 ns |         - |

**Proposed - Reference Equals**

|                        Method |      Mean |     Error |    StdDev |    Median | Allocated |
|------------------------------ |----------:|----------:|----------:|----------:|----------:|
|    GetTagValueEmptyTagObjects |  5.762 ns | 0.1512 ns | 0.4412 ns |  5.650 ns |         - |
| GetTagValueNonemptyTagObjects | 14.824 ns | 0.3339 ns | 0.8796 ns | 14.521 ns |         - |
|     GetTagValueEmptyAzMonList |  1.909 ns | 0.0737 ns | 0.1618 ns |  1.901 ns |         - |
|  GetTagValueNonemptyAzMonList |  9.269 ns | 0.2202 ns | 0.4833 ns |  9.220 ns |         - |