### PR TITLE
Record partition before consuming stream

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/PartitionedUploader.cs
@@ -308,6 +308,8 @@ namespace Azure.Storage
                         async: true,
                         cancellationToken).ConfigureAwait(false))
                     {
+                        partitions.Add((block.AbsolutePosition, block.Length));
+
                         await StagePartitionAndDisposeInternal(
                             block,
                             block.AbsolutePosition,
@@ -315,8 +317,6 @@ namespace Azure.Storage
                             progressHandler,
                             async: true,
                             cancellationToken).ConfigureAwait(false);
-
-                        partitions.Add((block.AbsolutePosition, block.Length));
                     }
                 }
                 else
@@ -329,6 +329,8 @@ namespace Azure.Storage
                         async: false,
                         cancellationToken).EnsureSyncEnumerable())
                     {
+                        partitions.Add((block.AbsolutePosition, block.Length));
+
                         StagePartitionAndDisposeInternal(
                             block,
                             block.AbsolutePosition,
@@ -336,8 +338,6 @@ namespace Azure.Storage
                             progressHandler,
                             async: false,
                             cancellationToken).EnsureCompleted();
-
-                        partitions.Add((block.AbsolutePosition, block.Length));
                     }
                 }
 


### PR DESCRIPTION
Fixes #18951.  See similar change in PartitionedUploader.cs around line 404 (in UploadInParallelAsync).  May want to consider adding safety checks to PooledMemoryStream public methods to check and throw if stream has been disposed.
