### PR TITLE
Add parameter for skipping the tagRepository deployment

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -43,51 +43,52 @@ stages:
         dependsOn: Signing
         condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr'))
         jobs:
-          - deployment: TagRepository
-            displayName: "Create release tag"
-            condition: ne(variables['Skip.TagRepository'], 'true')
-            environment: github
-
-            pool:
-              name: azsdk-pool-mms-win-2019-general
-              vmImage: MMS2019
-
-            strategy:
-              runOnce:
-                deploy:
-                  steps:
-                    - checkout: self
-                    - download: current
-                      artifact: ${{parameters.ArtifactName}}-signed
-                    - template: /eng/pipelines/templates/steps/install-dotnet.yml
-                      parameters:
-                        EnableNuGetCache: false
-                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
-                    - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
-                      parameters:
-                        PackageName: "Azure.Template"
-                        ServiceDirectory: "template"
-                        TestPipeline: ${{ parameters.TestPipeline }}
-                    - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
-                      parameters:
-                        PackageName: ${{artifact.name}}
-                        ServiceName: ${{parameters.ServiceDirectory}}
-                        ForRelease: true
-                    - task: PowerShell@2
-                      inputs:
-                        filePath: $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1
-                        pwsh: true
-                        arguments: >
-                          -ArtifactsDirectory "$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed"
-                          -Artifact ${{artifact.name}}
-                      condition: and(succeeded(),ne('${{ artifact.skipPublishPackage }}', 'true'))
-                      displayName: Verify Package Installation
-                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                      parameters:
-                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}
-                        PackageRepository: Nuget
-                        ReleaseSha: $(Build.SourceVersion)
-                        RepoId: Azure/azure-sdk-for-net
+          - ${{if ne(artifact.skipTagRepository, 'true')}}:
+            - deployment: TagRepository
+              displayName: "Create release tag"
+              condition: ne(variables['Skip.TagRepository'], 'true')
+              environment: github
+  
+              pool:
+                name: azsdk-pool-mms-win-2019-general
+                vmImage: MMS2019
+  
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: self
+                      - download: current
+                        artifact: ${{parameters.ArtifactName}}-signed
+                      - template: /eng/pipelines/templates/steps/install-dotnet.yml
+                        parameters:
+                          EnableNuGetCache: false
+                      - template: /eng/common/pipelines/templates/steps/retain-run.yml
+                      - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+                        parameters:
+                          PackageName: "Azure.Template"
+                          ServiceDirectory: "template"
+                          TestPipeline: ${{ parameters.TestPipeline }}
+                      - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
+                        parameters:
+                          PackageName: ${{artifact.name}}
+                          ServiceName: ${{parameters.ServiceDirectory}}
+                          ForRelease: true
+                      - task: PowerShell@2
+                        inputs:
+                          filePath: $(System.DefaultWorkingDirectory)/eng/scripts/InstallationCheck.ps1
+                          pwsh: true
+                          arguments: >
+                            -ArtifactsDirectory "$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed"
+                            -Artifact ${{artifact.name}}
+                        condition: and(succeeded(),ne('${{ artifact.skipPublishPackage }}', 'true'))
+                        displayName: Verify Package Installation
+                      - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                        parameters:
+                          ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}
+                          PackageRepository: Nuget
+                          ReleaseSha: $(Build.SourceVersion)
+                          RepoId: Azure/azure-sdk-for-net
 
           - ${{if ne(artifact.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage


### PR DESCRIPTION
- Add parameter `skipTagRepository` for skipping TagRepository step. This with other parameters will allow for effectively skipping the entire release stage of the pipeline.