### PR TITLE
Azure Monitor Exporter - Add public API AddAzureMonitorMetricExporter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -4,6 +4,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     {
         public static OpenTelemetry.Trace.TracerProviderBuilder AddAzureMonitorTraceExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null) { throw null; }
     }
+    public static partial class AzureMonitorExporterMetricExtensions
+    {
+        public static OpenTelemetry.Metrics.MeterProviderBuilder AddAzureMonitorMetricExporter(this OpenTelemetry.Metrics.MeterProviderBuilder builder, System.Action<Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions> configure = null) { throw null; }
+    }
     public partial class AzureMonitorExporterOptions : Azure.Core.ClientOptions
     {
         public AzureMonitorExporterOptions(Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion version = Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.ServiceVersion.V2020_09_15_Preview) { }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterMetricExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterMetricExtensions.cs
@@ -9,7 +9,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
     /// <summary>
     /// Extension methods to simplify registering of Azure Monitor Metrics Exporter.
     /// </summary>
-    internal static class AzureMonitorExporterMetricExtensions
+    public static class AzureMonitorExporterMetricExtensions
     {
         /// <summary>
         /// Adds Azure Monitor Metric exporter.


### PR DESCRIPTION
Modified `AzureMonitorExporterMetricExtensions` from internal to public to allow the apps to consume `AddAzureMonitorMetricExporter`

**Example**
```csharp
Meter meter = new Meter("MyCompany.MyProduct.MyLibrary", "1.0");
Counter<double> counter = meter.CreateCounter<double>("FruitCounter");

using var meterProvider = Sdk.CreateMeterProviderBuilder()
.AddMeter("MyCompany.MyProduct.MyLibrary")
.AddAzureMonitorMetricExporter(o =>
{
    o.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus2-1.in.applicationinsights.azure.com/";
})
.Build();

counter.Add(1, new("type", "fruit"), new("name", "apple"), new("color", "red"));
counter.Add(1, new("type", "fruit"), new("name", "apple"), new("color", "red"));
counter.Add(1, new("type", "fruit"), new("name", "apple"), new("color", "green"));
```