### PR TITLE
Instrument mock operations

### DIFF
--- a/common/ManagementTestShared/Redesign/ManagementRecordedTestBase.cs
+++ b/common/ManagementTestShared/Redesign/ManagementRecordedTestBase.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Azure.ResourceManager.TestFramework
@@ -35,6 +34,8 @@ namespace Azure.ResourceManager.TestFramework
 
         protected ManagementRecordedTestBase(bool isAsync, RecordedTestMode? mode = default) : base(isAsync, mode)
         {
+            AdditionalInterceptors = new[] { new ManagementInterceptor(this) };
+
             SessionEnvironment = new TEnvironment();
             SessionEnvironment.Mode = Mode;
             Initialize();
@@ -224,8 +225,5 @@ namespace Azure.ResourceManager.TestFramework
             if (!(GlobalClient is null))
                 throw new InvalidOperationException("StopSessionRecording was never called please make sure you call that at the end of your OneTimeSetup");
         }
-
-        protected override object InstrumentOperation(Type operationType, object operation)
-            => InstrumentOperationInternal(operationType, operation, new ManagementInterceptor(this));
     }
 }

--- a/sdk/communication/Azure.Communication.NetworkTraversal/tests/CommunicationRelayClient/CommunicationRelayClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.NetworkTraversal/tests/CommunicationRelayClient/CommunicationRelayClientLiveTests.cs
@@ -18,6 +18,7 @@ namespace Azure.Communication.NetworkTraversal.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
+    [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/27522")]
     public class CommunicationRelayClientLiveTests : CommunicationRelayClientLiveTestBase
     {
         /// <summary>

--- a/sdk/core/Azure.Core.TestFramework/src/ClientTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/ClientTestBase.cs
@@ -139,26 +139,21 @@ namespace Azure.Core.TestFramework
                 interceptors.ToArray());
         }
 
-        protected internal virtual object InstrumentOperation(Type operationType, object operation)
-        {
-            return operation;
-        }
+        protected internal virtual object InstrumentOperation(Type operationType, object operation) =>
+            InstrumentOperationInternal(operationType, operation, true);
 
         protected internal T InstrumentOperation<T>(T operation) where T : Operation =>
             (T)InstrumentOperation(typeof(T), operation);
 
-        protected object InstrumentMockOperation(Type operationType, object operation, params IInterceptor[] interceptors)
+        protected object InstrumentOperationInternal(Type operationType, object operation, bool noWait, params IInterceptor[] interceptors)
         {
-            var interceptorArray = interceptors.Concat(new IInterceptor[] { new GetOriginalInterceptor(operation), new OperationInterceptor(noWait: true) }).ToArray();
+            var interceptorArray = interceptors.Concat(new IInterceptor[] { new GetOriginalInterceptor(operation), new OperationInterceptor(noWait) }).ToArray();
             return ProxyGenerator.CreateClassProxyWithTarget(
                 operationType,
                 new[] { typeof(IInstrumented) },
                 operation,
                 interceptorArray);
         }
-
-        protected T InstrumentMockOperation<T>(T operation, params IInterceptor[] interceptors) where T : Operation =>
-            (T)InstrumentMockOperation(typeof(T), operation, interceptors);
 
         protected T GetOriginal<T>(T instrumented)
         {

--- a/sdk/core/Azure.Core.TestFramework/src/Instrumentation/OperationInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/Instrumentation/OperationInterceptor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using Castle.DynamicProxy;
 
@@ -18,16 +17,16 @@ namespace Azure.Core.TestFramework
 
         internal static readonly string PollerWaitForCompletionAsyncName = nameof(OperationPoller.WaitForCompletionAsync);
 
-        private readonly bool _noWait;
+        private readonly RecordedTestMode _mode;
 
-        public OperationInterceptor(bool noWait)
+        public OperationInterceptor(RecordedTestMode mode)
         {
-            _noWait = noWait;
+            _mode = mode;
         }
 
         public void Intercept(IInvocation invocation)
         {
-            if (_noWait)
+            if (_mode == RecordedTestMode.Playback)
             {
                 if (invocation.Method.Name == WaitForCompletionMethodName)
                 {

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -348,14 +348,7 @@ namespace Azure.Core.TestFramework
             => InstrumentOperationInternal(operationType, operation);
 
         protected object InstrumentOperationInternal(Type operationType, object operation, params IInterceptor[] interceptors)
-        {
-            var interceptorArray = interceptors.Concat(new IInterceptor[] { new GetOriginalInterceptor(operation), new OperationInterceptor(Mode == RecordedTestMode.Playback) }).ToArray();
-            return ProxyGenerator.CreateClassProxyWithTarget(
-                operationType,
-                new[] { typeof(IInstrumented) },
-                operation,
-                interceptorArray);
-        }
+            => InstrumentOperationInternal(operationType, operation, Mode == RecordedTestMode.Playback, interceptors);
 
         /// <summary>
         /// A number of our tests have built in delays while we wait an expected

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -344,11 +344,6 @@ namespace Azure.Core.TestFramework
             return base.InstrumentClient(clientType, client, preInterceptors);
         }
 
-        protected internal T InstrumentOperation<T>(T operation) where T: Operation
-        {
-            return (T) InstrumentOperation(typeof(T), operation);
-        }
-
         protected internal override object InstrumentOperation(Type operationType, object operation)
             => InstrumentOperationInternal(operationType, operation);
 

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -345,10 +345,15 @@ namespace Azure.Core.TestFramework
         }
 
         protected internal override object InstrumentOperation(Type operationType, object operation)
-            => InstrumentOperationInternal(operationType, operation);
-
-        protected object InstrumentOperationInternal(Type operationType, object operation, params IInterceptor[] interceptors)
-            => InstrumentOperationInternal(operationType, operation, Mode == RecordedTestMode.Playback, interceptors);
+        {
+            var interceptors = AdditionalInterceptors ?? Array.Empty<IInterceptor>();
+            var interceptorArray = interceptors.Concat(new IInterceptor[] { new GetOriginalInterceptor(operation), new OperationInterceptor(Mode) }).ToArray();
+            return ProxyGenerator.CreateClassProxyWithTarget(
+                operationType,
+                new[] { typeof(IInstrumented) },
+                operation,
+                interceptorArray);
+        }
 
         /// <summary>
         /// A number of our tests have built in delays while we wait an expected

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -356,10 +356,11 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             // Pretend a separate process was started subsequently and we need to get the operation again.
             CertificateOperation operation = new CertificateOperation(Client, certName);
+            operation = InstrumentOperation(operation);
 
             // Need to call the real async wait method or the sync version of this test fails because it's using the instrumented Client directly.
             using CancellationTokenSource cts = new CancellationTokenSource(DefaultCertificateOperationTimeout);
-            await operation.WaitForCompletionAsync(PollingInterval, cts.Token);
+            await operation.WaitForCompletionAsync(cts.Token);
 
             Assert.IsTrue(operation.HasCompleted);
             Assert.IsTrue(operation.HasValue);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateOperationTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateOperationTests.cs
@@ -66,6 +66,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+            operation = InstrumentMockOperation(operation);
 
             await WaitForOperationAsync(operation);
 
@@ -115,6 +116,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+            operation = InstrumentMockOperation(operation);
 
             await WaitForOperationAsync(operation);
 
@@ -158,6 +160,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+            operation = InstrumentMockOperation(operation);
 
             Exception ex = Assert.ThrowsAsync<OperationCanceledException>(async () => await WaitForOperationAsync(operation));
             Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
@@ -202,6 +205,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+            operation = InstrumentMockOperation(operation);
 
             Exception ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForOperationAsync(operation));
             Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
@@ -246,6 +250,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
+            operation = InstrumentMockOperation(operation);
 
             Exception ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForOperationAsync(operation));
             Assert.AreEqual("The certificate operation failed: mock failure message", ex.Message);
@@ -292,6 +297,11 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         {
             CertificateClientOptions options = new CertificateClientOptions
             {
+                Retry =
+                {
+                    Delay = TimeSpan.FromMilliseconds(10),
+                    Mode = RetryMode.Fixed,
+                },
                 Transport = transport,
             };
 
@@ -303,10 +313,8 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                     ));
         }
 
-        private async ValueTask<KeyVaultCertificateWithPolicy> WaitForOperationAsync(CertificateOperation operation)
-        {
-            return await operation.WaitForCompletionAsync(TimeSpan.Zero, default);
-        }
+        private async ValueTask<KeyVaultCertificateWithPolicy> WaitForOperationAsync(CertificateOperation operation) =>
+            await operation.WaitForCompletionAsync();
 
         public class MockCredential : TokenCredential
         {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateOperationTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateOperationTests.cs
@@ -66,7 +66,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
-            operation = InstrumentMockOperation(operation);
 
             await WaitForOperationAsync(operation);
 
@@ -116,7 +115,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
-            operation = InstrumentMockOperation(operation);
 
             await WaitForOperationAsync(operation);
 
@@ -160,7 +158,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
-            operation = InstrumentMockOperation(operation);
 
             Exception ex = Assert.ThrowsAsync<OperationCanceledException>(async () => await WaitForOperationAsync(operation));
             Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
@@ -205,7 +202,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
-            operation = InstrumentMockOperation(operation);
 
             Exception ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForOperationAsync(operation));
             Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
@@ -250,7 +246,6 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             CertificateClient client = CreateClient(transport);
             CertificateOperation operation = await client.StartCreateCertificateAsync(CertificateName, s_policy);
-            operation = InstrumentMockOperation(operation);
 
             Exception ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForOperationAsync(operation));
             Assert.AreEqual("The certificate operation failed: mock failure message", ex.Message);


### PR DESCRIPTION
Resolves #27393

Previously non-instrumented operations were potentially regressed in PR #27368 and would instead run with their default polling of 1s if not specified by a header. Since Key Vault uses the standard `Retry-After` header with a 1s resolution, one viable alternative was to instrument operations from `ClientTestBase` similar to clients themselves. The code is effectively the same as in `RecordedTestBase` but without the dependency of using recorded tests.