### PR TITLE
[Event Hubs] Buffered Producer Await Handlers

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -16,6 +16,8 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 ### Other Changes
 
+- The `EventHubBufferedProducer` will now invoke the handlers for success or failure when publishing a batch in a deterministic manner, as part of the publishing flow.  Handlers will now be awaited, causing the publishing operation to be considered incomplete until the handler returns.  Previously, handlers were invoked in the background non-deterministically and without a guaranteed ordering.  This ensured they could not interfere with publishing throughput but caused difficulty for reliably checkpointing with the source of events.
+
 - Attempt to retrieve AMQP objects synchronously before calling `GetOrCreateAsync`, avoiding an asynchronous call unless necessary.
 
 - Remove allocations from Event Source logging by introducing `WriteEvent` overloads to handle cases that would otherwise result in boxing to `object[]` via params array.  _(A community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -110,9 +110,6 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <summary>The count of total events that have been buffered across all partitions.</summary>
         private int _totalBufferedEventCount;
 
-        /// <summary>The set of publishing event handlers that are actively executing; these should be awaited when flushing.</summary>
-        private ConcurrentDictionary<Task, byte> _activePublishingHandlers = new();
-
         /// <summary>The handler to be called once a batch has successfully published.</summary>
         private Func<SendEventBatchSucceededEventArgs, Task> _sendSucceededHandler;
 
@@ -235,9 +232,12 @@ namespace Azure.Messaging.EventHubs.Producer
 
         /// <summary>
         ///   Invoked after each batch of events has been successfully published to the Event Hub, this handler is optional
-        ///   and is intended to provide notifications for interested listeners.  If this producer was not configured with
-        ///   <see cref="EventHubBufferedProducerClientOptions.MaximumConcurrentSends" /> and <see cref="EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition" />
-        ///   both set to 1, the handler will be invoked concurrently.
+        ///   and is intended to provide notifications for interested listeners.  If this producer was configured with
+        ///   <see cref="EventHubBufferedProducerClientOptions.MaximumConcurrentSends" /> or <see cref="EventHubBufferedProducerClientOptions.MaximumConcurrentSendsPerPartition" />
+        ///   set greater than 1, the handler will be invoked concurrently.
+        ///
+        ///   This handler will be awaited after publishing the batch; the publishing operation will not be considered complete until the handler
+        ///   call returns.  It is advised that no long-running operations be performed in the handler to avoid negatively impacting throughput.
         ///
         ///   It is not recommended to invoke <see cref="CloseAsync" /> or <see cref="DisposeAsync" /> from this handler; doing so may result
         ///   in a deadlock scenario if those calls are awaited.
@@ -299,6 +299,9 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         ///   It is safe to attempt resending the events by calling <see cref="EnqueueEventAsync(EventData, CancellationToken)" /> or <see cref="EnqueueEventAsync(EventData, EnqueueEventOptions, CancellationToken)" /> from within
         ///   this handler.  It is important to note that doing so will place them at the end of the buffer; the original order will not be maintained.
+        ///
+        ///   This handler will be awaited after failure to publish the batch; the publishing operation is not considered complete until the
+        ///   handler call returns.  It is advised that no long-running operations be performed in the handler to avoid negatively impacting throughput.
         ///
         ///   It is not recommended to invoke <see cref="CloseAsync" /> or <see cref="DisposeAsync" /> from this handler; doing so may result
         ///   in a deadlock scenario if those calls are awaited.
@@ -1329,11 +1332,10 @@ namespace Azure.Messaging.EventHubs.Producer
                     }
                 }
 
-                // Wait for any remaining partitions to complete, and then wait for outstanding handlers.  Both are
-                // expected to manage their own exceptions and should not throw.
+                // Wait for any remaining partitions to complete, which will also wait for outstanding handlers.  This
+                // is expected to manage their own exceptions and should not throw.
 
                 await Task.WhenAll(activeDrains).AwaitWithCancellation(cancellationToken);
-                await WaitForActivePublishHandlersAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -1415,7 +1417,7 @@ namespace Azure.Messaging.EventHubs.Producer
                                 // Handler invocation is performed in the background as a fire-and-forget operation.  Exceptions in the handler
                                 // are logged as part of the invocation.
 
-                                _ = InvokeOnSendFailedAsync(new List<EventData>(1) { currentEvent }, exception, partitionId);
+                                await SafeInvokeOnSendFailedAsync(new List<EventData>(1) { currentEvent }, exception, partitionId, cancellationToken).ConfigureAwait(false);
                                 return;
                             }
 
@@ -1458,7 +1460,7 @@ namespace Azure.Messaging.EventHubs.Producer
                     // are logged as part of the invocation.
 
                     await _producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
-                    _ = InvokeOnSendSucceededAsync(batchEvents, partitionId);
+                    await SafeInvokeOnSendSucceededAsync(batchEvents, partitionId, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
@@ -1470,7 +1472,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if (batch?.Count > 0)
                 {
-                    _ = InvokeOnSendFailedAsync(batchEvents, ex, partitionId);
+                    await SafeInvokeOnSendFailedAsync(batchEvents, ex, partitionId, cancellationToken).ConfigureAwait(false);
                 }
             }
             finally
@@ -1563,7 +1565,7 @@ namespace Azure.Messaging.EventHubs.Producer
                         var exception = new EventHubsException(EventHubName, message, EventHubsException.FailureReason.MessageSizeExceeded);
 
                         Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, message);
-                        _ = InvokeOnSendFailedAsync(new List<EventData>(1) { readEvent }, exception, partitionId);
+                        await SafeInvokeOnSendFailedAsync(new List<EventData>(1) { readEvent }, exception, partitionId, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -1579,12 +1581,12 @@ namespace Azure.Messaging.EventHubs.Producer
                         try
                         {
                             await _producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
-                            _ = InvokeOnSendSucceededAsync(batchEvents, partitionState.PartitionId);
+                            await SafeInvokeOnSendSucceededAsync(batchEvents, partitionState.PartitionId, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception ex)
                         {
                             Logger.BufferedProducerEventBatchPublishError(Identifier, EventHubName, partitionId, operationId, ex.Message);
-                            _ = InvokeOnSendFailedAsync(batchEvents, ex, partitionId);
+                            await SafeInvokeOnSendFailedAsync(batchEvents, ex, partitionId, cancellationToken).ConfigureAwait(false);
 
                             // If publishing was canceled, break out of the drain loop.
 
@@ -1635,7 +1637,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 Interlocked.Add(ref _totalBufferedEventCount, Math.Max(totalDeltaZero, partitionStateDelta));
                 Interlocked.Exchange(ref partitionState.BufferedEventCount, 0);
 
-                await InvokeOnSendFailedAsync(events, ex, partitionId).ConfigureAwait(false);
+                await SafeInvokeOnSendFailedAsync(events, ex, partitionId, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -1923,70 +1925,54 @@ namespace Azure.Messaging.EventHubs.Producer
         }
 
         /// <summary>
-        ///   Responsible for invoking <see cref="OnSendSucceededAsync" /> as an background task.
+        ///   Responsible for invoking <see cref="OnSendSucceededAsync" /> and ensuring that no exceptions
+        ///   are surfaced.  This is necessary because the method may be overridden and non-throwing behavior
+        ///   cannot be guaranteed.
         /// </summary>
         ///
         /// <param name="events">The set of events belonging to the batch that was successfully published.</param>
         /// <param name="partitionId">The identifier of the partition that the batch of events was published to.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the handler invocation.  It is the responsibility of the registered handler to make the decision to honor cancellation or not.</param>
         ///
-        private Task InvokeOnSendSucceededAsync(IReadOnlyList<EventData> events,
-                                                string partitionId) => TrackPublishHandlerAsActiveAsync(Task.Run(() => OnSendSucceededAsync(events, partitionId, CancellationToken.None)));
+        private async Task SafeInvokeOnSendSucceededAsync(IReadOnlyList<EventData> events,
+                                                          string partitionId,
+                                                          CancellationToken cancellationToken)
+        {
+            try
+            {
+                await OnSendSucceededAsync(events, partitionId, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Exceptions in the handler are logged as part of the invocation.  There is no value in throwing,
+                // as the source is a background task and the exception is not observable by application code.
+            }
+        }
 
         /// <summary>
-        ///   Responsible for invoking <see cref="OnSendFailedAsync" /> as an background task.
+        ///   Responsible for invoking <see cref="OnSendFailedAsync" /> and ensuring that no exceptions
+        ///   are surfaced.  This is necessary because the method may be overridden and non-throwing behavior
+        ///   cannot be guaranteed.
         /// </summary>
         ///
         /// <param name="events">The set of events belonging to the batch that failed to be published.</param>
         /// <param name="exception">The <see cref="Exception"/> that was raised when the events failed to publish.</param>
         /// <param name="partitionId">The identifier of the partition that the batch of events was published to.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the handler invocation.  It is the responsibility of the registered handler to make the decision to honor cancellation or not.</param>
         ///
-        private Task InvokeOnSendFailedAsync(IReadOnlyList<EventData> events,
-                                             Exception exception,
-                                             string partitionId) => TrackPublishHandlerAsActiveAsync(Task.Run(() => OnSendFailedAsync(events, exception, partitionId), CancellationToken.None));
-
-        /// <summary>
-        ///   Tracks a publishing event handler invocation as active, ensuring that
-        ///   tracking stops when the handler completes.
-        /// </summary>
-        ///
-        /// <param name="handlerTask">The publishing event handler task to track.</param>
-        ///
-        private Task TrackPublishHandlerAsActiveAsync(Task handlerTask)
+        private async Task SafeInvokeOnSendFailedAsync(IReadOnlyList<EventData> events,
+                                                       Exception exception,
+                                                       string partitionId,
+                                                       CancellationToken cancellationToken)
         {
-            // If the handler has already completed, there is no further tracking needed.
-
-            if (handlerTask.IsCompleted)
+            try
             {
-                return handlerTask;
+                await OnSendFailedAsync(events, exception, partitionId, cancellationToken).ConfigureAwait(false);
             }
-
-            // Track the handler invocation so that it can be awaited, if needed.  To ensure that
-            // the active set does not grow unbounded, attach a continuation that will prune the handler
-            // upon its completion.
-
-            _activePublishingHandlers.TryAdd(handlerTask, 0);
-
-            var continuationTask = handlerTask.ContinueWith(static (runTask, state) =>
+            catch
             {
-                var (trackedTask, activeHandlers) = (Tuple<Task, ConcurrentDictionary<Task, byte>>)state;
-                return activeHandlers.TryRemove(trackedTask, out _);
-            },
-            Tuple.Create(handlerTask, _activePublishingHandlers), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
-
-            return continuationTask;
-        }
-
-        /// <summary>
-        ///   Waits for all active publishing event handlers to complete.
-        /// </summary>
-        ///
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the stop operation.</param>
-        ///
-        private async Task WaitForActivePublishHandlersAsync(CancellationToken cancellationToken)
-        {
-            while (!_activePublishingHandlers.IsEmpty)
-            {
-                await Task.WhenAll(_activePublishingHandlers.Keys).AwaitWithCancellation(cancellationToken);
+                // Exceptions in the handler are logged as part of the invocation.  There is no value in throwing,
+                // as the source is a background task and the exception is not observable by application code.
             }
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to shift the invocation of event handlers for the `EventHubBufferedProducerClient` from a non-deterministic background approach to one that is deterministic and in consistent order.

Feedback from beta customers has indicated that the "random" nature of handler invocations made it difficult to "checkpoint" with the source of events to mark them as complete.  Handlers were potentially invoked in a different order than the batches were sent, and the handler was unable to pause publishing for a partition to accommodate completing a "checkpoint" operation.

Originally, the goal for background invocation was to ensure that handlers which were long-running or performed a heavy workload could not impact publishing throughput, but this also created additional pressure on the thread pool due to the unconstrained use of `Task.Run` to ensure that handlers written with synchronous code did not execute synchronously.