### PR TITLE
Azure Monitor Exporter - Fix incorrect aggregation showing up in ingested data

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MetricData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/MetricData.cs
@@ -10,6 +10,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class MetricsData
     {
+        // TODO: Change the export value when AzureMonitorExporterOptions
+        // could take a customized ExportIntervalMilliseconds.
+        internal const string DefaultExportIntervalMilliseconds = "60000";
+        internal const string AggregationIntervalMsKey = "_MS.AggregationIntervalMs";
+
         public MetricsData(int version, Metric metric, ref MetricPoint metricPoint) : base(version)
         {
             if (metric == null)
@@ -38,6 +43,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             {
                 Properties.Add(new KeyValuePair<string, string>(tag.Key, tag.Value?.ToString()));
             }
+            Properties.Add(AggregationIntervalMsKey, DefaultExportIntervalMilliseconds);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricsDataTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/MetricsDataTests.cs
@@ -55,7 +55,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             Assert.Equal(name, metricData.Metrics.First().Name);
             Assert.Equal(123.45, metricData.Metrics.First().Value);
             Assert.Equal(dataPointType, metricData.Metrics.First().DataPointType);
-            Assert.Empty(metricData.Properties);
+            // Properties will contain _MS.AggregationIntervalMs
+            Assert.Equal(1, metricData.Properties.Count);
         }
 
         [InlineData(MetricType.DoubleSum)]


### PR DESCRIPTION
- If exporter does not send `_MS.AggregationIntervalMs` key to ingestion service, data gets pre-aggregated at service level and results in incorrect min, max, sum and count values.
- Adding `_MS.AggregationIntervalMs` to properties resolves this issue.
- Exporter does not provide an option to customize  the `ExportIntervalMilliseconds` value for metrics. It works on the constant 60000 interval provided by `OpenTelemetry`.

**Sample from ingestion**

![image](https://user-images.githubusercontent.com/9479006/156060846-32f09981-1802-4fb5-9365-cb3e9584e7a0.png)
