### PR TITLE
Update Core tests with new DPG approach to ResponseClassifier

### DIFF
--- a/sdk/core/Azure.Core/tests/HttpMessageTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpMessageTests.cs
@@ -43,7 +43,7 @@ namespace Azure.Core.Tests
             context.AddClassifier(204, isError: true);
 
             HttpMessage message = new HttpMessage(new MockRequest(), default);
-            message.ApplyRequestContext(context, DpgClassifier.Instance);
+            message.ApplyRequestContext(context, ResponseClassifier200204304);
 
             message.Response = new MockResponse(204);
             Assert.IsTrue(message.ResponseClassifier.IsErrorResponse(message));
@@ -65,7 +65,7 @@ namespace Azure.Core.Tests
             context.AddClassifier(404, isError: false);
 
             HttpMessage message = new HttpMessage(new MockRequest(), default);
-            message.ApplyRequestContext(context, DpgClassifier.Instance);
+            message.ApplyRequestContext(context, ResponseClassifier200204304);
 
             message.Response = new MockResponse(204);
             Assert.IsFalse(message.ResponseClassifier.IsErrorResponse(message));
@@ -89,7 +89,7 @@ namespace Azure.Core.Tests
             context.AddClassifier(404, isError: false);
 
             HttpMessage message = new HttpMessage(new MockRequest(), default);
-            message.ApplyRequestContext(context, DpgClassifier.Instance);
+            message.ApplyRequestContext(context, ResponseClassifier200204304);
 
             message.Response = new MockResponse(204);
             Assert.IsFalse(message.ResponseClassifier.IsErrorResponse(message));
@@ -110,7 +110,7 @@ namespace Azure.Core.Tests
         [Test]
         public void SettingResponseClassifierReplacesBaseClassifier()
         {
-            HttpMessage message = new HttpMessage(new MockRequest(), DpgClassifier.Instance);
+            HttpMessage message = new HttpMessage(new MockRequest(), ResponseClassifier200204304);
 
             message.Response = new MockResponse(404);
             Assert.IsTrue(message.ResponseClassifier.IsErrorResponse(message));
@@ -135,7 +135,7 @@ namespace Azure.Core.Tests
         [Test]
         public void SettingResponseClassifierReplacesBaseClassifier_PerCallCustomization()
         {
-            HttpMessage message = new HttpMessage(new MockRequest(), DpgClassifier.Instance);
+            HttpMessage message = new HttpMessage(new MockRequest(), ResponseClassifier200204304);
 
             message.Response = new MockResponse(404);
             Assert.IsTrue(message.ResponseClassifier.IsErrorResponse(message));
@@ -143,7 +143,7 @@ namespace Azure.Core.Tests
             RequestContext context = new RequestContext();
             context.AddClassifier(new StatusCodeHandler(304, true));
 
-            message.ResponseClassifier = context.Apply(DpgClassifier.Instance);
+            message.ResponseClassifier = context.Apply(ResponseClassifier200204304);
 
             // This replaces the base classifier with one that only thinks 404 is a non-error
             // and doesn't have opinions on anything else.
@@ -184,7 +184,7 @@ namespace Azure.Core.Tests
             message.Response = new MockResponse(404);
             Assert.IsTrue(message.ResponseClassifier.IsErrorResponse(message));
 
-            message.ResponseClassifier = DpgClassifier.Instance;
+            message.ResponseClassifier = ResponseClassifier200204304;
 
             message.Response = new MockResponse(304);
             Assert.IsFalse(message.ResponseClassifier.IsErrorResponse(message));
@@ -203,7 +203,7 @@ namespace Azure.Core.Tests
             context.AddClassifier(new StatusCodeHandler(204, isError: true));
 
             HttpMessage message = new HttpMessage(new MockRequest(), default);
-            message.ApplyRequestContext(context, DpgClassifier.Instance);
+            message.ApplyRequestContext(context, ResponseClassifier200204304);
 
             message.Response = new MockResponse(204);
             Assert.IsTrue(message.ResponseClassifier.IsErrorResponse(message));
@@ -226,7 +226,7 @@ namespace Azure.Core.Tests
             context.AddClassifier(204, isError: false);
 
             HttpMessage message = new HttpMessage(new MockRequest(), default);
-            message.ApplyRequestContext(context, DpgClassifier.Instance);
+            message.ApplyRequestContext(context, ResponseClassifier200204304);
 
             message.Response = new MockResponse(204);
             Assert.IsTrue(message.ResponseClassifier.IsErrorResponse(message));
@@ -315,7 +315,7 @@ namespace Azure.Core.Tests
             context.AddClassifier(new StatusCodeHandler(204, false));
 
             HttpMessage message = new HttpMessage(new MockRequest(), default);
-            message.ApplyRequestContext(context, DpgClassifier.Instance);
+            message.ApplyRequestContext(context, ResponseClassifier200204304);
 
             message.Response = new MockResponse(204);
             Assert.IsFalse(message.ResponseClassifier.IsErrorResponse(message));
@@ -355,18 +355,9 @@ namespace Azure.Core.Tests
             }
         }
 
-        /// <summary>
-        /// Example DPG classifier for testing purposes.
-        /// </summary>
-        private sealed class DpgClassifier : CoreResponseClassifier
-        {
-            private static CoreResponseClassifier _instance;
-            public static CoreResponseClassifier Instance => _instance ??= new DpgClassifier();
-
-            public DpgClassifier() : base(stackalloc int[] { 200, 204, 304 })
-            {
-            }
-        }
+        // Example DPG classifier for testing purposes.
+        private static ResponseClassifier _responseClassifier200204304;
+        private static ResponseClassifier ResponseClassifier200204304 => _responseClassifier200204304 ??= new CoreResponseClassifier(stackalloc int[] { 200, 204, 304 });
 
         private sealed class HeadResponseClassifier : ResponseClassifier
         {

--- a/sdk/core/Azure.Core/tests/HttpPipelineTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineTests.cs
@@ -293,7 +293,7 @@ namespace Azure.Core.Tests
             var context = new RequestContext();
             context.AddClassifier(404, isError: false);
 
-            HttpMessage message = pipeline.CreateMessage(context, DpgClassifier.Instance);
+            HttpMessage message = pipeline.CreateMessage(context, ResponseClassifier200204304);
             Request request = message.Request;
             request.Method = RequestMethod.Get;
             request.Uri.Reset(new Uri("https://contoso.a.io"));
@@ -344,18 +344,9 @@ namespace Azure.Core.Tests
             }
         }
 
-        /// <summary>
-        /// Example DPG classifier for testing purposes.
-        /// </summary>
-        private sealed class DpgClassifier : CoreResponseClassifier
-        {
-            private static CoreResponseClassifier _instance;
-            public static CoreResponseClassifier Instance => _instance ??= new DpgClassifier();
-
-            public DpgClassifier() : base(stackalloc int[] { 200, 204, 304 })
-            {
-            }
-        }
+        // How classifiers will be generated in DPG.
+        private static ResponseClassifier _responseClassifier200204304;
+        private static ResponseClassifier ResponseClassifier200204304 => _responseClassifier200204304 ??= new CoreResponseClassifier(stackalloc int[] { 200, 204, 304 });
         #endregion
 
     }


### PR DESCRIPTION
Per https://github.com/Azure/autorest.csharp/issues/2006#issuecomment-1055887869, DPG will change its approach to generating per-method ResponseClassifiers to use CoreResponseClassifier slightly differently than originally planned.  This updates the tests in Core to validate that approach.