### PR TITLE
Fixed Storage UriBuilder to be case insensitive for parameters

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added nullable version of `BlobProperties.CopyStatus` called `BlobCopyStatus`, allowing a null value when Storage doesn't return a value.
 - Fixed a bug where BlobContainerClient.GetProperties() would throw an ArgumentNullException when the AccessPolicy was null
 - Removed preview support for SDK-calculated transactional checksums on data transfer.
+- Fixed a bug where BlobUriBuilder was case sensitive for parameter names.
 
 ## 12.11.0-beta.3 (2022-02-07)
 - Added support for service version 2021-04-10.

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Net;
 using Azure.Core.TestFramework;
 using Azure.Storage.Sas;
@@ -132,48 +134,69 @@ namespace Azure.Storage.Blobs.Test
         public void BlobUriBuilder_RegularUrl_SnapshotTest()
         {
             // Arrange
-            var uriString = "https://account.blob.core.windows.net/container/blob?snapshot=2011-03-09T01:42:34.9360000Z";
-            var originalUri = new UriBuilder(uriString);
+            IList<string> snapshotUris = new List<string>()
+            {
+                "https://account.blob.core.windows.net/container/blob?snapshot=2011-03-09T01:42:34.9360000Z",
+                "https://account.blob.core.windows.net/container/blob?sNAPSHOT=2011-03-09T01:42:34.9360000Z",
+                "https://account.blob.core.windows.net/container/blob?snapShot=2011-03-09T01:42:34.9360000Z",
+                "https://account.blob.core.windows.net/container/blob?sNaPsHoT=2011-03-09T01:42:34.9360000Z",
+            };
 
-            // Act
-            var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.ToUri();
+            foreach (var uriString in snapshotUris)
+            {
+                var originalUri = new UriBuilder(uriString);
 
-            // Assert
-            Assert.AreEqual("https", blobUriBuilder.Scheme);
-            Assert.AreEqual("account.blob.core.windows.net", blobUriBuilder.Host);
-            Assert.AreEqual("account", blobUriBuilder.AccountName);
-            Assert.AreEqual("container", blobUriBuilder.BlobContainerName);
-            Assert.AreEqual("blob", blobUriBuilder.BlobName);
-            Assert.AreEqual("2011-03-09T01:42:34.9360000Z", blobUriBuilder.Snapshot);
-            Assert.IsNull(blobUriBuilder.Sas);
-            Assert.AreEqual("", blobUriBuilder.Query);
-            Assert.AreEqual(443, blobUriBuilder.Port);
-            Assert.AreEqual(originalUri, newUri);
+                // Act
+                var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
+                Uri newUri = blobUriBuilder.ToUri();
+
+                // Assert
+                Assert.AreEqual("https", blobUriBuilder.Scheme);
+                Assert.AreEqual("account.blob.core.windows.net", blobUriBuilder.Host);
+                Assert.AreEqual("account", blobUriBuilder.AccountName);
+                Assert.AreEqual("container", blobUriBuilder.BlobContainerName);
+                Assert.AreEqual("blob", blobUriBuilder.BlobName);
+                Assert.AreEqual("2011-03-09T01:42:34.9360000Z", blobUriBuilder.Snapshot);
+                Assert.IsNull(blobUriBuilder.Sas);
+                Assert.AreEqual("", blobUriBuilder.Query);
+                Assert.AreEqual(443, blobUriBuilder.Port);
+                Assert.IsTrue(string.Equals(originalUri.Uri.AbsoluteUri, newUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase));
+            }
         }
 
         [RecordedTest]
         public void BlobUriBuilder_RegularUrl_VersionIdTest()
         {
             // Arrange
-            var uriString = "https://account.blob.core.windows.net/container/blob?versionid=2011-03-09T01:42:34.9360000Z";
-            var originalUri = new UriBuilder(uriString);
+            IList<string> snapshotUris = new List<string>()
+            {
+                "https://account.blob.core.windows.net/container/blob?versionid=2011-03-09T01:42:34.9360000Z",
+                "https://account.blob.core.windows.net/container/blob?versionId=2011-03-09T01:42:34.9360000Z",
+                "https://account.blob.core.windows.net/container/blob?VersionId=2011-03-09T01:42:34.9360000Z",
+                "https://account.blob.core.windows.net/container/blob?VERSIONID=2011-03-09T01:42:34.9360000Z",
+            };
 
-            // Act
-            var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.ToUri();
+            foreach (var uriString in snapshotUris)
+            {
+                // Arrange
+                var originalUri = new UriBuilder(uriString);
 
-            // Assert
-            Assert.AreEqual("https", blobUriBuilder.Scheme);
-            Assert.AreEqual("account.blob.core.windows.net", blobUriBuilder.Host);
-            Assert.AreEqual("account", blobUriBuilder.AccountName);
-            Assert.AreEqual("container", blobUriBuilder.BlobContainerName);
-            Assert.AreEqual("blob", blobUriBuilder.BlobName);
-            Assert.AreEqual("2011-03-09T01:42:34.9360000Z", blobUriBuilder.VersionId);
-            Assert.IsNull(blobUriBuilder.Sas);
-            Assert.AreEqual("", blobUriBuilder.Query);
-            Assert.AreEqual(443, blobUriBuilder.Port);
-            Assert.AreEqual(originalUri, newUri);
+                // Act
+                var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
+                Uri newUri = blobUriBuilder.ToUri();
+
+                // Assert
+                Assert.AreEqual("https", blobUriBuilder.Scheme);
+                Assert.AreEqual("account.blob.core.windows.net", blobUriBuilder.Host);
+                Assert.AreEqual("account", blobUriBuilder.AccountName);
+                Assert.AreEqual("container", blobUriBuilder.BlobContainerName);
+                Assert.AreEqual("blob", blobUriBuilder.BlobName);
+                Assert.AreEqual("2011-03-09T01:42:34.9360000Z", blobUriBuilder.VersionId);
+                Assert.IsNull(blobUriBuilder.Sas);
+                Assert.AreEqual("", blobUriBuilder.Query);
+                Assert.AreEqual(443, blobUriBuilder.Port);
+                Assert.IsTrue(string.Equals(originalUri.Uri.AbsoluteUri, newUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase));
+            }
         }
 
         [RecordedTest]

--- a/sdk/storage/Azure.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Common/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.10.0-beta.4 (Unreleased)
 - Updated StorageBearerTokenChallengeAuthorizationPolicy to use the AAD scope returned by a bearer challenges.
 - Removed preview support for SDK-calculated transactional checksums on data transfer.
+- Fixed bug where Storage Uri Builder was case sensitive for parameter names.
 
 ## 12.10.0-beta.3 (2022-02-07)
 - Fixed bug where AccountSasBuilder.SetPermissions(string rawPermissions) was not properly handling the Permanent Delete ('y') and set Immutability Policy ('i') permissions.

--- a/sdk/storage/Azure.Storage.Common/src/Shared/UriQueryParamsCollection.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/UriQueryParamsCollection.cs
@@ -17,7 +17,7 @@ namespace Azure.Storage
         /// Takes encoded query params string, output decoded params map
         /// </summary>
         /// <param name="encodedQueryParamString"></param>
-		public UriQueryParamsCollection(string encodedQueryParamString)
+		public UriQueryParamsCollection(string encodedQueryParamString) : base(StringComparer.OrdinalIgnoreCase)
         {
             encodedQueryParamString = encodedQueryParamString ?? throw Errors.ArgumentNull(nameof(encodedQueryParamString));
 

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed bug where ShareFileClient.StartCopy() and .StartCopyAsync() were not sending the ignoreReadonly parameter correctly.
 - Added new overload of ShareFileClient.StartCopy() and .StartCopyAsync(), added new parameters allowing the copying of the source file's CreatedOn, LastWrittenOn, and FileAttributes properties.
 - Removed preview support for SDK-calculated transactional checksums on data transfer.
+- Fixed bug where ShareUriBuilder was case sensitive for parameter names.
 
 ## 12.9.0-beta.3 (2022-02-07)
 - Added support for service version 2021-04-10.

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using Azure.Core.TestFramework;
 using Azure.Storage.Sas;
@@ -123,24 +124,34 @@ namespace Azure.Storage.Files.Shares.Tests
         public void FileUriBuilder_SnapshotTest()
         {
             // Arrange
-            var uriString = "https://account.file.core.windows.net/share?sharesnapshot=2011-03-09T01:42:34.9360000Z";
-            var originalUri = new UriBuilder(uriString);
+            IList<string> snapshotUris = new List<string>()
+            {
+                "https://account.file.core.windows.net/share?sharesnapshot=2011-03-09T01:42:34.9360000Z",
+                "https://account.file.core.windows.net/share?ShareSnapshot=2011-03-09T01:42:34.9360000Z",
+                "https://account.file.core.windows.net/share?shareSnapshot=2011-03-09T01:42:34.9360000Z",
+                "https://account.file.core.windows.net/share?SHARESNAPSHOT=2011-03-09T01:42:34.9360000Z",
+            };
 
-            // Act
-            var fileUriBuilder = new ShareUriBuilder(originalUri.Uri);
-            Uri newUri = fileUriBuilder.ToUri();
+            foreach (var uriString in snapshotUris)
+            {
+                var originalUri = new UriBuilder(uriString);
 
-            // Assert
-            Assert.AreEqual("https", fileUriBuilder.Scheme);
-            Assert.AreEqual("account.file.core.windows.net", fileUriBuilder.Host);
-            Assert.AreEqual("account", fileUriBuilder.AccountName);
-            Assert.AreEqual(443, fileUriBuilder.Port);
-            Assert.AreEqual("share", fileUriBuilder.ShareName);
-            Assert.AreEqual("", fileUriBuilder.DirectoryOrFilePath);
-            Assert.AreEqual("2011-03-09T01:42:34.9360000Z", fileUriBuilder.Snapshot);
-            Assert.IsNull(fileUriBuilder.Sas);
-            Assert.AreEqual("", fileUriBuilder.Query);
-            Assert.AreEqual(originalUri, newUri);
+                // Act
+                var fileUriBuilder = new ShareUriBuilder(originalUri.Uri);
+                Uri newUri = fileUriBuilder.ToUri();
+
+                // Assert
+                Assert.AreEqual("https", fileUriBuilder.Scheme);
+                Assert.AreEqual("account.file.core.windows.net", fileUriBuilder.Host);
+                Assert.AreEqual("account", fileUriBuilder.AccountName);
+                Assert.AreEqual(443, fileUriBuilder.Port);
+                Assert.AreEqual("share", fileUriBuilder.ShareName);
+                Assert.AreEqual("", fileUriBuilder.DirectoryOrFilePath);
+                Assert.AreEqual("2011-03-09T01:42:34.9360000Z", fileUriBuilder.Snapshot);
+                Assert.IsNull(fileUriBuilder.Sas);
+                Assert.AreEqual("", fileUriBuilder.Query);
+                Assert.IsTrue(string.Equals(originalUri.Uri.AbsoluteUri, newUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase));
+            }
         }
 
         [RecordedTest]


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/18401