### PR TITLE
Fix PartiallyDeployedAttribute to catch exceptions

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/PartiallyDeployedAttributeTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/PartiallyDeployedAttributeTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Security.KeyVault.Tests;
+using NUnit.Framework;
+
+namespace Azure.Security.KeyVault.Keys.Tests
+{
+    public class PartiallyDeployedAttributeTests
+    {
+        [Test]
+        [PartiallyDeployed]
+        public void ExportableNotSupportedThrowsInconclusive()
+        {
+            MockResponse resp = new MockResponse(400)
+                .WithHeader(HttpHeader.Names.ContentType, "application/json")
+                .WithContent(@"{""error"":{""code"":""BadParameter"",""message"":""AKV.SKR.1001: The exportable attribute is only supported with premium vaults and API version >= '7.3-preview'.""}}");
+
+            KeyClientOptions options = new()
+            {
+                Transport = new MockTransport(resp),
+            };
+
+            KeyClient client = new(new("https://myvault.vault.azure.net"), new MockCredential(), options);
+            client.CreateRsaKey(new("test-key")
+            {
+                Exportable = true,
+                KeySize = 2048,
+            });
+
+            Assert.Fail("Client method did not throw expected HTTP 400");
+        }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/PartiallyDeployedAttribute.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/PartiallyDeployedAttribute.cs
@@ -22,7 +22,21 @@ namespace Azure.Security.KeyVault.Tests
 
             public override TestResult Execute(TestExecutionContext context)
             {
-                context.CurrentResult = innerCommand.Execute(context);
+                RequestFailedException rex = null;
+                try
+                {
+                    context.CurrentResult = innerCommand.Execute(context);
+                }
+                catch (RequestFailedException ex)
+                {
+                    rex = ex;
+                }
+                catch (Exception ex) when (ex.InnerException is RequestFailedException _rex)
+                {
+                    rex = _rex;
+                }
+
+                context.CurrentResult.SetResult(ResultState.Failure, rex.Message, rex.StackTrace);
 
                 if (context.CurrentResult.ResultState.Status == TestStatus.Failed &&
                     context.CurrentResult.Message.Contains("Status: 400") &&

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/PartiallyDeployedAttribute.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/tests/PartiallyDeployedAttribute.cs
@@ -36,7 +36,10 @@ namespace Azure.Security.KeyVault.Tests
                     rex = _rex;
                 }
 
-                context.CurrentResult.SetResult(ResultState.Failure, rex.Message, rex.StackTrace);
+                if (rex != null)
+                {
+                    context.CurrentResult.SetResult(ResultState.Failure, rex.Message, rex.StackTrace);
+                }
 
                 if (context.CurrentResult.ResultState.Status == TestStatus.Failed &&
                     context.CurrentResult.Message.Contains("Status: 400") &&


### PR DESCRIPTION
Despite being patterned from RecordedTestAttribute that does get a failed result from tests that throw, the same didn't work here. Spent a little time investigating to no avail, but this is a simple, straight-forward workaround given limited time.
