### PR TITLE
Cancelling function execution after partition ownership lost

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -147,63 +147,67 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
                 return Task.CompletedTask;
             }
 
-            public async Task ProcessEventsAsync(EventProcessorHostPartition context, IEnumerable<EventData> messages)
+            public async Task ProcessEventsAsync(EventProcessorHostPartition context, IEnumerable<EventData> messages, CancellationToken processingCancellationToken)
             {
-                var events = messages.ToArray();
-                EventData eventToCheckpoint = null;
-
-                var triggerInput = new EventHubTriggerInput
+                using (CancellationTokenSource linkedCts =
+                        CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, processingCancellationToken))
                 {
-                    Events = events,
-                    ProcessorPartition = context
-                };
+                    var events = messages.ToArray();
+                    EventData eventToCheckpoint = null;
 
-                if (_singleDispatch)
-                {
-                    // Single dispatch
-                    int eventCount = triggerInput.Events.Length;
-
-                    for (int i = 0; i < eventCount; i++)
+                    var triggerInput = new EventHubTriggerInput
                     {
-                        if (_cts.IsCancellationRequested)
-                        {
-                            break;
-                        }
-
-                        EventHubTriggerInput eventHubTriggerInput = triggerInput.GetSingleEventTriggerInput(i);
-                        TriggeredFunctionData input = new TriggeredFunctionData
-                        {
-                            TriggerValue = eventHubTriggerInput,
-                            TriggerDetails = eventHubTriggerInput.GetTriggerDetails(context)
-                        };
-
-                        await _executor.TryExecuteAsync(input, _cts.Token).ConfigureAwait(false);
-                        eventToCheckpoint = events[i];
-                    }
-                }
-                else
-                {
-                    // Batch dispatch
-                    TriggeredFunctionData input = new TriggeredFunctionData
-                    {
-                        TriggerValue = triggerInput,
-                        TriggerDetails = triggerInput.GetTriggerDetails(context)
+                        Events = events,
+                        ProcessorPartition = context
                     };
 
-                    await _executor.TryExecuteAsync(input, _cts.Token).ConfigureAwait(false);
-                    eventToCheckpoint = events.LastOrDefault();
-                }
+                    if (_singleDispatch)
+                    {
+                        // Single dispatch
+                        int eventCount = triggerInput.Events.Length;
 
-                // Checkpoint if we processed any events.
-                // Don't checkpoint if no events. This can reset the sequence counter to 0.
-                // Note: we intentionally checkpoint the batch regardless of function
-                // success/failure. EventHub doesn't support any sort "poison event" model,
-                // so that is the responsibility of the user's function currently. E.g.
-                // the function should have try/catch handling around all event processing
-                // code, and capture/log/persist failed events, since they won't be retried.
-                if (eventToCheckpoint != null)
-                {
-                    await CheckpointAsync(eventToCheckpoint, context).ConfigureAwait(false);
+                        for (int i = 0; i < eventCount; i++)
+                        {
+                            if (linkedCts.Token.IsCancellationRequested)
+                            {
+                                break;
+                            }
+
+                            EventHubTriggerInput eventHubTriggerInput = triggerInput.GetSingleEventTriggerInput(i);
+                            TriggeredFunctionData input = new TriggeredFunctionData
+                            {
+                                TriggerValue = eventHubTriggerInput,
+                                TriggerDetails = eventHubTriggerInput.GetTriggerDetails(context)
+                            };
+
+                            await _executor.TryExecuteAsync(input, linkedCts.Token).ConfigureAwait(false);
+                            eventToCheckpoint = events[i];
+                        }
+                    }
+                    else
+                    {
+                        // Batch dispatch
+                        TriggeredFunctionData input = new TriggeredFunctionData
+                        {
+                            TriggerValue = triggerInput,
+                            TriggerDetails = triggerInput.GetTriggerDetails(context)
+                        };
+
+                        await _executor.TryExecuteAsync(input, linkedCts.Token).ConfigureAwait(false);
+                        eventToCheckpoint = events.LastOrDefault();
+                    }
+
+                    // Checkpoint if we processed any events.
+                    // Don't checkpoint if no events. This can reset the sequence counter to 0.
+                    // Note: we intentionally checkpoint the batch regardless of function
+                    // success/failure. EventHub doesn't support any sort "poison event" model,
+                    // so that is the responsibility of the user's function currently. E.g.
+                    // the function should have try/catch handling around all event processing
+                    // code, and capture/log/persist failed events, since they won't be retried.
+                    if (eventToCheckpoint != null)
+                    {
+                        await CheckpointAsync(eventToCheckpoint, context).ConfigureAwait(false);
+                    }
                 }
             }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
                 return Task.CompletedTask;
             }
 
-            return partition.EventProcessor.ProcessEventsAsync(partition, events);
+            return partition.EventProcessor.ProcessEventsAsync(partition, events, cancellationToken);
         }
 
         protected override async Task OnInitializingPartitionAsync(EventProcessorHostPartition partition, CancellationToken cancellationToken)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/IEventProcessor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/IEventProcessor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Processor;
@@ -14,6 +15,6 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
         Task CloseAsync(EventProcessorHostPartition context, ProcessingStoppedReason reason);
         Task OpenAsync(EventProcessorHostPartition context);
         Task ProcessErrorAsync(EventProcessorHostPartition context, Exception error);
-        Task ProcessEventsAsync(EventProcessorHostPartition context, IEnumerable<EventData> messages);
+        Task ProcessEventsAsync(EventProcessorHostPartition context, IEnumerable<EventData> messages, CancellationToken cancellationToken);
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubListenerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             for (int i = 0; i < 100; i++)
             {
                 List<EventData> events = new List<EventData>() { new EventData(new byte[0]) };
-                await eventProcessor.ProcessEventsAsync(partitionContext, events);
+                await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
             }
 
             Assert.AreEqual(expected, checkpoints);
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             for (int i = 0; i < 100; i++)
             {
                 List<EventData> events = new List<EventData>() { new EventData(new byte[0]), new EventData(new byte[0]), new EventData(new byte[0]) };
-                await eventProcessor.ProcessEventsAsync(partitionContext, events);
+                await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
             }
 
             processor.Verify(
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true);
 
-            await eventProcessor.ProcessEventsAsync(partitionContext, events);
+            await eventProcessor.ProcessEventsAsync(partitionContext, events, CancellationToken.None);
 
             processor.Verify(
                 p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>()),
@@ -268,6 +268,37 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 
             (listener as IListener).Cancel();
             host.Verify(h => h.StopProcessingAsync(CancellationToken.None), Times.Exactly(2));
+        }
+
+        [Test]
+        public async Task ProcessEvents_CancellationToken_CancelsExecution()
+        {
+            var partitionContext = EventHubTests.GetPartitionContext();
+            var options = new EventHubOptions();
+            var processor = new Mock<EventProcessorHost>(MockBehavior.Strict);
+            processor.Setup(p => p.CheckpointAsync(partitionContext.PartitionId, It.IsAny<EventData>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            partitionContext.ProcessorHost = processor.Object;
+
+            var loggerMock = new Mock<ILogger>();
+            var executor = new Mock<ITriggeredFunctionExecutor>(MockBehavior.Strict);
+            executor.Setup(p => p.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+            .Callback<TriggeredFunctionData, CancellationToken>(async (TriggeredFunctionData triggeredFunctionData, CancellationToken cancellationToken) =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await Task.Delay(100);
+                }
+            })
+            .ReturnsAsync(new FunctionResult(true));
+            var eventProcessor = new EventHubListener.EventProcessor(options, executor.Object, loggerMock.Object, true);
+            List<EventData> events = new List<EventData>() { new EventData(new byte[0]) };
+            CancellationTokenSource source = new CancellationTokenSource();
+            // Start another thread to cancel execution
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(500);
+            });
+            await eventProcessor.ProcessEventsAsync(partitionContext, events, source.Token);
         }
     }
 }


### PR DESCRIPTION
Currently a function execution `CancellationToken` is canceled on [CloseAsync]([url](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs#L129)). [CloseAsync ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs#L129) will be called after [ProcessEventsAsync](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs#L150) is finished. [Retries](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages?tabs=csharp) are in [TryExecuteAsync ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs#L193) meaning we will retry to execute the function code even the partition ownership was lost. The change in the PR cancels the function execution `CancellationToken` earlier so the retries can be canceled.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
