### PR TITLE
Fixed bug in Storage OAuth async path

### DIFF
--- a/sdk/storage/Azure.Storage.Common/src/Shared/StorageBearerTokenChallengeAuthorizationPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StorageBearerTokenChallengeAuthorizationPolicy.cs
@@ -55,21 +55,20 @@ namespace Azure.Storage
         protected override ValueTask AuthorizeRequestAsync(HttpMessage message)
             => AuthorizeRequestInternal(message, true);
 
-        private ValueTask AuthorizeRequestInternal(HttpMessage message, bool async)
+        private async ValueTask AuthorizeRequestInternal(HttpMessage message, bool async)
         {
             if (tenantId != null || !_enableTenantDiscovery)
             {
                 TokenRequestContext context = new TokenRequestContext(_scopes, message.Request.ClientRequestId, tenantId: tenantId);
                 if (async)
                 {
-                    base.AuthenticateAndAuthorizeRequestAsync(message, context);
+                    await base.AuthenticateAndAuthorizeRequestAsync(message, context).ConfigureAwait(false);
                 }
                 else
                 {
                     base.AuthenticateAndAuthorizeRequest(message, context);
                 }
             }
-            return default;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
I noticed we were failing OAuth-related live tests - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1358987&view=ms.vss-test-web.build-test-results-tab&runId=28567186&resultId=104845&paneView=debug

This PR should address this issue.